### PR TITLE
fix: update Tailscale serve syntax and remove missing SK plugin

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,10 +35,10 @@ echo "==> Configuring Tailscale Funnel routes..."
 if command -v tailscale &>/dev/null; then
     TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
     if [[ -n "$TS_HOSTNAME" ]]; then
-        tailscale serve https / http://localhost:3002
-        tailscale serve https /grafana/ http://localhost:3001
-        tailscale serve https /signalk/ http://localhost:3000
-        tailscale funnel 443 on
+        tailscale serve --bg / http://localhost:3002
+        tailscale serve --bg /grafana/ http://localhost:3001
+        tailscale serve --bg /signalk/ http://localhost:3000
+        tailscale funnel --bg 443
         echo "    Routes verified for https://${TS_HOSTNAME}"
         # Keep PUBLIC_URL in .env current so the webapp generates correct links
         PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -96,8 +96,7 @@ cat > "$HOME/.signalk/package.json" << 'EOF'
   "name": "signalk-server-config",
   "version": "1.0.0",
   "dependencies": {
-    "signalk-to-influxdb2": "*",
-    "@signalk/derived-data": "*"
+    "signalk-to-influxdb2": "*"
   }
 }
 EOF
@@ -395,11 +394,11 @@ if command -v tailscale &>/dev/null; then
     if [[ -n "$TS_HOSTNAME" ]]; then
         PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"
         # Path-based serve rules (idempotent — safe to re-run)
-        tailscale serve https / http://localhost:3002
-        tailscale serve https /grafana/ http://localhost:3001
-        tailscale serve https /signalk/ http://localhost:3000
+        tailscale serve --bg / http://localhost:3002
+        tailscale serve --bg /grafana/ http://localhost:3001
+        tailscale serve --bg /signalk/ http://localhost:3000
         # Make the serve rules publicly reachable via Funnel
-        tailscale funnel 443 on
+        tailscale funnel --bg 443
         info "Tailscale Funnel enabled: ${PUBLIC_URL_VALUE}"
         # Persist PUBLIC_URL in .env so the webapp generates correct links
         if grep -q '^PUBLIC_URL=' "$ENV_FILE" 2>/dev/null; then


### PR DESCRIPTION
## Problems

Two new failures after #83 merged:

1. **Tailscale CLI syntax changed** — the Pi's Tailscale version no longer accepts the old `tailscale serve https / TARGET` / `tailscale funnel 443 on` positional syntax. It now requires `tailscale serve --bg MOUNT TARGET` / `tailscale funnel --bg PORT`.

2. **`@signalk/derived-data` is 404 on npm** — the package doesn't exist in the registry, causing `npm install` to fail even after the non-fatal fix from #83. It's not needed for j105-logger (only `signalk-to-influxdb2` is required for the InfluxDB integration).

## Changes

### `scripts/setup.sh`
- Update Tailscale serve/funnel commands to new `--bg` syntax
- Remove `@signalk/derived-data` from `~/.signalk/package.json`

### `scripts/deploy.sh`
- Same Tailscale syntax update

## Test plan
- [ ] On Pi: `./scripts/deploy.sh` — Tailscale routes apply cleanly, no npm 404 error
- [ ] `tailscale serve status` shows `/`, `/grafana/`, `/signalk/` routes
- [ ] `https://corvopi.taileb1513.ts.net/grafana/d/j105-sailing/sailing-data?refresh=10s` loads Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)