### PR TITLE
feat(#21,#44): audio download/stream + photo caching

### DIFF
--- a/src/logger/storage.py
+++ b/src/logger/storage.py
@@ -829,6 +829,16 @@ class Storage:
         await db.commit()
         logger.debug("Audio session {} end_utc updated", session_id)
 
+    async def get_audio_session_row(self, session_id: int) -> dict[str, Any] | None:
+        """Return a single audio_sessions row as a dict, or None if not found."""
+        cur = await self._conn().execute(
+            "SELECT id, file_path, device_name, start_utc, end_utc, sample_rate, channels"
+            " FROM audio_sessions WHERE id = ?",
+            (session_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
     async def list_audio_sessions(self) -> list[AudioSession]:
         """Return all audio sessions ordered by start_utc descending."""
         from datetime import datetime as _datetime


### PR DESCRIPTION
## Summary

- **#21**: `GET /api/audio/{id}/download` and `/stream` endpoints — WAV download and seekable in-browser playback; inline `<audio>` player added to history page session cards
- **#44**: ETag + `Cache-Control: immutable` on `/notes/{path}` photos; `loading="lazy"` on all note photo `<img>` tags; 304 Not Modified short-circuit

## Storage change
- `Storage.get_audio_session_row()` — look up a single audio session by id

## Test plan
- [ ] `test_download_audio_404_unknown_session` — 404 on unknown session
- [ ] `test_download_audio_404_missing_file` — 404 when DB row exists but file is gone
- [ ] `test_download_audio_200` — 200, `Content-Disposition: attachment`
- [ ] `test_stream_audio_200` — 200, `content-type: audio/wav`
- [ ] `test_serve_note_photo_cache_headers` — `Cache-Control` + `ETag` present
- [ ] `test_serve_note_photo_304_if_none_match` — 304 on matching ETag
- [ ] `test_serve_note_photo_403_traversal` — traversal attempt handled
- [ ] `test_serve_note_photo_404` — missing file → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)