### PR TITLE
fix: use tailscale funnel --set-path for path-based routing

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,10 +35,9 @@ echo "==> Configuring Tailscale Funnel routes..."
 if command -v tailscale &>/dev/null; then
     TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
     if [[ -n "$TS_HOSTNAME" ]]; then
-        tailscale serve --bg / http://localhost:3002
-        tailscale serve --bg /grafana/ http://localhost:3001
-        tailscale serve --bg /signalk/ http://localhost:3000
-        tailscale funnel --bg 443
+        tailscale funnel --bg 3002
+        tailscale funnel --bg --set-path /grafana/ 3001
+        tailscale funnel --bg --set-path /signalk/ 3000
         echo "    Routes verified for https://${TS_HOSTNAME}"
         # Keep PUBLIC_URL in .env current so the webapp generates correct links
         PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -394,12 +394,10 @@ if command -v tailscale &>/dev/null; then
     TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
     if [[ -n "$TS_HOSTNAME" ]]; then
         PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"
-        # Path-based serve rules (idempotent — safe to re-run)
-        tailscale serve --bg / http://localhost:3002
-        tailscale serve --bg /grafana/ http://localhost:3001
-        tailscale serve --bg /signalk/ http://localhost:3000
-        # Make the serve rules publicly reachable via Funnel
-        tailscale funnel --bg 443
+        # Path-based funnel rules (idempotent — safe to re-run)
+        tailscale funnel --bg 3002
+        tailscale funnel --bg --set-path /grafana/ 3001
+        tailscale funnel --bg --set-path /signalk/ 3000
         info "Tailscale Funnel enabled: ${PUBLIC_URL_VALUE}"
         # Persist PUBLIC_URL in .env so the webapp generates correct links
         if grep -q '^PUBLIC_URL=' "$ENV_FILE" 2>/dev/null; then


### PR DESCRIPTION
The Tailscale CLI's path-based routing syntax changed again. The correct new form is `tailscale funnel --bg --set-path /path/ <port>` — no separate serve + funnel-enable step needed.

Old (broken):
```
tailscale serve --bg / http://localhost:3002
tailscale serve --bg /grafana/ http://localhost:3001
tailscale serve --bg /signalk/ http://localhost:3000
tailscale funnel --bg 443
```

New (correct):
```
tailscale funnel --bg 3002
tailscale funnel --bg --set-path /grafana/ 3001
tailscale funnel --bg --set-path /signalk/ 3000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)