### PR TITLE
Fix data/ group-write permissions for j105logger service

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -163,6 +163,9 @@ if $PROMTAIL_CHANGED; then
 fi
 $LOKI_CHANGED || $PROMTAIL_CHANGED || echo "    Loki + Promtail configs unchanged."
 
+echo "==> Fixing data directory permissions..."
+chmod -R g+w "$PROJECT_DIR/data" 2>/dev/null || true
+
 echo "==> Restarting j105-logger service..."
 sudo systemctl restart j105-logger
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -643,6 +643,7 @@ ExecStart=${UV_BIN} run --no-sync --project ${PROJECT_DIR} j105-logger run
 Restart=on-failure
 RestartSec=5
 SupplementaryGroups=netdev audio
+UMask=0002
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Files created by CLI commands (e.g. `j105-logger add-user`) as `weaties` inherit the default umask `022`, stripping group-write. The `j105logger` service account could read but not write the database.

- **setup.sh**: Add `UMask=0002` to the systemd unit so the service creates group-writable files
- **deploy.sh**: `chmod -R g+w data/` before restart so files created by CLI commands become writable by the service

Found during fresh install on corvopi-test.

## Test plan
- [x] 425 tests pass
- [x] Diagnosed on corvopi-test: service could connect to DB read-only but web task crashed on write

🤖 Generated with [Claude Code](https://claude.com/claude-code)