### PR TITLE
feat(#78): add network throughput to Pi health dashboard

### DIFF
--- a/scripts/grafana/pi-health.json
+++ b/scripts/grafana/pi-health.json
@@ -290,6 +290,36 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Network Throughput Over Time",
+      "id": 8,
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 8 },
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system_health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"net_bytes_sent_per_s\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _field: \"TX\"}))\n  |> yield(name: \"tx\")",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system_health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"net_bytes_recv_per_s\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _field: \"RX\"}))\n  |> yield(name: \"rx\")",
+          "refId": "B"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **`monitor.py`**: Track `psutil.net_io_counters()` between collection cycles and compute `net_bytes_sent_per_s` / `net_bytes_recv_per_s` as delta/elapsed. First cycle safely skips (no previous sample). Both fields are added to the existing `system_health` InfluxDB point.
- **`pi-health.json`**: New full-width **Network Throughput Over Time** time series panel at the bottom of the dashboard — TX and RX lines, unit `Bps` (bytes/sec).

Closes #78

## Test plan
- [x] `uv run pytest` — 351 passed
- [x] `uv run mypy src/` — only pre-existing errors in `web.py`
- [x] `uv run ruff check . && uv run ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)