### PR TITLE
Add audio recording support for Gordik 2T1R wireless lavalier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ LOG_LEVEL=INFO
 DATA_SOURCE=signalk     # signalk (default) or can
 SK_HOST=localhost        # Signal K server hostname
 SK_PORT=3000             # Signal K WebSocket port
+# Audio recording (Gordik 2T1R or any USB Audio Class device)
+# AUDIO_DEVICE=Gordik   # name substring or integer index; omit to auto-detect first input
+AUDIO_DIR=data/audio    # directory for WAV files
+AUDIO_SAMPLE_RATE=48000
+AUDIO_CHANNELS=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ CAN_INTERFACE=can0          # CAN bus interface name
 CAN_BITRATE=250000          # NMEA 2000 standard bitrate
 DB_PATH=data/logger.db      # SQLite database path
 LOG_LEVEL=INFO              # loguru log level
+AUDIO_DEVICE=Gordik         # name substring to match (or integer index); omit to auto-detect
+AUDIO_DIR=data/audio        # where WAV files are saved
+AUDIO_SAMPLE_RATE=48000     # sample rate in Hz
+AUDIO_CHANNELS=1            # 1=mono, 2=stereo
 ```
 
 ---

--- a/docs/audio-setup.md
+++ b/docs/audio-setup.md
@@ -1,0 +1,141 @@
+# Audio Recording Setup — Gordik 2T1R Wireless Lavalier
+
+## Overview
+
+The j105-logger can record voice commentary (crew calls, tactical notes) in sync with instrument data. Audio is captured from a USB audio input device and saved as a WAV file per session, anchored to UTC time for later correlation with instrument logs and video.
+
+---
+
+## Hardware
+
+**Gordik 2T1R** (or any USB Audio Class receiver):
+
+1. Plug the USB receiver into one of the Pi's USB ports.
+2. The receiver appears as a standard UAC device — no drivers needed on Linux.
+
+---
+
+## System Dependencies
+
+Install PortAudio and libsndfile if not already present:
+
+```bash
+sudo apt install libportaudio2 libsndfile1
+```
+
+---
+
+## Finding the Device Name / Index
+
+Run:
+
+```bash
+j105-logger list-devices
+```
+
+Example output:
+
+```
+Idx  Name                                      Ch    Default rate
+-----------------------------------------------------------------
+  0  Built-in Microphone                        2           44100
+  1  Gordik 2T1R USB Audio                      1           48000
+```
+
+Note the **Name** or **Idx** for the next step.
+
+---
+
+## Configuration
+
+Add to your `.env` file (or export as environment variables):
+
+```env
+# Name substring (case-insensitive) — matches any device whose name contains "Gordik"
+AUDIO_DEVICE=Gordik
+
+# Or use the integer index from list-devices
+# AUDIO_DEVICE=1
+
+# Where WAV files are saved (default: data/audio)
+AUDIO_DIR=data/audio
+
+# Sample rate in Hz (default: 48000)
+AUDIO_SAMPLE_RATE=48000
+
+# Number of channels: 1=mono, 2=stereo (default: 1)
+AUDIO_CHANNELS=1
+```
+
+If `AUDIO_DEVICE` is not set, the first available input device is used automatically.
+
+---
+
+## Running
+
+Audio recording starts automatically with the logger:
+
+```bash
+j105-logger run
+```
+
+Look for this log line on startup:
+
+```
+Audio recording started: data/audio/audio_20250810_140530.wav
+```
+
+On Ctrl-C or SIGTERM:
+
+```
+Audio recording saved: data/audio/audio_20250810_140530.wav
+```
+
+---
+
+## Listing Recorded Sessions
+
+```bash
+j105-logger list-audio
+```
+
+Example output:
+
+```
+File                                          Duration  Start UTC
+--------------------------------------------------------------------------------
+data/audio/audio_20250810_140530.wav             1:23:45  2025-08-10T14:05:30+00:00
+```
+
+---
+
+## WAV File Naming
+
+Files are named using the UTC timestamp at the moment recording began:
+
+```
+audio/audio_YYYYMMDD_HHMMSS.wav
+```
+
+Example: `audio_20250810_140530.wav` → recording started 2025-08-10 at 14:05:30 UTC.
+
+---
+
+## Verifying Playback
+
+```bash
+aplay data/audio/audio_*.wav
+```
+
+Or open the file in any audio editor (Audacity, etc.).
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `No audio input device found` in logs | Check `j105-logger list-devices`; verify USB receiver is plugged in |
+| Wrong device selected | Set `AUDIO_DEVICE=<name or index>` in `.env` |
+| Distorted or noisy audio | Check `AUDIO_SAMPLE_RATE` matches receiver's default rate |
+| libportaudio errors on startup | `sudo apt install libportaudio2` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "aiosqlite>=0.22.1",
     # Signal K WebSocket client
     "websockets>=14.0",
+    "sounddevice>=0.5.5",
+    "soundfile>=0.13.1",
 ]
 
 [project.scripts]
@@ -76,6 +78,10 @@ strict = true
 warn_return_any = true
 warn_unused_configs = true
 mypy_path = "src"
+
+[[tool.mypy.overrides]]
+module = ["sounddevice", "soundfile"]
+ignore_missing_imports = true
 
 # ---------------------------------------------------------------------------
 # Pytest

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -38,7 +38,8 @@ step "Installing system prerequisites..."
 sudo apt-get update -qq
 sudo apt-get install -y \
     git can-utils curl gnupg2 apt-transport-https \
-    ca-certificates lsb-release jq
+    ca-certificates lsb-release jq \
+    libportaudio2 libsndfile1
 
 # ---------------------------------------------------------------------------
 # b) Node.js 24 LTS
@@ -293,9 +294,11 @@ set +a
 CAN_INTERFACE="${CAN_INTERFACE:-can0}"
 CAN_BITRATE="${CAN_BITRATE:-250000}"
 
-step "Ensuring data directory exists..."
+step "Ensuring data directories exist..."
 mkdir -p "$PROJECT_DIR/data"
-info "$PROJECT_DIR/data"
+mkdir -p "$PROJECT_DIR/data/audio"
+info "$PROJECT_DIR/data (SQLite DB)"
+info "$PROJECT_DIR/data/audio (WAV recordings)"
 
 # ---------------------------------------------------------------------------
 # i) netdev group (allows non-root SocketCAN access)
@@ -401,6 +404,10 @@ echo "    sudo systemctl status can-interface signalk influxd grafana-server j10
 echo ""
 echo "  View logger output:"
 echo "    sudo journalctl -fu j105-logger"
+echo ""
+echo "  To list available audio input devices (e.g. Gordik USB receiver):"
+echo "    j105-logger list-devices"
+echo "  Then set AUDIO_DEVICE in .env to match the device name or index."
 echo ""
 echo "  To update after a git pull:"
 echo "    git pull && ./scripts/setup.sh"

--- a/src/logger/audio.py
+++ b/src/logger/audio.py
@@ -1,0 +1,302 @@
+"""Audio recording module for sailing session voice capture.
+
+Supports USB Audio Class (UAC) devices such as the Gordik 2T1R wireless
+lavalier receiver. Hardware isolation: all sounddevice/soundfile access lives
+here so the rest of the codebase can be tested without physical hardware.
+
+Recording pattern:
+    InputStream callback → queue.Queue → writer thread → SoundFile.write()
+
+Configuration via environment variables (see AudioConfig).
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class AudioDeviceNotFoundError(Exception):
+    """Raised when no matching audio input device can be found."""
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AudioConfig:
+    """Configuration for audio recording, read from environment variables."""
+
+    device: str | int | None = field(
+        default_factory=lambda: _parse_device(os.environ.get("AUDIO_DEVICE"))
+    )
+    sample_rate: int = field(
+        default_factory=lambda: int(os.environ.get("AUDIO_SAMPLE_RATE", "48000"))
+    )
+    channels: int = field(default_factory=lambda: int(os.environ.get("AUDIO_CHANNELS", "1")))
+    output_dir: str = field(default_factory=lambda: os.environ.get("AUDIO_DIR", "data/audio"))
+
+
+def _parse_device(val: str | None) -> str | int | None:
+    """Parse AUDIO_DEVICE: integer index, name substring, or None."""
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        return val
+
+
+# ---------------------------------------------------------------------------
+# AudioSession
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AudioSession:
+    """Metadata for a completed or in-progress audio recording."""
+
+    file_path: str
+    device_name: str
+    start_utc: datetime
+    end_utc: datetime | None
+    sample_rate: int
+    channels: int
+
+
+# ---------------------------------------------------------------------------
+# AudioRecorder
+# ---------------------------------------------------------------------------
+
+
+class AudioRecorder:
+    """Records audio from a USB input device to a WAV file.
+
+    Usage::
+
+        recorder = AudioRecorder()
+        session = await recorder.start(config)
+        ...
+        completed = await recorder.stop()
+    """
+
+    def __init__(self) -> None:
+        self._stream: Any | None = None
+        self._sound_file: Any | None = None
+        self._writer_thread: threading.Thread | None = None
+        self._stop_event: threading.Event = threading.Event()
+        self._chunk_queue: queue.Queue[Any] = queue.Queue()
+        self._session: AudioSession | None = None
+
+    # ------------------------------------------------------------------
+    # Device enumeration
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def list_devices() -> list[dict[str, object]]:
+        """Return a list of available audio input devices.
+
+        Each entry is a dict with keys: index, name, max_input_channels,
+        default_samplerate.
+        """
+        import sounddevice as sd
+
+        devices = sd.query_devices()
+        result: list[dict[str, object]] = []
+        for idx, dev in enumerate(devices):
+            if dev["max_input_channels"] > 0:
+                result.append(
+                    {
+                        "index": idx,
+                        "name": dev["name"],
+                        "max_input_channels": dev["max_input_channels"],
+                        "default_samplerate": dev["default_samplerate"],
+                    }
+                )
+        return result
+
+    # ------------------------------------------------------------------
+    # Start / stop
+    # ------------------------------------------------------------------
+
+    async def start(self, config: AudioConfig) -> AudioSession:
+        """Open the audio stream and start recording to a WAV file.
+
+        Returns an AudioSession with start_utc set (end_utc is None until
+        stop() is called).
+
+        Raises AudioDeviceNotFoundError if no matching input device is found.
+        """
+        import sounddevice as sd
+        import soundfile as sf
+
+        device_index, device_name = _resolve_device(config.device)
+
+        # Ensure output directory exists
+        Path(config.output_dir).mkdir(parents=True, exist_ok=True)
+
+        # Build filename from UTC timestamp
+        start_utc = datetime.now(UTC)
+        filename = f"audio_{start_utc.strftime('%Y%m%d_%H%M%S')}.wav"
+        file_path = str(Path(config.output_dir) / filename)
+
+        # Open the sound file (writer thread will use this)
+        self._sound_file = sf.SoundFile(
+            file_path,
+            mode="w",
+            samplerate=config.sample_rate,
+            channels=config.channels,
+            format="WAV",
+            subtype="PCM_16",
+        )
+
+        # Clear any leftover state
+        self._stop_event.clear()
+        while not self._chunk_queue.empty():
+            self._chunk_queue.get_nowait()
+
+        # Start background writer thread
+        self._writer_thread = threading.Thread(
+            target=self._write_loop,
+            name="audio-writer",
+            daemon=True,
+        )
+        self._writer_thread.start()
+
+        # Open the InputStream — callback enqueues numpy chunks
+        self._stream = sd.InputStream(
+            device=device_index,
+            samplerate=config.sample_rate,
+            channels=config.channels,
+            dtype="int16",
+            callback=self._audio_callback,
+        )
+        self._stream.start()
+
+        self._session = AudioSession(
+            file_path=file_path,
+            device_name=device_name,
+            start_utc=start_utc,
+            end_utc=None,
+            sample_rate=config.sample_rate,
+            channels=config.channels,
+        )
+
+        logger.debug(
+            "Audio stream opened: device={!r} file={} rate={} ch={}",
+            device_name,
+            file_path,
+            config.sample_rate,
+            config.channels,
+        )
+        return self._session
+
+    async def stop(self) -> AudioSession:
+        """Stop recording, flush all buffered audio, and close the file.
+
+        Returns the completed AudioSession with end_utc set.
+        """
+        if self._session is None:
+            raise RuntimeError("AudioRecorder.stop() called before start()")
+
+        # Stop the InputStream (no more callbacks after this)
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+
+        # Signal writer thread and wait for it to drain the queue
+        self._stop_event.set()
+        if self._writer_thread is not None:
+            self._writer_thread.join(timeout=10)
+            self._writer_thread = None
+
+        # Close the sound file
+        if self._sound_file is not None:
+            self._sound_file.close()
+            self._sound_file = None
+
+        self._session.end_utc = datetime.now(UTC)
+        logger.debug("Audio stream closed: file={}", self._session.file_path)
+        return self._session
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _audio_callback(
+        self,
+        indata: Any,  # noqa: ANN401
+        frames: int,  # noqa: ARG002
+        time: Any,  # noqa: ANN401, ARG002
+        status: Any,  # noqa: ANN401
+    ) -> None:
+        """sounddevice callback: enqueue a copy of the incoming audio chunk."""
+        if status:
+            logger.warning("Audio input status: {}", status)
+        self._chunk_queue.put(indata.copy())
+
+    def _write_loop(self) -> None:
+        """Writer thread: drain the queue and write chunks to the WAV file."""
+        while not self._stop_event.is_set() or not self._chunk_queue.empty():
+            try:
+                chunk = self._chunk_queue.get(timeout=0.1)
+                if self._sound_file is not None:
+                    self._sound_file.write(chunk)
+            except queue.Empty:
+                continue
+            except Exception as exc:
+                logger.error("Audio writer thread error: {}", exc)
+
+
+# ---------------------------------------------------------------------------
+# Device resolution helper
+# ---------------------------------------------------------------------------
+
+
+def _resolve_device(spec: str | int | None) -> tuple[int, str]:
+    """Resolve a device spec (name substring, index, or None) to (index, name).
+
+    Raises AudioDeviceNotFoundError if no matching input device is found.
+    """
+    import sounddevice as sd
+
+    devices = sd.query_devices()
+
+    if spec is None:
+        # Auto-detect: first device with input channels
+        for idx, dev in enumerate(devices):
+            if dev["max_input_channels"] > 0:
+                return idx, str(dev["name"])
+        raise AudioDeviceNotFoundError("No audio input devices found")
+
+    if isinstance(spec, int):
+        if spec < 0 or spec >= len(devices):
+            raise AudioDeviceNotFoundError(f"Audio device index {spec} out of range")
+        dev = devices[spec]
+        if dev["max_input_channels"] == 0:
+            raise AudioDeviceNotFoundError(f"Device {spec} ({dev['name']!r}) has no input channels")
+        return spec, str(dev["name"])
+
+    # Name substring match (case-insensitive)
+    spec_lower = spec.lower()
+    for idx, dev in enumerate(devices):
+        if spec_lower in str(dev["name"]).lower() and dev["max_input_channels"] > 0:
+            return idx, str(dev["name"])
+    raise AudioDeviceNotFoundError(
+        f"No audio input device matching {spec!r}. "
+        "Run `j105-logger list-devices` to see available devices."
+    )

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,249 @@
+"""Tests for src/logger/audio.py.
+
+All tests mock sounddevice and soundfile so they run without physical hardware.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from logger.audio import (
+    AudioConfig,
+    AudioDeviceNotFoundError,
+    AudioRecorder,
+    _resolve_device,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_DEVICES = [
+    {
+        "name": "Built-in Microphone",
+        "max_input_channels": 2,
+        "max_output_channels": 0,
+        "default_samplerate": 44100.0,
+    },
+    {
+        "name": "Gordik 2T1R USB Audio",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+        "default_samplerate": 48000.0,
+    },
+    {
+        "name": "HDMI Output",
+        "max_input_channels": 0,
+        "max_output_channels": 2,
+        "default_samplerate": 48000.0,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# test_audio_config_defaults
+# ---------------------------------------------------------------------------
+
+
+def test_audio_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AudioConfig reads defaults from env vars (or uses hard-coded fallbacks)."""
+    monkeypatch.delenv("AUDIO_DEVICE", raising=False)
+    monkeypatch.delenv("AUDIO_SAMPLE_RATE", raising=False)
+    monkeypatch.delenv("AUDIO_CHANNELS", raising=False)
+    monkeypatch.delenv("AUDIO_DIR", raising=False)
+
+    config = AudioConfig()
+
+    assert config.device is None
+    assert config.sample_rate == 48000
+    assert config.channels == 1
+    assert config.output_dir == "data/audio"
+
+
+def test_audio_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AudioConfig picks up env var overrides."""
+    monkeypatch.setenv("AUDIO_DEVICE", "Gordik")
+    monkeypatch.setenv("AUDIO_SAMPLE_RATE", "44100")
+    monkeypatch.setenv("AUDIO_CHANNELS", "2")
+    monkeypatch.setenv("AUDIO_DIR", "/tmp/audio")
+
+    config = AudioConfig()
+
+    assert config.device == "Gordik"
+    assert config.sample_rate == 44100
+    assert config.channels == 2
+    assert config.output_dir == "/tmp/audio"
+
+
+def test_audio_config_integer_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUDIO_DEVICE as a numeric string is parsed to an int."""
+    monkeypatch.setenv("AUDIO_DEVICE", "3")
+    config = AudioConfig()
+    assert config.device == 3
+
+
+# ---------------------------------------------------------------------------
+# test_wav_filename_format
+# ---------------------------------------------------------------------------
+
+
+def test_wav_filename_format() -> None:
+    """The WAV filename embeds the UTC timestamp in YYYYMMDD_HHMMSS format."""
+    fixed_dt = datetime(2025, 8, 10, 14, 5, 30, tzinfo=UTC)
+    filename = f"audio_{fixed_dt.strftime('%Y%m%d_%H%M%S')}.wav"
+    assert filename == "audio_20250810_140530.wav"
+    assert filename.endswith(".wav")
+
+
+# ---------------------------------------------------------------------------
+# test_list_devices_filters_inputs
+# ---------------------------------------------------------------------------
+
+
+def test_list_devices_filters_inputs() -> None:
+    """list_devices() returns only devices with max_input_channels > 0."""
+    with patch("sounddevice.query_devices", return_value=_FAKE_DEVICES):
+        devices = AudioRecorder.list_devices()
+
+    assert len(devices) == 2
+    names = [d["name"] for d in devices]
+    assert "HDMI Output" not in names
+    assert "Built-in Microphone" in names
+    assert "Gordik 2T1R USB Audio" in names
+
+    # Verify index assignment is correct (HDMI is index 2, skipped)
+    assert devices[0]["index"] == 0
+    assert devices[1]["index"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_start_records_utc
+# ---------------------------------------------------------------------------
+
+
+def test_start_records_utc(tmp_path: Path) -> None:
+    """start() sets start_utc before the stream opens."""
+    before = datetime.now(UTC)
+
+    mock_stream = MagicMock()
+    mock_sf = MagicMock()
+    mock_sf.__enter__ = MagicMock(return_value=mock_sf)
+    mock_sf.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_DEVICES),
+        patch("sounddevice.InputStream", return_value=mock_stream),
+        patch("soundfile.SoundFile", return_value=mock_sf),
+    ):
+        config = AudioConfig(
+            device=None,
+            sample_rate=48000,
+            channels=1,
+            output_dir=str(tmp_path),
+        )
+        recorder = AudioRecorder()
+
+        import asyncio
+
+        session = asyncio.run(recorder.start(config))
+
+    after = datetime.now(UTC)
+
+    assert before <= session.start_utc <= after
+    assert session.end_utc is None
+    assert session.file_path.endswith(".wav")
+    assert "audio_" in session.file_path
+
+
+# ---------------------------------------------------------------------------
+# test_stop_sets_end_utc
+# ---------------------------------------------------------------------------
+
+
+def test_stop_sets_end_utc(tmp_path: Path) -> None:
+    """stop() sets end_utc after closing the stream."""
+    mock_stream = MagicMock()
+    mock_sf = MagicMock()
+
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_DEVICES),
+        patch("sounddevice.InputStream", return_value=mock_stream),
+        patch("soundfile.SoundFile", return_value=mock_sf),
+    ):
+        config = AudioConfig(
+            device=None,
+            sample_rate=48000,
+            channels=1,
+            output_dir=str(tmp_path),
+        )
+        recorder = AudioRecorder()
+
+        import asyncio
+
+        asyncio.run(recorder.start(config))
+        before_stop = datetime.now(UTC)
+        completed = asyncio.run(recorder.stop())
+        after_stop = datetime.now(UTC)
+
+    assert completed.end_utc is not None
+    assert before_stop <= completed.end_utc <= after_stop
+    assert completed.start_utc < completed.end_utc
+
+
+# ---------------------------------------------------------------------------
+# test_no_device_raises
+# ---------------------------------------------------------------------------
+
+
+def test_no_device_raises() -> None:
+    """AudioDeviceNotFoundError is raised when no input devices exist."""
+    output_only_devices = [
+        {
+            "name": "HDMI Output",
+            "max_input_channels": 0,
+            "max_output_channels": 2,
+            "default_samplerate": 48000.0,
+        }
+    ]
+
+    with (
+        patch("sounddevice.query_devices", return_value=output_only_devices),
+        pytest.raises(AudioDeviceNotFoundError),
+    ):
+        _resolve_device(None)
+
+
+def test_no_device_name_match_raises() -> None:
+    """AudioDeviceNotFoundError is raised when name substring doesn't match."""
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_DEVICES),
+        pytest.raises(AudioDeviceNotFoundError, match="nonexistent"),
+    ):
+        _resolve_device("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# test_resolve_device_by_index
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_device_by_index() -> None:
+    """Resolving by integer index works correctly."""
+    with patch("sounddevice.query_devices", return_value=_FAKE_DEVICES):
+        idx, name = _resolve_device(0)
+
+    assert idx == 0
+    assert name == "Built-in Microphone"
+
+
+def test_resolve_device_by_name_substring() -> None:
+    """Case-insensitive substring match selects the correct device."""
+    with patch("sounddevice.query_devices", return_value=_FAKE_DEVICES):
+        idx, name = _resolve_device("gordik")
+
+    assert idx == 1
+    assert "Gordik" in name

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -191,6 +248,8 @@ dependencies = [
     { name = "loguru" },
     { name = "python-can" },
     { name = "python-dotenv" },
+    { name = "sounddevice" },
+    { name = "soundfile" },
     { name = "websockets" },
     { name = "yt-dlp" },
 ]
@@ -211,6 +270,8 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "python-can", specifier = ">=4.4.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "sounddevice", specifier = ">=0.5.5" },
+    { name = "soundfile", specifier = ">=0.13.1" },
     { name = "websockets", specifier = ">=14.0" },
     { name = "yt-dlp", specifier = ">=2024.11.4" },
 ]
@@ -340,6 +401,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6e/6f394c9c77668153e14d4da83bcc247beb5952f6ead7699a1a2992613bea/numpy-2.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:21982668592194c609de53ba4933a7471880ccbaadcc52352694a59ecc860b3a", size = 16667963, upload-time = "2026-01-31T23:10:52.147Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/55483431f2b2fd015ae6ed4fe62288823ce908437ed49db5a03d15151678/numpy-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40397bda92382fcec844066efb11f13e1c9a3e2a8e8f318fb72ed8b6db9f60f1", size = 14693571, upload-time = "2026-01-31T23:10:54.789Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/20/18026832b1845cdc82248208dd929ca14c9d8f2bac391f67440707fff27c/numpy-2.4.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b3a24467af63c67829bfaa61eecf18d5432d4f11992688537be59ecd6ad32f5e", size = 5203469, upload-time = "2026-01-31T23:10:57.343Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/2eb97c8a77daaba34eaa3fa7241a14ac5f51c46a6bd5911361b644c4a1e2/numpy-2.4.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:805cc8de9fd6e7a22da5aed858e0ab16be5a4db6c873dde1d7451c541553aa27", size = 6550820, upload-time = "2026-01-31T23:10:59.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/91/b97fdfd12dc75b02c44e26c6638241cc004d4079a0321a69c62f51470c4c/numpy-2.4.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d82351358ffbcdcd7b686b90742a9b86632d6c1c051016484fa0b326a0a1548", size = 15663067, upload-time = "2026-01-31T23:11:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c6/a18e59f3f0b8071cc85cbc8d80cd02d68aa9710170b2553a117203d46936/numpy-2.4.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e35d3e0144137d9fdae62912e869136164534d64a169f86438bc9561b6ad49f", size = 16619782, upload-time = "2026-01-31T23:11:03.669Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/83/9751502164601a79e18847309f5ceec0b1446d7b6aa12305759b72cf98b2/numpy-2.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adb6ed2ad29b9e15321d167d152ee909ec73395901b70936f029c3bc6d7f4460", size = 17013128, upload-time = "2026-01-31T23:11:05.913Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c4/c4066322256ec740acc1c8923a10047818691d2f8aec254798f3dd90f5f2/numpy-2.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8906e71fd8afcb76580404e2a950caef2685df3d2a57fe82a86ac8d33cc007ba", size = 18345324, upload-time = "2026-01-31T23:11:08.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/af/6157aa6da728fa4525a755bfad486ae7e3f76d4c1864138003eb84328497/numpy-2.4.2-cp312-cp312-win32.whl", hash = "sha256:ec055f6dae239a6299cace477b479cca2fc125c5675482daf1dd886933a1076f", size = 5960282, upload-time = "2026-01-31T23:11:10.497Z" },
+    { url = "https://files.pythonhosted.org/packages/92/0f/7ceaaeaacb40567071e94dbf2c9480c0ae453d5bb4f52bea3892c39dc83c/numpy-2.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:209fae046e62d0ce6435fcfe3b1a10537e858249b3d9b05829e2a05218296a85", size = 12314210, upload-time = "2026-01-31T23:11:12.176Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a3/56c5c604fae6dd40fa2ed3040d005fca97e91bd320d232ac9931d77ba13c/numpy-2.4.2-cp312-cp312-win_arm64.whl", hash = "sha256:fbde1b0c6e81d56f5dccd95dd4a711d9b95df1ae4009a60887e56b27e8d903fa", size = 10220171, upload-time = "2026-01-31T23:11:14.684Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/22/815b9fe25d1d7ae7d492152adbc7226d3eff731dffc38fe970589fcaaa38/numpy-2.4.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25f2059807faea4b077a2b6837391b5d830864b3543627f381821c646f31a63c", size = 16663696, upload-time = "2026-01-31T23:11:17.516Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/817d03a03f93ba9c6c8993de509277d84e69f9453601915e4a69554102a1/numpy-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bd3a7a9f5847d2fb8c2c6d1c862fa109c31a9abeca1a3c2bd5a64572955b2979", size = 14688322, upload-time = "2026-01-31T23:11:19.883Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b4/f805ab79293c728b9a99438775ce51885fd4f31b76178767cfc718701a39/numpy-2.4.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8e4549f8a3c6d13d55041925e912bfd834285ef1dd64d6bc7d542583355e2e98", size = 5198157, upload-time = "2026-01-31T23:11:22.375Z" },
+    { url = "https://files.pythonhosted.org/packages/74/09/826e4289844eccdcd64aac27d13b0fd3f32039915dd5b9ba01baae1f436c/numpy-2.4.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:aea4f66ff44dfddf8c2cffd66ba6538c5ec67d389285292fe428cb2c738c8aef", size = 6546330, upload-time = "2026-01-31T23:11:23.958Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/cbfdbfa3057a10aea5422c558ac57538e6acc87ec1669e666d32ac198da7/numpy-2.4.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3cd545784805de05aafe1dde61752ea49a359ccba9760c1e5d1c88a93bbf2b7", size = 15660968, upload-time = "2026-01-31T23:11:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dc/46066ce18d01645541f0186877377b9371b8fa8017fa8262002b4ef22612/numpy-2.4.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0d9b7c93578baafcbc5f0b83eaf17b79d345c6f36917ba0c67f45226911d499", size = 16607311, upload-time = "2026-01-31T23:11:28.117Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/4b5adfc39a43fa6bf918c6d544bc60c05236cc2f6339847fc5b35e6cb5b0/numpy-2.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f74f0f7779cc7ae07d1810aab8ac6b1464c3eafb9e283a40da7309d5e6e48fbb", size = 17012850, upload-time = "2026-01-31T23:11:30.888Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/20/adb6e6adde6d0130046e6fdfb7675cc62bc2f6b7b02239a09eb58435753d/numpy-2.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7ac672d699bf36275c035e16b65539931347d68b70667d28984c9fb34e07fa7", size = 18334210, upload-time = "2026-01-31T23:11:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/78/0e/0a73b3dff26803a8c02baa76398015ea2a5434d9b8265a7898a6028c1591/numpy-2.4.2-cp313-cp313-win32.whl", hash = "sha256:8e9afaeb0beff068b4d9cd20d322ba0ee1cecfb0b08db145e4ab4dd44a6b5110", size = 5958199, upload-time = "2026-01-31T23:11:35.385Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bc/6352f343522fcb2c04dbaf94cb30cca6fd32c1a750c06ad6231b4293708c/numpy-2.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:7df2de1e4fba69a51c06c28f5a3de36731eb9639feb8e1cf7e4a7b0daf4cf622", size = 12310848, upload-time = "2026-01-31T23:11:38.001Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8d/6da186483e308da5da1cc6918ce913dcfe14ffde98e710bfeff2a6158d4e/numpy-2.4.2-cp313-cp313-win_arm64.whl", hash = "sha256:0fece1d1f0a89c16b03442eae5c56dc0be0c7883b5d388e0c03f53019a4bfd71", size = 10221082, upload-time = "2026-01-31T23:11:40.392Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a1/9510aa43555b44781968935c7548a8926274f815de42ad3997e9e83680dd/numpy-2.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5633c0da313330fd20c484c78cdd3f9b175b55e1a766c4a174230c6b70ad8262", size = 14815866, upload-time = "2026-01-31T23:11:42.495Z" },
+    { url = "https://files.pythonhosted.org/packages/36/30/6bbb5e76631a5ae46e7923dd16ca9d3f1c93cfa8d4ed79a129814a9d8db3/numpy-2.4.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d9f64d786b3b1dd742c946c42d15b07497ed14af1a1f3ce840cce27daa0ce913", size = 5325631, upload-time = "2026-01-31T23:11:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/46/00/3a490938800c1923b567b3a15cd17896e68052e2145d8662aaf3e1ffc58f/numpy-2.4.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:b21041e8cb6a1eb5312dd1d2f80a94d91efffb7a06b70597d44f1bd2dfc315ab", size = 6646254, upload-time = "2026-01-31T23:11:46.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e9/fac0890149898a9b609caa5af7455a948b544746e4b8fe7c212c8edd71f8/numpy-2.4.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00ab83c56211a1d7c07c25e3217ea6695e50a3e2f255053686b081dc0b091a82", size = 15720138, upload-time = "2026-01-31T23:11:48.082Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5c/08887c54e68e1e28df53709f1893ce92932cc6f01f7c3d4dc952f61ffd4e/numpy-2.4.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fb882da679409066b4603579619341c6d6898fc83a8995199d5249f986e8e8f", size = 16655398, upload-time = "2026-01-31T23:11:50.293Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/253db0fa0e66e9129c745e4ef25631dc37d5f1314dad2b53e907b8538e6d/numpy-2.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:66cb9422236317f9d44b67b4d18f44efe6e9c7f8794ac0462978513359461554", size = 17079064, upload-time = "2026-01-31T23:11:52.927Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d5/cbade46ce97c59c6c3da525e8d95b7abe8a42974a1dc5c1d489c10433e88/numpy-2.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0f01dcf33e73d80bd8dc0f20a71303abbafa26a19e23f6b68d1aa9990af90257", size = 18379680, upload-time = "2026-01-31T23:11:55.22Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/48f99ae172a4b63d981babe683685030e8a3df4f246c893ea5c6ef99f018/numpy-2.4.2-cp313-cp313t-win32.whl", hash = "sha256:52b913ec40ff7ae845687b0b34d8d93b60cb66dcee06996dd5c99f2fc9328657", size = 6082433, upload-time = "2026-01-31T23:11:58.096Z" },
+    { url = "https://files.pythonhosted.org/packages/07/38/e054a61cfe48ad9f1ed0d188e78b7e26859d0b60ef21cd9de4897cdb5326/numpy-2.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:5eea80d908b2c1f91486eb95b3fb6fab187e569ec9752ab7d9333d2e66bf2d6b", size = 12451181, upload-time = "2026-01-31T23:11:59.782Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a4/a05c3a6418575e185dd84d0b9680b6bb2e2dc3e4202f036b7b4e22d6e9dc/numpy-2.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fd49860271d52127d61197bb50b64f58454e9f578cb4b2c001a6de8b1f50b0b1", size = 10290756, upload-time = "2026-01-31T23:12:02.438Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/b7df6050bf18fdcfb7046286c6535cabbdd2064a3440fca3f069d319c16e/numpy-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:444be170853f1f9d528428eceb55f12918e4fda5d8805480f36a002f1415e09b", size = 16663092, upload-time = "2026-01-31T23:12:04.521Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/1fee4329abc705a469a4afe6e69b1ef7e915117747886327104a8493a955/numpy-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1240d50adff70c2a88217698ca844723068533f3f5c5fa6ee2e3220e3bdb000", size = 14698770, upload-time = "2026-01-31T23:12:06.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0b/f9e49ba6c923678ad5bc38181c08ac5e53b7a5754dbca8e581aa1a56b1ff/numpy-2.4.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:7cdde6de52fb6664b00b056341265441192d1291c130e99183ec0d4b110ff8b1", size = 5208562, upload-time = "2026-01-31T23:12:09.632Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/12/d7de8f6f53f9bb76997e5e4c069eda2051e3fe134e9181671c4391677bb2/numpy-2.4.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:cda077c2e5b780200b6b3e09d0b42205a3d1c68f30c6dceb90401c13bff8fe74", size = 6543710, upload-time = "2026-01-31T23:12:11.969Z" },
+    { url = "https://files.pythonhosted.org/packages/09/63/c66418c2e0268a31a4cf8a8b512685748200f8e8e8ec6c507ce14e773529/numpy-2.4.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d30291931c915b2ab5717c2974bb95ee891a1cf22ebc16a8006bd59cd210d40a", size = 15677205, upload-time = "2026-01-31T23:12:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6c/7f237821c9642fb2a04d2f1e88b4295677144ca93285fd76eff3bcba858d/numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba37bc29d4d85761deed3954a1bc62be7cf462b9510b51d367b769a8c8df325", size = 16611738, upload-time = "2026-01-31T23:12:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/39c4cdda9f019b609b5c473899d87abff092fc908cfe4d1ecb2fcff453b0/numpy-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b2f0073ed0868db1dcd86e052d37279eef185b9c8db5bf61f30f46adac63c909", size = 17028888, upload-time = "2026-01-31T23:12:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/e84bb64bdfea967cc10950d71090ec2d84b49bc691df0025dddb7c26e8e3/numpy-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7f54844851cdb630ceb623dcec4db3240d1ac13d4990532446761baede94996a", size = 18339556, upload-time = "2026-01-31T23:12:21.816Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f5/954a291bc1192a27081706862ac62bb5920fbecfbaa302f64682aa90beed/numpy-2.4.2-cp314-cp314-win32.whl", hash = "sha256:12e26134a0331d8dbd9351620f037ec470b7c75929cb8a1537f6bfe411152a1a", size = 6006899, upload-time = "2026-01-31T23:12:24.14Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cb/eff72a91b2efdd1bc98b3b8759f6a1654aa87612fc86e3d87d6fe4f948c4/numpy-2.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:068cdb2d0d644cdb45670810894f6a0600797a69c05f1ac478e8d31670b8ee75", size = 12443072, upload-time = "2026-01-31T23:12:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/37/75/62726948db36a56428fce4ba80a115716dc4fad6a3a4352487f8bb950966/numpy-2.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ed0be1ee58eef41231a5c943d7d1375f093142702d5723ca2eb07db9b934b05", size = 10494886, upload-time = "2026-01-31T23:12:28.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/ee93744f1e0661dc267e4b21940870cabfae187c092e1433b77b09b50ac4/numpy-2.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98f16a80e917003a12c0580f97b5f875853ebc33e2eaa4bccfc8201ac6869308", size = 14818567, upload-time = "2026-01-31T23:12:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/6535212add7d76ff938d8bdc654f53f88d35cddedf807a599e180dcb8e66/numpy-2.4.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:20abd069b9cda45874498b245c8015b18ace6de8546bf50dfa8cea1696ed06ef", size = 5328372, upload-time = "2026-01-31T23:12:32.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/c48f0a035725f925634bf6b8994253b43f2047f6778a54147d7e213bc5a7/numpy-2.4.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e98c97502435b53741540a5717a6749ac2ada901056c7db951d33e11c885cc7d", size = 6649306, upload-time = "2026-01-31T23:12:34.797Z" },
+    { url = "https://files.pythonhosted.org/packages/81/05/7c73a9574cd4a53a25907bad38b59ac83919c0ddc8234ec157f344d57d9a/numpy-2.4.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6cad4e82cb893db4b69105c604d805e0c3ce11501a55b5e9f9083b47d2ffe8", size = 15722394, upload-time = "2026-01-31T23:12:36.565Z" },
+    { url = "https://files.pythonhosted.org/packages/35/fa/4de10089f21fc7d18442c4a767ab156b25c2a6eaf187c0db6d9ecdaeb43f/numpy-2.4.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e4424677ce4b47fe73c8b5556d876571f7c6945d264201180db2dc34f676ab5", size = 16653343, upload-time = "2026-01-31T23:12:39.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/d33e4ffc857f3763a57aa85650f2e82486832d7492280ac21ba9efda80da/numpy-2.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2b8f157c8a6f20eb657e240f8985cc135598b2b46985c5bccbde7616dc9c6b1e", size = 17078045, upload-time = "2026-01-31T23:12:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/54bdb43b6225badbea6389fa038c4ef868c44f5890f95dd530a218706da3/numpy-2.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5daf6f3914a733336dab21a05cdec343144600e964d2fcdabaac0c0269874b2a", size = 18380024, upload-time = "2026-01-31T23:12:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
+    { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
+    { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +486,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -464,6 +595,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
     { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
     { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751, upload-time = "2025-01-25T09:16:44.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/73e97a5b3cc46bba7ff8650a1504348fa1863a6f9d57d7001c6b67c5f20e/soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33", size = 1142250, upload-time = "2025-01-25T09:16:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/58fd1a8d7b26fc113af244f966ee3aecf03cb9293cb935daaddc1e455e18/soundfile-0.13.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:743f12c12c4054921e15736c6be09ac26b3b3d603aef6fd69f9dde68748f2593", size = 1101406, upload-time = "2025-01-25T09:16:49.662Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ae/c0e4a53d77cf6e9a04179535766b3321b0b9ced5f70522e4caf9329f0046/soundfile-0.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9c9e855f5a4d06ce4213f31918653ab7de0c5a8d8107cd2427e44b42df547deb", size = 1235729, upload-time = "2025-01-25T09:16:53.018Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Records voice commentary (crew calls, tactical notes) to a WAV file per session, anchored to UTC time for post-session correlation with instrument data and video.

- audio.py: AudioRecorder using sounddevice InputStream → queue → writer thread → SoundFile pattern; AudioConfig from env vars; device resolution by name substring or integer index with graceful AudioDeviceNotFoundError
- storage.py: migration 6 adds audio_sessions table; write/update/list methods
- main.py: _audio_loop background task (auto-starts with `run`); list-audio and list-devices subcommands
- tests/test_audio.py: 11 hardware-free tests via sounddevice/soundfile mocks
- docs/audio-setup.md: Gordik setup guide, device discovery, troubleshooting
- setup.sh: install libportaudio2 + libsndfile1; create data/audio/ directory
- .env.example + README.md + CLAUDE.md: document AUDIO_DEVICE, AUDIO_DIR, AUDIO_SAMPLE_RATE, AUDIO_CHANNELS env vars