### PR TITLE
feat: harden Pi deployment and bake security into setup.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,10 @@ WHISPER_MODEL=base
 # Photo notes
 NOTES_DIR=data/notes
 # Authentication (magic-link invite tokens)
-# AUTH_DISABLED=true          # set to bypass auth entirely (useful for local/Tailscale-only use)
+# AUTH_DISABLED=true          # bypass auth entirely — LOCAL DEV ONLY; NEVER with Tailscale Funnel
 AUTH_SESSION_TTL_DAYS=90      # how long session cookies stay valid
 # ADMIN_EMAIL=you@example.com # if set, a user with this email is auto-created as admin on startup
+# Create users without email flow: j105-logger add-user --email x --name y --role admin
 # Web interface (race marker)
 WEB_HOST=0.0.0.0
 WEB_PORT=3002

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ data/notes/
 # Claude Code project directory
 .claude/
 
+# Credentials reference (contains real secrets — never commit)
+docs/credentials.md
+
 # Environment — ignore real env files but not the example template
 .env
 .env.local

--- a/scripts/provision-grafana.sh
+++ b/scripts/provision-grafana.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# provision-grafana.sh — Deploy sailing dashboard and enable anonymous access.
+# provision-grafana.sh — Deploy sailing dashboards and datasource provisioning.
 # Idempotent: safe to run multiple times.
+#
+# NOTE: Auth and network binding for Grafana are managed via systemd env vars
+# in /etc/systemd/system/grafana-server.service.d/port.conf (set by setup.sh).
+# This script does NOT touch grafana.ini or auth settings.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -12,7 +16,6 @@ DATASOURCE_SRC="$SCRIPT_DIR/grafana/datasources.yaml"
 DASHBOARD_DEST_DIR="/var/lib/grafana/dashboards"
 PROVISION_DEST="/etc/grafana/provisioning/dashboards/j105-logger.yaml"
 DATASOURCE_DEST="/etc/grafana/provisioning/datasources/j105-logger.yaml"
-GRAFANA_INI="/etc/grafana/grafana.ini"
 
 echo "==> Creating dashboard directory: $DASHBOARD_DEST_DIR"
 sudo mkdir -p "$DASHBOARD_DEST_DIR"
@@ -26,46 +29,6 @@ sudo cp "$PROVISION_SRC" "$PROVISION_DEST"
 
 echo "==> Copying datasource provisioning config"
 sudo cp "$DATASOURCE_SRC" "$DATASOURCE_DEST"
-
-echo "==> Enabling anonymous access in $GRAFANA_INI"
-# Insert/update the [auth.anonymous] section.
-# If the section already exists, update enabled and org_role.
-# If not, append the section at the end.
-if sudo grep -q '^\[auth\.anonymous\]' "$GRAFANA_INI"; then
-  # Section exists — update or insert the two keys inside it
-  sudo python3 - "$GRAFANA_INI" <<'PYEOF'
-import sys, re
-
-path = sys.argv[1]
-with open(path) as f:
-    text = f.read()
-
-# Split into sections
-sections = re.split(r'(?=^\[)', text, flags=re.MULTILINE)
-out = []
-for sec in sections:
-    if sec.startswith('[auth.anonymous]'):
-        # Ensure enabled = true
-        if re.search(r'^enabled\s*=', sec, re.MULTILINE):
-            sec = re.sub(r'^(enabled\s*=\s*).*$', r'\1true', sec, flags=re.MULTILINE)
-        else:
-            sec = sec.rstrip('\n') + '\nenabled = true\n'
-        # Ensure org_role = Viewer
-        if re.search(r'^org_role\s*=', sec, re.MULTILINE):
-            sec = re.sub(r'^(org_role\s*=\s*).*$', r'\1Viewer', sec, flags=re.MULTILINE)
-        else:
-            sec = sec.rstrip('\n') + '\norg_role = Viewer\n'
-    out.append(sec)
-
-with open(path, 'w') as f:
-    f.write(''.join(out))
-print("  grafana.ini updated (section existed)")
-PYEOF
-else
-  # Section does not exist — append it
-  printf '\n[auth.anonymous]\nenabled = true\norg_role = Viewer\n' | sudo tee -a "$GRAFANA_INI" > /dev/null
-  echo "  grafana.ini updated (section appended)"
-fi
 
 echo "==> Restarting grafana-server"
 sudo systemctl restart grafana-server


### PR DESCRIPTION
## Summary

- **setup.sh** rewritten to include all Phase 1+2 security hardening: automatic security updates (unattended-upgrades), mask unused services, SSH hardening, InfluxDB/Grafana loopback binding, `j105logger` dedicated service account, Signal K bcrypt admin password, scoped NOPASSWD sudo replacing Pi OS blanket default, `.env` chmod 600
- **deploy.sh** cleaned up to use only scoped-sudo commands; Grafana port.conf write now includes all env vars (HTTP_ADDR, auth settings)
- **provision-grafana.sh** removed anonymous access enabling (managed by systemd env vars)
- **main.py** adds `add-user` CLI subcommand for admin bootstrap; fixes `_load_env()` PermissionError when service runs as `j105logger`
- **README.md** updated: Security section rewritten with magic-link auth docs, Fresh SD setup includes all 18 hardening steps + Step 9 (create admin user)
- **CLAUDE.md** adds Deployed Service Architecture section and auth env vars
- **docs/credentials.md** created (gitignored) for operator credential reference

## Test plan

- [x] `uv run pytest` — 388 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Run `./scripts/setup.sh` on a fresh Pi to verify idempotent setup
- [ ] Run `./scripts/deploy.sh` on corvopi to verify scoped sudo works

Closes #102, #103, #104, #105, #106, #107, #108, #111, #112, #113, #114, #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)