### PR TITLE
Add Mac development workflow and Pi deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# deploy.sh — Pull latest code from main and restart the logger service.
+#
+# Run this on the Raspberry Pi after merging a PR to main. Covers the
+# common case: code-only changes with no new system dependencies or
+# service file modifications.
+#
+# If pyproject.toml changed (new deps) or systemd service files changed,
+# run the full idempotent setup instead:
+#   ./scripts/setup.sh && sudo systemctl daemon-reload
+#
+# Usage: ./scripts/deploy.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+echo "==> Pulling latest from main..."
+git checkout main
+git pull origin main
+
+echo "==> Syncing Python dependencies..."
+uv sync
+
+echo "==> Restarting j105-logger service..."
+sudo systemctl restart j105-logger
+
+echo ""
+echo "==> Deploy complete."
+sudo systemctl status j105-logger --no-pager -l


### PR DESCRIPTION
## Summary

- **`scripts/deploy.sh`** — new lightweight Pi deploy script: `git pull main` → `uv sync` → `systemctl restart j105-logger`. Use this after every PR merge instead of re-running the full `setup.sh`.
- **`CLAUDE.md`** — new *Development Workflow* section covering Mac one-time setup, daily dev loop (pytest, ruff, mypy), PR workflow, and Pi deploy steps.
- **`README.md`** — new *Mac development* section (one-time setup, dev loop, PR workflow); *Updating* section split into *Normal deploy* (deploy.sh) vs *Full update* (setup.sh) paths.

## Test plan

- [ ] `uv run pytest` passes locally (254 tests, confirmed green)
- [ ] `uv run python -m logger.main run` starts and http://localhost:3002 responds
- [ ] `scripts/deploy.sh` is executable and runs cleanly on the Pi after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)