### PR TITLE
fix(#36): pre-populate boat picker cache after each result entry

### DIFF
--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -679,6 +679,11 @@ async function selectBoat(raceId, boatId) {
   if (dd) dd.style.display = 'none';
   delete _pickerBoats[raceId];
   await refreshResults(raceId);
+  // Pre-populate the boat cache immediately so the next entry works without
+  // requiring a focus event. On mobile, the input may retain focus after
+  // selection so onfocus never re-fires — openPicker here ensures filterBoats
+  // has boats to display when the user starts typing the next entry (#36).
+  openPicker(raceId);
 }
 
 async function selectNewBoat(raceId, sailNumber) {
@@ -694,6 +699,8 @@ async function selectNewBoat(raceId, sailNumber) {
   if (dd) dd.style.display = 'none';
   delete _pickerBoats[raceId];
   await refreshResults(raceId);
+  // Same fix as selectBoat — pre-populate cache for the next entry (#36).
+  openPicker(raceId);
 }
 
 async function toggleResultFlag(raceId, place, boatId, dnf, dns) {


### PR DESCRIPTION
## Summary

- After selecting a boat from the picker, the input field retains focus on mobile (because `onmousedown="event.preventDefault()"` prevents the blur that would normally fire before a tap registers)
- Since the input already has focus, `onfocus` never re-fires when the user taps it or starts typing the next entry — so `openPicker()` is never called, `_pickerBoats[raceId]` stays `undefined`, and `filterBoats()` does nothing
- On desktop users could work around it by clicking away and back; on mobile there was no workaround

## Fix

Call `openPicker(raceId)` at the end of both `selectBoat()` and `selectNewBoat()`. This kicks off the async boat-list fetch immediately after each selection so the cache is populated before the user starts typing the next entry.

## Test plan

- [ ] Enter multiple race results back-to-back on mobile — each subsequent entry should show the dropdown as soon as you start typing
- [ ] Verify the same on desktop
- [ ] `uv run pytest` passes (259 tests)

Closes #36 (second part — first part landed in #45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)