### PR TITLE
feat(#18): race track Geomap panel in Grafana

### DIFF
--- a/docs/grafana-race-track.md
+++ b/docs/grafana-race-track.md
@@ -1,0 +1,103 @@
+# Grafana — Race Track Panel
+
+The **Race Track** panel in the `Sailing Data` dashboard shows the GPS track for
+the current time window as a coloured route on a map.
+
+---
+
+## What it shows
+
+| Element | Source |
+|---|---|
+| Track line | `navigation.position.latitude/longitude` — aggregated to 5 s |
+| Line colour | Boatspeed through water (`navigation.speedThroughWater`) |
+| Tooltip | BSP (kts), TWS (kts), TWA (°), TWD (°) at each point |
+| Click action | Opens the linked YouTube video at that exact timestamp |
+
+### Speed colour scale
+
+| Colour | Speed |
+|---|---|
+| Blue | < 4 kts |
+| Green | 4–6 kts |
+| Yellow | 6–8 kts |
+| Red | > 8 kts |
+
+---
+
+## Data source
+
+All data comes from InfluxDB (`signalk` bucket) via the Signal K →
+`signalk-to-influxdb2` plugin. No additional j105-logger endpoints are used.
+
+The Flux query joins six Signal K paths using `pivot`:
+
+| Signal K path | Field | Conversion |
+|---|---|---|
+| `navigation.position.latitude` | `latitude` | — |
+| `navigation.position.longitude` | `longitude` | — |
+| `navigation.speedThroughWater` | `BSP (kts)` | ×1.94384 (m/s → kts) |
+| `environment.wind.speedTrue` | `TWS (kts)` | ×1.94384 (m/s → kts) |
+| `environment.wind.angleTrueWater` | `TWA (°)` | ×57.29578 (rad → °) |
+| `environment.wind.directionTrue` | `TWD (°)` | ×57.29578 (rad → °) |
+
+Data is aggregated to 5-second windows (`fn: last`) before pivoting.
+Rows without a GPS position are filtered out.
+
+---
+
+## YouTube deep-link
+
+Clicking a track point opens the linked video at that moment using the existing
+`/api/videos/redirect?at=<ISO 8601>` endpoint (same as the time-series panels).
+The link is only functional when a video has been linked to the race via the
+History page or `j105-logger link-video`.
+
+---
+
+## Grafana requirements
+
+- **Panel type**: Geomap (built-in since Grafana 9 — no plugin required)
+- **Datasource**: InfluxDB 2.x with Flux query language
+- **Grafana version**: 12.4.0+ (tested); should work on 10+
+
+---
+
+## Deploying the updated dashboard
+
+The dashboard JSON is provisioned automatically by `scripts/provision-grafana.sh`.
+After a deploy, re-run the provision script on the Pi:
+
+```bash
+ssh weaties@corvopi
+cd ~/j105-logger
+./scripts/provision-grafana.sh
+```
+
+Or restart Grafana to pick up the new JSON from the provisioning directory:
+
+```bash
+sudo systemctl restart grafana-server
+```
+
+---
+
+## Troubleshooting
+
+**Track is empty / no data**
+- Check the time range includes a session where GPS was active.
+- Verify `navigation.position.latitude` exists in InfluxDB:
+  ```
+  influx query 'from(bucket:"signalk") |> range(start:-1h) |> filter(fn:(r) => r._measurement == "navigation.position.latitude") |> limit(n:5)'
+  ```
+- If the query returns nothing, the GPS source (Signal K path `navigation.position`)
+  may not be enabled in the `signalk-to-influxdb2` plugin — check its filter
+  settings in the Signal K admin panel.
+
+**Track shows but has no colour**
+- Speed data may not be present in the selected time range.
+- The route will render in the default blue if `BSP (kts)` is null for all points.
+
+**Map tiles don't load**
+- The Pi needs internet access to fetch OpenStreetMap tiles.
+- Grafana caches tiles; the map still renders the route offline after initial load.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ Checked items are complete.
       (`admin` / `crew` / `viewer`), session cookies in SQLite, HTTPS deployment guide
       (Caddy / Cloudflare Tunnel / Tailscale Funnel).
 
-- [ ] **Grafana race track panel** (#18) — Geomap panel with speed-coloured GPS track,
+- [x] **Grafana race track panel** (#18) — Geomap panel with speed-coloured GPS track,
       wind tooltip, and YouTube deep-link per track point.
 
 - [ ] **External SSD** (#19) — mount at `/mnt/ssd`, relocate SQLite + audio + InfluxDB data,

--- a/scripts/grafana/sailing-data.json
+++ b/scripts/grafana/sailing-data.json
@@ -27,6 +27,12 @@
       "id": "timeseries",
       "name": "Time series",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "geomap",
+      "name": "Geomap",
+      "version": ""
     }
   ],
   "annotations": {
@@ -544,6 +550,119 @@
       ],
       "title": "Heading & COG",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "GPS track coloured by boatspeed. Tooltip shows BSP, TWS, TWA, TWD. Click any point to jump to that moment in the linked YouTube video.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#6495ed", "value": null },
+              { "color": "#86efac", "value": 4 },
+              { "color": "#fde68a", "value": 6 },
+              { "color": "#fca5a5", "value": 8 }
+            ]
+          },
+          "links": [
+            {
+              "title": "Watch Video at this moment",
+              "url": "${logger_url}/api/videos/redirect?at=${__value.time:date:iso}",
+              "targetBlank": true
+            }
+          ]
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "latitude" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": false, "viz": false } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "longitude" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": false, "viz": false } }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "style": {
+                "color": {
+                  "field": "BSP (kts)",
+                  "fixed": "#6495ed"
+                },
+                "lineWidth": 3,
+                "opacity": 0.85
+              }
+            },
+            "location": {
+              "mode": "auto"
+            },
+            "name": "Track",
+            "tooltip": true,
+            "type": "route"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "allLayers": true,
+          "id": "fit",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 5
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>\n      r[\"_measurement\"] == \"navigation.position.latitude\" or\n      r[\"_measurement\"] == \"navigation.position.longitude\" or\n      r[\"_measurement\"] == \"navigation.speedThroughWater\" or\n      r[\"_measurement\"] == \"environment.wind.speedTrue\" or\n      r[\"_measurement\"] == \"environment.wind.angleTrueWater\" or\n      r[\"_measurement\"] == \"environment.wind.directionTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> drop(columns: [\"context\", \"self\"])\n  |> aggregateWindow(every: 5s, fn: last, createEmpty: false)\n  |> drop(columns: [\"_field\", \"_start\", \"_stop\"])\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_measurement\"], valueColumn: \"_value\")\n  |> rename(columns: {\n      \"navigation.position.latitude\":    \"latitude\",\n      \"navigation.position.longitude\":   \"longitude\",\n      \"navigation.speedThroughWater\":    \"bsp_ms\",\n      \"environment.wind.speedTrue\":      \"tws_ms\",\n      \"environment.wind.angleTrueWater\": \"twa_rad\",\n      \"environment.wind.directionTrue\":  \"twd_rad\"})\n  |> map(fn: (r) => ({r with\n      \"BSP (kts)\": if exists r.bsp_ms  then r.bsp_ms  * 1.94384  else 0.0,\n      \"TWS (kts)\": if exists r.tws_ms  then r.tws_ms  * 1.94384  else 0.0,\n      \"TWA (\u00b0)\":   if exists r.twa_rad then r.twa_rad * 57.29578 else 0.0,\n      \"TWD (\u00b0)\":   if exists r.twd_rad then r.twd_rad * 57.29578 else 0.0}))\n  |> drop(columns: [\"bsp_ms\", \"tws_ms\", \"twa_rad\", \"twd_rad\"])\n  |> filter(fn: (r) => exists r.latitude and exists r.longitude)",
+          "refId": "A"
+        }
+      ],
+      "title": "Race Track",
+      "type": "geomap"
     }
   ],
   "refresh": "",
@@ -593,5 +712,5 @@
   "timezone": "browser",
   "title": "Sailing Data",
   "uid": "j105-sailing",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Summary

Adds a **Race Track** Geomap panel to the provisioned Grafana `Sailing Data` dashboard.

### Changes
- **Grafana dashboard** (`scripts/grafana/sailing-data.json`): new Geomap panel with a speed-coloured GPS route layer, wind tooltip (BSP, TWS, TWA, TWD), and a YouTube deep-link per track point
- **Docs** (`docs/grafana-race-track.md`): panel guide covering data source, colour scale, deployment, and troubleshooting
- **Roadmap** (`docs/roadmap.md`): marked #18 complete

### Acceptance criteria (from #18)
- [x] Geomap panel added to the provisioned dashboard JSON
- [x] Track line coloured by BSP with threshold scale (blue < 4 kts, green 4–6, yellow 6–8, red 8+)
- [x] Hover tooltip displays BSP, TWS, TWA, TWD
- [x] Data link opens YouTube video at the correct timestamp via `/api/videos/redirect?at=`
- [x] Panel scoped to dashboard time range

Closes #18