### PR TITLE
fix: correct Race Track panel query for navigation.position schema

### DIFF
--- a/scripts/grafana/sailing-data.json
+++ b/scripts/grafana/sailing-data.json
@@ -572,10 +572,22 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "#6495ed", "value": null },
-              { "color": "#86efac", "value": 4 },
-              { "color": "#fde68a", "value": 6 },
-              { "color": "#fca5a5", "value": 8 }
+              {
+                "color": "#6495ed",
+                "value": null
+              },
+              {
+                "color": "#86efac",
+                "value": 4
+              },
+              {
+                "color": "#fde68a",
+                "value": 6
+              },
+              {
+                "color": "#fca5a5",
+                "value": 8
+              }
             ]
           },
           "links": [
@@ -588,15 +600,35 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "latitude" },
+            "matcher": {
+              "id": "byName",
+              "options": "latitude"
+            },
             "properties": [
-              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": false, "viz": false } }
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "longitude" },
+            "matcher": {
+              "id": "byName",
+              "options": "longitude"
+            },
             "properties": [
-              { "id": "custom.hideFrom", "value": { "legend": true, "tooltip": false, "viz": false } }
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
             ]
           }
         ]
@@ -657,7 +689,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>\n      r[\"_measurement\"] == \"navigation.position.latitude\" or\n      r[\"_measurement\"] == \"navigation.position.longitude\" or\n      r[\"_measurement\"] == \"navigation.speedThroughWater\" or\n      r[\"_measurement\"] == \"environment.wind.speedTrue\" or\n      r[\"_measurement\"] == \"environment.wind.angleTrueWater\" or\n      r[\"_measurement\"] == \"environment.wind.directionTrue\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> drop(columns: [\"context\", \"self\"])\n  |> aggregateWindow(every: 5s, fn: last, createEmpty: false)\n  |> drop(columns: [\"_field\", \"_start\", \"_stop\"])\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_measurement\"], valueColumn: \"_value\")\n  |> rename(columns: {\n      \"navigation.position.latitude\":    \"latitude\",\n      \"navigation.position.longitude\":   \"longitude\",\n      \"navigation.speedThroughWater\":    \"bsp_ms\",\n      \"environment.wind.speedTrue\":      \"tws_ms\",\n      \"environment.wind.angleTrueWater\": \"twa_rad\",\n      \"environment.wind.directionTrue\":  \"twd_rad\"})\n  |> map(fn: (r) => ({r with\n      \"BSP (kts)\": if exists r.bsp_ms  then r.bsp_ms  * 1.94384  else 0.0,\n      \"TWS (kts)\": if exists r.tws_ms  then r.tws_ms  * 1.94384  else 0.0,\n      \"TWA (\u00b0)\":   if exists r.twa_rad then r.twa_rad * 57.29578 else 0.0,\n      \"TWD (\u00b0)\":   if exists r.twd_rad then r.twd_rad * 57.29578 else 0.0}))\n  |> drop(columns: [\"bsp_ms\", \"tws_ms\", \"twa_rad\", \"twd_rad\"])\n  |> filter(fn: (r) => exists r.latitude and exists r.longitude)",
+          "query": "pos_lat = from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"navigation.position\" and r._field == \"lat\")\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\", \"_start\", \"_stop\"])\n  |> set(key: \"_measurement\", value: \"navigation.position.latitude\")\n  |> set(key: \"_field\", value: \"value\")\n\npos_lon = from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"navigation.position\" and r._field == \"lon\")\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\", \"_start\", \"_stop\"])\n  |> set(key: \"_measurement\", value: \"navigation.position.longitude\")\n  |> set(key: \"_field\", value: \"value\")\n\nother = from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>\n      r._measurement == \"navigation.speedThroughWater\" or\n      r._measurement == \"environment.wind.speedTrue\" or\n      r._measurement == \"environment.wind.angleTrueWater\" or\n      r._measurement == \"environment.wind.directionTrue\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\", \"_field\", \"_start\", \"_stop\"])\n\nunion(tables: [pos_lat, pos_lon, other])\n  |> aggregateWindow(every: 5s, fn: last, createEmpty: false)\n  |> drop(columns: [\"_field\", \"_start\", \"_stop\"])\n  |> group()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_measurement\"], valueColumn: \"_value\")\n  |> rename(columns: {\n      \"navigation.position.latitude\":    \"latitude\",\n      \"navigation.position.longitude\":   \"longitude\",\n      \"navigation.speedThroughWater\":    \"bsp_ms\",\n      \"environment.wind.speedTrue\":      \"tws_ms\",\n      \"environment.wind.angleTrueWater\": \"twa_rad\",\n      \"environment.wind.directionTrue\":  \"twd_rad\"})\n  |> map(fn: (r) => ({r with\n      \"BSP (kts)\": if exists r.bsp_ms  then r.bsp_ms  * 1.94384  else 0.0,\n      \"TWS (kts)\": if exists r.tws_ms  then r.tws_ms  * 1.94384  else 0.0,\n      \"TWA (\u00b0)\":   if exists r.twa_rad then r.twa_rad * 57.29578 else 0.0,\n      \"TWD (\u00b0)\":   if exists r.twd_rad then r.twd_rad * 57.29578 else 0.0}))\n  |> drop(columns: [\"bsp_ms\", \"tws_ms\", \"twa_rad\", \"twd_rad\"])\n  |> filter(fn: (r) => exists r.latitude and exists r.longitude)",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Problem

The Race Track panel was failing with:

> runtime error @16:6-22:53: rename: rename error: column "navigation.position.latitude" doesn't exist

Signal K stores position data as a single measurement (`navigation.position`) with two fields — `lat` and `lon` — not as separate `navigation.position.latitude` / `navigation.position.longitude` measurements. After the `pivot`, those column names never existed so the `rename` call errored.

## Fix

Split the position query into two variable sub-queries (`pos_lat`, `pos_lon`), use `set()` to rename `_measurement` to the expected names, then `union` with the other measurements before `aggregateWindow` + `pivot`. All tables are `keep()`'d to a uniform column set before the union.

## Validated

Query tested against live InfluxDB — returns rows with `latitude`, `longitude`, `BSP (kts)`, `TWS (kts)`, `TWA (°)`, `TWD (°)` correctly populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)