### PR TITLE
Fix Signal K crash: allowedCorsOrigins must be string

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -497,7 +497,7 @@ import os, json, bcrypt
 pw = os.environ['SK_ADMIN_PASS'].encode()
 h = bcrypt.hashpw(pw, bcrypt.gensalt(rounds=12)).decode()
 data = {
-    'allowedCorsOrigins': [],
+    'allowedCorsOrigins': '',
     'immutableConfig': False,
     'acls': [],
     'users': [


### PR DESCRIPTION
## Summary
Signal K calls `.split(',')` on `allowedCorsOrigins`, which fails when it receives a JSON array `[]` instead of a string `''`. Found during fresh install on corvopi-test.

## Test plan
- [x] Verified Signal K starts cleanly after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)