### PR TITLE
fix: show error message when race start fails

### DIFF
--- a/src/logger/web.py
+++ b/src/logger/web.py
@@ -709,6 +709,10 @@ async function startSession(type) {
       await loadRecentSailors();
     }
     pendingCrew = null;
+  } else {
+    const err = await resp.json().catch(()=>null);
+    const msg = err && err.detail ? err.detail : 'Failed to start session';
+    alert(msg);
   }
   await loadState();
   clearInterval(tickInterval);


### PR DESCRIPTION
## Summary
- Display API error detail to the user when starting a race/practice fails
- Previously the 422 response (e.g. "No event set for today") was silently ignored

Closes #153

## Test plan
- [x] `uv run pytest` — 109 web tests pass
- [ ] Manual: try starting a race without an event set → should show alert with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)