### PR TITLE
Add settings and photo notes (issue #23, phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ AUDIO_DEVICE=Gordik         # name substring to match (or integer index); omit t
 AUDIO_DIR=data/audio        # where WAV files are saved
 AUDIO_SAMPLE_RATE=48000     # sample rate in Hz
 AUDIO_CHANNELS=1            # 1=mono, 2=stereo
+NOTES_DIR=data/notes        # where photo notes are saved
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "soundfile>=0.13.1",
     "fastapi>=0.133.1",
     "uvicorn>=0.41.0",
+    "python-multipart>=0.0.22",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,7 @@ dependencies = [
     { name = "loguru" },
     { name = "python-can" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "sounddevice" },
     { name = "soundfile" },
     { name = "uvicorn" },
@@ -319,6 +320,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "python-can", specifier = ">=4.4.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "sounddevice", specifier = ">=0.5.5" },
     { name = "soundfile", specifier = ">=0.13.1" },
     { name = "uvicorn", specifier = ">=0.41.0" },
@@ -706,6 +708,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #23 (phase 2)

## Summary
- **Settings notes**: tabbed note panel → Settings tab lets sailors record key/value pairs (e.g. `TWS: 15`, `Sail: A3`); body stored as JSON, rendered inline as `Key: Value · Key: Value`
- **Photo notes**: Photo tab triggers camera/file picker; image uploaded via `POST /api/sessions/{id}/notes/photo`, saved to `NOTES_DIR/{session_id}/`, thumbnail shown inline in race card and history page
- **Serve endpoint**: `GET /notes/{path:path}` serves saved photos with path-traversal protection (403 on escape attempt)
- `python-multipart` dep added (required by FastAPI for `UploadFile`/`Form`)

## Test plan
- [x] `test_create_settings_note_returns_201` — valid JSON body → 201
- [x] `test_create_settings_note_invalid_json_returns_422` — non-JSON body → 422
- [x] `test_create_photo_note_returns_201` — multipart upload → 201, file on disk
- [x] `test_serve_note_photo_returns_200` — GET existing file → 200
- [x] `test_serve_note_photo_traversal_blocked` — path traversal → 403/404
- [x] Full suite: 259 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)