### PR TITLE
ci: add GitHub Actions workflow for tests, lint, and type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libportaudio2 libsndfile1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest --tb=short
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format
+        run: uv run ruff format --check .
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: mypy
+        run: uv run mypy src/
+        continue-on-error: true  # pre-existing errors from aiosqlite/slowapi; track trend


### PR DESCRIPTION
## Summary

- Add CI workflow that runs pytest, ruff check, ruff format, and mypy on all PRs and pushes to main
- Three parallel jobs: test, lint, typecheck

## Manual step required

The PAT lacks `workflow` scope, so the workflow file must be added to this PR via the GitHub web UI. Create `.github/workflows/ci.yml` on this branch with the contents below.

<details>
<summary><strong>📋 .github/workflows/ci.yml — click to expand, then copy</strong></summary>

```yaml
name: CI

on:
  push:
    branches: [main]
  pull_request:

permissions:
  contents: read

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - name: Install system dependencies
        run: sudo apt-get update && sudo apt-get install -y libportaudio2 libsndfile1

      - name: Install uv
        uses: astral-sh/setup-uv@v4

      - name: Set up Python
        run: uv python install

      - name: Install dependencies
        run: uv sync

      - name: Run tests
        run: uv run pytest --tb=short

  lint:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - name: Install uv
        uses: astral-sh/setup-uv@v4

      - name: Set up Python
        run: uv python install

      - name: Install dependencies
        run: uv sync

      - name: Ruff check
        run: uv run ruff check .

      - name: Ruff format
        run: uv run ruff format --check .

  typecheck:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - name: Install uv
        uses: astral-sh/setup-uv@v4

      - name: Set up Python
        run: uv python install

      - name: Install dependencies
        run: uv sync

      - name: mypy
        run: uv run mypy src/
        continue-on-error: true  # pre-existing errors from aiosqlite/slowapi; track trend
```

</details>

## Test plan

- [ ] Add the workflow file via GitHub web UI on this branch
- [ ] Verify CI runs on this PR after the file is added
- [ ] All three jobs pass (test, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)