### PR TITLE
feat(#35): add build_grafana_url() utility + tests

### DIFF
--- a/src/logger/races.py
+++ b/src/logger/races.py
@@ -82,3 +82,34 @@ def build_race_name(event: str, d: date, race_num: int, session_type: str = "rac
     """
     num_str = f"P{race_num}" if session_type == "practice" else str(race_num)
     return f"{d.strftime('%Y%m%d')}-{event}-{num_str}"
+
+
+def build_grafana_url(
+    base_url: str,
+    uid: str,
+    start_ms: int,
+    end_ms: int | None,
+    *,
+    org_id: int = 1,
+) -> str:
+    """Build a Grafana deep-link URL for a session.
+
+    For an active session (*end_ms* is ``None``) the URL includes
+    ``refresh=10s`` so the dashboard auto-refreshes while the race is live.
+    For a closed session (*end_ms* is set) the URL includes ``refresh=``
+    (empty string) to disable auto-refresh.
+
+    Example::
+
+        # Closed session
+        build_grafana_url("http://host:3001", "j105", 1700000000000, 1700003600000)
+        # → "http://host:3001/d/j105/sailing-data?from=1700000000000&to=1700003600000&orgId=1&refresh="
+
+        # Active session
+        build_grafana_url("http://host:3001", "j105", 1700000000000, None)
+        # → "http://host:3001/d/j105/sailing-data?from=1700000000000&to=now&orgId=1&refresh=10s"
+    """
+    to = str(end_ms) if end_ms is not None else "now"
+    refresh = "" if end_ms is not None else "10s"
+    path = f"/d/{uid}/sailing-data?from={start_ms}&to={to}&orgId={org_id}&refresh={refresh}"
+    return f"{base_url}{path}"


### PR DESCRIPTION
## Summary

The web.py refresh behaviour (disabled for closed sessions, 10s for live) landed in main via #33. This PR closes out the remaining item from #35: a tested utility function in `races.py` that centralises Grafana URL construction.

- **`races.py`** — new `build_grafana_url(base_url, uid, start_ms, end_ms, *, org_id)`:
  - Closed session → `&refresh=` (auto-refresh off)
  - Active session → `&to=now&refresh=10s` (live updates)
- **`tests/test_races.py`** — 3 unit tests: closed session, active session, custom `org_id`

## Test plan

- [ ] `uv run pytest` passes (262 tests, +3 new)
- [ ] `uv run mypy src/` clean

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)