### PR TITLE
feat(#40): boatspeed vs historical polar baseline

### DIFF
--- a/src/logger/main.py
+++ b/src/logger/main.py
@@ -383,6 +383,25 @@ async def _list_audio() -> None:
 
 
 # ---------------------------------------------------------------------------
+# build-polar
+# ---------------------------------------------------------------------------
+
+
+async def _build_polar(min_sessions: int) -> None:
+    """Rebuild the polar performance baseline from historical session data."""
+    import logger.polar as polar
+    from logger.storage import Storage, StorageConfig
+
+    storage = Storage(StorageConfig())
+    await storage.connect()
+    try:
+        count = await polar.build_polar_baseline(storage, min_sessions=min_sessions)
+        print(f"Polar baseline built: {count} bins")
+    finally:
+        await storage.close()
+
+
+# ---------------------------------------------------------------------------
 # list-devices
 # ---------------------------------------------------------------------------
 
@@ -469,6 +488,9 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("list-audio", help="List recorded audio sessions")
     sub.add_parser("list-devices", help="List available audio input devices")
 
+    bp = sub.add_parser("build-polar", help="Rebuild polar baseline from historical session data")
+    bp.add_argument("--min-sessions", type=int, default=3, metavar="N")
+
     return parser
 
 
@@ -499,6 +521,8 @@ def main() -> None:
                 asyncio.run(_list_audio())
             case "list-devices":
                 asyncio.run(_list_devices())
+            case "build-polar":
+                asyncio.run(_build_polar(args.min_sessions))
     except KeyboardInterrupt:
         logger.info("Interrupted by user — shutting down")
     except Exception as exc:

--- a/src/logger/polar.py
+++ b/src/logger/polar.py
@@ -1,0 +1,199 @@
+"""Polar performance baseline: build and query BSP vs (TWS, TWA) buckets.
+
+Historical (TWS, TWA, BSP) triplets from completed race sessions are bucketed,
+then mean and p90 BSP are stored per bin. Live BSP can then be compared against
+this baseline to show whether the boat is over or under-performing.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from logger.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TWA_BIN_SIZE = 5
+
+# wind reference values that appear in the winds table
+_WIND_REF_BOAT = 0  # wind_angle_deg IS the TWA (true wind, boat-referenced)
+_WIND_REF_NORTH = 4  # wind_angle_deg is TWD; need heading to derive TWA
+
+# ---------------------------------------------------------------------------
+# Pure helpers (all unit-testable without Storage)
+# ---------------------------------------------------------------------------
+
+
+def _tws_bin(tws_kts: float) -> int:
+    """Return the integer TWS bin (floor of knots, min 0)."""
+    return max(0, int(math.floor(tws_kts)))
+
+
+def _twa_bin(twa_deg: float) -> int:
+    """Return the TWA bin: fold to [0, 180) and floor to nearest _TWA_BIN_SIZE."""
+    twa_abs = abs(twa_deg) % 360
+    if twa_abs > 180:
+        twa_abs = 360 - twa_abs
+    return int(math.floor(twa_abs / _TWA_BIN_SIZE)) * _TWA_BIN_SIZE
+
+
+def _compute_twa(
+    wind_angle_deg: float,
+    reference: int,
+    heading_deg: float | None,
+) -> float | None:
+    """Derive TWA magnitude from a wind record.
+
+    Returns the absolute TWA in [0, 180], or None if the reference is
+    unsupported or the required heading is absent.
+    """
+    if reference == _WIND_REF_BOAT:
+        return abs(wind_angle_deg) % 360
+    if reference == _WIND_REF_NORTH:
+        if heading_deg is None:
+            return None
+        twa_raw = (wind_angle_deg - heading_deg + 360) % 360
+        return twa_raw if twa_raw <= 180 else 360 - twa_raw
+    return None  # apparent wind or unknown reference
+
+
+# ---------------------------------------------------------------------------
+# Baseline builder
+# ---------------------------------------------------------------------------
+
+
+async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
+    """Compute polar baseline from all completed race sessions and persist it.
+
+    For each (tws_bin, twa_bin) cell, the baseline is only written when data
+    from at least *min_sessions* distinct races contributed.
+
+    Returns:
+        Number of bins written to polar_baseline.
+    """
+    db = storage._conn()
+
+    # 1. Fetch all completed races
+    cur = await db.execute("SELECT id, start_utc, end_utc FROM races WHERE end_utc IS NOT NULL")
+    races = list(await cur.fetchall())
+    if not races:
+        logger.info("Polar: no completed races found; baseline not built")
+        await storage.upsert_polar_baseline([], datetime.now(UTC).isoformat())
+        return 0
+
+    # bin_samples[(tws_bin, twa_bin)] = list of (race_id, bsp_kts)
+    bin_samples: dict[tuple[int, int], list[tuple[int, float]]] = defaultdict(list)
+
+    for race_row in races:
+        race_id = int(race_row["id"])
+        try:
+            start = datetime.fromisoformat(str(race_row["start_utc"])).replace(tzinfo=UTC)
+            end = datetime.fromisoformat(str(race_row["end_utc"])).replace(tzinfo=UTC)
+        except ValueError:
+            logger.warning("Polar: skipping race {} — bad timestamps", race_id)
+            continue
+
+        speeds = await storage.query_range("speeds", start, end)
+        winds = await storage.query_range("winds", start, end)
+        headings = await storage.query_range("headings", start, end)
+
+        # Index by truncated second key (first 19 chars of ISO string)
+        spd_by_s: dict[str, dict[str, Any]] = {}
+        for s in speeds:
+            key = str(s["ts"])[:19]
+            spd_by_s.setdefault(key, s)
+
+        hdg_by_s: dict[str, dict[str, Any]] = {}
+        for h in headings:
+            key = str(h["ts"])[:19]
+            hdg_by_s.setdefault(key, h)
+
+        # Filter winds: only reference 0 (boat) and 4 (north); skip apparent (2)
+        tw_by_s: dict[str, dict[str, Any]] = {}
+        for w in winds:
+            if int(w.get("reference", -1)) not in (_WIND_REF_BOAT, _WIND_REF_NORTH):
+                continue
+            key = str(w["ts"])[:19]
+            tw_by_s.setdefault(key, w)
+
+        for sk, spd_row in spd_by_s.items():
+            wind_row = tw_by_s.get(sk)
+            if wind_row is None:
+                continue
+
+            ref = int(wind_row.get("reference", -1))
+            wind_angle = float(wind_row["wind_angle_deg"])
+            tws_kts = float(wind_row["wind_speed_kts"])
+            bsp_kts = float(spd_row["speed_kts"])
+
+            hdg_row = hdg_by_s.get(sk)
+            heading = float(hdg_row["heading_deg"]) if hdg_row else None
+
+            twa = _compute_twa(wind_angle, ref, heading)
+            if twa is None:
+                continue
+
+            tb = _tws_bin(tws_kts)
+            ab = _twa_bin(twa)
+            bin_samples[(tb, ab)].append((race_id, bsp_kts))
+
+    # 2. Compute statistics per bin; enforce min_sessions
+    rows_to_write: list[dict[str, Any]] = []
+    for (tws_bin, twa_bin), samples in bin_samples.items():
+        unique_races = {s[0] for s in samples}
+        if len(unique_races) < min_sessions:
+            continue
+        bsp_values = sorted(s[1] for s in samples)
+        n = len(bsp_values)
+        mean_bsp = sum(bsp_values) / n
+        p90_idx = max(0, math.ceil(0.9 * n) - 1)
+        p90_bsp = bsp_values[p90_idx]
+        rows_to_write.append(
+            {
+                "tws_bin": tws_bin,
+                "twa_bin": twa_bin,
+                "mean_bsp": round(mean_bsp, 4),
+                "p90_bsp": round(p90_bsp, 4),
+                "session_count": len(unique_races),
+                "sample_count": n,
+            }
+        )
+
+    built_at = datetime.now(UTC).isoformat()
+    await storage.upsert_polar_baseline(rows_to_write, built_at)
+    logger.info("Polar baseline built: {} bins from {} races", len(rows_to_write), len(races))
+    return len(rows_to_write)
+
+
+# ---------------------------------------------------------------------------
+# Live lookup
+# ---------------------------------------------------------------------------
+
+
+async def lookup_polar(
+    storage: Storage,
+    tws_kts: float,
+    twa_deg: float,
+    min_sessions: int = 3,
+) -> dict[str, Any] | None:
+    """Return the polar_baseline row for the given wind condition, or None.
+
+    Returns None if no row exists or the row doesn't meet the *min_sessions*
+    threshold (guards against sparse baseline data).
+    """
+    tb = _tws_bin(tws_kts)
+    ab = _twa_bin(twa_deg)
+    row = await storage.get_polar_point(tb, ab)
+    if row is None:
+        return None
+    if int(row["session_count"]) < min_sessions:
+        return None
+    return row

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -60,6 +60,8 @@ _EXPECTED_COLS = {
     "crew_jib",
     "crew_spin",
     "crew_tactician",
+    "BSP_BASELINE",
+    "BSP_DELTA",
 }
 
 
@@ -369,3 +371,22 @@ class TestExportToFile:
         with out.open() as fh:
             first_line = fh.readline()
         assert "timestamp" in first_line
+
+
+# ---------------------------------------------------------------------------
+# Polar baseline columns
+# ---------------------------------------------------------------------------
+
+
+class TestPolarBaselineColumns:
+    async def test_bsp_baseline_null_without_polar(self, storage: Storage, tmp_path: Path) -> None:
+        """Export with no polar baseline data → BSP_BASELINE and BSP_DELTA are empty."""
+        await _populate(storage)
+        out = tmp_path / "export.csv"
+        await export_csv(storage, _TS, _END, out)
+        with out.open() as fh:
+            reader = csv.DictReader(fh)
+            rows = list(reader)
+        first = rows[0]
+        assert first["BSP_BASELINE"] == ""
+        assert first["BSP_DELTA"] == ""

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -1,0 +1,212 @@
+"""Tests for src/logger/polar.py — pure helpers and integration with Storage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from logger.nmea2000 import (
+    PGN_SPEED_THROUGH_WATER,
+    PGN_WIND_DATA,
+    SpeedRecord,
+    WindRecord,
+)
+from logger.polar import (
+    _compute_twa,
+    _twa_bin,
+    _tws_bin,
+    build_polar_baseline,
+    lookup_polar,
+)
+
+if TYPE_CHECKING:
+    from logger.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestTwsBin:
+    def test_floor(self) -> None:
+        assert _tws_bin(8.9) == 8
+
+    def test_integer_boundary(self) -> None:
+        assert _tws_bin(15.0) == 15
+
+    def test_fractional(self) -> None:
+        assert _tws_bin(15.5) == 15
+
+    def test_zero(self) -> None:
+        assert _tws_bin(0.0) == 0
+
+    def test_below_zero_clamps(self) -> None:
+        assert _tws_bin(-1.0) == 0
+
+
+class TestTwaBin:
+    def test_port_starboard_symmetry(self) -> None:
+        """Port and starboard same angle → same bin."""
+        assert _twa_bin(45.0) == _twa_bin(-45.0)
+
+    def test_zero(self) -> None:
+        assert _twa_bin(0.0) == 0
+
+    def test_just_below_five(self) -> None:
+        assert _twa_bin(4.9) == 0
+
+    def test_exactly_five(self) -> None:
+        assert _twa_bin(5.0) == 5
+
+    def test_just_below_180(self) -> None:
+        assert _twa_bin(179.9) == 175
+
+    def test_exactly_180(self) -> None:
+        # 180° → twa_abs = 180; floor(180/5)*5 = 180 but that's the max
+        assert _twa_bin(180.0) == 180
+
+    def test_beyond_180_folds(self) -> None:
+        # 200° → twa_abs = 200; >180 → 360-200 = 160 → bin 160
+        assert _twa_bin(200.0) == 160
+
+
+class TestComputeTwa:
+    def test_ref0_positive(self) -> None:
+        result = _compute_twa(45.0, 0, None)
+        assert result == pytest.approx(45.0)
+
+    def test_ref0_negative(self) -> None:
+        result = _compute_twa(-45.0, 0, None)
+        assert result == pytest.approx(45.0)
+
+    def test_ref0_ignores_heading(self) -> None:
+        assert _compute_twa(30.0, 0, 180.0) == pytest.approx(30.0)
+
+    def test_ref4_basic(self) -> None:
+        # TWD=90, heading=45 → TWA=45
+        result = _compute_twa(90.0, 4, 45.0)
+        assert result == pytest.approx(45.0)
+
+    def test_ref4_wraps_correctly(self) -> None:
+        # TWD=10, heading=350 → raw=(10-350+360)%360=20 → TWA=20
+        result = _compute_twa(10.0, 4, 350.0)
+        assert result == pytest.approx(20.0)
+
+    def test_ref4_no_heading_returns_none(self) -> None:
+        assert _compute_twa(90.0, 4, None) is None
+
+    def test_apparent_wind_ref_returns_none(self) -> None:
+        """reference=2 (apparent) → should return None."""
+        assert _compute_twa(45.0, 2, None) is None
+
+    def test_unknown_ref_returns_none(self) -> None:
+        assert _compute_twa(45.0, 99, None) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (use storage fixture from conftest.py)
+# ---------------------------------------------------------------------------
+
+_BASE_TS = datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _make_session(
+    storage: Storage,
+    race_num: int,
+    bsp: float,
+    tws: float,
+    twa: float,
+) -> None:
+    """Insert a completed race + 10 matching speed and wind records."""
+    start = _BASE_TS + timedelta(hours=race_num)
+    end = start + timedelta(seconds=10)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES (?, 'TestEvent', ?, ?, ?, ?)",
+        (
+            f"TestEvent-R{race_num}",
+            race_num,
+            start.date().isoformat(),
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    await db.commit()
+
+    for i in range(10):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, bsp))
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, tws, twa, 0))
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_no_sessions(storage: Storage) -> None:
+    count = await build_polar_baseline(storage)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_builds_bins_from_three_sessions(storage: Storage) -> None:
+    for i in range(1, 4):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)
+    count = await build_polar_baseline(storage)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_min_sessions_guard(storage: Storage) -> None:
+    """2 sessions with min_sessions=3 → no bins written."""
+    for i in range(1, 3):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)
+    count = await build_polar_baseline(storage, min_sessions=3)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_mean_bsp_correct(storage: Storage) -> None:
+    """BSP=[4, 6, 8] across 3 sessions → mean≈6.0."""
+    for i, bsp in enumerate([4.0, 6.0, 8.0], start=1):
+        await _make_session(storage, i, bsp=bsp, tws=10.0, twa=45.0)
+    await build_polar_baseline(storage)
+    row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+    assert row is not None
+    assert row["mean_bsp"] == pytest.approx(6.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_port_starboard_fold(storage: Storage) -> None:
+    """TWA=+45 and TWA=-45 should land in the same bin."""
+    for i, twa in enumerate([45.0, -45.0, 45.0], start=1):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=twa)
+    count = await build_polar_baseline(storage)
+    # All three sessions contribute to the same bin
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_no_data(storage: Storage) -> None:
+    result = await lookup_polar(storage, 10.0, 45.0)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_row_when_sufficient(storage: Storage) -> None:
+    for i in range(1, 4):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)
+    await build_polar_baseline(storage)
+    result = await lookup_polar(storage, 10.0, 45.0)
+    assert result is not None
+    assert result["mean_bsp"] == pytest.approx(6.0, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_lookup_guards_min_sessions(storage: Storage) -> None:
+    """Row written with session_count=3 but lookup min_sessions=5 → None."""
+    for i in range(1, 4):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)
+    await build_polar_baseline(storage)
+    result = await lookup_polar(storage, 10.0, 45.0, min_sessions=5)
+    assert result is None


### PR DESCRIPTION
## Summary

- Buckets historical (TWS, TWA, BSP) triplets from completed race sessions into integer wind bins (1 kt TWS, 5° TWA)
- Computes mean and p90 BSP per bin (requires ≥3 distinct sessions)
- Live BSP is compared against the baseline on the race-marker page and in CSV exports

## Changes

- **`storage.py`**: schema v18 — `polar_baseline` table + `get_polar_point` / `upsert_polar_baseline` methods
- **`polar.py`** (new module): `_tws_bin`, `_twa_bin`, `_compute_twa` helpers; `build_polar_baseline`; `lookup_polar`
- **`main.py`**: `build-polar` subcommand with `--min-sessions N` flag
- **`web.py`**: `GET /api/polar/current` route + "Boatspeed vs Baseline" card with green/red delta colouring, polling every 2s
- **`export.py`**: `BSP_BASELINE` and `BSP_DELTA` columns in CSV output
- **`tests/test_polar.py`** (new): 28 unit + integration tests
- **`tests/test_web.py`**: 2 new polar endpoint tests
- **`tests/test_export.py`**: updated expected columns + null-baseline test

## Test plan

- [x] `uv run pytest` — 382 tests pass
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — only 3 pre-existing web.py errors, no new ones
- [x] `uv run python -m logger.main build-polar --help` — subcommand registered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)