### PR TITLE
fix: make SK npm install non-fatal; apply Tailscale routes in deploy.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,12 +186,12 @@ cd ~/j105-logger
 ./scripts/deploy.sh
 ```
 
-The script pulls `main`, syncs Python dependencies, and restarts the
-`j105-logger` systemd service. It prints the service status at the end so you
-can confirm everything came up cleanly.
+The script pulls `main`, syncs Python dependencies, re-applies Tailscale Funnel
+routes, updates `PUBLIC_URL` in `.env`, and restarts `j105-logger`. It prints
+the service status at the end so you can confirm everything came up cleanly.
 
-> **Heads up**: if `pyproject.toml` gained new dependencies _or_ the systemd
-> service files changed, run the full idempotent setup script instead:
+> **Heads up**: if systemd service unit files or apt packages changed (rare),
+> run the full idempotent setup script instead:
 > ```bash
 > ./scripts/setup.sh && sudo systemctl daemon-reload && sudo systemctl restart j105-logger
 > ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,14 +4,16 @@
 # Run this on the Raspberry Pi after merging a PR to main. Handles the
 # common case: code changes, dashboard/annotation updates, plugin installs.
 # provision-grafana.sh is called every time and is fully idempotent.
+# Tailscale Funnel routes are re-applied on every deploy (idempotent).
 #
-# If systemd service files changed, also run:
+# If systemd service files or apt packages changed, also run:
 #   ./scripts/setup.sh && sudo systemctl daemon-reload
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_DIR/.env"
 
 cd "$PROJECT_DIR"
 
@@ -24,6 +26,35 @@ uv sync
 
 echo "==> Provisioning Grafana (dashboard, datasources, plugins)..."
 "$SCRIPT_DIR/provision-grafana.sh"
+
+# ---------------------------------------------------------------------------
+# Tailscale Funnel routes — re-applied on every deploy (idempotent, fast)
+# Also updates PUBLIC_URL in .env so the app generates correct deep-links.
+# ---------------------------------------------------------------------------
+echo "==> Configuring Tailscale Funnel routes..."
+if command -v tailscale &>/dev/null; then
+    TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
+    if [[ -n "$TS_HOSTNAME" ]]; then
+        tailscale serve https / http://localhost:3002
+        tailscale serve https /grafana/ http://localhost:3001
+        tailscale serve https /signalk/ http://localhost:3000
+        tailscale funnel 443 on
+        echo "    Routes verified for https://${TS_HOSTNAME}"
+        # Keep PUBLIC_URL in .env current so the webapp generates correct links
+        PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"
+        if [[ -f "$ENV_FILE" ]]; then
+            if grep -q '^PUBLIC_URL=' "$ENV_FILE" 2>/dev/null; then
+                sed -i "s|^PUBLIC_URL=.*|PUBLIC_URL=${PUBLIC_URL_VALUE}|" "$ENV_FILE"
+            else
+                printf '\nPUBLIC_URL=%s\n' "${PUBLIC_URL_VALUE}" >> "$ENV_FILE"
+            fi
+        fi
+    else
+        echo "    Tailscale not connected — skipping (run 'tailscale up' then re-deploy)."
+    fi
+else
+    echo "    tailscale CLI not found — skipping."
+fi
 
 echo "==> Restarting j105-logger service..."
 sudo systemctl restart j105-logger

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -101,7 +101,8 @@ cat > "$HOME/.signalk/package.json" << 'EOF'
   }
 }
 EOF
-(cd "$HOME/.signalk" && npm install --silent)
+(cd "$HOME/.signalk" && npm install --no-fund --no-audit --legacy-peer-deps) || \
+    warn "Signal K plugin install had errors — run 'cd ~/.signalk && npm install --legacy-peer-deps' to retry."
 
 # systemd service for Signal K
 sudo tee /etc/systemd/system/signalk.service > /dev/null << EOF


### PR DESCRIPTION
## Problem

Two bugs caused `/grafana/d/...` to return `{"detail":"Not Found"}` (FastAPI's 404) after PR #82 merged:

1. **`setup.sh` aborted early** — `npm install --silent` in `~/.signalk` exited non-zero (peer dependency conflicts) and `set -euo pipefail` killed the script before reaching the Tailscale Funnel section. Result: only the root `/` serve rule was ever applied, routing all traffic (including `/grafana/`) to FastAPI on port 3002.

2. **`deploy.sh` never applied Tailscale routes** — the normal deploy path doesn't call `setup.sh`, so new infra added to `setup.sh` in a PR (like the path-based serve rules from #82) never landed on the box without a manual intervention.

## Changes

### `scripts/setup.sh`
- Add `--no-fund --no-audit --legacy-peer-deps` to the Signal K `npm install`
- Treat install failure as a warning (`|| warn`) so the script continues to the Tailscale section even when plugins have peer dep issues on a fresh Pi

### `scripts/deploy.sh`
- Re-apply all three Tailscale serve rules (`/`, `/grafana/`, `/signalk/`) + `funnel 443 on` on every deploy (idempotent, fast — just CLI calls)
- Update `PUBLIC_URL` in `.env` so the app generates correct deep-links
- Restart `j105-logger` after the env update so it picks up the change
- Update header comment to reflect new behaviour

### `CLAUDE.md`
- Update deploy description to mention Tailscale routes and `PUBLIC_URL`
- Tighten the "run setup.sh instead" note to only cover systemd/apt changes

## Test plan
- [ ] On Pi: `./scripts/deploy.sh` — verify `tailscale serve status` shows all three routes and Grafana link works
- [ ] Fresh Pi: run `setup.sh` with a broken npm registry — confirm script continues past the warning and applies Tailscale rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)