### PR TITLE
Fix Grafana anonymous access: set org role to Viewer

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -343,7 +343,7 @@ Environment=GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s/grafana/
 Environment=GF_SERVER_SERVE_FROM_SUB_PATH=true
 Environment=GF_AUTH_DISABLE_LOGIN_FORM=false
 Environment=GF_AUTH_ANONYMOUS_ENABLED=true
-Environment=GF_AUTH_ANONYMOUS_ORG_ROLE=None
+Environment=GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
 EOF
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Summary

- Grafana anonymous users had `org_role=None`, which blocked dashboard access
- Deep-links from HelmLog web UI to Grafana dashboards showed "Forbidden"
- Changed to `Viewer` so dashboards are accessible without login

## Test plan

- [x] Verified Grafana dashboard loads via `http://corvopi-live/grafana/d/helmlog-sailing/...`
- [x] No login prompt required for viewing dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)