### PR TITLE
feat: add hostname to footer version info (#175)

### DIFF
--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -66,8 +66,11 @@ def _get_git_info() -> str:
             except Exception:  # noqa: BLE001
                 pass  # no upstream configured
 
+        import socket
+
+        hostname = socket.gethostname()
         status = "dirty" if dirty else "clean"
-        return f"{branch} @ {sha} · {status}"
+        return f"{hostname} · {branch} @ {sha} · {status}"
     except Exception:  # noqa: BLE001
         return ""
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -21,7 +21,7 @@ from helmlog.nmea2000 import (
     SpeedRecord,
     WindRecord,
 )
-from helmlog.web import create_app
+from helmlog.web import _get_git_info, create_app
 
 if TYPE_CHECKING:
     from helmlog.storage import Storage
@@ -29,6 +29,16 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def test_git_info_includes_hostname() -> None:
+    """_get_git_info() should include the system hostname."""
+    import socket
+
+    info = _get_git_info()
+    assert info  # non-empty (we're in a git repo)
+    assert socket.gethostname() in info
+
 
 _DEVICE = "Gordik 2T1R USB Audio"
 _START_UTC = datetime(2026, 2, 26, 14, 0, 0, tzinfo=UTC)


### PR DESCRIPTION
## Summary

- Prepend `socket.gethostname()` to the git info string in the page footer
- Footer now shows e.g. `corvopi · main @ abc1234 · clean` instead of just `main @ abc1234 · clean`

## Test plan

- [x] `uv run pytest` — passes
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] New test: `test_git_info_includes_hostname` verifies hostname is present in the string

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)