### PR TITLE
feat: community contribution infrastructure (#174)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug Report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Start the logger with `helmlog run`
+        2. Navigate to http://hostname/
+        3. Click "Start Race"
+        4. See error in ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Raspberry Pi (production)
+        - Mac (development)
+        - Other Linux
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `git rev-parse --short HEAD` or the version you're running.
+      placeholder: e.g. 36ead41
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output (journalctl, browser console, etc.)
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, hardware setup, Signal K version, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Data Licensing Policy
+    url: https://github.com/weaties/helmlog/blob/main/docs/data-licensing.md
+    about: Review the data ownership and privacy policy before working on data-related features

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem does this solve? What sailing scenario motivates it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should this work? Be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why is the proposed solution better?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How big is this change?
+      options:
+        - "Small — single file or function"
+        - "Medium — multiple files, one module"
+        - "Large — cross-module or new module"
+        - "Not sure"
+
+  - type: checkboxes
+    id: data-policy
+    attributes:
+      label: Data policy
+      options:
+        - label: This feature touches user data (storage, export, PII, or co-op sharing) and should be reviewed against `docs/data-licensing.md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does and why -->
+
+-
+
+## Test plan
+
+<!-- How did you verify this works? Check all that apply. -->
+
+- [ ] `uv run pytest` — all tests pass
+- [ ] `uv run ruff check .` — lint clean
+- [ ] `uv run ruff format --check .` — format clean
+- [ ] `uv run mypy src/` — types clean (no new errors)
+- [ ] New tests added for new functionality
+- [ ] Manual testing (describe below)
+
+## Checklist
+
+- [ ] Changes follow the [coding standards](CONTRIBUTING.md#coding-standards)
+- [ ] No secrets, credentials, or `.env` files committed
+- [ ] Data-handling changes reviewed against [`docs/data-licensing.md`](docs/data-licensing.md) (if applicable)
+- [ ] Documentation updated (if applicable)
+
+## Related issues
+
+<!-- e.g. Closes #123, Fixes #456 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+HelmLog a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+**Positive behavior includes:**
+
+- Being respectful and constructive in code reviews and discussions
+- Welcoming new contributors and helping them get started
+- Focusing on what's best for the project and the sailing community
+- Accepting feedback gracefully
+
+**Unacceptable behavior includes:**
+
+- Harassment, insults, or derogatory comments
+- Publishing others' private information (boat data, personal details) without
+  consent
+- Trolling or deliberately disruptive behavior
+- Any conduct that violates the [data licensing policy](docs/data-licensing.md),
+  particularly misuse of co-op sailing data
+
+## Scope
+
+This code of conduct applies to all project spaces — GitHub issues, pull
+requests, discussions, and any communication channels associated with HelmLog.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers.
+All complaints will be reviewed and investigated. Maintainers have the right to
+remove, edit, or reject contributions that violate this code of conduct, and to
+temporarily or permanently ban contributors for behavior they deem inappropriate.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,26 @@ Use the `/data-license` skill to review changes against the policy.
 - Use `httpx.AsyncClient` with `ASGITransport` for web route tests
 - Mock hardware modules (`audio.py`, `can_reader.py`, `sk_reader.py`, `cameras.py`)
 
+## AI Agent Collaboration
+
+HelmLog is developed with AI coding agents (primarily Claude Code). If you use
+AI agents in your contributions:
+
+- **Co-Authored-By**: Include `Co-Authored-By: <Agent> <noreply@anthropic.com>`
+  in commit messages when an AI agent wrote or substantially modified the code
+- **TDD workflow**: Agents should follow the same TDD cycle as human
+  contributors — write a failing test first, then implement
+- **Human review required**: Schema migrations, auth changes, data deletion
+  logic, and anything touching `storage.py` FK constraints or `auth.py` must
+  have human review regardless of who (or what) wrote the code
+- **Agent-friendly issues**: Well-scoped issues with clear acceptance criteria,
+  test cases, and module boundaries work best for agent-assisted development.
+  The `good first issue` label marks issues suitable for new contributors
+  (human or AI)
+- **Plan before implementing**: For non-trivial changes (new modules,
+  cross-module refactors, schema changes), write a plan or design comment on the
+  issue before coding
+
 ## Skills
 
 Claude Code skills are available for common workflows:
@@ -92,6 +112,28 @@ Claude Code skills are available for common workflows:
 | `/deploy-pi` | Pi deployment reference |
 | `/pr-checklist` | Pre-PR verification checks |
 | `/data-license` | Review changes against the data licensing policy |
+
+## Module Review Guide
+
+Some modules require extra care:
+
+| Module | Risk | Notes |
+|---|---|---|
+| `storage.py` | High | Schema migrations must be backwards-compatible; FK constraints affect cascading deletes |
+| `auth.py` | High | Security-sensitive; changes affect all authenticated endpoints |
+| `main.py` | Medium | Wiring only — no business logic; changes affect startup order |
+| `web.py` | Medium | Large file; check auth decorators and rate limits on new endpoints |
+| `export.py` | Medium | Data leaves the system; check GPS precision and data policy compliance |
+| `transcribe.py` | Low | Isolated; mock-friendly |
+| `cameras.py`, `sk_reader.py`, `can_reader.py` | Low | Hardware-isolated; well-contained |
+| `nmea2000.py`, `races.py`, `polar.py` | Low | Pure logic; easy to test |
+
+## Review Process
+
+- PRs require CI to pass (tests, lint, format) and at least one maintainer approval
+- Expect a response within a few days; complex changes may take longer
+- Maintainers may request changes, ask questions, or suggest alternatives
+- Once approved, the maintainer will merge via squash-and-merge
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Open-source sailing data platform — instrument logging, race debrief, fleet performance"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = { text = "AGPL-3.0-or-later" }
 
 dependencies = [
     # CAN bus


### PR DESCRIPTION
## Summary

- Add issue templates (bug report, feature request), PR template, Dependabot config, and Code of Conduct
- Update CONTRIBUTING.md with AI agent collaboration patterns, module review guide, and review process
- Fix license mismatch in `pyproject.toml` (was MIT, should be AGPL-3.0-or-later)

## Not included (needs manual setup)

- **CI workflow**: `.github/workflows/ci.yml` is written and exists locally but the GitHub PAT lacks `workflow` scope to push it. Either:
  1. Update the PAT to include `workflow` scope and I'll push it, or
  2. Copy the file content from the branch and add it via the GitHub web UI
- **Branch protection rules**: Must be configured via GitHub Settings > Branches (require CI pass + 1 approval before merge to main)
- **Good first issues**: Should be labeled on existing issues once CI is running — I can identify candidates after merge

## What's in the PR

| File | Purpose |
|---|---|
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured bug report with environment, repro steps, logs |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature request with use case, scope, data policy checkbox |
| `.github/ISSUE_TEMPLATE/config.yml` | Links to data licensing policy from issue chooser |
| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist: tests, lint, format, types, data policy |
| `.github/dependabot.yml` | Weekly updates for pip + GitHub Actions deps |
| `CODE_OF_CONDUCT.md` | Contributor Covenant adapted for sailing community |
| `CONTRIBUTING.md` | Added: agent collaboration, module review guide, review process |
| `pyproject.toml` | License fix: MIT → AGPL-3.0-or-later |

## Test plan

- [x] `uv run pytest` — 552 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template populates on new PRs

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)