### PR TITLE
Add Grafana sailing dashboard and web UI links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,15 +2,18 @@ CAN_INTERFACE=can0
 CAN_BITRATE=250000
 DB_PATH=data/logger.db
 LOG_LEVEL=INFO
-DATA_SOURCE=signalk     # signalk (default) or can
-SK_HOST=localhost        # Signal K server hostname
-SK_PORT=3000             # Signal K WebSocket port
+DATA_SOURCE=signalk
+SK_HOST=localhost
+SK_PORT=3000
 # Audio recording (Gordik 2T1R or any USB Audio Class device)
-# AUDIO_DEVICE=Gordik   # name substring or integer index; omit to auto-detect first input
-AUDIO_DIR=data/audio    # directory for WAV files
+# AUDIO_DEVICE=Gordik
+AUDIO_DIR=data/audio
 AUDIO_SAMPLE_RATE=48000
 AUDIO_CHANNELS=1
 # Web interface (race marker)
-WEB_HOST=0.0.0.0        # bind address for the web interface
-WEB_PORT=3002           # http://corvopi:3002 on Tailscale
-# WEB_PIN=             # optional PIN for Layer 2 auth (not yet implemented)
+WEB_HOST=0.0.0.0
+WEB_PORT=3002
+# WEB_PIN=
+# Grafana dashboard links
+GRAFANA_URL=http://corvopi:3001
+GRAFANA_DASHBOARD_UID=j105-sailing

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Raspberry Pi with a CAN bus HAT connected to the B&G instrument network. Signal 
 Server decodes the NMEA 2000 bus and feeds both InfluxDB → Grafana (real-time
 dashboards) and j105-logger (SQLite → CSV/GPX/JSON for regatta analysis tools).
 
+Two Signal K plugins are required:
+- **signalk-to-influxdb2** — forwards all SK data to InfluxDB for Grafana dashboards
+- **@signalk/derived-data** — computes true wind (TWS/TWA/TWD) from apparent wind + boatspeed + heading; without this, true wind fields will be empty in the logger and exports
+
 ---
 
 ## Architecture
@@ -541,7 +545,7 @@ This script is fully idempotent — safe to re-run after updates. It installs an
 configures:
 
 1. Node.js 24 LTS (via NodeSource)
-2. Signal K Server + signalk-to-influxdb2 plugin
+2. Signal K Server + plugins (`signalk-to-influxdb2`, `@signalk/derived-data`)
 3. InfluxDB 2.7.11 (pinned; `apt-mark hold` prevents v3 auto-upgrade)
 4. Grafana OSS (pre-provisioned InfluxDB datasource, port 3001)
 5. `uv` and all Python dependencies

--- a/scripts/grafana/dashboards.yaml
+++ b/scripts/grafana/dashboards.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: J105 Logger
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/scripts/grafana/sailing-data.json
+++ b/scripts/grafana/sailing-data.json
@@ -1,0 +1,327 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.4.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "J105 sailboat performance data from Signal K via InfluxDB",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "velocityknot"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"navigation.speedThroughWater\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 1.94384}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"BSP\")",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"navigation.speedOverGround\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 1.94384}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"SOG\")",
+          "refId": "B"
+        }
+      ],
+      "title": "Boatspeed & SOG",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "velocityknot"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"environment.wind.speedTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 1.94384}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"TWS\")",
+          "refId": "A"
+        }
+      ],
+      "title": "True Wind Speed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"environment.wind.angleTrueWater\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 57.29578}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"TWA\")",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"environment.wind.directionTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 57.29578}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"TWD\")",
+          "refId": "B"
+        }
+      ],
+      "title": "True Wind Angle & Direction",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "velocityknot"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "AWA" },
+            "properties": [
+              { "id": "unit", "value": "degree" },
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"environment.wind.speedApparent\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 1.94384}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"AWS\")",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"environment.wind.angleApparent\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 57.29578}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"AWA\")",
+          "refId": "B"
+        }
+      ],
+      "title": "Apparent Wind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "max": 360,
+          "min": 0,
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"navigation.headingTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 57.29578}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"HDG\")",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"navigation.courseOverGroundTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> map(fn: (r) => ({r with _value: r._value * 57.29578}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"COG\")",
+          "refId": "B"
+        }
+      ],
+      "title": "Heading & COG",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": ["sailing", "j105"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_INFLUXDB",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Sailing Data",
+  "uid": "j105-sailing",
+  "version": 1
+}

--- a/scripts/provision-grafana.sh
+++ b/scripts/provision-grafana.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# provision-grafana.sh — Deploy sailing dashboard and enable anonymous access.
+# Idempotent: safe to run multiple times.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DASHBOARD_SRC="$SCRIPT_DIR/grafana/sailing-data.json"
+PROVISION_SRC="$SCRIPT_DIR/grafana/dashboards.yaml"
+
+DASHBOARD_DEST_DIR="/var/lib/grafana/dashboards"
+PROVISION_DEST="/etc/grafana/provisioning/dashboards/j105-logger.yaml"
+GRAFANA_INI="/etc/grafana/grafana.ini"
+
+echo "==> Creating dashboard directory: $DASHBOARD_DEST_DIR"
+sudo mkdir -p "$DASHBOARD_DEST_DIR"
+
+echo "==> Copying dashboard JSON"
+sudo cp "$DASHBOARD_SRC" "$DASHBOARD_DEST_DIR/sailing-data.json"
+
+echo "==> Copying provisioning config"
+sudo cp "$PROVISION_SRC" "$PROVISION_DEST"
+
+echo "==> Enabling anonymous access in $GRAFANA_INI"
+# Insert/update the [auth.anonymous] section.
+# If the section already exists, update enabled and org_role.
+# If not, append the section at the end.
+if sudo grep -q '^\[auth\.anonymous\]' "$GRAFANA_INI"; then
+  # Section exists — update or insert the two keys inside it
+  sudo python3 - "$GRAFANA_INI" <<'PYEOF'
+import sys, re
+
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+
+# Split into sections
+sections = re.split(r'(?=^\[)', text, flags=re.MULTILINE)
+out = []
+for sec in sections:
+    if sec.startswith('[auth.anonymous]'):
+        # Ensure enabled = true
+        if re.search(r'^enabled\s*=', sec, re.MULTILINE):
+            sec = re.sub(r'^(enabled\s*=\s*).*$', r'\1true', sec, flags=re.MULTILINE)
+        else:
+            sec = sec.rstrip('\n') + '\nenabled = true\n'
+        # Ensure org_role = Viewer
+        if re.search(r'^org_role\s*=', sec, re.MULTILINE):
+            sec = re.sub(r'^(org_role\s*=\s*).*$', r'\1Viewer', sec, flags=re.MULTILINE)
+        else:
+            sec = sec.rstrip('\n') + '\norg_role = Viewer\n'
+    out.append(sec)
+
+with open(path, 'w') as f:
+    f.write(''.join(out))
+print("  grafana.ini updated (section existed)")
+PYEOF
+else
+  # Section does not exist — append it
+  printf '\n[auth.anonymous]\nenabled = true\norg_role = Viewer\n' | sudo tee -a "$GRAFANA_INI" > /dev/null
+  echo "  grafana.ini updated (section appended)"
+fi
+
+echo "==> Restarting grafana-server"
+sudo systemctl restart grafana-server
+
+echo ""
+echo "Done. Dashboard available at http://$(hostname):3001/d/j105-sailing/sailing-data"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -77,7 +77,8 @@ if [[ ! -f "$HOME/.signalk/settings.json" ]]; then
     "id": "n2k-canbus",
     "pipeElements": [
       { "type": "providers/canbus", "options": { "canDevice": "can0" } },
-      { "type": "providers/canboatjs", "options": {} }
+      { "type": "providers/canboatjs", "options": {} },
+      { "type": "providers/n2k-signalk", "options": {} }
     ],
     "enabled": true
   }],
@@ -88,13 +89,16 @@ else
     info "~/.signalk/settings.json already exists — skipping."
 fi
 
-# Install signalk-to-influxdb2 plugin
-info "Installing signalk-to-influxdb2 plugin..."
+# Install Signal K plugins
+info "Installing Signal K plugins..."
 cat > "$HOME/.signalk/package.json" << 'EOF'
 {
   "name": "signalk-server-config",
   "version": "1.0.0",
-  "dependencies": { "signalk-to-influxdb2": "*" }
+  "dependencies": {
+    "signalk-to-influxdb2": "*",
+    "@signalk/derived-data": "*"
+  }
 }
 EOF
 (cd "$HOME/.signalk" && npm install --silent)

--- a/src/logger/races.py
+++ b/src/logger/races.py
@@ -44,6 +44,12 @@ class RaceConfig:
 
     web_host: str = field(default_factory=lambda: os.environ.get("WEB_HOST", "0.0.0.0"))
     web_port: int = field(default_factory=lambda: int(os.environ.get("WEB_PORT", "3002")))
+    grafana_url: str = field(
+        default_factory=lambda: os.environ.get("GRAFANA_URL", "http://corvopi:3001")
+    )
+    grafana_uid: str = field(
+        default_factory=lambda: os.environ.get("GRAFANA_DASHBOARD_UID", "j105-sailing")
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from logger.races import build_race_name, default_event_for_date
+from logger.races import RaceConfig, build_race_name, default_event_for_date
 
 if TYPE_CHECKING:
     from logger.storage import Storage
@@ -16,6 +16,22 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Pure function tests (no DB needed)
 # ---------------------------------------------------------------------------
+
+
+def test_race_config_grafana_defaults() -> None:
+    """RaceConfig has sensible defaults for Grafana fields."""
+    cfg = RaceConfig()
+    assert cfg.grafana_url == "http://corvopi:3001"
+    assert cfg.grafana_uid == "j105-sailing"
+
+
+def test_race_config_grafana_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RaceConfig reads Grafana fields from environment variables."""
+    monkeypatch.setenv("GRAFANA_URL", "http://myhost:3001")
+    monkeypatch.setenv("GRAFANA_DASHBOARD_UID", "custom-uid")
+    cfg = RaceConfig()
+    assert cfg.grafana_url == "http://myhost:3001"
+    assert cfg.grafana_uid == "custom-uid"
 
 
 def test_default_event_monday() -> None:


### PR DESCRIPTION
## Summary

- **Grafana dashboard** (`scripts/grafana/sailing-data.json`): provisioned 5-panel sailing dashboard (UID `j105-sailing`) — BSP/SOG, TWS, TWA/TWD, apparent wind, heading/COG; Flux queries with unit conversions (m/s → kts, rad → °)
- **Provisioning config** (`scripts/grafana/dashboards.yaml`): file provider watching `/var/lib/grafana/dashboards/`
- **Deploy script** (`scripts/provision-grafana.sh`): idempotent — copies files, enables anonymous Viewer access in `grafana.ini`, restarts Grafana
- **`races.py`**: added `grafana_url` / `grafana_uid` fields to `RaceConfig` (env vars `GRAFANA_URL`, `GRAFANA_DASHBOARD_UID`)
- **`web.py`**: header "📊 Grafana" button + per-race time-scoped "📊 Grafana" / "📊 Live" links; amber `btn-grafana` CSS; URL/UID baked in at `create_app()` time
- **README + setup.sh**: document and install `@signalk/derived-data` plugin required for true wind computation

## Test plan

- [ ] `uv run pytest` — all 190 tests pass
- [ ] `bash scripts/provision-grafana.sh` — deploys dashboard, returns HTTP 200
- [ ] `http://corvopi:3001/d/j105-sailing/sailing-data` — dashboard visible without login
- [ ] `http://corvopi:3002` — header shows "📊 Grafana" link; each race shows "📊 Grafana" or "📊 Live" button
- [ ] Clicking a completed race Grafana button opens dashboard scoped to that race's time range

🤖 Generated with [Claude Code](https://claude.com/claude-code)