### PR TITLE
Add audio recording and race marker web interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ SK_PORT=3000             # Signal K WebSocket port
 AUDIO_DIR=data/audio    # directory for WAV files
 AUDIO_SAMPLE_RATE=48000
 AUDIO_CHANNELS=1
+# Web interface (race marker)
+WEB_HOST=0.0.0.0        # bind address for the web interface
+WEB_PORT=3002           # http://corvopi:3002 on Tailscale
+# WEB_PIN=             # optional PIN for Layer 2 auth (not yet implemented)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "websockets>=14.0",
     "sounddevice>=0.5.5",
     "soundfile>=0.13.1",
+    "fastapi>=0.133.1",
+    "uvicorn>=0.41.0",
 ]
 
 [project.scripts]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -390,6 +390,7 @@ echo ""
 echo "  Signal K:  http://corvopi:3000"
 echo "  Grafana:   http://corvopi:3001"
 echo "  InfluxDB:  http://corvopi:8086"
+echo "  Race marker: http://corvopi:3002"
 echo ""
 if [[ -f "$INFLUX_TOKEN_FILE" ]]; then
     echo "  InfluxDB token saved to: $INFLUX_TOKEN_FILE"

--- a/src/logger/races.py
+++ b/src/logger/races.py
@@ -1,0 +1,74 @@
+"""Race lifecycle management — naming logic and configuration.
+
+Pure domain logic only. No database access here; storage methods live in
+storage.py. This module is importable without hardware or a running server.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import date, datetime
+
+
+# ---------------------------------------------------------------------------
+# Domain objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Race:
+    """A single race window."""
+
+    id: int
+    name: str  # e.g. "20250810-BallardCup-2"
+    event: str  # e.g. "BallardCup"
+    race_num: int
+    date: str  # UTC date "YYYY-MM-DD"
+    start_utc: datetime
+    end_utc: datetime | None
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RaceConfig:
+    """Web server bind configuration (from environment variables)."""
+
+    web_host: str = field(default_factory=lambda: os.environ.get("WEB_HOST", "0.0.0.0"))
+    web_port: int = field(default_factory=lambda: int(os.environ.get("WEB_PORT", "3002")))
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+_WEEKDAY_EVENTS: dict[int, str] = {
+    0: "BallardCup",  # Monday
+    2: "CYC",  # Wednesday
+}
+
+
+def default_event_for_date(d: date) -> str | None:
+    """Return the default event name for a given UTC date, or None.
+
+    Monday  → "BallardCup"
+    Wednesday → "CYC"
+    Any other day → None (user must supply the event name)
+    """
+    return _WEEKDAY_EVENTS.get(d.weekday())
+
+
+def build_race_name(event: str, d: date, race_num: int) -> str:
+    """Build a race identifier string.
+
+    Example: build_race_name("BallardCup", date(2025, 8, 10), 2)
+             → "20250810-BallardCup-2"
+    """
+    return f"{d.strftime('%Y%m%d')}-{event}-{race_num}"

--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -1,0 +1,473 @@
+"""FastAPI web interface for race marking.
+
+Provides a mobile-optimised single-page app at http://corvopi:3002 that lets
+crew tap a button to start/end races. The app factory pattern (create_app)
+keeps this testable without running a live server.
+
+Security:
+  Layer 1 (current) — Tailscale is the security boundary. All tailnet devices
+    are trusted; no additional auth code.
+  Layer 2 (TODO) — Optional WEB_PIN env var. If set, POST /login accepts the
+    PIN, sets a signed session cookie (HMAC-SHA256(pin, WEB_SECRET_KEY) using
+    stdlib hmac + hashlib only). GET / checks for cookie; redirect to /login
+    if missing or invalid.
+  Layer 3 (TODO) — Tailscale Whois API (GET http://100.100.100.100/v0/whois
+    ?addr=<client_ip>) returns the caller's Tailscale identity for audit logs
+    and per-device permissions — zero login UI, no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from logger.storage import Storage
+
+# ---------------------------------------------------------------------------
+# HTML — inline mobile-first single-page app
+# ---------------------------------------------------------------------------
+
+_HTML = """\
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>J105 Logger</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,sans-serif;background:#0a1628;color:#e8eaf0;
+padding:16px;max-width:480px;margin:0 auto}
+h1{font-size:1.3rem;font-weight:700;color:#7eb8f7;margin-bottom:2px}
+.sub{font-size:.9rem;color:#8892a4;margin-bottom:20px}
+.card{background:#131f35;border-radius:12px;padding:16px;margin-bottom:16px}
+.race-name{font-size:1rem;font-weight:600;color:#e8eaf0;margin-bottom:4px}
+.race-meta{font-size:.8rem;color:#8892a4}
+.status-dot{display:inline-block;width:10px;height:10px;border-radius:50%;
+background:#22c55e;margin-right:6px;animation:pulse 1.4s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
+.label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:#8892a4;margin-bottom:8px}
+.duration{font-size:1.6rem;font-weight:700;color:#22c55e;font-variant-numeric:tabular-nums}
+.btn{display:block;width:100%;padding:18px;border:none;border-radius:10px;font-size:1.1rem;font-weight:700;cursor:pointer;margin-bottom:10px;letter-spacing:.02em}
+.btn-primary{background:#2563eb;color:#fff}
+.btn-primary:active{background:#1d4ed8}
+.btn-secondary{background:#1e3a5f;color:#7eb8f7;border:1px solid #2563eb}
+.btn-secondary:active{background:#163252}
+.btn-danger{background:#7f1d1d;color:#fca5a5;border:1px solid #dc2626}
+.event-row{display:flex;gap:8px;margin-bottom:16px}
+.event-input{flex:1;background:#0a1628;border:1px solid #2563eb;
+border-radius:8px;padding:12px;color:#e8eaf0;font-size:1rem}
+.btn-save{padding:12px 18px;border:none;border-radius:8px;background:#2563eb;
+color:#fff;font-weight:700;cursor:pointer;font-size:1rem}
+.race-list{margin-top:8px}
+.race-item{padding:10px 0;border-bottom:1px solid #1e3a5f}
+.race-item:last-child{border-bottom:none}
+.race-item-name{font-weight:600;font-size:.9rem;margin-bottom:4px}
+.race-item-time{font-size:.8rem;color:#8892a4}
+.race-exports{margin-top:6px;display:flex;gap:8px}
+.btn-export{padding:5px 12px;border:1px solid #2563eb;border-radius:6px;
+background:#131f35;color:#7eb8f7;font-size:.8rem;cursor:pointer;text-decoration:none}
+.hidden{display:none}
+</style>
+</head>
+<body>
+<h1>J105 Logger</h1>
+<div class="sub" id="header-sub">Loading…</div>
+
+<div id="event-section" class="hidden">
+  <div class="label">Event name</div>
+  <div class="event-row">
+    <input id="event-input" class="event-input" placeholder="e.g. Regatta" maxlength="40"/>
+    <button class="btn-save" onclick="saveEvent()">Save</button>
+  </div>
+</div>
+
+<div id="current-card" class="card hidden">
+  <div class="label"><span class="status-dot"></span>Race in progress</div>
+  <div class="race-name" id="cur-name">—</div>
+  <div class="race-meta" id="cur-meta">—</div>
+  <div class="label" style="margin-top:12px">Duration</div>
+  <div class="duration" id="cur-duration">—</div>
+</div>
+
+<div id="controls">
+  <button class="btn btn-primary" id="btn-start" onclick="startRace()">▶ START RACE</button>
+  <button class="btn btn-secondary hidden" id="btn-end" onclick="endRace()">■ END RACE</button>
+</div>
+
+<div class="card" id="history-card" style="display:none">
+  <div class="label">Today's races</div>
+  <div class="race-list" id="race-list"></div>
+</div>
+
+<script>
+let state = null;
+let tickInterval = null;
+let curRaceStartMs = null;
+
+async function loadState() {
+  try {
+    const r = await fetch('/api/state');
+    state = await r.json();
+    render(state);
+  } catch(e) { console.error('state error', e); }
+}
+
+function fmt(s) {
+  const h = Math.floor(s/3600), m = Math.floor((s%3600)/60), ss = s%60;
+  if(h) return `${h}:${String(m).padStart(2,'0')}:${String(ss).padStart(2,'0')}`;
+  return `${m}:${String(ss).padStart(2,'0')}`;
+}
+
+function fmtTime(iso) {
+  if(!iso) return '—';
+  return new Date(iso).toISOString().substring(11,19) + ' UTC';
+}
+
+function render(s) {
+  document.getElementById('header-sub').textContent =
+    `${s.weekday} · ${s.event || '(no event)'}`;
+
+  const evSec = document.getElementById('event-section');
+  if(!s.event_is_default) {
+    evSec.classList.remove('hidden');
+    if(!document.getElementById('event-input').value && s.event) {
+      document.getElementById('event-input').value = s.event;
+    }
+  } else {
+    evSec.classList.add('hidden');
+  }
+
+  const cur = s.current_race;
+  const curCard = document.getElementById('current-card');
+  const btnEnd = document.getElementById('btn-end');
+  const btnStart = document.getElementById('btn-start');
+
+  if(cur) {
+    curCard.classList.remove('hidden');
+    btnEnd.classList.remove('hidden');
+    document.getElementById('cur-name').textContent = cur.name;
+    document.getElementById('cur-meta').textContent =
+      'Started ' + fmtTime(cur.start_utc);
+    curRaceStartMs = new Date(cur.start_utc).getTime();
+    btnEnd.textContent = '■ END ' + cur.name;
+  } else {
+    curCard.classList.add('hidden');
+    btnEnd.classList.add('hidden');
+    curRaceStartMs = null;
+    clearInterval(tickInterval);
+  }
+
+  btnStart.textContent = `▶ START RACE ${s.next_race_num}`;
+
+  const hist = document.getElementById('history-card');
+  const list = document.getElementById('race-list');
+  if(s.today_races && s.today_races.length) {
+    hist.style.display = '';
+    list.innerHTML = s.today_races.slice().reverse().map(r => {
+      const start = fmtTime(r.start_utc);
+      const end = r.end_utc ? fmtTime(r.end_utc) : 'in progress';
+      const dur = (r.end_utc && r.duration_s != null)
+        ? ` (${fmt(Math.round(r.duration_s))})` : '';
+      const exports = r.end_utc
+        ? `<div class="race-exports">
+             <a class="btn-export" href="/api/races/${r.id}/export.csv">↓ CSV</a>
+             <a class="btn-export" href="/api/races/${r.id}/export.gpx">↓ GPX</a>
+           </div>`
+        : '';
+      return `<div class="race-item">
+        <div class="race-item-name">${r.name}</div>
+        <div class="race-item-time">${start} → ${end}${dur}</div>
+        ${exports}
+      </div>`;
+    }).join('');
+  } else {
+    hist.style.display = 'none';
+  }
+}
+
+function tick() {
+  if(!curRaceStartMs) return;
+  const elapsed = Math.floor((Date.now() - curRaceStartMs) / 1000);
+  document.getElementById('cur-duration').textContent = fmt(elapsed);
+}
+
+async function startRace() {
+  await fetch('/api/races/start', {method:'POST'});
+  await loadState();
+  clearInterval(tickInterval);
+  if(curRaceStartMs) tickInterval = setInterval(tick, 1000);
+}
+
+async function endRace() {
+  if(!state || !state.current_race) return;
+  await fetch(`/api/races/${state.current_race.id}/end`, {method:'POST'});
+  await loadState();
+}
+
+async function saveEvent() {
+  const name = document.getElementById('event-input').value.trim();
+  if(!name) return;
+  await fetch('/api/event', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({event_name: name})
+  });
+  await loadState();
+}
+
+loadState();
+setInterval(loadState, 10000);
+setInterval(tick, 1000);
+</script>
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Request/Response models
+# ---------------------------------------------------------------------------
+
+
+class EventRequest(BaseModel):
+    event_name: str
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def create_app(storage: Storage) -> FastAPI:
+    """Create and return the FastAPI application bound to the given Storage."""
+    app = FastAPI(title="J105 Logger", docs_url=None, redoc_url=None)
+
+    # ------------------------------------------------------------------
+    # HTML UI
+    # ------------------------------------------------------------------
+
+    @app.get("/", response_class=HTMLResponse, include_in_schema=False)
+    async def index() -> HTMLResponse:
+        return HTMLResponse(_HTML)
+
+    # ------------------------------------------------------------------
+    # /api/state
+    # ------------------------------------------------------------------
+
+    @app.get("/api/state")
+    async def api_state() -> JSONResponse:
+        from logger.races import Race as _Race
+        from logger.races import default_event_for_date
+
+        now = datetime.now(UTC)
+        today = now.date()
+        date_str = today.isoformat()
+        weekday = today.strftime("%A")
+
+        default_event = default_event_for_date(today)
+        custom_event = await storage.get_daily_event(date_str)
+
+        if default_event is not None:
+            event: str | None = default_event
+            event_is_default = True
+        elif custom_event is not None:
+            event = custom_event
+            event_is_default = False
+        else:
+            event = None
+            event_is_default = False
+
+        current = await storage.get_current_race()
+        today_races = await storage.list_races_for_date(date_str)
+
+        next_race_num = len(today_races) + 1
+
+        def _race_dict(r: _Race) -> dict[str, Any]:
+            duration_s: float | None = None
+            if r.end_utc is not None:
+                duration_s = (r.end_utc - r.start_utc).total_seconds()
+            else:
+                elapsed = (now - r.start_utc).total_seconds()
+                duration_s = elapsed
+            return {
+                "id": r.id,
+                "name": r.name,
+                "event": r.event,
+                "race_num": r.race_num,
+                "date": r.date,
+                "start_utc": r.start_utc.isoformat(),
+                "end_utc": r.end_utc.isoformat() if r.end_utc else None,
+                "duration_s": round(duration_s, 1) if duration_s is not None else None,
+            }
+
+        return JSONResponse(
+            {
+                "date": date_str,
+                "weekday": weekday,
+                "event": event,
+                "event_is_default": event_is_default,
+                "current_race": _race_dict(current) if current else None,
+                "next_race_num": next_race_num,
+                "today_races": [_race_dict(r) for r in today_races],
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # /api/event
+    # ------------------------------------------------------------------
+
+    @app.post("/api/event", status_code=204)
+    async def api_set_event(body: EventRequest) -> None:
+        event_name = body.event_name.strip()
+        if not event_name:
+            raise HTTPException(status_code=422, detail="event_name must not be blank")
+        date_str = datetime.now(UTC).date().isoformat()
+        await storage.set_daily_event(date_str, event_name)
+
+    # ------------------------------------------------------------------
+    # /api/races/start
+    # ------------------------------------------------------------------
+
+    @app.post("/api/races/start", status_code=201)
+    async def api_start_race() -> JSONResponse:
+        from logger.races import build_race_name, default_event_for_date
+
+        now = datetime.now(UTC)
+        today = now.date()
+        date_str = today.isoformat()
+
+        default_event = default_event_for_date(today)
+        custom_event = await storage.get_daily_event(date_str)
+        event = default_event or custom_event
+        if event is None:
+            raise HTTPException(
+                status_code=422,
+                detail="No event set for today. POST /api/event first.",
+            )
+
+        today_races = await storage.list_races_for_date(date_str)
+        race_num = len(today_races) + 1
+        name = build_race_name(event, today, race_num)
+
+        race = await storage.start_race(event, now, date_str, race_num, name)
+        return JSONResponse(
+            {
+                "id": race.id,
+                "name": race.name,
+                "event": race.event,
+                "race_num": race.race_num,
+                "start_utc": race.start_utc.isoformat(),
+            },
+            status_code=201,
+        )
+
+    # ------------------------------------------------------------------
+    # /api/races/{id}/end
+    # ------------------------------------------------------------------
+
+    @app.post("/api/races/{race_id}/end", status_code=204)
+    async def api_end_race(race_id: int) -> None:
+        now = datetime.now(UTC)
+        await storage.end_race(race_id, now)
+
+    # ------------------------------------------------------------------
+    # /api/races/{id}/export.{fmt}
+    # ------------------------------------------------------------------
+
+    @app.get("/api/races/{race_id}/export.{fmt}")
+    async def api_export_race(race_id: int, fmt: str) -> FileResponse:
+        if fmt not in ("csv", "gpx", "json"):
+            raise HTTPException(status_code=400, detail="fmt must be csv, gpx, or json")
+
+        races = await storage.list_races_for_date(datetime.now(UTC).date().isoformat())
+        # Also search across all dates by fetching by id directly
+        race = None
+        for r in races:
+            if r.id == race_id:
+                race = r
+                break
+
+        if race is None:
+            # Fallback: search all races (no date filter)
+            cur = await storage._conn().execute(
+                "SELECT id, name, event, race_num, date, start_utc, end_utc"
+                " FROM races WHERE id = ?",
+                (race_id,),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                raise HTTPException(status_code=404, detail="Race not found")
+            from datetime import datetime as _dt
+
+            from logger.races import Race
+
+            race = Race(
+                id=row["id"],
+                name=row["name"],
+                event=row["event"],
+                race_num=row["race_num"],
+                date=row["date"],
+                start_utc=_dt.fromisoformat(row["start_utc"]),
+                end_utc=_dt.fromisoformat(row["end_utc"]) if row["end_utc"] else None,
+            )
+
+        if race.end_utc is None:
+            raise HTTPException(status_code=409, detail="Race is still in progress")
+
+        from logger.export import export_to_file
+
+        suffix = f".{fmt}"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+            out_path = f.name
+
+        await export_to_file(storage, race.start_utc, race.end_utc, out_path)
+
+        filename = f"{race.name}.{fmt}"
+        media = {
+            "csv": "text/csv",
+            "gpx": "application/gpx+xml",
+            "json": "application/json",
+        }[fmt]
+        return FileResponse(
+            out_path,
+            media_type=media,
+            filename=filename,
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    # ------------------------------------------------------------------
+    # /api/races
+    # ------------------------------------------------------------------
+
+    @app.get("/api/races")
+    async def api_list_races(date: str | None = None) -> JSONResponse:
+        if date is None:
+            date = datetime.now(UTC).date().isoformat()
+        races = await storage.list_races_for_date(date)
+        result = []
+        for r in races:
+            duration_s: float | None = None
+            if r.end_utc is not None:
+                duration_s = (r.end_utc - r.start_utc).total_seconds()
+            result.append(
+                {
+                    "id": r.id,
+                    "name": r.name,
+                    "event": r.event,
+                    "race_num": r.race_num,
+                    "date": r.date,
+                    "start_utc": r.start_utc.isoformat(),
+                    "end_utc": r.end_utc.isoformat() if r.end_utc else None,
+                    "duration_s": round(duration_s, 1) if duration_s is not None else None,
+                }
+            )
+        return JSONResponse(result)
+
+    return app

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -1,0 +1,116 @@
+"""Tests for race naming logic and storage race/event methods."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from logger.races import build_race_name, default_event_for_date
+
+if TYPE_CHECKING:
+    from logger.storage import Storage
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_default_event_monday() -> None:
+    assert default_event_for_date(date(2025, 8, 11)) == "BallardCup"  # Monday
+
+
+def test_default_event_wednesday() -> None:
+    assert default_event_for_date(date(2025, 8, 13)) == "CYC"  # Wednesday
+
+
+def test_default_event_saturday() -> None:
+    assert default_event_for_date(date(2025, 8, 9)) is None  # Saturday
+
+
+def test_build_race_name() -> None:
+    assert build_race_name("BallardCup", date(2025, 8, 10), 2) == "20250810-BallardCup-2"
+
+
+def test_build_race_name_single_digit() -> None:
+    assert build_race_name("CYC", date(2025, 8, 13), 1) == "20250813-CYC-1"
+
+
+# ---------------------------------------------------------------------------
+# Storage race method tests (use in-memory DB via conftest `storage` fixture)
+# ---------------------------------------------------------------------------
+
+
+_DATE = "2025-08-10"
+_START1 = datetime(2025, 8, 10, 13, 45, 0, tzinfo=UTC)
+_START2 = datetime(2025, 8, 10, 14, 5, 30, tzinfo=UTC)
+_END1 = datetime(2025, 8, 10, 14, 5, 0, tzinfo=UTC)
+_END2 = datetime(2025, 8, 10, 14, 30, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_start_race_closes_previous(storage: Storage) -> None:
+    r1 = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    assert r1.end_utc is None
+
+    # Starting race 2 should close race 1
+    await storage.start_race("BallardCup", _START2, _DATE, 2, "20250810-BallardCup-2")
+
+    races = await storage.list_races_for_date(_DATE)
+    closed = next(r for r in races if r.id == r1.id)
+    assert closed.end_utc is not None
+    assert closed.end_utc == _START2
+
+
+@pytest.mark.asyncio
+async def test_end_race_sets_end_utc(storage: Storage) -> None:
+    race = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    await storage.end_race(race.id, _END1)
+
+    races = await storage.list_races_for_date(_DATE)
+    assert races[0].end_utc == _END1
+
+
+@pytest.mark.asyncio
+async def test_get_current_race_returns_open(storage: Storage) -> None:
+    await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+
+    current = await storage.get_current_race()
+    assert current is not None
+    assert current.name == "20250810-BallardCup-1"
+    assert current.end_utc is None
+
+
+@pytest.mark.asyncio
+async def test_get_current_race_none_when_all_closed(storage: Storage) -> None:
+    race = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    await storage.end_race(race.id, _END1)
+
+    current = await storage.get_current_race()
+    assert current is None
+
+
+@pytest.mark.asyncio
+async def test_list_races_for_date_ordered(storage: Storage) -> None:
+    await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    await storage.start_race("BallardCup", _START2, _DATE, 2, "20250810-BallardCup-2")
+
+    races = await storage.list_races_for_date(_DATE)
+    assert len(races) == 2
+    assert races[0].race_num == 1
+    assert races[1].race_num == 2
+    assert races[0].start_utc < races[1].start_utc
+
+
+@pytest.mark.asyncio
+async def test_daily_event_roundtrip(storage: Storage) -> None:
+    assert await storage.get_daily_event("2025-08-09") is None
+
+    await storage.set_daily_event("2025-08-09", "Regatta")
+    assert await storage.get_daily_event("2025-08-09") == "Regatta"
+
+    # Upsert
+    await storage.set_daily_event("2025-08-09", "Regatta2")
+    assert await storage.get_daily_event("2025-08-09") == "Regatta2"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,24 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -88,6 +106,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -184,6 +214,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.133.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/6f/0eafed8349eea1fa462238b54a624c8b408cd1ba2795c8e64aa6c34f8ab7/fastapi-0.133.1.tar.gz", hash = "sha256:ed152a45912f102592976fde6cbce7dae1a8a1053da94202e51dd35d184fadd6", size = 378741, upload-time = "2026-02-25T18:18:17.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/c9/a175a7779f3599dfa4adfc97a6ce0e157237b3d7941538604aadaf97bfb6/fastapi-0.133.1-py3-none-any.whl", hash = "sha256:658f34ba334605b1617a65adf2ea6461901bdb9af3a3080d63ff791ecf7dc2e2", size = 109029, upload-time = "2026-02-25T18:18:18.578Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -244,12 +290,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "python-can" },
     { name = "python-dotenv" },
     { name = "sounddevice" },
     { name = "soundfile" },
+    { name = "uvicorn" },
     { name = "websockets" },
     { name = "yt-dlp" },
 ]
@@ -266,12 +314,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.22.1" },
+    { name = "fastapi", specifier = ">=0.133.1" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "python-can", specifier = ">=4.4.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "sounddevice", specifier = ">=0.5.5" },
     { name = "soundfile", specifier = ">=0.13.1" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "websockets", specifier = ">=14.0" },
     { name = "yt-dlp", specifier = ">=2024.11.4" },
 ]
@@ -498,6 +548,92 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -633,12 +769,50 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Audio recording** (`src/logger/audio.py`): auto-records from the Gordik 2T1R USB lavalier (or any UAC device) whenever `j105-logger run` is active; WAV files saved to `data/audio/` named by UTC start time
- **Race marker web UI** (`src/logger/web.py`): mobile-optimised page at `http://corvopi:3002` — one-tap Start/End Race with auto race naming (`YYYYMMDD-Event-N`), Mon→BallardCup / Wed→CYC auto-event, custom event name input for other days, per-race CSV/GPX download
- **Schema v7** (`storage.py`): adds `races` and `daily_events` tables; 6 new async storage methods
- **FastAPI + uvicorn** added as dependencies; web server runs as a background task in the same asyncio loop as the rest of the logger

## Test plan

- [ ] `uv run pytest` — 157 tests pass
- [ ] `uv run mypy src/` — clean
- [ ] `uv run ruff check . && ruff format --check .` — clean
- [ ] `j105-logger run` — log shows `Web interface: http://0.0.0.0:3002` and `Audio recording started:`
- [ ] Open `http://corvopi:3002` on phone via Tailscale
- [ ] Monday: event shows "BallardCup" automatically
- [ ] Start Race 1 → status card + duration counter appear
- [ ] Start Race 2 → Race 1 gets end time in history list
- [ ] End Race 2 → next Start shows "Race 3"
- [ ] Non-standard day: event name input appears; custom name persists after restart
- [ ] [↓ CSV] on completed race → browser downloads file
- [ ] Plug in Gordik USB receiver; WAV file appears in `data/audio/` after stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)