### PR TITLE
docs: update documentation for Tailscale Funnel public access (PRs #82-#89)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,37 @@
 # Release Notes
 
-## Unreleased (main, 2026-02-28)
+## Unreleased (main, 2026-03-01)
+
+### Public internet access via Tailscale Funnel (#82–#89)
+
+The logger, Grafana, and Signal K are now accessible over the public internet
+via Tailscale Funnel — no separate domain, certificate, or firewall changes
+needed. All three routes are configured automatically by `setup.sh` and
+`deploy.sh`.
+
+| Public path | Local service |
+|---|---|
+| `https://corvopi.<tailnet>.ts.net/` | j105-logger (port 3002) |
+| `https://corvopi.<tailnet>.ts.net/grafana/` | Grafana (port 3001) |
+| `https://corvopi.<tailnet>.ts.net/signalk/` | Signal K (port 3000) |
+
+Changes across PRs #82–#89:
+
+- **PR #82** — initial Tailscale path-based routing added to `setup.sh`
+- **PR #83** — made Signal K npm install non-fatal (was aborting setup); added
+  Tailscale route application to `deploy.sh` so deploys keep routes current
+- **PR #84** — updated to current Tailscale CLI syntax (`tailscale funnel --bg`)
+- **PR #85** — fixed Signal K plugin name from `@signalk/derived-data` (404 on
+  npm) to the correct unscoped name `signalk-derived-data`; required for true
+  wind (TWS/TWA/TWD) computation
+- **PR #86** — used `tailscale funnel --bg --set-path` for sub-path routing
+- **PR #87** — added `sudo tailscale set --operator=$USER` prerequisite; without
+  it `tailscale funnel` returns "Access denied"
+- **PR #88** — set Grafana `GF_SERVER_ROOT_URL` to the actual Tailscale hostname
+  so Grafana deep-links resolve to the correct public URL
+- **PR #89** — removed `GF_SERVER_SERVE_FROM_SUB_PATH=true`; with Tailscale
+  Funnel stripping path prefixes, the `SERVE_FROM_SUB_PATH` flag caused an
+  infinite redirect loop
 
 ### Audio transcription (#42, PR #63)
 

--- a/docs/operators-guide.md
+++ b/docs/operators-guide.md
@@ -1,18 +1,60 @@
 # J105 Logger — Crew Operations Guide
 
-_Last reviewed: 2026-02-28 · App version: schema v16_
+_Last reviewed: 2026-03-01 · App version: schema v16_
 
 Quick reference for using the logger on race day.
 No technical knowledge required. Print double-sided, laminate, keep in the nav station.
 
 ---
 
+## What the system does
+
+The J105 Logger is an always-on Raspberry Pi that collects data from the boat's
+B&G instrument system (via NMEA 2000) and gives the crew tools to:
+
+- **Mark races** — one tap to start and stop race sessions; every instrument
+  reading is captured automatically for the duration
+- **Log notes** — text observations, boat settings (vang, cunningham, etc.), or
+  photos, all timestamped and attached to the session
+- **Record the debrief** — if the Gordik USB mic is plugged in, record audio
+  debriefs and get an automatic text transcript
+- **Track results** — record finishing positions with boat names / sail numbers
+  directly in the app
+- **Track sails** — record which main, jib, and spinnaker were used each race
+- **Export data** — download a CSV spreadsheet or GPX track for any race for
+  import into Sailmon, Expedition, or a spreadsheet tool
+- **Link YouTube videos** — sync a GoPro upload with instrument data by
+  marking a common timestamp; the app then generates a deep-link to the exact
+  moment in the video for any point in the race
+- **View Grafana dashboards** — one-tap link from any race card opens a live
+  time-series Grafana dashboard scoped to that race window, showing boatspeed,
+  true wind, COG, heading, and more
+- **Browse history** — searchable, filterable log of every session with all of
+  the above tools available for past races
+
+---
+
 ## 1. Connecting to the system
+
+**On the boat (Tailscale network):**
 
 1. Make sure your phone or tablet is on the boat's **Tailscale** network.
    _(One-time setup — ask the navigator if you haven't joined yet.)_
 2. Open your browser and go to: **`http://corvopi:3002`**
 3. Bookmark this address — you'll open it at the start line.
+
+**From anywhere over the internet (Tailscale Funnel):**
+
+The logger, Grafana, and Signal K are also accessible publicly via Tailscale Funnel:
+
+| Interface | Public URL |
+|---|---|
+| Race marker / history | `https://corvopi.taileb1513.ts.net/` |
+| Grafana dashboards | `https://corvopi.taileb1513.ts.net/grafana/` |
+| Signal K explorer | `https://corvopi.taileb1513.ts.net/signalk/` |
+
+These URLs work from any device — no Tailscale app required.
+Ask the navigator for the exact URL for your tailnet.
 
 The page refreshes itself. You do not need to reload it manually.
 


### PR DESCRIPTION
Updates README, RELEASES.md, docs/operators-guide.md, and docs/https-deployment.md to reflect all the infrastructure changes from PRs #82–#89.

## Changes

**README.md**
- Fix Signal K plugin name: `@signalk/derived-data` → `signalk-derived-data`
- Update web interfaces table to include public Tailscale Funnel URLs alongside LAN URLs
- Update deploy section: `deploy.sh` now handles Tailscale routes, Grafana ROOT_URL, and PUBLIC_URL
- Add `PUBLIC_URL` env var comment to the config example

**RELEASES.md**
- New section covering PRs #82–#89: Tailscale Funnel public access, setup/deploy script fixes, Grafana redirect loop fix

**docs/operators-guide.md**
- Added _System Overview_ section at the top: what the logger does for a racing crew
- Updated connection section with public Funnel URL table (no Tailscale app required)

**docs/https-deployment.md**
- Rewrote Option C (Tailscale Funnel) to reflect current CLI syntax, automatic setup.sh configuration, and the path-stripping behaviour that caused the redirect loop