### PR TITLE
fix: Loki/Promtail config for loopback-only deployment

### DIFF
--- a/scripts/loki/loki-config.yaml
+++ b/scripts/loki/loki-config.yaml
@@ -7,9 +7,12 @@ auth_enabled: false
 server:
   http_listen_address: 127.0.0.1
   http_listen_port: 3100
+  grpc_listen_address: 127.0.0.1
+  grpc_listen_port: 9095
 
 common:
   path_prefix: /var/lib/loki
+  instance_addr: 127.0.0.1
   replication_factor: 1
   ring:
     kvstore:

--- a/scripts/loki/promtail-config.yaml
+++ b/scripts/loki/promtail-config.yaml
@@ -8,6 +8,7 @@
 server:
   http_listen_address: 127.0.0.1
   http_listen_port: 9080
+  grpc_listen_port: 0
 
 positions:
   filename: /var/lib/promtail/positions.yaml


### PR DESCRIPTION
## Summary
- Loki's internal ring was advertising the LAN IP (192.168.8.154) instead of 127.0.0.1, causing all queries to hang because gRPC was bound to loopback only
- Added `instance_addr: 127.0.0.1` to Loki config so ring uses loopback
- Added `grpc_listen_port: 0` to Promtail to avoid port 9095 conflict with Loki

## Root cause
The default Promtail config from the apt package was scraping `/var/log/messages` (doesn't exist on this Pi). The repo configs were correct but the systemd overrides pointing to them weren't deployed. After deploying the correct configs, Loki's ring auto-detected the LAN IP for internal gRPC, which didn't match the loopback bind address.

## Test plan
- [x] `curl http://127.0.0.1:3100/loki/api/v1/label/service/values` returns all 6 services
- [x] Grafana Service Logs dashboard should now show data
- [ ] Verify on fresh install via setup.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)