### PR TITLE
fix: correct signalk-derived-data package name

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -96,7 +96,8 @@ cat > "$HOME/.signalk/package.json" << 'EOF'
   "name": "signalk-server-config",
   "version": "1.0.0",
   "dependencies": {
-    "signalk-to-influxdb2": "*"
+    "signalk-to-influxdb2": "*",
+    "signalk-derived-data": "*"
   }
 }
 EOF


### PR DESCRIPTION
The plugin is published on npm as `signalk-derived-data` (unscoped), not `@signalk/derived-data`. The scoped name returns 404. Restores true wind speed/direction calculation in Signal K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)