### PR TITLE
fix: remove GF_SERVER_SERVE_FROM_SUB_PATH from Grafana config

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,7 +45,6 @@ if command -v tailscale &>/dev/null; then
 [Service]
 Environment=GF_SERVER_HTTP_PORT=3001
 Environment=GF_SERVER_ROOT_URL=https://${TS_HOSTNAME}/grafana/
-Environment=GF_SERVER_SERVE_FROM_SUB_PATH=true
 EOF
         sudo systemctl daemon-reload
         sudo systemctl restart grafana-server

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -189,7 +189,6 @@ sudo tee /etc/systemd/system/grafana-server.service.d/port.conf > /dev/null << '
 [Service]
 Environment=GF_SERVER_HTTP_PORT=3001
 Environment=GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s/grafana/
-Environment=GF_SERVER_SERVE_FROM_SUB_PATH=true
 EOF
 sudo systemctl daemon-reload
 sudo systemctl enable --now grafana-server
@@ -406,7 +405,6 @@ if command -v tailscale &>/dev/null; then
 [Service]
 Environment=GF_SERVER_HTTP_PORT=3001
 Environment=GF_SERVER_ROOT_URL=https://${TS_HOSTNAME}/grafana/
-Environment=GF_SERVER_SERVE_FROM_SUB_PATH=true
 EOF
         sudo systemctl daemon-reload
         sudo systemctl restart grafana-server


### PR DESCRIPTION
## Problem

Tailscale strips the path prefix when proxying: `/grafana/d/...` → Grafana receives `/d/...`. With `SERVE_FROM_SUB_PATH=true`, Grafana redirected back to `/grafana/d/...` → Tailscale stripped it again → `ERR_TOO_MANY_REDIRECTS`.

## Fix

Remove `GF_SERVER_SERVE_FROM_SUB_PATH=true` from all three `port.conf` writes (initial install + Tailscale section in setup.sh + deploy.sh). Grafana now serves root paths normally while `GF_SERVER_ROOT_URL` ensures external links use the correct `https://hostname/grafana/` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)