### PR TITLE
feat(#81): expose webapp, Grafana & Signal K via Tailscale Funnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,13 @@ AUTH_SESSION_TTL_DAYS=90      # how long session cookies stay valid
 WEB_HOST=0.0.0.0
 WEB_PORT=3002
 # WEB_PIN=
+# Tailscale Funnel public base URL (set automatically by setup.sh when Tailscale is connected)
+# When set, Grafana deep-links resolve to PUBLIC_URL/grafana and a Signal K link appears.
+# Leave unset for LAN-only / local-dev use.
+# PUBLIC_URL=https://corvopi.<tailnet>.ts.net
+
 # Grafana dashboard links
+# When PUBLIC_URL is set, GRAFANA_URL is ignored — links use PUBLIC_URL/grafana instead.
 GRAFANA_URL=http://corvopi:3001
 GRAFANA_DASHBOARD_UID=j105-sailing
 # InfluxDB — required only for system health metrics; omit if not using InfluxDB

--- a/src/logger/races.py
+++ b/src/logger/races.py
@@ -44,11 +44,23 @@ class RaceConfig:
 
     web_host: str = field(default_factory=lambda: os.environ.get("WEB_HOST", "0.0.0.0"))
     web_port: int = field(default_factory=lambda: int(os.environ.get("WEB_PORT", "3002")))
+    public_url: str = field(default_factory=lambda: os.environ.get("PUBLIC_URL", "").rstrip("/"))
     grafana_url: str = field(
-        default_factory=lambda: os.environ.get("GRAFANA_URL", "http://corvopi:3001")
+        default_factory=lambda: (
+            os.environ.get("PUBLIC_URL", "").rstrip("/") + "/grafana"
+            if os.environ.get("PUBLIC_URL")
+            else os.environ.get("GRAFANA_URL", "http://corvopi:3001")
+        )
     )
     grafana_uid: str = field(
         default_factory=lambda: os.environ.get("GRAFANA_DASHBOARD_UID", "j105-sailing")
+    )
+    signalk_url: str = field(
+        default_factory=lambda: (
+            os.environ.get("PUBLIC_URL", "").rstrip("/") + "/signalk"
+            if os.environ.get("PUBLIC_URL")
+            else ""
+        )
     )
 
 

--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -162,6 +162,7 @@ background:#131f35;color:#7eb8f7;font-size:.8rem;cursor:pointer;text-decoration:
     <a class="btn-export" href="/history">📋 History</a>
     <a class="btn-export" href="/admin/boats">⚓ Boats</a>
     <a class="btn-export btn-grafana" href="__GRAFANA_URL__/d/__GRAFANA_UID__/sailing-data?refresh=10s" target="_blank">📊 Grafana</a>
+    __SIGNALK_LINK__
   </div>
 </div>
 <div class="sub" id="header-sub">Loading…</div>
@@ -2334,9 +2335,15 @@ def create_app(
     from logger.races import RaceConfig
 
     cfg = RaceConfig()
+    _signalk_link = (
+        f'<a class="btn-export" href="{cfg.signalk_url}" target="_blank">⚙ Signal K</a>'
+        if cfg.signalk_url
+        else ""
+    )
     _page = (
         _HTML.replace("__GRAFANA_URL__", cfg.grafana_url)
         .replace("__GRAFANA_UID__", cfg.grafana_uid)
+        .replace("__SIGNALK_LINK__", _signalk_link)
         .replace("__GIT_INFO__", _GIT_INFO)
     )
     _history_page = (
@@ -3586,7 +3593,7 @@ def create_app(
                     "tags": [n["note_type"]],
                 }
             )
-        return JSONResponse(result)
+        return JSONResponse(result, headers={"Access-Control-Allow-Origin": "*"})
 
     # ------------------------------------------------------------------
     # /api/sails  &  /api/sessions/{id}/sails

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -23,6 +23,8 @@ def test_race_config_grafana_defaults() -> None:
     cfg = RaceConfig()
     assert cfg.grafana_url == "http://corvopi:3001"
     assert cfg.grafana_uid == "j105-sailing"
+    assert cfg.signalk_url == ""
+    assert cfg.public_url == ""
 
 
 def test_race_config_grafana_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -32,6 +34,31 @@ def test_race_config_grafana_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = RaceConfig()
     assert cfg.grafana_url == "http://myhost:3001"
     assert cfg.grafana_uid == "custom-uid"
+
+
+def test_race_config_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When PUBLIC_URL is set, grafana_url and signalk_url derive from it."""
+    monkeypatch.setenv("PUBLIC_URL", "https://corvopi.tail1234.ts.net")
+    cfg = RaceConfig()
+    assert cfg.grafana_url == "https://corvopi.tail1234.ts.net/grafana"
+    assert cfg.signalk_url == "https://corvopi.tail1234.ts.net/signalk"
+    assert cfg.public_url == "https://corvopi.tail1234.ts.net"
+
+
+def test_race_config_public_url_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PUBLIC_URL trailing slash is stripped before appending path segments."""
+    monkeypatch.setenv("PUBLIC_URL", "https://corvopi.tail1234.ts.net/")
+    cfg = RaceConfig()
+    assert cfg.grafana_url == "https://corvopi.tail1234.ts.net/grafana"
+    assert cfg.signalk_url == "https://corvopi.tail1234.ts.net/signalk"
+
+
+def test_race_config_public_url_overrides_grafana_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PUBLIC_URL takes precedence over GRAFANA_URL when both are set."""
+    monkeypatch.setenv("PUBLIC_URL", "https://corvopi.tail1234.ts.net")
+    monkeypatch.setenv("GRAFANA_URL", "http://corvopi:3001")
+    cfg = RaceConfig()
+    assert cfg.grafana_url == "https://corvopi.tail1234.ts.net/grafana"
 
 
 def test_default_event_monday() -> None:


### PR DESCRIPTION
Closes #81

## Summary

- **`setup.sh`**: new idempotent step configures `tailscale serve` path-based routing and enables `tailscale funnel 443`; auto-detects Tailscale hostname and writes `PUBLIC_URL` to `.env`; also adds `GF_SERVER_ROOT_URL` + `GF_SERVER_SERVE_FROM_SUB_PATH=true` to the Grafana systemd override so Grafana assets/redirects work under `/grafana/`
- **`races.py`**: `RaceConfig` gains `public_url` and `signalk_url` fields; when `PUBLIC_URL` is set, `grafana_url` derives from it (`PUBLIC_URL/grafana`) instead of falling back to `GRAFANA_URL`
- **`web.py`**: injects a Signal K header button when `signalk_url` is set; adds `Access-Control-Allow-Origin: *` to `/api/grafana/annotations` so Grafana can query it cross-origin
- **`.env.example`**: documents `PUBLIC_URL` with clear guidance that `setup.sh` sets it automatically

## Public URLs (after running setup.sh)

| Service | URL |
|---|---|
| Race marker | `https://<machine>.ts.net/` |
| Grafana | `https://<machine>.ts.net/grafana/` |
| Signal K | `https://<machine>.ts.net/signalk/` |

## Test plan

- [x] `uv run pytest` — 127 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — only pre-existing errors (documented in CLAUDE.md)
- [ ] On Pi: run `./scripts/setup.sh` and verify Funnel URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)