### PR TITLE
feat: self-service login link for existing users

### DIFF
--- a/src/logger/email.py
+++ b/src/logger/email.py
@@ -69,6 +69,21 @@ async def send_welcome_email(name: str | None, email: str, role: str, login_url:
     return await send_email(email, subject, body)
 
 
+async def send_login_link_email(name: str | None, email: str, login_url: str) -> bool:
+    """Send a self-service login link email."""
+    greeting = f"Hi {name}" if name else "Hi"
+    subject = "Your login link — J105 Logger"
+    body = (
+        f"{greeting},\n\n"
+        f"You requested a login link for J105 Logger.\n\n"
+        f"Click the link below to sign in (expires in 7 days):\n"
+        f"  {login_url}\n\n"
+        f"If you didn't request this, you can safely ignore this email.\n\n"
+        f"Fair winds!"
+    )
+    return await send_email(email, subject, body)
+
+
 async def send_device_alert(user_email: str, ip: str | None, user_agent: str | None) -> bool:
     """Notify a user about a new device login."""
     subject = "New device login — J105 Logger"

--- a/src/logger/storage.py
+++ b/src/logger/storage.py
@@ -2045,7 +2045,7 @@ class Storage:
         token: str,
         email: str,
         role: str,
-        created_by: int,
+        created_by: int | None,
         expires_at: str,
     ) -> None:
         db = self._conn()
@@ -2074,6 +2074,28 @@ class Storage:
         db = self._conn()
         await db.execute("UPDATE invite_tokens SET used_at = ? WHERE token = ?", (now, token))
         await db.commit()
+
+    async def count_recent_tokens_for_email(
+        self, email: str, window_hours: int = 1
+    ) -> int:
+        """Count invite tokens created for *email* in the last *window_hours* hours.
+
+        Since ``invite_tokens`` has no ``created_at`` column, we derive creation
+        time from ``expires_at`` (tokens expire 7 days after creation).  A token
+        created within the window has ``expires_at > now + 7d - window``.
+        """
+        from datetime import UTC, timedelta
+        from datetime import datetime as _dt
+
+        threshold = (
+            _dt.now(UTC) + timedelta(days=7) - timedelta(hours=window_hours)
+        ).isoformat()
+        cur = await self._conn().execute(
+            "SELECT COUNT(*) FROM invite_tokens WHERE email = ? AND expires_at > ?",
+            (email.lower().strip(), threshold),
+        )
+        row = await cur.fetchone()
+        return row[0] if row else 0
 
     async def create_session(
         self,

--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -2307,8 +2307,19 @@ font-size:1rem;font-weight:700;cursor:pointer;background:#2563eb;color:#fff}
 </form>
 <!--ERROR-->
 </div>
+__EMAIL_FORM__
 </body>
 </html>
+"""
+
+_EMAIL_FORM_HTML = """\
+<div class="card" style="margin-top:16px">
+<form method="post" action="/auth/request-link">
+<label>Don't have a token?</label>
+<input type="email" name="email" placeholder="Enter your email address" required/>
+<button class="btn" type="submit" style="background:#475569">Send me a login link</button>
+</form>
+</div>
 """
 
 
@@ -2604,7 +2615,7 @@ def create_app(
         session_expires_at,
     )
 
-    _PUBLIC_PATHS = {"/login", "/logout", "/healthz", "/avatars"}
+    _PUBLIC_PATHS = {"/login", "/logout", "/healthz", "/avatars", "/auth/request-link"}
 
     async def _audit(
         request: Request,
@@ -2676,7 +2687,14 @@ def create_app(
 
     @app.get("/login", response_class=HTMLResponse, include_in_schema=False)
     async def login_page(next: str = "/", token: str = "") -> HTMLResponse:
-        html = _LOGIN_HTML.replace("__NEXT__", next).replace("__TOKEN__", token)
+        from logger.email import smtp_configured
+
+        email_form = _EMAIL_FORM_HTML if smtp_configured() else ""
+        html = (
+            _LOGIN_HTML.replace("__NEXT__", next)
+            .replace("__TOKEN__", token)
+            .replace("__EMAIL_FORM__", email_form)
+        )
         return HTMLResponse(html)
 
     @app.post("/login", include_in_schema=False)
@@ -2698,7 +2716,8 @@ def create_app(
                 .replace(
                     "<!--ERROR-->",
                     '<p style="color:#f87171;margin-top:12px">Invalid or expired token.</p>',
-                ),
+                )
+                .replace("__EMAIL_FORM__", ""),
                 status_code=400,
             )
         if row["used_at"] is not None:
@@ -2708,7 +2727,8 @@ def create_app(
                 .replace(
                     "<!--ERROR-->",
                     '<p style="color:#f87171;margin-top:12px">Token already used.</p>',
-                ),
+                )
+                .replace("__EMAIL_FORM__", ""),
                 status_code=400,
             )
         expires_dt = _dt.fromisoformat(row["expires_at"])
@@ -2719,7 +2739,8 @@ def create_app(
                 .replace(
                     "<!--ERROR-->",
                     '<p style="color:#f87171;margin-top:12px">Token expired.</p>',
-                ),
+                )
+                .replace("__EMAIL_FORM__", ""),
                 status_code=400,
             )
 
@@ -2762,6 +2783,51 @@ def create_app(
             )
 
         return response
+
+    _REQUEST_LINK_RESPONSE = (
+        '<p style="color:#34d399;margin-top:12px">'
+        "If an account exists for that email, a login link has been sent.</p>"
+    )
+
+    @app.post("/auth/request-link", include_in_schema=False)
+    @limiter.limit("5/minute")
+    async def request_login_link(
+        request: Request,
+        email: str = Form(default=""),
+    ) -> HTMLResponse:
+        from logger.email import send_login_link_email, smtp_configured
+
+        html = (
+            _LOGIN_HTML.replace("__NEXT__", "/")
+            .replace("__TOKEN__", "")
+            .replace("<!--ERROR-->", _REQUEST_LINK_RESPONSE)
+            .replace("__EMAIL_FORM__", "")
+        )
+        email = email.strip().lower()
+        if not email or not smtp_configured():
+            return HTMLResponse(html)
+
+        user = await storage.get_user_by_email(email)
+        if user is None:
+            return HTMLResponse(html)
+
+        # Per-email rate limit: max 3 tokens/hour
+        recent = await storage.count_recent_tokens_for_email(email)
+        if recent >= 3:
+            return HTMLResponse(html)
+
+        # Create token and send email
+        token = generate_token()
+        await storage.create_invite_token(
+            token, email, user["role"], user["id"], invite_expires_at()
+        )
+        public_url = os.getenv("PUBLIC_URL", "").rstrip("/")
+        login_url = f"{public_url}/login?token={token}"
+        asyncio.ensure_future(
+            send_login_link_email(user.get("name"), email, login_url)
+        )
+        await _audit(request, "auth.request_link", detail=email)
+        return HTMLResponse(html)
 
     @app.post("/logout", include_in_schema=False)
     async def logout(request: Request) -> Response:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -403,3 +403,257 @@ async def test_login_rate_limited(storage: Storage) -> None:
                 await client.post("/login", data={"token": "bad", "next": "/"})
             resp = await client.post("/login", data={"token": "bad", "next": "/"})
     assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Self-service login link (issue #148)
+# ---------------------------------------------------------------------------
+
+_SMTP_ENV = {"SMTP_HOST": "localhost", "SMTP_PORT": "587", "SMTP_FROM": "test@test.com"}
+
+
+@pytest.mark.asyncio
+async def test_count_recent_tokens_empty(storage: Storage) -> None:
+    """count_recent_tokens_for_email returns 0 when no tokens exist."""
+    count = await storage.count_recent_tokens_for_email("nobody@x.com")
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_count_recent_tokens_counts(storage: Storage) -> None:
+    """count_recent_tokens_for_email counts recently-created tokens."""
+    user_id = await storage.create_user("counter@x.com", None, "crew")
+    for _ in range(3):
+        await storage.create_invite_token(
+            generate_token(), "counter@x.com", "crew", user_id, invite_expires_at()
+        )
+    count = await storage.count_recent_tokens_for_email("counter@x.com")
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_invite_token_null_created_by(storage: Storage) -> None:
+    """create_invite_token accepts None for created_by."""
+    token = generate_token()
+    await storage.create_invite_token(token, "null@x.com", "viewer", None, invite_expires_at())
+    row = await storage.get_invite_token(token)
+    assert row is not None
+    assert row["email"] == "null@x.com"
+
+
+@pytest.mark.asyncio
+async def test_send_login_link_email() -> None:
+    """send_login_link_email calls send_email with correct subject."""
+    with patch("logger.email.send_email", return_value=True) as mock_send:
+        from logger.email import send_login_link_email
+
+        result = await send_login_link_email("Alice", "a@x.com", "http://test/login?token=abc")
+    assert result is True
+    mock_send.assert_called_once()
+    args = mock_send.call_args
+    assert args[0][0] == "a@x.com"
+    assert "login link" in args[0][1].lower()
+    assert "http://test/login?token=abc" in args[0][2]
+    assert "didn't request" in args[0][2].lower()
+
+
+@pytest.mark.asyncio
+async def test_request_link_sends_email(storage: Storage) -> None:
+    """POST /auth/request-link for an existing user creates a token and sends email."""
+    await storage.create_user("crew@boat.com", "Sailor", "crew")
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with (
+        patch.dict(os.environ, env),
+        patch("logger.email._send_sync") as mock_smtp,
+    ):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/auth/request-link", data={"email": "crew@boat.com"})
+
+    assert resp.status_code == 200
+    assert "login link has been sent" in resp.text.lower()
+    mock_smtp.assert_called_once()
+
+    # A token was created for this email
+    cur = await storage._conn().execute(
+        "SELECT COUNT(*) FROM invite_tokens WHERE email = ?", ("crew@boat.com",)
+    )
+    row = await cur.fetchone()
+    assert row[0] == 1
+
+    # Audit log entry exists
+    entries = await storage.list_audit_log(limit=10)
+    actions = [e["action"] for e in entries]
+    assert "auth.request_link" in actions
+
+
+@pytest.mark.asyncio
+async def test_request_link_unknown_email(storage: Storage) -> None:
+    """POST /auth/request-link for unknown email returns same HTML, no token."""
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with (
+        patch.dict(os.environ, env),
+        patch("logger.email._send_sync") as mock_smtp,
+    ):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/auth/request-link", data={"email": "ghost@x.com"})
+
+    assert resp.status_code == 200
+    assert "login link has been sent" in resp.text.lower()
+    mock_smtp.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_link_no_smtp(storage: Storage) -> None:
+    """Without SMTP, POST /auth/request-link returns generic response."""
+    await storage.create_user("nosend@x.com", None, "crew")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/auth/request-link", data={"email": "nosend@x.com"})
+
+    assert resp.status_code == 200
+    assert "login link has been sent" in resp.text.lower()
+
+    # No token was created
+    cur = await storage._conn().execute(
+        "SELECT COUNT(*) FROM invite_tokens WHERE email = ?", ("nosend@x.com",)
+    )
+    row = await cur.fetchone()
+    assert row[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_request_link_rate_limited_by_ip(storage: Storage) -> None:
+    """POST /auth/request-link is rate-limited by IP (5/minute)."""
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with (
+        patch.dict(os.environ, env),
+        patch("logger.email._send_sync"),
+    ):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            for _ in range(5):
+                await client.post("/auth/request-link", data={"email": "x@x.com"})
+            resp = await client.post("/auth/request-link", data={"email": "x@x.com"})
+    assert resp.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_request_link_rate_limited_by_email(storage: Storage) -> None:
+    """4th request for the same email in an hour creates no new token."""
+    user_id = await storage.create_user("busy@x.com", "Busy", "crew")
+    # Pre-create 3 tokens (simulating 3 recent requests)
+    for _ in range(3):
+        await storage.create_invite_token(
+            generate_token(), "busy@x.com", "crew", user_id, invite_expires_at()
+        )
+
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with (
+        patch.dict(os.environ, env),
+        patch("logger.email._send_sync") as mock_smtp,
+    ):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/auth/request-link", data={"email": "busy@x.com"})
+
+    assert resp.status_code == 200  # Still generic response
+    mock_smtp.assert_not_called()  # No email sent
+
+    # Still only 3 tokens
+    cur = await storage._conn().execute(
+        "SELECT COUNT(*) FROM invite_tokens WHERE email = ?", ("busy@x.com",)
+    )
+    row = await cur.fetchone()
+    assert row[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_request_link_empty_email(storage: Storage) -> None:
+    """POST /auth/request-link with empty email returns generic response."""
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with patch.dict(os.environ, env):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/auth/request-link", data={"email": ""})
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_login_page_shows_email_form_with_smtp(storage: Storage) -> None:
+    """GET /login shows the email form when SMTP is configured."""
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with patch.dict(os.environ, env):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/login")
+    assert resp.status_code == 200
+    assert 'action="/auth/request-link"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_login_page_hides_email_form_without_smtp(storage: Storage) -> None:
+    """GET /login hides the email form when SMTP is not configured."""
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}, clear=False):
+        # Ensure no SMTP vars
+        os.environ.pop("SMTP_HOST", None)
+        os.environ.pop("SMTP_PORT", None)
+        os.environ.pop("SMTP_FROM", None)
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/login")
+    assert resp.status_code == 200
+    assert 'action="/auth/request-link"' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_request_link_token_redeemable(storage: Storage) -> None:
+    """E2E: request link → extract token from DB → POST /login → session created."""
+    await storage.create_user("e2e@x.com", "E2E", "crew")
+
+    env = {"AUTH_DISABLED": "false", **_SMTP_ENV}
+    with (
+        patch.dict(os.environ, env),
+        patch("logger.email._send_sync"),
+    ):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            # Step 1: request a login link
+            await client.post("/auth/request-link", data={"email": "e2e@x.com"})
+
+            # Step 2: extract the token from the DB
+            cur = await storage._conn().execute(
+                "SELECT token FROM invite_tokens WHERE email = ? AND used_at IS NULL",
+                ("e2e@x.com",),
+            )
+            row = await cur.fetchone()
+            assert row is not None
+            token = row[0]
+
+            # Step 3: redeem the token via POST /login
+            resp = await client.post("/login", data={"token": token, "next": "/"})
+
+    assert resp.status_code == 303
+    assert "session" in resp.cookies


### PR DESCRIPTION
## Summary

Closes #148.

- Adds a "Send me a login link" email form to `/login` (only shown when SMTP is configured)
- New `POST /auth/request-link` endpoint creates an invite token and emails a magic link to existing users
- Rate-limited by IP (5/min via slowapi) and per-email (3 tokens/hour via `count_recent_tokens_for_email`)
- Always returns a generic response to prevent email enumeration
- `create_invite_token` now accepts `created_by: int | None` for self-service tokens

## Files changed

| File | Change |
|------|--------|
| `src/logger/email.py` | Add `send_login_link_email()` |
| `src/logger/storage.py` | Add `count_recent_tokens_for_email()`, widen `created_by` to `int \| None` |
| `src/logger/web.py` | Add `POST /auth/request-link`, conditional email form on login page |
| `tests/test_auth.py` | 13 new tests (storage, email, endpoint, rate limiting, e2e) |

## Test plan

- [x] `uv run pytest` — 438 passed
- [x] `uv run ruff check .` — clean (only pre-existing E501s)
- [x] `uv run mypy src/` — clean (only pre-existing errors)
- [ ] Manual test on Pi: verify email form appears with SMTP configured, hidden without
- [ ] Manual test: request link → receive email → click link → logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)