### PR TITLE
Fix setup.sh: bcrypt module + data/ permissions

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -382,7 +382,7 @@ if ! id j105logger &>/dev/null; then
 else
     info "j105logger already exists — skipping useradd."
 fi
-sudo usermod -aG audio,netdev j105logger
+sudo usermod -aG "audio,netdev,${CURRENT_USER}" j105logger
 
 # uv cache directory (service account has no home dir, so uv can't write ~/.cache/uv)
 sudo mkdir -p /var/cache/j105-logger
@@ -538,9 +538,11 @@ info "$PROJECT_DIR/data (SQLite DB)"
 info "$PROJECT_DIR/data/audio (WAV recordings)"
 info "$PROJECT_DIR/data/notes (photo notes)"
 
-# Transfer data directory ownership to j105logger so the service can write to it
-sudo chown -R j105logger:j105logger "$PROJECT_DIR/data"
-info "data/ ownership transferred to j105logger."
+# Shared ownership: deploy user owns, deploy user's group is shared with j105logger.
+# setgid ensures new files/dirs inherit the group so both users can always read/write.
+sudo chown -R "$CURRENT_USER:$CURRENT_USER" "$PROJECT_DIR/data"
+sudo chmod -R g+ws "$PROJECT_DIR/data"
+info "data/ owned by $CURRENT_USER, group-writable (j105logger is a member)."
 
 # ---------------------------------------------------------------------------
 # i) netdev group (allows non-root SocketCAN access)


### PR DESCRIPTION
## Summary
- **bcrypt**: `uv run --project` can't find `bcrypt` (not a project dep). Switch to `uv run --with bcrypt` so uv pulls it on the fly for the Signal K password hash.
- **data/ permissions**: was `chown j105logger:j105logger` exclusively, so CLI commands as `weaties` couldn't open the DB. Now owned by deploy user with group-write + setgid; `j105logger` is added to the deploy user's group.

Both issues hit during fresh setup on corvopi-test.

## Test plan
- [x] 425 tests pass
- [x] Verified on corvopi-test: `j105-logger add-user` works, service starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)