### PR TITLE
Live instrument display without active session

### DIFF
--- a/src/logger/main.py
+++ b/src/logger/main.py
@@ -197,6 +197,7 @@ async def _run() -> None:
                     storage_config.db_path,
                 )
                 async for record in SKReader(sk_config):
+                    storage.update_live(record)
                     if storage.session_active:
                         await storage.write(record)
             else:
@@ -213,8 +214,10 @@ async def _run() -> None:
                     pgn = extract_pgn(frame.arbitration_id)
                     src = frame.arbitration_id & 0xFF
                     decoded = decode(pgn, frame.data, src, frame.timestamp)
-                    if decoded is not None and storage.session_active:
-                        await storage.write(decoded)
+                    if decoded is not None:
+                        storage.update_live(decoded)
+                        if storage.session_active:
+                            await storage.write(decoded)
         except asyncio.CancelledError:
             logger.info("Shutdown signal received — flushing and stopping")
         finally:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -269,3 +269,157 @@ class TestSessionGate:
         assert await storage.count_sessions_for_date(_DATE, "race") == 1
         assert await storage.count_sessions_for_date(_DATE, "practice") == 1
         assert await storage.count_sessions_for_date("2025-08-11", "race") == 0
+
+
+# ---------------------------------------------------------------------------
+# Live instrument cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveCache:
+    def test_cache_initially_empty(self, storage: Storage) -> None:
+        result = storage.live_instruments()
+        assert all(v is None for v in result.values())
+
+    def test_update_live_heading(self, storage: Storage) -> None:
+        record = HeadingRecord(
+            pgn=PGN_VESSEL_HEADING,
+            source_addr=5,
+            timestamp=_TS,
+            heading_deg=270.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+        storage.update_live(record)
+        result = storage.live_instruments()
+        assert result["heading_deg"] == 270.0
+
+    def test_update_live_speed(self, storage: Storage) -> None:
+        record = SpeedRecord(
+            pgn=PGN_SPEED_THROUGH_WATER,
+            source_addr=5,
+            timestamp=_TS,
+            speed_kts=6.54,
+        )
+        storage.update_live(record)
+        result = storage.live_instruments()
+        assert result["bsp_kts"] == 6.54
+
+    def test_update_live_cogsog(self, storage: Storage) -> None:
+        record = COGSOGRecord(
+            pgn=PGN_COG_SOG_RAPID,
+            source_addr=5,
+            timestamp=_TS,
+            cog_deg=45.0,
+            sog_kts=7.0,
+        )
+        storage.update_live(record)
+        result = storage.live_instruments()
+        assert result["cog_deg"] == 45.0
+        assert result["sog_kts"] == 7.0
+
+    def test_update_live_apparent_wind(self, storage: Storage) -> None:
+        record = WindRecord(
+            pgn=PGN_WIND_DATA,
+            source_addr=5,
+            timestamp=_TS,
+            wind_speed_kts=12.0,
+            wind_angle_deg=35.0,
+            reference=2,
+        )
+        storage.update_live(record)
+        result = storage.live_instruments()
+        assert result["aws_kts"] == 12.0
+        assert result["awa_deg"] == 35.0
+
+    def test_update_live_true_wind_boat_ref(self, storage: Storage) -> None:
+        """reference=0 (TWA boat-referenced): TWD computed from heading."""
+        hdg = HeadingRecord(
+            pgn=PGN_VESSEL_HEADING,
+            source_addr=5,
+            timestamp=_TS,
+            heading_deg=100.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+        tw = WindRecord(
+            pgn=PGN_WIND_DATA,
+            source_addr=5,
+            timestamp=_TS,
+            wind_speed_kts=10.0,
+            wind_angle_deg=45.0,
+            reference=0,
+        )
+        storage.update_live(hdg)
+        storage.update_live(tw)
+        result = storage.live_instruments()
+        assert result["tws_kts"] == 10.0
+        assert result["twa_deg"] == 45.0
+        assert result["twd_deg"] == 145.0  # (100 + 45) % 360
+
+    def test_update_live_true_wind_north_ref(self, storage: Storage) -> None:
+        """reference=4 (TWD north-referenced): TWA computed from heading."""
+        hdg = HeadingRecord(
+            pgn=PGN_VESSEL_HEADING,
+            source_addr=5,
+            timestamp=_TS,
+            heading_deg=100.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+        tw = WindRecord(
+            pgn=PGN_WIND_DATA,
+            source_addr=5,
+            timestamp=_TS,
+            wind_speed_kts=10.0,
+            wind_angle_deg=145.0,
+            reference=4,
+        )
+        storage.update_live(hdg)
+        storage.update_live(tw)
+        result = storage.live_instruments()
+        assert result["tws_kts"] == 10.0
+        assert result["twd_deg"] == 145.0
+        assert result["twa_deg"] == 45.0  # (145 - 100 + 360) % 360
+
+    def test_update_live_twa_no_heading(self, storage: Storage) -> None:
+        """TWD is None when heading unavailable and reference=0."""
+        tw = WindRecord(
+            pgn=PGN_WIND_DATA,
+            source_addr=5,
+            timestamp=_TS,
+            wind_speed_kts=10.0,
+            wind_angle_deg=45.0,
+            reference=0,
+        )
+        storage.update_live(tw)
+        result = storage.live_instruments()
+        assert result["twa_deg"] == 45.0
+        assert result["twd_deg"] is None
+
+    async def test_latest_instruments_uses_live_cache(self, storage: Storage) -> None:
+        """latest_instruments() returns live values when cache is populated."""
+        record = SpeedRecord(
+            pgn=PGN_SPEED_THROUGH_WATER,
+            source_addr=5,
+            timestamp=_TS,
+            speed_kts=8.5,
+        )
+        storage.update_live(record)
+        result = await storage.latest_instruments()
+        assert result["bsp_kts"] == 8.5
+
+    async def test_latest_instruments_db_fallback_when_cache_empty(
+        self, storage: Storage
+    ) -> None:
+        """latest_instruments() falls back to DB when cache is entirely empty."""
+        record = SpeedRecord(
+            pgn=PGN_SPEED_THROUGH_WATER,
+            source_addr=5,
+            timestamp=_TS,
+            speed_kts=4.2,
+        )
+        await storage.write(record)
+        result = await storage.latest_instruments()
+        assert result["bsp_kts"] is not None
+        assert abs(result["bsp_kts"] - 4.2) < 0.01


### PR DESCRIPTION
## Summary

- **Fix TWS/TWA/TWD not displaying**: handle all Signal K true wind paths (reference 0, 2, and 4) in `sk_reader.py`
- **Always-live instruments panel**: instruments in the web UI now update in real time even when no race or practice session is active

## How it works

Added an in-memory `_live` cache to `Storage` that is updated on every incoming SK (or CAN) record unconditionally — before the `session_active` gate that controls DB writes. `latest_instruments()` returns this cache when populated, falling back to DB queries only on startup before the first message arrives.

DB writes, exports, and schema are unchanged.

## Test plan

- [ ] Open web UI at http://corvopi:3002 without starting a session — instruments should update every 2s
- [ ] Start a race — instruments continue updating; DB records data
- [ ] End the race — instruments stay live (don't freeze on last session value)
- [ ] 28 unit tests all pass (`uv run pytest tests/test_storage.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)