### PR TITLE
feat(#76): automated Pi-to-Mac backup via rsync + launchd

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,189 @@
+# Backup Guide
+
+The logger stores all data on a microSD card inside the Raspberry Pi.
+This guide covers how to pull a complete backup to your Mac automatically,
+and how to restore from it if the card fails.
+
+---
+
+## What gets backed up
+
+| Source | Destination in snapshot |
+|---|---|
+| `~/j105-logger/data/` — SQLite DB, WAV audio, photo notes, exports | `<snapshot>/data/` |
+| InfluxDB (system health metrics) | `<snapshot>/influxdb/` |
+| Grafana (dashboards, datasources) | `<snapshot>/grafana/` |
+
+Snapshots land in `~/backups/j105-logger/<timestamp>/`.
+The 10 most recent are kept; older ones are deleted automatically.
+
+---
+
+## First-time setup
+
+### 1. Prerequisites on the Mac
+
+```bash
+# SSH key-based auth to the Pi (skip if already done)
+ssh-keygen -t ed25519 -C "mac-to-pi-backup"
+ssh-copy-id weaties@corvopi
+
+# InfluxDB CLI (for restore; backup is handled on the Pi)
+brew install influxdb-cli
+```
+
+### 2. Pi: allow sudo rsync without a password (for Grafana backup)
+
+SSH into the Pi and add a sudoers rule:
+
+```bash
+ssh weaties@corvopi
+echo 'weaties ALL=(ALL) NOPASSWD: /usr/bin/rsync' | sudo tee /etc/sudoers.d/rsync-backup
+sudo chmod 440 /etc/sudoers.d/rsync-backup
+```
+
+### 3. Install the daily launchd agent on the Mac
+
+From the project root:
+
+```bash
+./scripts/setup-backup-mac.sh
+```
+
+This:
+- Checks SSH connectivity to `corvopi`
+- Creates `~/backups/j105-logger/`
+- Installs `~/Library/LaunchAgents/com.j105.backup.plist`
+- Schedules the backup to run every day at **03:00 local time**
+
+### 4. Run a test backup now
+
+```bash
+./scripts/backup.sh
+```
+
+Verify the snapshot contains:
+
+```
+~/backups/j105-logger/20260228T030000Z/
+  data/
+    logger.db
+    audio/
+    notes/
+    exports/
+  influxdb/
+  grafana/
+```
+
+---
+
+## Monitoring backups
+
+Logs are written to `~/backups/j105-logger/backup.log`:
+
+```bash
+tail -f ~/backups/j105-logger/backup.log
+```
+
+To check that the launchd agent is active:
+
+```bash
+launchctl list com.j105.backup
+```
+
+To trigger an immediate run:
+
+```bash
+launchctl start com.j105.backup
+```
+
+---
+
+## Restoring from a backup
+
+Pick the snapshot you want:
+
+```bash
+ls ~/backups/j105-logger/
+# e.g. 20260228T030000Z
+SNAP=~/backups/j105-logger/20260228T030000Z
+```
+
+### SQLite
+
+```bash
+# Stop the logger service on the Pi first
+ssh weaties@corvopi "sudo systemctl stop j105-logger"
+
+# Copy the DB back
+rsync -az "$SNAP/data/" weaties@corvopi:~/j105-logger/data/
+
+# Restart
+ssh weaties@corvopi "sudo systemctl start j105-logger"
+```
+
+### InfluxDB
+
+```bash
+# Restore to the running InfluxDB instance (overwrites existing data)
+influx restore "$SNAP/influxdb/" \
+  --host http://corvopi:8086 \
+  --token "$(cat ~/influx-token.txt)"
+```
+
+If restoring to a fresh InfluxDB install, add `--full` to wipe and replace all buckets.
+
+### Grafana
+
+```bash
+# Stop Grafana on the Pi
+ssh weaties@corvopi "sudo systemctl stop grafana-server"
+
+# Restore the data directory
+rsync -az --rsync-path='sudo rsync' \
+  "$SNAP/grafana/" \
+  weaties@corvopi:/var/lib/grafana/
+
+# Fix ownership and restart
+ssh weaties@corvopi "sudo chown -R grafana:grafana /var/lib/grafana && sudo systemctl start grafana-server"
+```
+
+---
+
+## Configuration
+
+All settings are overridable via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `PI` | `weaties@corvopi` | SSH target for the Pi |
+| `BACKUP_DEST` | `~/backups/j105-logger` | Local snapshot root |
+| `KEEP_SNAPSHOTS` | `10` | Number of snapshots to retain |
+| `INFLUX_TOKEN_FILE` | `~/influx-token.txt` | Path on the Pi to the InfluxDB token |
+
+Example — keep 30 days of snapshots:
+
+```bash
+KEEP_SNAPSHOTS=30 ./scripts/backup.sh
+```
+
+---
+
+## Changing the backup schedule
+
+Edit `~/Library/LaunchAgents/com.j105.backup.plist` and change the
+`StartCalendarInterval` hour/minute, then reload:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.j105.backup.plist
+launchctl load   ~/Library/LaunchAgents/com.j105.backup.plist
+```
+
+---
+
+## Disabling the backup
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.j105.backup.plist
+rm ~/Library/LaunchAgents/com.j105.backup.plist
+```

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# backup.sh — Pull all persistent data from corvopi to this Mac.
+#
+# Run manually:  ./scripts/backup.sh
+# Or let setup-backup-mac.sh schedule it daily via launchd.
+#
+# Creates a timestamped snapshot under $BACKUP_DEST (default ~/backups/j105-logger/).
+# Keeps the most recent $KEEP_SNAPSHOTS snapshots; older ones are deleted.
+#
+# Prerequisites on the Mac:
+#   - SSH access to corvopi (via Tailscale; key-based auth recommended)
+#   - influx CLI for InfluxDB restore: brew install influxdb-cli
+#   - sudo rsync allowed on the Pi for the SSH user (for Grafana dir)
+#
+# Environment overrides:
+#   PI                 SSH target           (default: weaties@corvopi)
+#   BACKUP_DEST        local snapshot root  (default: ~/backups/j105-logger)
+#   KEEP_SNAPSHOTS     how many to retain   (default: 10)
+#   INFLUX_TOKEN_FILE  path on the Pi       (default: ~/influx-token.txt)
+
+set -euo pipefail
+
+PI="${PI:-weaties@corvopi}"
+BACKUP_DEST="${BACKUP_DEST:-$HOME/backups/j105-logger}"
+KEEP_SNAPSHOTS="${KEEP_SNAPSHOTS:-10}"
+INFLUX_TOKEN_FILE="${INFLUX_TOKEN_FILE:-~/influx-token.txt}"
+
+DATE=$(date -u +%Y%m%dT%H%M%SZ)
+SNAP="$BACKUP_DEST/$DATE"
+
+log() { echo "[$(date -u +%H:%M:%SZ)] $*"; }
+
+mkdir -p "$SNAP"
+log "Starting backup → $SNAP"
+log "Source: $PI"
+
+# ── 1. SQLite — WAL checkpoint then rsync ────────────────────────────────────
+log "Step 1/4: SQLite WAL checkpoint + rsync"
+ssh "$PI" "sqlite3 ~/j105-logger/data/logger.db 'PRAGMA wal_checkpoint(TRUNCATE);'" 2>/dev/null || \
+  log "  WARNING: WAL checkpoint failed (DB may not exist yet); continuing"
+
+rsync -az --info=progress2 \
+  "$PI:~/j105-logger/data/" \
+  "$SNAP/data/"
+log "  SQLite + file data done"
+
+# ── 2. InfluxDB — remote backup then rsync ───────────────────────────────────
+log "Step 2/4: InfluxDB backup"
+if ssh "$PI" "test -f $INFLUX_TOKEN_FILE" 2>/dev/null; then
+  ssh "$PI" "influx backup /tmp/influx-backup \
+    --host http://localhost:8086 \
+    --token \$(cat $INFLUX_TOKEN_FILE)" 2>/dev/null && \
+  rsync -az --info=progress2 \
+    "$PI:/tmp/influx-backup/" \
+    "$SNAP/influxdb/" && \
+  ssh "$PI" "rm -rf /tmp/influx-backup" && \
+  log "  InfluxDB backup done" || \
+  log "  WARNING: InfluxDB backup failed; skipping (data dir intact on Pi)"
+else
+  log "  WARNING: $INFLUX_TOKEN_FILE not found on Pi; skipping InfluxDB backup"
+fi
+
+# ── 3. Grafana — rsync with sudo ─────────────────────────────────────────────
+log "Step 3/4: Grafana data dir"
+if rsync -az --info=progress2 \
+    --rsync-path='sudo rsync' \
+    "$PI:/var/lib/grafana/" \
+    "$SNAP/grafana/" 2>/dev/null; then
+  log "  Grafana backup done"
+else
+  log "  WARNING: Grafana rsync failed (sudo rsync not configured?); skipping"
+fi
+
+# ── 4. Rotate old snapshots ───────────────────────────────────────────────────
+log "Step 4/4: Rotating snapshots (keeping $KEEP_SNAPSHOTS)"
+# shellcheck disable=SC2012
+STALE=$(ls -1dt "$BACKUP_DEST"/20* 2>/dev/null | tail -n +"$((KEEP_SNAPSHOTS + 1))")
+if [ -n "$STALE" ]; then
+  echo "$STALE" | xargs rm -rf
+  log "  Removed $(echo "$STALE" | wc -l | tr -d ' ') old snapshot(s)"
+else
+  log "  Nothing to rotate"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+SNAP_SIZE=$(du -sh "$SNAP" 2>/dev/null | cut -f1)
+log "Backup complete — $SNAP  ($SNAP_SIZE)"
+echo ""
+echo "Snapshots in $BACKUP_DEST:"
+ls -1t "$BACKUP_DEST" | head -"$KEEP_SNAPSHOTS" | sed 's/^/  /'

--- a/scripts/com.j105.backup.plist
+++ b/scripts/com.j105.backup.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.j105.backup.plist — launchd agent for daily Pi-to-Mac backup.
+  Installed by scripts/setup-backup-mac.sh into ~/Library/LaunchAgents/.
+
+  Runs backup.sh every day at 03:00 local time.
+  Logs stdout+stderr to ~/backups/j105-logger/backup.log.
+
+  Manual control (after installation):
+    launchctl start  com.j105.backup   # run now
+    launchctl stop   com.j105.backup   # cancel running job
+    launchctl unload ~/Library/LaunchAgents/com.j105.backup.plist  # disable
+    launchctl load   ~/Library/LaunchAgents/com.j105.backup.plist  # re-enable
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.j105.backup</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>BACKUP_SCRIPT_PATH</string>
+  </array>
+
+  <!-- Daily at 03:00 local time -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <!-- Log file — directory must exist before launchd writes to it -->
+  <key>StandardOutPath</key>
+  <string>BACKUP_LOG_PATH</string>
+  <key>StandardErrorPath</key>
+  <string>BACKUP_LOG_PATH</string>
+
+  <!-- Run even if the scheduled time was missed (e.g. Mac was asleep) -->
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>HOME_PATH</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/setup-backup-mac.sh
+++ b/scripts/setup-backup-mac.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# setup-backup-mac.sh — Install the daily Pi-to-Mac backup launchd agent.
+#
+# Run once on your Mac from the project root:
+#   ./scripts/setup-backup-mac.sh
+#
+# What it does:
+#   1. Verifies SSH connectivity to corvopi
+#   2. Creates ~/backups/j105-logger/
+#   3. Copies com.j105.backup.plist → ~/Library/LaunchAgents/ (with real paths)
+#   4. Loads (enables) the agent — runs daily at 03:00
+#
+# To uninstall:
+#   launchctl unload ~/Library/LaunchAgents/com.j105.backup.plist
+#   rm ~/Library/LaunchAgents/com.j105.backup.plist
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_SCRIPT="$SCRIPT_DIR/backup.sh"
+PLIST_SRC="$SCRIPT_DIR/com.j105.backup.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.j105.backup.plist"
+BACKUP_DEST="${BACKUP_DEST:-$HOME/backups/j105-logger}"
+LOG_FILE="$BACKUP_DEST/backup.log"
+PI="${PI:-weaties@corvopi}"
+
+log() { echo "==> $*"; }
+warn() { echo "    WARNING: $*" >&2; }
+
+# ── 1. Pre-flight checks ──────────────────────────────────────────────────────
+log "Checking dependencies..."
+
+if ! command -v rsync &>/dev/null; then
+  echo "ERROR: rsync not found. Install via Xcode CLT: xcode-select --install" >&2
+  exit 1
+fi
+
+if ! command -v influx &>/dev/null; then
+  warn "influx CLI not found — InfluxDB backup will be skipped."
+  warn "Install with: brew install influxdb-cli"
+fi
+
+log "Testing SSH connectivity to $PI..."
+if ! ssh -o ConnectTimeout=10 -o BatchMode=yes "$PI" "echo ok" &>/dev/null; then
+  echo "" >&2
+  echo "ERROR: Cannot SSH to $PI." >&2
+  echo "Make sure:" >&2
+  echo "  1. Tailscale is running on both machines ('tailscale status')" >&2
+  echo "  2. SSH key is installed on the Pi ('ssh-copy-id $PI')" >&2
+  echo "  3. You can reach the Pi: ssh $PI" >&2
+  exit 1
+fi
+log "  SSH OK"
+
+# ── 2. Create backup destination ─────────────────────────────────────────────
+mkdir -p "$BACKUP_DEST"
+log "Backup destination: $BACKUP_DEST"
+
+# ── 3. Install plist ──────────────────────────────────────────────────────────
+log "Installing launchd agent..."
+
+# Substitute real paths into the plist template
+sed \
+  -e "s|BACKUP_SCRIPT_PATH|$BACKUP_SCRIPT|g" \
+  -e "s|BACKUP_LOG_PATH|$LOG_FILE|g" \
+  -e "s|HOME_PATH|$HOME|g" \
+  "$PLIST_SRC" > "$PLIST_DEST"
+
+log "  Plist written → $PLIST_DEST"
+
+# ── 4. Load the agent ────────────────────────────────────────────────────────
+# Unload first in case it was previously installed with a different path
+launchctl unload "$PLIST_DEST" 2>/dev/null || true
+launchctl load "$PLIST_DEST"
+log "  Agent loaded (runs daily at 03:00)"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Setup complete."
+echo ""
+echo "  Schedule : daily at 03:00 local time"
+echo "  Log      : $LOG_FILE"
+echo "  Snapshots: $BACKUP_DEST/<timestamp>/"
+echo "  Retention: 10 snapshots (override with KEEP_SNAPSHOTS=N ./scripts/backup.sh)"
+echo ""
+echo "Run a backup now:"
+echo "  $BACKUP_SCRIPT"
+echo ""
+echo "Or trigger via launchd:"
+echo "  launchctl start com.j105.backup"


### PR DESCRIPTION
Closes #76

Four files, no code changes — scripts and docs only.

## Files
- `scripts/backup.sh` — rsync pull: SQLite WAL checkpoint, `data/`, InfluxDB `influx backup`, Grafana with `sudo rsync`; rotates to keep 10 snapshots
- `scripts/com.j105.backup.plist` — launchd agent template (daily 03:00, logs to `~/backups/j105-logger/backup.log`)
- `scripts/setup-backup-mac.sh` — one-shot installer: checks deps, tests SSH, creates backup dir, instantiates plist, loads agent
- `docs/backup.md` — first-time setup, monitoring, full restore walkthrough (SQLite / InfluxDB / Grafana), schedule and retention config