### PR TITLE
feat: Loki + Promtail for centralized log management (#132)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,19 @@
 
 ## Unreleased (main, 2026-03-02)
 
+### Centralized log management with Loki + Promtail (#132)
+
+Service logs are now searchable from Grafana — no more SSH + `journalctl` grepping:
+
+- **Loki** log aggregation server installed on the Pi (loopback-only, port 3100)
+- **Promtail** scrapes journald for the 5 managed services: `j105-logger`,
+  `signalk`, `grafana-server`, `influxdb`, `can-interface`
+- **Service Logs dashboard** in Grafana with service filter, text search, and
+  log volume bar chart (`/d/service-logs/`)
+- 30-day retention; ~54 MB disk budget (negligible on Pi 4)
+- Fully automated: `setup.sh` installs, configures, and starts both services
+- Scoped sudoers entries for `loki` and `promtail` service management
+
 ### Shared navigation, version footer, timezone support (#129, #130)
 
 Consistent navigation and timezone-aware timestamps across all pages:

--- a/scripts/grafana/datasources.yaml
+++ b/scripts/grafana/datasources.yaml
@@ -8,3 +8,11 @@ datasources:
     access: proxy
     isDefault: false
     editable: false
+
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://127.0.0.1:3100
+    access: proxy
+    isDefault: false
+    editable: false

--- a/scripts/grafana/service-logs.json
+++ b/scripts/grafana/service-logs.json
@@ -1,0 +1,83 @@
+{
+  "uid": "service-logs",
+  "title": "Service Logs",
+  "tags": ["j105-logger", "logs"],
+  "timezone": "browser",
+  "editable": true,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values(service)",
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all" },
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" },
+        "label": "Search"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume",
+      "type": "barchart",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "sum by (service)(rate({service=~\"$service\"} |= \"$search\" [1m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "stacking": { "mode": "normal" },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Logs",
+      "type": "logs",
+      "gridPos": { "h": 20, "w": 24, "x": 0, "y": 5 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\"} |= \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/scripts/loki/loki-config.yaml
+++ b/scripts/loki/loki-config.yaml
@@ -1,0 +1,43 @@
+# Loki configuration for j105-logger
+# Single-tenant, filesystem storage, loopback-only binding.
+# Deployed by setup.sh to /etc/loki/loki-config.yaml
+
+auth_enabled: false
+
+server:
+  http_listen_address: 127.0.0.1
+  http_listen_port: 3100
+
+common:
+  path_prefix: /var/lib/loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /var/lib/loki/chunks
+
+compactor:
+  working_directory: /var/lib/loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+limits_config:
+  retention_period: 720h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+analytics:
+  reporting_enabled: false

--- a/scripts/loki/promtail-config.yaml
+++ b/scripts/loki/promtail-config.yaml
@@ -1,0 +1,32 @@
+# Promtail configuration for j105-logger
+# Scrapes journald for the 5 services we care about.
+# Deployed by setup.sh to /etc/promtail/promtail-config.yaml
+
+server:
+  http_listen_address: 127.0.0.1
+  http_listen_port: 9080
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: http://127.0.0.1:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: journal
+    journal:
+      max_age: 12h
+      labels:
+        host: corvopi
+    relabel_configs:
+      # Keep only our services
+      - source_labels: [__journal__systemd_unit]
+        regex: "(j105-logger|signalk|grafana-server|influxdb|can-interface)\\.service"
+        action: keep
+      # Extract a clean service label from the unit name
+      - source_labels: [__journal__systemd_unit]
+        regex: "(.+)\\.service"
+        target_label: service
+      # Map journal priority to a level label
+      - source_labels: [__journal_priority_keyword]
+        target_label: level

--- a/scripts/provision-grafana.sh
+++ b/scripts/provision-grafana.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DASHBOARD_SRC="$SCRIPT_DIR/grafana/sailing-data.json"
 PI_HEALTH_SRC="$SCRIPT_DIR/grafana/pi-health.json"
+SERVICE_LOGS_SRC="$SCRIPT_DIR/grafana/service-logs.json"
 PROVISION_SRC="$SCRIPT_DIR/grafana/dashboards.yaml"
 DATASOURCE_SRC="$SCRIPT_DIR/grafana/datasources.yaml"
 
@@ -20,6 +21,7 @@ DATASOURCE_DEST="/etc/grafana/provisioning/datasources/j105-logger.yaml"
 echo "==> Copying dashboard JSONs"
 sudo rsync --mkpath "$DASHBOARD_SRC" "$DASHBOARD_DEST_DIR/sailing-data.json"
 sudo rsync "$PI_HEALTH_SRC" "$DASHBOARD_DEST_DIR/pi-health.json"
+sudo rsync "$SERVICE_LOGS_SRC" "$DASHBOARD_DEST_DIR/service-logs.json"
 
 echo "==> Copying dashboard provisioning config"
 sudo rsync "$PROVISION_SRC" "$PROVISION_DEST"
@@ -32,5 +34,6 @@ sudo systemctl restart grafana-server
 
 echo ""
 echo "Done."
-echo "  Sailing data: http://$(hostname):3001/d/j105-sailing/sailing-data"
-echo "  Pi health:    http://$(hostname):3001/d/pi-health/pi-health"
+echo "  Sailing data:  http://$(hostname):3001/d/j105-sailing/sailing-data"
+echo "  Pi health:     http://$(hostname):3001/d/pi-health/pi-health"
+echo "  Service logs:  http://$(hostname):3001/d/service-logs/service-logs"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,6 +16,7 @@
 #   d)   InfluxDB 2.7.11 (pinned; loopback-only binding)
 #   e)   Grafana OSS (loopback-only; login required; no anonymous access)
 #   e.1) j105logger dedicated service account
+#   e.2) Loki + Promtail (centralized log management)
 #   f)   Signal K → InfluxDB plugin config
 #   g)   uv + Python dependencies
 #   g.1) Signal K authentication (bcrypt admin password)
@@ -356,6 +357,51 @@ EOF
 sudo systemctl restart grafana-server
 info "Grafana installed on port 3001 (loopback-only, login required)."
 info "Default Grafana admin credentials: admin / changeme123 — change after first login."
+
+# ---------------------------------------------------------------------------
+# e.2) Loki + Promtail — centralized log management
+#      Uses the Grafana apt repo added in section e) above.
+#      Loki stores logs on the local filesystem; Promtail scrapes journald.
+#      Both bind to loopback only.
+# ---------------------------------------------------------------------------
+
+step "Installing Loki + Promtail..."
+sudo apt-get install -y loki promtail
+
+# Deploy Loki config
+sudo mkdir -p /etc/loki
+sudo cp "$SCRIPT_DIR/loki/loki-config.yaml" /etc/loki/loki-config.yaml
+
+# Deploy Promtail config
+sudo mkdir -p /etc/promtail
+sudo cp "$SCRIPT_DIR/loki/promtail-config.yaml" /etc/promtail/promtail-config.yaml
+
+# Data directories
+sudo mkdir -p /var/lib/loki /var/lib/promtail
+sudo chown loki:loki /var/lib/loki
+sudo chown promtail:promtail /var/lib/promtail
+
+# Promtail needs journal access
+sudo usermod -aG systemd-journal promtail
+
+# Systemd overrides to use our config files
+sudo mkdir -p /etc/systemd/system/loki.service.d
+sudo tee /etc/systemd/system/loki.service.d/config.conf > /dev/null << 'EOF'
+[Service]
+ExecStart=
+ExecStart=/usr/bin/loki -config.file=/etc/loki/loki-config.yaml
+EOF
+
+sudo mkdir -p /etc/systemd/system/promtail.service.d
+sudo tee /etc/systemd/system/promtail.service.d/config.conf > /dev/null << 'EOF'
+[Service]
+ExecStart=
+ExecStart=/usr/bin/promtail -config.file=/etc/promtail/promtail-config.yaml
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now loki promtail
+info "Loki (port 3100) + Promtail installed and running."
 
 # ---------------------------------------------------------------------------
 # e.1) j105logger dedicated service account
@@ -715,6 +761,22 @@ ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start influxdb.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop influxdb.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart influxdb.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status influxdb.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start loki
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop loki
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart loki
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status loki
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start loki.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop loki.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart loki.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status loki.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start promtail
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop promtail
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart promtail
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status promtail
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl start promtail.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop promtail.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart promtail.service
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status promtail.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl is-active j105-logger
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl is-active j105-logger.service
 
@@ -761,6 +823,7 @@ echo -e "${GREEN}═════════════════════
 echo ""
 echo "  Signal K:    http://corvopi:3000   (admin password in ~/.signalk-admin-pass.txt)"
 echo "  Grafana:     http://corvopi:3001   (admin / changeme123 — change after first login)"
+echo "  Loki:        http://corvopi:3100   (loopback-only — log aggregation for Grafana)"
 echo "  InfluxDB:    http://corvopi:8086   (loopback-only — access via SSH tunnel or Tailscale)"
 echo "  Race marker: http://corvopi:3002   (login required — see below)"
 if [[ -n "${TS_HOSTNAME:-}" ]]; then
@@ -790,7 +853,7 @@ echo "  4. Reboot:"
 echo "       sudo reboot"
 echo ""
 echo "  After reboot, check service status:"
-echo "    sudo systemctl status can-interface signalk influxd grafana-server j105-logger"
+echo "    sudo systemctl status can-interface signalk influxd grafana-server loki promtail j105-logger"
 echo ""
 echo "  View logger output:"
 echo "    sudo journalctl -fu j105-logger"


### PR DESCRIPTION
## Summary
- **Loki** log aggregation server (loopback-only, port 3100, 30-day retention)
- **Promtail** scrapes journald for 5 managed services: `j105-logger`, `signalk`, `grafana-server`, `influxdb`, `can-interface`
- **Service Logs dashboard** in Grafana with service filter, text search, and log volume bar chart (`/d/service-logs/`)
- Fully automated via `setup.sh` with scoped sudoers entries

## Test plan
- [ ] Run `./scripts/setup.sh` on Pi — verify Loki + Promtail install
- [ ] `sudo systemctl status loki promtail` — both active
- [ ] `curl -s 'http://127.0.0.1:3100/loki/api/v1/labels'` — Loki responding
- [ ] `./scripts/provision-grafana.sh` — dashboard + datasource deployed
- [ ] Open Grafana → Explore → Loki → `{service="j105-logger"}` — logs visible
- [ ] Open `/d/service-logs/` dashboard — service filter and search working

🤖 Generated with [Claude Code](https://claude.com/claude-code)