### PR TITLE
feat: add fan speed to Pi Health dashboard and enable shared crosshairs

### DIFF
--- a/scripts/grafana/pi-health.json
+++ b/scripts/grafana/pi-health.json
@@ -37,12 +37,13 @@
   ],
   "title": "Pi Health",
   "uid": "pi-health",
-  "description": "Raspberry Pi system health — CPU, memory, disk, temperature",
+  "description": "Raspberry Pi system health — CPU, memory, disk, temperature, fan speed",
   "tags": ["system", "pi"],
   "timezone": "browser",
   "refresh": "1m",
+  "graphTooltip": 1,
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "time": { "from": "now-6h", "to": "now" },
   "templating": {
     "list": [
@@ -64,7 +65,7 @@
       "type": "gauge",
       "title": "CPU Usage",
       "id": 1,
-      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 6 },
+      "gridPos": { "x": 0, "y": 0, "w": 5, "h": 6 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -99,7 +100,7 @@
       "type": "gauge",
       "title": "Memory Usage",
       "id": 2,
-      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 6 },
+      "gridPos": { "x": 5, "y": 0, "w": 5, "h": 6 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -134,7 +135,7 @@
       "type": "gauge",
       "title": "Disk Usage",
       "id": 3,
-      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 6 },
+      "gridPos": { "x": 10, "y": 0, "w": 5, "h": 6 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -169,7 +170,7 @@
       "type": "gauge",
       "title": "CPU Temperature",
       "id": 4,
-      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 6 },
+      "gridPos": { "x": 15, "y": 0, "w": 5, "h": 6 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "reduceOptions": { "calcs": ["lastNotNull"] },
@@ -197,6 +198,42 @@
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
           "query": "from(bucket: \"signalk\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system_health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"cpu_temp_c\")\n  |> last()",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Fan Speed",
+      "id": 9,
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 6 },
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rotrpm",
+          "min": 0,
+          "max": 8000,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 1000 },
+              { "color": "yellow", "value": 5000 },
+              { "color": "red", "value": 7000 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system_health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"fan_rpm\")\n  |> last()",
           "refId": "A"
         }
       ]
@@ -236,7 +273,7 @@
       "type": "timeseries",
       "title": "CPU Temperature Over Time",
       "id": 6,
-      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 14, "w": 8, "h": 8 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "legend": { "displayMode": "list", "placement": "bottom" },
@@ -267,9 +304,35 @@
     },
     {
       "type": "timeseries",
+      "title": "Fan Speed Over Time",
+      "id": 10,
+      "gridPos": { "x": 8, "y": 14, "w": 8, "h": 8 },
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rotrpm",
+          "min": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "fixedColor": "blue", "mode": "fixed" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "from(bucket: \"signalk\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system_health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"fan_rpm\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _field: \"Fan RPM\"}))\n  |> yield(name: \"fan\")",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
       "title": "Disk Usage Over Time",
       "id": 7,
-      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
+      "gridPos": { "x": 16, "y": 14, "w": 8, "h": 8 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "options": {
         "legend": { "displayMode": "list", "placement": "bottom" },

--- a/src/helmlog/monitor.py
+++ b/src/helmlog/monitor.py
@@ -50,6 +50,19 @@ def _collect_and_write() -> None:
                     temp_c = float(current)
                 break
 
+    # Fan speed (RPM) — available on Raspberry Pi 5 with active cooler
+    fan_rpm: float | None = None
+    get_fans = getattr(psutil, "sensors_fans", None)
+    if get_fans is not None:
+        fans: dict[str, list[object]] = get_fans()
+        for fan_entries in fans.values():
+            if fan_entries:
+                fan_first = fan_entries[0]
+                fan_current = getattr(fan_first, "current", None)
+                if fan_current is not None:
+                    fan_rpm = float(fan_current)
+                break
+
     # Network throughput: compute bytes/sec since the previous sample
     net_now: Any = psutil.net_io_counters()
     net_time_now: float = time.monotonic()
@@ -80,6 +93,8 @@ def _collect_and_write() -> None:
         )
         if temp_c is not None:
             p = p.field("cpu_temp_c", temp_c)
+        if fan_rpm is not None:
+            p = p.field("fan_rpm", fan_rpm)
         if net_bytes_sent_per_s is not None:
             p = p.field("net_bytes_sent_per_s", net_bytes_sent_per_s)
         if net_bytes_recv_per_s is not None:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,128 @@
+"""Tests for the system health monitor module."""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from helmlog.monitor import _collect_and_write
+
+# Fake psutil types --------------------------------------------------------
+
+_FanReading = namedtuple("_FanReading", ["label", "current"])
+
+_VirtualMemory = namedtuple("_VirtualMemory", ["percent"])
+_DiskUsage = namedtuple("_DiskUsage", ["percent"])
+_NetIO = namedtuple("_NetIO", ["bytes_sent", "bytes_recv"])
+
+
+def _make_psutil_mock(
+    *,
+    fan_entries: dict[str, list[Any]] | None = None,
+    has_sensors_fans: bool = True,
+) -> MagicMock:
+    """Return a mock psutil module with controllable fan data."""
+    mock = MagicMock()
+    mock.cpu_percent.return_value = 25.0
+    mock.virtual_memory.return_value = _VirtualMemory(percent=40.0)
+    mock.disk_usage.return_value = _DiskUsage(percent=55.0)
+    mock.net_io_counters.return_value = _NetIO(bytes_sent=0, bytes_recv=0)
+
+    # Temperature — always provide a value
+    _TempReading = namedtuple("_TempReading", ["label", "current"])
+    mock.sensors_temperatures.return_value = {"cpu_thermal": [_TempReading(label="", current=50.0)]}
+
+    # Fan
+    if has_sensors_fans:
+        mock.sensors_fans.return_value = fan_entries or {}
+    else:
+        del mock.sensors_fans  # simulate platform without the API
+
+    return mock
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestFanSpeedCollection:
+    """Fan RPM is collected when psutil exposes it."""
+
+    def test_fan_rpm_written_when_available(self) -> None:
+        """Fan RPM should be written to InfluxDB when psutil reports fan data."""
+        psutil_mock = _make_psutil_mock(
+            fan_entries={"cooling_fan0": [_FanReading(label="", current=3500)]}
+        )
+        point_instance = MagicMock()
+        point_cls = MagicMock(return_value=point_instance)
+        point_instance.field.return_value = point_instance  # chaining
+
+        write_api = MagicMock()
+        client = MagicMock()
+
+        with (
+            patch.dict("sys.modules", {"psutil": psutil_mock}),
+            patch("helmlog.influx._client", return_value=(client, write_api)),
+            patch.dict("sys.modules", {"influxdb_client": MagicMock(Point=point_cls)}),
+        ):
+            # Reset network state so rate calc is skipped on first call
+            import helmlog.monitor as mod
+
+            mod._prev_net = None
+            mod._prev_net_time = None
+            _collect_and_write()
+
+        # Gather all .field() calls
+        field_calls = {call.args[0]: call.args[1] for call in point_instance.field.call_args_list}
+        assert "fan_rpm" in field_calls
+        assert field_calls["fan_rpm"] == 3500.0
+
+    def test_fan_rpm_omitted_when_no_fans(self) -> None:
+        """No fan_rpm field when psutil reports empty fan dict."""
+        psutil_mock = _make_psutil_mock(fan_entries={})
+        point_instance = MagicMock()
+        point_cls = MagicMock(return_value=point_instance)
+        point_instance.field.return_value = point_instance
+
+        write_api = MagicMock()
+        client = MagicMock()
+
+        with (
+            patch.dict("sys.modules", {"psutil": psutil_mock}),
+            patch("helmlog.influx._client", return_value=(client, write_api)),
+            patch.dict("sys.modules", {"influxdb_client": MagicMock(Point=point_cls)}),
+        ):
+            import helmlog.monitor as mod
+
+            mod._prev_net = None
+            mod._prev_net_time = None
+            _collect_and_write()
+
+        field_names = [call.args[0] for call in point_instance.field.call_args_list]
+        assert "fan_rpm" not in field_names
+
+    def test_fan_rpm_omitted_when_no_api(self) -> None:
+        """No fan_rpm field when psutil lacks sensors_fans entirely (e.g. macOS)."""
+        psutil_mock = _make_psutil_mock(has_sensors_fans=False)
+        point_instance = MagicMock()
+        point_cls = MagicMock(return_value=point_instance)
+        point_instance.field.return_value = point_instance
+
+        write_api = MagicMock()
+        client = MagicMock()
+
+        with (
+            patch.dict("sys.modules", {"psutil": psutil_mock}),
+            patch("helmlog.influx._client", return_value=(client, write_api)),
+            patch.dict("sys.modules", {"influxdb_client": MagicMock(Point=point_cls)}),
+        ):
+            import helmlog.monitor as mod
+
+            mod._prev_net = None
+            mod._prev_net_time = None
+            _collect_and_write()
+
+        field_names = [call.args[0] for call in point_instance.field.call_args_list]
+        assert "fan_rpm" not in field_names


### PR DESCRIPTION
## Summary
- Collect fan RPM via `psutil.sensors_fans()` in `monitor.py` and write to InfluxDB as `fan_rpm`
- Add Fan Speed gauge and time series panels to the Grafana `pi-health` dashboard
- Enable `graphTooltip: 1` (shared crosshairs) so hovering on any time series panel shows a crosshair across all panels

## Test plan
- [x] 3 new tests in `tests/test_monitor.py` — fan RPM written when available, omitted when empty, omitted when API doesn't exist
- [x] Full test suite passes (567 passed)
- [x] Ruff lint and format clean
- [x] mypy clean (only pre-existing `web.py` errors)
- [ ] Deploy to Pi and verify fan speed appears in Grafana dashboard
- [ ] Verify shared crosshairs work across all time series panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)