### PR TITLE
Add live instrument display to race marker web UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ select = [
 ]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+"src/logger/web.py" = ["E501"]  # HTML strings contain long lines that can't be wrapped
+
 [tool.ruff.lint.isort]
 known-first-party = ["logger"]
 


### PR DESCRIPTION
## Summary

- Adds an instrument card to the race marker page (http://corvopi:3002) showing SOG, COG, HDG, BSP, AWS, AWA, TWS, TWA, and TWD
- New `GET /api/instruments` endpoint backed by `Storage.latest_instruments()` — queries the five instrument tables and returns the most recent reading from each
- TWD is computed server-side as `(heading_deg + twa_deg) % 360`
- Instrument values poll every 2 seconds; UTC clock updates every second inside the existing `tick()` interval

## Test plan

- [ ] `uv run pytest` — 170 tests pass
- [ ] `uv run ruff check . && uv run mypy src/` — clean
- [ ] Open http://corvopi:3002 — instrument card appears above the race controls
- [ ] Values update every 2 seconds while data is flowing from the CAN bus
- [ ] All values show `—` when no instrument data is in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)