### PR TITLE
fix: grant Tailscale operator permission before funnel commands

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,6 +35,7 @@ echo "==> Configuring Tailscale Funnel routes..."
 if command -v tailscale &>/dev/null; then
     TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
     if [[ -n "$TS_HOSTNAME" ]]; then
+        sudo tailscale set --operator="$(id -un)"
         tailscale funnel --bg 3002
         tailscale funnel --bg --set-path /grafana/ 3001
         tailscale funnel --bg --set-path /signalk/ 3000

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -394,6 +394,8 @@ if command -v tailscale &>/dev/null; then
     TS_HOSTNAME="$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//' || echo '')"
     if [[ -n "$TS_HOSTNAME" ]]; then
         PUBLIC_URL_VALUE="https://${TS_HOSTNAME}"
+        # Grant current user permission to configure Tailscale serve/funnel (idempotent)
+        sudo tailscale set --operator="$CURRENT_USER"
         # Path-based funnel rules (idempotent — safe to re-run)
         tailscale funnel --bg 3002
         tailscale funnel --bg --set-path /grafana/ 3001


### PR DESCRIPTION
`tailscale funnel` fails with `Access denied: serve config denied` unless the user is registered as a Tailscale operator. The error message itself says to run `sudo tailscale set --operator=$USER` once. Added this idempotent call in both `setup.sh` and `deploy.sh` before the funnel commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)