### PR TITLE
Add Signal K integration, rewrite setup.sh, update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ CAN_INTERFACE=can0
 CAN_BITRATE=250000
 DB_PATH=data/logger.db
 LOG_LEVEL=INFO
+DATA_SOURCE=signalk     # signalk (default) or can
+SK_HOST=localhost        # Signal K server hostname
+SK_PORT=3000             # Signal K WebSocket port

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     # Environment / config
     "python-dotenv>=1.0.1",
     "aiosqlite>=0.22.1",
+    # Signal K WebSocket client
+    "websockets>=14.0",
 ]
 
 [project.scripts]
@@ -60,10 +62,7 @@ select = [
     "SIM", # flake8-simplify
     "TCH", # flake8-type-checking
 ]
-ignore = [
-    "ANN101", # missing type annotation for `self`
-    "ANN102", # missing type annotation for `cls`
-]
+ignore = []
 
 [tool.ruff.lint.isort]
 known-first-party = ["logger"]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,42 +1,234 @@
 #!/usr/bin/env bash
-# setup.sh — One-shot setup for j105-logger on Raspberry Pi.
+# setup.sh — Full automated setup for j105-logger + Signal K + InfluxDB + Grafana.
 #
 # Usage:
 #   ./scripts/setup.sh
 #
-# Safe to re-run after `git pull` — all steps are idempotent.
-# Requires sudo for systemd service installation and group membership changes.
+# Fully idempotent — safe to re-run after a git pull. No browser steps required.
+# Requires sudo for package installation and systemd service management.
 
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Paths
+# Paths & constants
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CURRENT_USER="$(id -un)"
 ENV_FILE="$PROJECT_DIR/.env"
+INFLUX_TOKEN_FILE="$HOME/influx-token.txt"
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+INFLUX_VERSION="2.7.11"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-RED='\033[0;31m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 step()  { echo -e "\n${GREEN}==> $*${NC}"; }
 warn()  { echo -e "${YELLOW}WARN:${NC} $*"; }
-error() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+info()  { echo -e "${CYAN}    $*${NC}"; }
 
 # ---------------------------------------------------------------------------
-# 1. uv
+# a) System prerequisites
+# ---------------------------------------------------------------------------
+
+step "Installing system prerequisites..."
+sudo apt-get update -qq
+sudo apt-get install -y \
+    git can-utils curl gnupg2 apt-transport-https \
+    software-properties-common ca-certificates lsb-release jq
+
+# ---------------------------------------------------------------------------
+# b) Node.js 24 LTS
+# ---------------------------------------------------------------------------
+
+step "Checking Node.js..."
+if ! node --version 2>/dev/null | grep -q "^v24"; then
+    info "Installing Node.js 24 LTS via NodeSource..."
+    curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+else
+    info "Node.js $(node --version) already installed."
+fi
+
+# ---------------------------------------------------------------------------
+# c) Signal K Server
+# ---------------------------------------------------------------------------
+
+step "Installing Signal K Server..."
+sudo npm install -g signalk-server
+
+SK_BIN="$(command -v signalk-server || echo '/usr/lib/node_modules/signalk-server/bin/signalk-server')"
+info "signalk-server: $SK_BIN"
+
+# Signal K config directory
+mkdir -p "$HOME/.signalk"
+
+# Write settings.json (CAN bus pipedProvider pre-configured)
+if [[ ! -f "$HOME/.signalk/settings.json" ]]; then
+    info "Writing ~/.signalk/settings.json..."
+    cat > "$HOME/.signalk/settings.json" << 'EOF'
+{
+  "vessel": { "name": "corvopi" },
+  "pipedProviders": [{
+    "id": "n2k-canbus",
+    "pipeElements": [
+      { "type": "providers/rawsocketcan", "options": { "interface": "can0" } },
+      { "type": "providers/canboatjs", "options": {} }
+    ],
+    "enabled": true
+  }],
+  "interfaces": { "plugins": true }
+}
+EOF
+else
+    info "~/.signalk/settings.json already exists — skipping."
+fi
+
+# Install signalk-to-influxdb2 plugin
+info "Installing signalk-to-influxdb2 plugin..."
+cat > "$HOME/.signalk/package.json" << 'EOF'
+{
+  "name": "signalk-server-config",
+  "version": "1.0.0",
+  "dependencies": { "signalk-to-influxdb2": "*" }
+}
+EOF
+(cd "$HOME/.signalk" && npm install --silent)
+
+# systemd service for Signal K
+sudo tee /etc/systemd/system/signalk.service > /dev/null << EOF
+[Unit]
+Description=Signal K Server
+After=can-interface.service network.target
+Wants=can-interface.service
+
+[Service]
+User=${CURRENT_USER}
+WorkingDirectory=/home/${CURRENT_USER}/.signalk
+ExecStart=/usr/bin/node ${SK_BIN} -c /home/${CURRENT_USER}/.signalk
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable signalk.service
+info "signalk.service installed and enabled."
+
+# ---------------------------------------------------------------------------
+# d) InfluxDB 2.7.11 (pinned; apt-mark hold prevents v3 auto-upgrade)
+# ---------------------------------------------------------------------------
+
+step "Checking InfluxDB..."
+if ! influx version 2>/dev/null | grep -q "${INFLUX_VERSION}"; then
+    info "Installing InfluxDB ${INFLUX_VERSION}..."
+    INFLUX_DEB="influxdb2_${INFLUX_VERSION}_arm64.deb"
+    wget -q "https://dl.influxdata.com/influxdb/releases/${INFLUX_DEB}"
+    sudo dpkg -i "${INFLUX_DEB}"
+    rm "${INFLUX_DEB}"
+    sudo systemctl enable --now influxd
+    sudo apt-mark hold influxdb2
+    # Wait for influxd to be ready
+    info "Waiting for influxd to start..."
+    for i in {1..15}; do
+        influx ping 2>/dev/null && break
+        sleep 2
+    done
+else
+    info "InfluxDB ${INFLUX_VERSION} already installed."
+fi
+
+# Initial setup (idempotent — exits 0 if already configured)
+influx setup \
+    --username admin \
+    --password changeme123 \
+    --org j105 \
+    --bucket signalk \
+    --retention 0 \
+    --force 2>/dev/null || true
+
+# Capture token for downstream configs
+INFLUX_TOKEN="$(influx auth list --json 2>/dev/null | jq -r '.[0].token' || echo '')"
+if [[ -z "$INFLUX_TOKEN" || "$INFLUX_TOKEN" == "null" ]]; then
+    warn "Could not retrieve InfluxDB token. Plugin config will need manual token update."
+    INFLUX_TOKEN="REPLACE_WITH_INFLUX_TOKEN"
+else
+    echo "$INFLUX_TOKEN" > "$INFLUX_TOKEN_FILE"
+    chmod 600 "$INFLUX_TOKEN_FILE"
+    info "InfluxDB token saved to: $INFLUX_TOKEN_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# e) Grafana OSS (latest via apt repo, port 3001 to avoid clash with Signal K)
+# ---------------------------------------------------------------------------
+
+step "Installing Grafana..."
+sudo mkdir -p /etc/apt/keyrings
+wget -q -O - https://apt.grafana.com/gpg.key | \
+    gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | \
+    sudo tee /etc/apt/sources.list.d/grafana.list > /dev/null
+sudo apt-get update -qq && sudo apt-get install -y grafana
+
+# Override Grafana's default port (3000 is taken by Signal K)
+sudo mkdir -p /etc/systemd/system/grafana-server.service.d
+sudo tee /etc/systemd/system/grafana-server.service.d/port.conf > /dev/null << 'EOF'
+[Service]
+Environment=GF_SERVER_HTTP_PORT=3001
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable --now grafana-server
+
+# Pre-provision InfluxDB datasource via Grafana provisioning
+sudo mkdir -p /etc/grafana/provisioning/datasources
+sudo tee /etc/grafana/provisioning/datasources/influxdb.yaml > /dev/null << EOF
+apiVersion: 1
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://localhost:8086
+    jsonData:
+      version: Flux
+      organization: j105
+      defaultBucket: signalk
+      httpMode: POST
+    secureJsonData:
+      token: ${INFLUX_TOKEN}
+    isDefault: true
+EOF
+sudo systemctl restart grafana-server
+info "Grafana installed and provisioned on port 3001."
+
+# ---------------------------------------------------------------------------
+# f) Signal K → InfluxDB plugin config (with captured token)
+# ---------------------------------------------------------------------------
+
+step "Configuring signalk-to-influxdb2 plugin..."
+mkdir -p "$HOME/.signalk/plugin-config-data"
+cat > "$HOME/.signalk/plugin-config-data/signalk-to-influxdb2.json" << EOF
+{
+  "configuration": {
+    "url": "http://localhost:8086",
+    "token": "${INFLUX_TOKEN}",
+    "org": "j105",
+    "bucket": "signalk",
+    "enabled": true
+  },
+  "enabled": true
+}
+EOF
+info "Plugin config written."
+
+# ---------------------------------------------------------------------------
+# g) uv + Python dependencies
 # ---------------------------------------------------------------------------
 
 step "Checking uv..."
-
 UV_BIN=""
 if command -v uv &>/dev/null; then
     UV_BIN="$(command -v uv)"
@@ -45,35 +237,29 @@ elif [[ -x "$HOME/.local/bin/uv" ]]; then
 fi
 
 if [[ -z "$UV_BIN" ]]; then
-    step "Installing uv..."
+    info "Installing uv..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
     UV_BIN="$HOME/.local/bin/uv"
 fi
-
-echo "  uv: $UV_BIN ($("$UV_BIN" --version))"
-
-# ---------------------------------------------------------------------------
-# 2. Python dependencies
-# ---------------------------------------------------------------------------
+info "uv: $UV_BIN ($("$UV_BIN" --version))"
 
 step "Syncing Python dependencies..."
 "$UV_BIN" sync --project "$PROJECT_DIR"
 
 # ---------------------------------------------------------------------------
-# 3. .env
+# h) .env file and data directory
 # ---------------------------------------------------------------------------
 
 step "Configuring environment..."
 if [[ ! -f "$ENV_FILE" ]]; then
     cp "$PROJECT_DIR/.env.example" "$ENV_FILE"
-    echo "  Created .env from template."
-    echo "  Edit $ENV_FILE if your CAN interface name or bitrate differs."
+    info "Created .env from template."
+    info "Review $ENV_FILE and adjust if needed."
 else
-    echo "  .env already exists — leaving untouched."
+    info ".env already exists — leaving untouched."
 fi
 
-# Load CAN_INTERFACE and CAN_BITRATE from .env for use in service generation.
-# Strip comments and blank lines; export only KEY=VALUE pairs.
+# Load env vars for service generation
 set -a
 # shellcheck disable=SC1090
 source <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_FILE" | grep -v '^#')
@@ -82,37 +268,30 @@ set +a
 CAN_INTERFACE="${CAN_INTERFACE:-can0}"
 CAN_BITRATE="${CAN_BITRATE:-250000}"
 
-# ---------------------------------------------------------------------------
-# 4. data directory
-# ---------------------------------------------------------------------------
-
 step "Ensuring data directory exists..."
 mkdir -p "$PROJECT_DIR/data"
-echo "  $PROJECT_DIR/data"
+info "$PROJECT_DIR/data"
 
 # ---------------------------------------------------------------------------
-# 5. netdev group (allows non-root SocketCAN access)
+# i) netdev group (allows non-root SocketCAN access)
 # ---------------------------------------------------------------------------
 
 step "Checking group membership..."
 if ! id -nG "$CURRENT_USER" | grep -qw netdev; then
     sudo usermod -aG netdev "$CURRENT_USER"
-    warn "Added $CURRENT_USER to the 'netdev' group."
-    warn "A reboot (or 'newgrp netdev') is required for this to take effect."
+    warn "Added $CURRENT_USER to the 'netdev' group — reboot required."
 else
-    echo "  $CURRENT_USER is already in the 'netdev' group."
+    info "$CURRENT_USER is already in the 'netdev' group."
 fi
 
 # ---------------------------------------------------------------------------
-# 6. CAN interface systemd service
+# j) CAN interface systemd service
 # ---------------------------------------------------------------------------
 
 step "Installing CAN interface service (interface=$CAN_INTERFACE bitrate=$CAN_BITRATE)..."
-
-sudo tee /etc/systemd/system/can-interface.service > /dev/null <<EOF
+sudo tee /etc/systemd/system/can-interface.service > /dev/null << EOF
 [Unit]
 Description=SocketCAN interface ${CAN_INTERFACE}
-# Wait for the kernel network device to appear (requires HAT + SPI overlay).
 After=sys-subsystem-net-devices-${CAN_INTERFACE}.device
 BindsTo=sys-subsystem-net-devices-${CAN_INTERFACE}.device
 
@@ -126,70 +305,78 @@ ExecStop=/sbin/ip link set ${CAN_INTERFACE} down
 [Install]
 WantedBy=multi-user.target
 EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable can-interface.service
 
-# Start only if the interface device is already present (HAT is configured).
 if ip link show "$CAN_INTERFACE" &>/dev/null; then
     sudo systemctl restart can-interface.service
-    echo "  CAN interface ${CAN_INTERFACE} is up."
+    info "CAN interface ${CAN_INTERFACE} is up."
 else
     warn "Network device '${CAN_INTERFACE}' not found — service enabled but not started."
-    warn "If your CAN HAT isn't configured yet:"
-    warn "  1. Add the correct dtoverlay to /boot/firmware/config.txt (or /boot/config.txt)"
-    warn "     e.g.: dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25"
-    warn "  2. Reboot the Pi."
-    warn "  3. Re-run this script."
+    warn "Add dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25 to /boot/firmware/config.txt"
+    warn "and reboot, then re-run this script."
 fi
 
 # ---------------------------------------------------------------------------
-# 7. j105-logger systemd service
+# k) j105-logger systemd service (depends on Signal K, not directly on CAN)
 # ---------------------------------------------------------------------------
 
 step "Installing j105-logger service..."
-
-sudo tee /etc/systemd/system/j105-logger.service > /dev/null <<EOF
+sudo tee /etc/systemd/system/j105-logger.service > /dev/null << EOF
 [Unit]
 Description=J105 NMEA 2000 Data Logger
-After=can-interface.service
-Requires=can-interface.service
+After=signalk.service
+Wants=signalk.service
 
 [Service]
 User=${CURRENT_USER}
 WorkingDirectory=${PROJECT_DIR}
 EnvironmentFile=${ENV_FILE}
-ExecStart=${UV_BIN} run --project ${PROJECT_DIR} j105-logger
+ExecStart=${UV_BIN} run --project ${PROJECT_DIR} j105-logger run
 Restart=on-failure
 RestartSec=5
-# Allow read access to the CAN socket
 SupplementaryGroups=netdev
 
 [Install]
 WantedBy=multi-user.target
 EOF
-
 sudo systemctl daemon-reload
 sudo systemctl enable j105-logger.service
 
-if sudo systemctl is-active --quiet can-interface.service 2>/dev/null; then
+if sudo systemctl is-active --quiet signalk.service 2>/dev/null; then
     sudo systemctl restart j105-logger.service
-    echo "  Logger service started."
+    info "Logger service started."
 else
-    echo "  Logger service installed and enabled (will start once CAN interface is up)."
+    info "Logger service enabled (will start once Signal K is running)."
 fi
 
 # ---------------------------------------------------------------------------
-# Done
+# l) Done — summary
 # ---------------------------------------------------------------------------
 
 echo ""
-echo -e "${GREEN}Setup complete!${NC}"
+echo -e "${GREEN}══════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  Setup complete. Reboot, then verify:${NC}"
+echo -e "${GREEN}══════════════════════════════════════════════════${NC}"
 echo ""
-echo "  View logs:    sudo journalctl -fu j105-logger"
-echo "  Status:       sudo systemctl status j105-logger"
-echo "  Stop:         sudo systemctl stop j105-logger"
-echo "  Start:        sudo systemctl start j105-logger"
+echo "  Signal K:  http://corvopi:3000"
+echo "  Grafana:   http://corvopi:3001"
+echo "  InfluxDB:  http://corvopi:8086"
+echo ""
+if [[ -f "$INFLUX_TOKEN_FILE" ]]; then
+    echo "  InfluxDB token saved to: $INFLUX_TOKEN_FILE"
+fi
+echo ""
+echo "  sudo reboot"
+echo ""
+echo -e "${GREEN}══════════════════════════════════════════════════${NC}"
+echo ""
+echo "  After reboot, check service status:"
+echo "    sudo systemctl status can-interface signalk influxd grafana-server j105-logger"
+echo ""
+echo "  View logger output:"
+echo "    sudo journalctl -fu j105-logger"
 echo ""
 echo "  To update after a git pull:"
 echo "    git pull && ./scripts/setup.sh"
+echo "    sudo npm update -g signalk-server"

--- a/src/logger/sk_reader.py
+++ b/src/logger/sk_reader.py
@@ -1,0 +1,242 @@
+"""Signal K WebSocket reader — consumes SK delta feed, emits NMEARecord types.
+
+Replaces can_reader.py when Signal K Server owns the CAN bus.
+Emits the same record types as nmea2000.py so storage and export are unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+from websockets.asyncio.client import connect as _ws_connect
+
+from logger.nmea2000 import (
+    PGN_COG_SOG_RAPID,
+    PGN_ENVIRONMENTAL,
+    PGN_POSITION_RAPID,
+    PGN_SPEED_THROUGH_WATER,
+    PGN_VESSEL_HEADING,
+    PGN_WATER_DEPTH,
+    PGN_WIND_DATA,
+    COGSOGRecord,
+    DepthRecord,
+    EnvironmentalRecord,
+    HeadingRecord,
+    PGNRecord,
+    PositionRecord,
+    SpeedRecord,
+    WindRecord,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable
+
+_RAD_TO_DEG: float = 180.0 / math.pi
+_MPS_TO_KTS: float = 1.94384449
+_KELVIN_OFFSET: float = 273.15
+SK_SOURCE_ADDR: int = 0  # no CAN source address for SK-originated records
+
+
+@dataclass
+class SKReaderConfig:
+    """Configuration for the Signal K WebSocket reader.
+
+    Values fall back to environment variables SK_HOST / SK_PORT if not set.
+    """
+
+    host: str = field(default_factory=lambda: os.environ.get("SK_HOST", "localhost"))
+    port: int = field(default_factory=lambda: int(os.environ.get("SK_PORT", "3000")))
+    reconnect_delay_s: float = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Simple single-value record constructors
+# ---------------------------------------------------------------------------
+
+
+def _mk_heading(v: float, ts: datetime) -> HeadingRecord:
+    return HeadingRecord(PGN_VESSEL_HEADING, SK_SOURCE_ADDR, ts, v * _RAD_TO_DEG, None, None)
+
+
+def _mk_speed(v: float, ts: datetime) -> SpeedRecord:
+    return SpeedRecord(PGN_SPEED_THROUGH_WATER, SK_SOURCE_ADDR, ts, v * _MPS_TO_KTS)
+
+
+def _mk_depth(v: float, ts: datetime) -> DepthRecord:
+    return DepthRecord(PGN_WATER_DEPTH, SK_SOURCE_ADDR, ts, v, None)
+
+
+def _mk_env(v: float, ts: datetime) -> EnvironmentalRecord:
+    return EnvironmentalRecord(PGN_ENVIRONMENTAL, SK_SOURCE_ADDR, ts, v - _KELVIN_OFFSET)
+
+
+# ---------------------------------------------------------------------------
+# Paired record builders (buffer until both values arrive)
+# ---------------------------------------------------------------------------
+
+
+def _try_cogsog(buf: dict[str, float], ts: datetime) -> COGSOGRecord | None:
+    cog = buf.get("navigation.courseOverGroundTrue")
+    sog = buf.get("navigation.speedOverGround")
+    if cog is None or sog is None:
+        return None
+    return COGSOGRecord(PGN_COG_SOG_RAPID, SK_SOURCE_ADDR, ts, cog * _RAD_TO_DEG, sog * _MPS_TO_KTS)
+
+
+def _try_true_wind(buf: dict[str, float], ts: datetime) -> WindRecord | None:
+    spd = buf.get("environment.wind.speedTrue")
+    ang = buf.get("environment.wind.angleTrue")
+    if spd is None or ang is None:
+        return None
+    return WindRecord(PGN_WIND_DATA, SK_SOURCE_ADDR, ts, spd * _MPS_TO_KTS, ang * _RAD_TO_DEG, 0)
+
+
+def _try_app_wind(buf: dict[str, float], ts: datetime) -> WindRecord | None:
+    spd = buf.get("environment.wind.speedApparent")
+    ang = buf.get("environment.wind.angleApparent")
+    if spd is None or ang is None:
+        return None
+    return WindRecord(PGN_WIND_DATA, SK_SOURCE_ADDR, ts, spd * _MPS_TO_KTS, ang * _RAD_TO_DEG, 2)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tables
+# ---------------------------------------------------------------------------
+
+_SIMPLE: dict[str, Callable[[float, datetime], PGNRecord]] = {
+    "navigation.headingTrue": _mk_heading,
+    "navigation.speedThroughWater": _mk_speed,
+    "environment.depth.belowKeel": _mk_depth,
+    "environment.water.temperature": _mk_env,
+}
+
+_PAIR: dict[str, Callable[[dict[str, float], datetime], PGNRecord | None]] = {
+    "navigation.courseOverGroundTrue": _try_cogsog,
+    "navigation.speedOverGround": _try_cogsog,
+    "environment.wind.speedTrue": _try_true_wind,
+    "environment.wind.angleTrue": _try_true_wind,
+    "environment.wind.speedApparent": _try_app_wind,
+    "environment.wind.angleApparent": _try_app_wind,
+}
+
+
+# ---------------------------------------------------------------------------
+# Delta parser (pure function — testable without a WebSocket)
+# ---------------------------------------------------------------------------
+
+
+def process_delta(raw: str, buf: dict[str, float]) -> list[PGNRecord]:
+    """Parse a Signal K delta message; return any records it produces.
+
+    Updates *buf* in-place for multi-field records (COG+SOG, wind speed+angle).
+    Unknown paths are silently ignored at DEBUG level.
+    Malformed numeric values are logged at WARNING and skipped.
+    """
+    try:
+        delta: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("SK: malformed JSON: {}", exc)
+        return []
+
+    records: list[PGNRecord] = []
+    for update in delta.get("updates", []):
+        ts_str: str = update.get("timestamp", "")
+        try:
+            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            ts = datetime.now(UTC)
+
+        for entry in update.get("values", []):
+            path: str = entry.get("path", "")
+            value: Any = entry.get("value")
+            if value is None:
+                continue
+
+            if path == "navigation.position":
+                try:
+                    records.append(
+                        PositionRecord(
+                            PGN_POSITION_RAPID,
+                            SK_SOURCE_ADDR,
+                            ts,
+                            float(value["latitude"]),
+                            float(value["longitude"]),
+                        )
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    logger.warning("SK: bad position value {!r}: {}", value, exc)
+                continue
+
+            if simple_fn := _SIMPLE.get(path):
+                try:
+                    records.append(simple_fn(float(value), ts))
+                except (TypeError, ValueError) as exc:
+                    logger.warning("SK: non-numeric value for {!r}: {}", path, exc)
+                continue
+
+            if pair_fn := _PAIR.get(path):
+                try:
+                    buf[path] = float(value)
+                    rec = pair_fn(buf, ts)
+                    if rec is not None:
+                        records.append(rec)
+                except (TypeError, ValueError) as exc:
+                    logger.warning("SK: non-numeric value for {!r}: {}", path, exc)
+                continue
+
+            logger.debug("SK: unknown path {!r} — ignoring", path)
+
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+class SKReader:
+    """Async iterable that yields NMEARecord instances from a Signal K WebSocket.
+
+    Reconnects automatically on disconnect using exponential backoff capped at
+    ``config.reconnect_delay_s``.  Propagates ``asyncio.CancelledError`` cleanly.
+
+    Usage::
+
+        async for record in SKReader(SKReaderConfig()):
+            await storage.write(record)
+    """
+
+    def __init__(self, config: SKReaderConfig) -> None:
+        self._config = config
+        self._buf: dict[str, float] = {}
+
+    def __aiter__(self) -> AsyncIterator[PGNRecord]:
+        return self._stream()
+
+    async def _stream(self) -> AsyncGenerator[PGNRecord, None]:
+        config = self._config
+        uri = f"ws://{config.host}:{config.port}/signalk/v1/stream?subscribe=all"
+        delay = 1.0
+        while True:
+            try:
+                logger.info("SK: connecting to {}", uri)
+                async with _ws_connect(uri) as ws:
+                    delay = 1.0
+                    logger.info("SK: connected")
+                    async for raw in ws:
+                        for record in process_delta(str(raw), self._buf):
+                            yield record
+            except asyncio.CancelledError:
+                logger.info("SK: cancelled — stopping")
+                raise
+            except Exception as exc:
+                logger.warning("SK: connection error ({}). Reconnecting in {:.1f}s", exc, delay)
+                await asyncio.sleep(delay)
+                delay = min(delay * 2.0, config.reconnect_delay_s)

--- a/src/logger/video.py
+++ b/src/logger/video.py
@@ -34,13 +34,13 @@ class VideoSession:
     the UTC time from the instrument log and where it appears in the video.
     """
 
-    url: str            # original YouTube URL
-    video_id: str       # extracted video ID, e.g. "dQw4w9WgXcQ"
+    url: str  # original YouTube URL
+    video_id: str  # extracted video ID, e.g. "dQw4w9WgXcQ"
     title: str
-    duration_s: float   # total video duration in seconds
+    duration_s: float  # total video duration in seconds
 
-    sync_utc: datetime      # UTC wall-clock time at the sync point
-    sync_offset_s: float    # seconds into the video at sync_utc
+    sync_utc: datetime  # UTC wall-clock time at the sync point
+    sync_offset_s: float  # seconds into the video at sync_utc
 
     def video_offset_at(self, utc: datetime) -> float:
         """Return the video playback position (seconds) at the given UTC time."""

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -1,0 +1,350 @@
+"""Tests for sk_reader: Signal K delta parsing and SKReader reconnect behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import math
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from logger.nmea2000 import (
+    COGSOGRecord,
+    DepthRecord,
+    EnvironmentalRecord,
+    HeadingRecord,
+    PositionRecord,
+    SpeedRecord,
+    WindRecord,
+)
+from logger.sk_reader import SK_SOURCE_ADDR, SKReader, SKReaderConfig, process_delta
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TS = "2025-08-10T14:05:30.000Z"
+_TS_DT = datetime(2025, 8, 10, 14, 5, 30, tzinfo=UTC)
+
+
+def _delta(path: str, value: object, ts: str = _TS) -> str:
+    """Minimal Signal K delta JSON for a single path/value pair."""
+    return json.dumps(
+        {
+            "context": "vessels.self",
+            "updates": [{"timestamp": ts, "values": [{"path": path, "value": value}]}],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestPathConversions — pure unit tests of process_delta conversions
+# ---------------------------------------------------------------------------
+
+
+class TestPathConversions:
+    """Each SK path → correct record type with correct unit conversion."""
+
+    def test_heading_rad_to_deg(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("navigation.headingTrue", math.pi), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, HeadingRecord)
+        assert abs(rec.heading_deg - 180.0) < 1e-6
+        assert rec.deviation_deg is None
+        assert rec.variation_deg is None
+        assert rec.source_addr == SK_SOURCE_ADDR
+        assert rec.timestamp == _TS_DT
+
+    def test_speed_mps_to_kts(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("navigation.speedThroughWater", 1.0), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, SpeedRecord)
+        assert abs(rec.speed_kts - 1.94384449) < 1e-4
+
+    def test_depth_passthrough(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("environment.depth.belowKeel", 12.5), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, DepthRecord)
+        assert rec.depth_m == pytest.approx(12.5)
+        assert rec.offset_m is None
+
+    def test_position_dict_passthrough(self) -> None:
+        buf: dict[str, float] = {}
+        pos = {"latitude": 41.79, "longitude": -71.87}
+        records = process_delta(_delta("navigation.position", pos), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, PositionRecord)
+        assert rec.latitude_deg == pytest.approx(41.79)
+        assert rec.longitude_deg == pytest.approx(-71.87)
+
+    def test_temperature_kelvin_to_celsius(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("environment.water.temperature", 293.15), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, EnvironmentalRecord)
+        assert abs(rec.water_temp_c - 20.0) < 1e-6
+
+    def test_true_wind_ref_zero(self) -> None:
+        buf: dict[str, float] = {}
+        # Speed arrives first — no record yet
+        r1 = process_delta(_delta("environment.wind.speedTrue", 5.144), buf)
+        assert r1 == []
+        # Angle arrives — combined record emitted with ref=0
+        r2 = process_delta(_delta("environment.wind.angleTrue", math.pi / 4), buf)
+        assert len(r2) == 1
+        rec = r2[0]
+        assert isinstance(rec, WindRecord)
+        assert rec.reference == 0
+        assert abs(rec.wind_speed_kts - 5.144 * 1.94384449) < 1e-4
+        assert abs(rec.wind_angle_deg - 45.0) < 1e-4
+
+    def test_apparent_wind_ref_two(self) -> None:
+        buf: dict[str, float] = {}
+        process_delta(_delta("environment.wind.speedApparent", 3.0), buf)
+        r = process_delta(_delta("environment.wind.angleApparent", math.pi / 2), buf)
+        assert len(r) == 1
+        rec = r[0]
+        assert isinstance(rec, WindRecord)
+        assert rec.reference == 2
+        assert abs(rec.wind_angle_deg - 90.0) < 1e-4
+
+    def test_cog_rad_to_deg(self) -> None:
+        buf: dict[str, float] = {}
+        process_delta(_delta("navigation.courseOverGroundTrue", math.pi), buf)
+        r = process_delta(_delta("navigation.speedOverGround", 2.0), buf)
+        assert len(r) == 1
+        rec = r[0]
+        assert isinstance(rec, COGSOGRecord)
+        assert abs(rec.cog_deg - 180.0) < 1e-6
+        assert abs(rec.sog_kts - 2.0 * 1.94384449) < 1e-4
+
+
+# ---------------------------------------------------------------------------
+# TestSKReaderDelta — delta parsing behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSKReaderDelta:
+    """Test process_delta message handling rules."""
+
+    def test_single_path_emits_immediately(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("navigation.headingTrue", 0.5), buf)
+        assert len(records) == 1
+        assert isinstance(records[0], HeadingRecord)
+
+    def test_cogsog_buffers_until_both_seen(self) -> None:
+        buf: dict[str, float] = {}
+        # First field — no record
+        r1 = process_delta(_delta("navigation.courseOverGroundTrue", 1.0), buf)
+        assert r1 == []
+        # Second field — record emitted
+        r2 = process_delta(_delta("navigation.speedOverGround", 1.0), buf)
+        assert len(r2) == 1
+        assert isinstance(r2[0], COGSOGRecord)
+
+    def test_wind_buffers_until_both_seen(self) -> None:
+        buf: dict[str, float] = {}
+        r1 = process_delta(_delta("environment.wind.speedTrue", 5.0), buf)
+        assert r1 == []
+        r2 = process_delta(_delta("environment.wind.angleTrue", 1.0), buf)
+        assert len(r2) == 1
+        assert isinstance(r2[0], WindRecord)
+
+    def test_unknown_path_ignored_no_error(self) -> None:
+        buf: dict[str, float] = {}
+        records = process_delta(_delta("navigation.someFutureField", 42.0), buf)
+        assert records == []
+
+    def test_malformed_numeric_value_warns_no_record(self) -> None:
+        buf: dict[str, float] = {}
+        with patch("logger.sk_reader.logger") as mock_log:
+            records = process_delta(_delta("navigation.headingTrue", "not-a-number"), buf)
+        assert records == []
+        mock_log.warning.assert_called_once()
+        assert "non-numeric" in str(mock_log.warning.call_args)
+
+    def test_malformed_json_warns_no_record(self) -> None:
+        buf: dict[str, float] = {}
+        with patch("logger.sk_reader.logger") as mock_log:
+            records = process_delta("{bad json}", buf)
+        assert records == []
+        mock_log.warning.assert_called_once()
+        assert "malformed JSON" in str(mock_log.warning.call_args)
+
+    def test_bad_position_value_warns(self) -> None:
+        buf: dict[str, float] = {}
+        with patch("logger.sk_reader.logger") as mock_log:
+            records = process_delta(_delta("navigation.position", "not-a-dict"), buf)
+        assert records == []
+        mock_log.warning.assert_called_once()
+        assert "bad position" in str(mock_log.warning.call_args)
+
+    def test_multiple_updates_in_one_delta(self) -> None:
+        buf: dict[str, float] = {}
+        msg = json.dumps(
+            {
+                "context": "vessels.self",
+                "updates": [
+                    {
+                        "timestamp": _TS,
+                        "values": [
+                            {"path": "navigation.headingTrue", "value": 1.0},
+                            {"path": "navigation.speedThroughWater", "value": 2.0},
+                        ],
+                    }
+                ],
+            }
+        )
+        records = process_delta(msg, buf)
+        assert len(records) == 2
+        assert isinstance(records[0], HeadingRecord)
+        assert isinstance(records[1], SpeedRecord)
+
+    def test_true_apparent_wind_buffered_independently(self) -> None:
+        """True and apparent wind use separate buffer slots."""
+        buf: dict[str, float] = {}
+        process_delta(_delta("environment.wind.speedTrue", 5.0), buf)
+        # Apparent speed should not contaminate true wind
+        r = process_delta(_delta("environment.wind.speedApparent", 4.0), buf)
+        assert r == []  # angle not yet buffered for either type
+
+    def test_timestamp_fallback_to_now_on_bad_ts(self) -> None:
+        buf: dict[str, float] = {}
+        before = datetime.now(UTC)
+        records = process_delta(_delta("navigation.headingTrue", 1.0, ts="invalid-ts"), buf)
+        after = datetime.now(UTC)
+        assert len(records) == 1
+        assert before <= records[0].timestamp <= after
+
+
+# ---------------------------------------------------------------------------
+# TestSKReaderReconnect — reconnect and cancellation behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSKReaderReconnect:
+    """Test SKReader reconnect and CancelledError propagation."""
+
+    async def test_cancelled_error_propagates(self) -> None:
+        """CancelledError from the outer task propagates through the reader."""
+
+        class FakeWS:
+            """WebSocket that blocks forever until cancelled."""
+
+            async def __aenter__(self) -> FakeWS:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            def __aiter__(self) -> AsyncGenerator[str, None]:
+                return self._gen()
+
+            async def _gen(self) -> AsyncGenerator[str, None]:
+                await asyncio.sleep(3600)  # block until cancelled
+                yield ""  # never reached
+
+        with patch("logger.sk_reader._ws_connect", FakeWS):
+            reader = SKReader(SKReaderConfig())
+            task = asyncio.create_task(self._collect_one(reader))
+            await asyncio.sleep(0)  # let task start
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    async def _collect_one(self, reader: SKReader) -> None:
+        async for _ in reader:
+            break
+
+    async def test_reconnects_after_normal_disconnect(self) -> None:
+        """Reader reconnects immediately after a graceful WebSocket close."""
+        connect_calls: list[int] = [0]
+
+        class FakeWS:
+            def __init__(self) -> None:
+                self._call = connect_calls[0]
+                connect_calls[0] += 1
+
+            async def __aenter__(self) -> FakeWS:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            def __aiter__(self) -> AsyncGenerator[str, None]:
+                return self._gen()
+
+            async def _gen(self) -> AsyncGenerator[str, None]:
+                if self._call == 0:
+                    # First connection: yield one record then close gracefully
+                    yield _delta("navigation.headingTrue", math.pi / 2)
+                else:
+                    # Second connection: block until test task is cancelled
+                    await asyncio.sleep(3600)
+                    yield ""  # never reached
+
+        with patch("logger.sk_reader._ws_connect", lambda _uri: FakeWS()):
+            reader = SKReader(SKReaderConfig())
+
+            async def collect() -> list[object]:
+                results: list[object] = []
+                async for record in reader:
+                    results.append(record)
+                    # Stop once we've confirmed a second connect was attempted
+                    if connect_calls[0] >= 2:
+                        return results
+                return results
+
+            task = asyncio.create_task(collect())
+            # Give ample time for the first WS to close and reconnect to fire
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+                await task
+
+        assert connect_calls[0] >= 2, "Expected at least 2 connection attempts"
+
+    async def test_reconnects_with_backoff_on_exception(self) -> None:
+        """Reader applies backoff delay when connection raises an exception."""
+        connect_calls: list[int] = [0]
+
+        class FailWS:
+            async def __aenter__(self) -> FailWS:
+                connect_calls[0] += 1
+                raise ConnectionRefusedError("no server")
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            def __aiter__(self) -> AsyncGenerator[str, None]:
+                return self._gen()
+
+            async def _gen(self) -> AsyncGenerator[str, None]:
+                yield ""  # never reached
+
+        with patch("logger.sk_reader._ws_connect", lambda _uri: FailWS()):
+            reader = SKReader(SKReaderConfig(reconnect_delay_s=0.05))
+            task = asyncio.create_task(self._collect_one(reader))
+            await asyncio.sleep(0.15)  # let at least 2 retries fire
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert connect_calls[0] >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,7 @@ dependencies = [
     { name = "loguru" },
     { name = "python-can" },
     { name = "python-dotenv" },
+    { name = "websockets" },
     { name = "yt-dlp" },
 ]
 
@@ -210,6 +211,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "python-can", specifier = ">=4.4.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "websockets", specifier = ">=14.0" },
     { name = "yt-dlp", specifier = ">=2024.11.4" },
 ]
 
@@ -471,6 +473,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Signal K Server now owns can0 and decodes NMEA 2000 via canboatjs. j105-logger consumes Signal K's WebSocket feed instead of raw CAN frames, eliminating the conflict between the two processes on the CAN bus.

New/changed:
- src/logger/sk_reader.py: SKReader async iterable consumes SK deltas, emits same NMEARecord types as nmea2000.py; process_delta() is a pure function with 97% test coverage. Auto-reconnects with exponential backoff.
- tests/test_sk_reader.py: 21 tests — path conversions, delta parsing, reconnect/cancellation via mocked WebSocket.
- src/logger/main.py: DATA_SOURCE env var selects signalk (default) or can reader at startup.
- pyproject.toml: add websockets>=14.0 dependency.
- .env.example: add DATA_SOURCE, SK_HOST, SK_PORT.
- scripts/setup.sh: full idempotent rewrite — installs Node.js 24 LTS, Signal K Server + signalk-to-influxdb2 plugin, InfluxDB 2.7.11 (pinned, apt-mark hold), Grafana OSS (port 3001, pre-provisioned InfluxDB datasource), all systemd services with correct dependency chain.
- README.md: architecture diagram, web interfaces section, updated fresh SD card setup, configuration, and troubleshooting.

All 135 tests pass. ruff and mypy clean.