### PR TITLE
fix: custom event should take precedence over weekday default

### DIFF
--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -2728,7 +2728,7 @@ def create_app(
 
         default_event = default_event_for_date(today)
         custom_event = await storage.get_daily_event(date_str)
-        event = default_event or custom_event
+        event = custom_event or default_event
         if event is None:
             raise HTTPException(
                 status_code=422,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -86,11 +86,14 @@ async def test_state_endpoint_returns_json(storage: Storage) -> None:
 @pytest.mark.asyncio
 async def test_start_race_no_event_returns_422(storage: Storage) -> None:
     """POST /api/races/start fails with 422 when no event is configured."""
+    from unittest.mock import patch
+
     app = create_app(storage)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
-        resp = await client.post("/api/races/start")
+        with patch("logger.races.default_event_for_date", return_value=None):
+            resp = await client.post("/api/races/start")
 
     assert resp.status_code == 422
 


### PR DESCRIPTION
## Summary
- Swapped `default_event or custom_event` → `custom_event or default_event` in the race-start endpoint so a user-set event overrides the weekday default (BallardCup/CYC)
- Patched `test_start_race_no_event_returns_422` to mock `default_event_for_date` so it passes on any day of the week

## Test plan
- [x] All 388 tests pass
- [x] ruff check + format clean
- [x] mypy clean (3 pre-existing errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)