### PR TITLE
feat: maneuver detection — tacks and gybes (#232)

### DIFF
--- a/src/helmlog/maneuver_detector.py
+++ b/src/helmlog/maneuver_detector.py
@@ -1,0 +1,509 @@
+"""Maneuver detection from 1 Hz instrument data (#232).
+
+Detects sailing maneuvers (tacks, gybes) from stored SQLite instrument data and
+writes them to the ``maneuvers`` table.  No hardware dependencies — all input
+comes from decoded data structures.
+
+Algorithm
+---------
+1. Build aligned time series from headings / speeds / winds tables.
+2. Compute a rolling heading rate-of-change over a short window.
+3. Accumulate heading change within a wider detection window.
+4. When the accumulated change exceeds the threshold, confirm upwind/downwind
+   from the mean TWA in a surrounding context window.
+5. Measure BSP loss: min BSP during the event vs mean BSP in the pre-window.
+6. Measure duration: start of heading inflection to BSP recovery (90% of pre).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_WIND_REF_BOAT = 0  # wind_angle_deg is TWA (boat-referenced, reference=0)
+_WIND_REF_NORTH = 4  # wind_angle_deg is TWD (north-referenced, reference=4)
+
+
+@dataclass(frozen=True)
+class ManeuverConfig:
+    """Thresholds for maneuver detection.
+
+    Phase 1 uses conservative defaults; per §23 of federation-design.md,
+    auto-calibration after ≥20 sessions is deferred to a future phase.
+    """
+
+    # Minimum cumulative heading change to consider a candidate maneuver
+    tack_hdg_threshold_deg: float = 70.0
+    gybe_hdg_threshold_deg: float = 60.0
+
+    # Window sizes (seconds)
+    detection_window_s: int = 15  # accumulate HDG change within this window
+    context_window_s: int = 30  # TWA + pre-BSP context window (each side)
+    recovery_window_s: int = 30  # look this far ahead for BSP recovery
+
+    # BSP recovery threshold
+    bsp_recovery_fraction: float = 0.90  # 90% of pre-maneuver BSP
+
+    # Minimum pre-window samples to trust baseline BSP
+    min_baseline_samples: int = 5
+
+    # Minimum jitter filter: ignore HDG changes smaller than this per second
+    hdg_noise_threshold_deg: float = 3.0
+
+
+# ---------------------------------------------------------------------------
+# Maneuver dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Maneuver:
+    """A single detected sailing maneuver."""
+
+    type: str  # "tack" | "gybe"
+    ts: datetime  # UTC, maneuver start
+    end_ts: datetime | None  # UTC, BSP recovery time
+    duration_sec: float | None  # seconds from start to recovery
+    loss_kts: float | None  # BSP loss vs pre-maneuver baseline
+    vmg_loss_kts: float | None  # VMG loss (reserved; None for now)
+    tws_bin: int | None  # floor(TWS) at maneuver time
+    twa_bin: int | None  # 5° bin, folded to [0, 180]
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _hdg_change(from_deg: float, to_deg: float) -> float:
+    """Signed heading change in degrees, normalised to [-180, 180].
+
+    Positive = right turn, negative = left turn.  Handles wrap-around.
+    """
+    delta = (to_deg - from_deg + 360) % 360
+    if delta > 180:
+        delta -= 360
+    return delta
+
+
+def _tws_bin(tws_kts: float) -> int:
+    """Integer TWS bin — matches polar.py convention."""
+    return max(0, int(math.floor(tws_kts)))
+
+
+def _twa_bin(twa_deg: float) -> int:
+    """5° TWA bin folded to [0, 180] — matches polar.py convention."""
+    twa_abs = abs(twa_deg) % 360
+    if twa_abs > 180:
+        twa_abs = 360 - twa_abs
+    return int(math.floor(twa_abs / 5)) * 5
+
+
+# ---------------------------------------------------------------------------
+# Time-series alignment helpers
+# ---------------------------------------------------------------------------
+
+
+def _index_by_ts(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index rows by truncated-second ISO timestamp key."""
+    idx: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        key = str(r["ts"])[:19]
+        idx.setdefault(key, r)
+    return idx
+
+
+def _aligned_ts_keys(
+    hdg_idx: dict[str, dict[str, Any]],
+    bsp_idx: dict[str, dict[str, Any]],
+    twa_idx: dict[str, dict[str, Any]],
+) -> list[str]:
+    """Return sorted timestamp keys present in all three indices."""
+    common = set(hdg_idx) & set(bsp_idx) & set(twa_idx)
+    return sorted(common)
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _min_val(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return min(values)
+
+
+def _twa_from_row(row: dict[str, Any]) -> float | None:
+    """Extract absolute TWA from a wind row (reference 0 or 4)."""
+    ref = int(row.get("reference", -1))
+    angle = float(row["wind_angle_deg"])
+    if ref == _WIND_REF_BOAT:
+        return abs(angle) % 360
+    # For reference=4 (north-referenced TWD), we'd need heading; skip for now
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core detection logic
+# ---------------------------------------------------------------------------
+
+
+def _find_maneuver_candidates(
+    ts_keys: list[str],
+    hdg_idx: dict[str, dict[str, Any]],
+    config: ManeuverConfig,
+) -> list[int]:
+    """Return indices into ts_keys where a maneuver candidate starts.
+
+    Groups consecutive seconds with significant heading change (above the noise
+    threshold) into events, then returns the start index of each event whose
+    accumulated absolute change exceeds the minimum detection threshold.
+    """
+    n = len(ts_keys)
+    threshold = min(config.tack_hdg_threshold_deg, config.gybe_hdg_threshold_deg)
+
+    # Step 1: compute per-second HDG deltas (filtered for noise)
+    deltas: list[float] = []
+    for j in range(n - 1):
+        h0 = float(hdg_idx[ts_keys[j]]["heading_deg"])
+        h1 = float(hdg_idx[ts_keys[j + 1]]["heading_deg"])
+        step = _hdg_change(h0, h1)
+        deltas.append(step if abs(step) >= config.hdg_noise_threshold_deg else 0.0)
+
+    # Step 2: group into events — consecutive active (non-zero) seconds
+    # with at most 2 s gap allowed (to bridge brief noise gaps)
+    candidates: list[int] = []
+    i = 0
+    while i < len(deltas):
+        if abs(deltas[i]) < config.hdg_noise_threshold_deg:
+            i += 1
+            continue
+        # Start of an event
+        event_start = i
+        total = 0.0
+        gap = 0
+        j = i
+        while j < len(deltas):
+            if abs(deltas[j]) >= config.hdg_noise_threshold_deg:
+                total += abs(deltas[j])
+                gap = 0
+            else:
+                gap += 1
+                if gap > 2:
+                    break
+            j += 1
+        if total >= threshold:
+            candidates.append(event_start)
+        i = j + 1  # advance past this event
+    return candidates
+
+
+def _build_maneuver(
+    start_idx: int,
+    ts_keys: list[str],
+    hdg_idx: dict[str, dict[str, Any]],
+    bsp_idx: dict[str, dict[str, Any]],
+    twa_idx: dict[str, dict[str, Any]],
+    maneuver_type: str,
+    config: ManeuverConfig,
+) -> Maneuver | None:
+    """Build a Maneuver from a candidate start index."""
+    n = len(ts_keys)
+    ctx = config.context_window_s
+    w = config.detection_window_s
+    end_idx = min(start_idx + w, n - 1)
+
+    # Pre-window indices
+    pre_start = max(0, start_idx - ctx)
+    pre_keys = ts_keys[pre_start:start_idx]
+
+    # Post-window indices (for recovery)
+    post_end = min(n, end_idx + config.recovery_window_s)
+    post_keys = ts_keys[end_idx:post_end]
+
+    # --- BSP baseline ---
+    pre_bsp = [float(bsp_idx[k]["speed_kts"]) for k in pre_keys if k in bsp_idx]
+    if len(pre_bsp) < config.min_baseline_samples:
+        return None
+    baseline_bsp = sum(pre_bsp) / len(pre_bsp)
+
+    # --- BSP during maneuver ---
+    during_keys = ts_keys[start_idx : end_idx + 1]
+    during_bsp = [float(bsp_idx[k]["speed_kts"]) for k in during_keys if k in bsp_idx]
+    min_bsp = min(during_bsp) if during_bsp else baseline_bsp
+    loss_kts = round(max(0.0, baseline_bsp - min_bsp), 3)
+
+    # --- TWA / TWS context ---
+    ctx_start = max(0, start_idx - ctx)
+    ctx_end = min(n, end_idx + ctx)
+    ctx_keys = ts_keys[ctx_start:ctx_end]
+
+    twa_values: list[float] = []
+    tws_values: list[float] = []
+    for k in ctx_keys:
+        if k not in twa_idx:
+            continue
+        row = twa_idx[k]
+        twa = _twa_from_row(row)
+        if twa is not None:
+            twa_values.append(twa)
+        tws = float(row.get("wind_speed_kts", 0))
+        tws_values.append(tws)
+
+    mean_twa = _mean(twa_values)
+    mean_tws = _mean(tws_values)
+
+    # --- BSP recovery time ---
+    recovery_threshold = baseline_bsp * config.bsp_recovery_fraction
+    end_ts_str: str | None = None
+    duration_sec: float | None = None
+    for k in post_keys:
+        if k not in bsp_idx:
+            continue
+        if float(bsp_idx[k]["speed_kts"]) >= recovery_threshold:
+            end_ts_str = k
+            break
+
+    start_ts_str = ts_keys[start_idx]
+    if end_ts_str is not None:
+        try:
+            t0 = datetime.fromisoformat(start_ts_str).replace(tzinfo=UTC)
+            t1 = datetime.fromisoformat(end_ts_str).replace(tzinfo=UTC)
+            duration_sec = round((t1 - t0).total_seconds(), 1)
+        except ValueError:
+            pass
+
+    import contextlib
+
+    ts_dt = datetime.fromisoformat(start_ts_str).replace(tzinfo=UTC)
+    end_ts_dt: datetime | None = None
+    if end_ts_str is not None:
+        with contextlib.suppress(ValueError):
+            end_ts_dt = datetime.fromisoformat(end_ts_str).replace(tzinfo=UTC)
+
+    return Maneuver(
+        type=maneuver_type,
+        ts=ts_dt,
+        end_ts=end_ts_dt,
+        duration_sec=duration_sec,
+        loss_kts=loss_kts,
+        vmg_loss_kts=None,
+        tws_bin=_tws_bin(mean_tws) if mean_tws is not None else None,
+        twa_bin=_twa_bin(mean_twa) if mean_twa is not None else None,
+        details={"pre_bsp": round(baseline_bsp, 3), "min_bsp": round(min_bsp, 3)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def detect_tacks(
+    hdg: list[dict[str, Any]],
+    bsp: list[dict[str, Any]],
+    twa: list[dict[str, Any]],
+    config: ManeuverConfig | None = None,
+) -> list[Maneuver]:
+    """Detect tacks from aligned 1 Hz heading, BSP, and TWA series.
+
+    A tack is a heading change >= ``tack_hdg_threshold_deg`` with mean TWA < 90°.
+    """
+    if config is None:
+        config = ManeuverConfig()
+
+    hdg_idx = _index_by_ts(hdg)
+    bsp_idx = _index_by_ts(bsp)
+    twa_idx = _index_by_ts(twa)
+    ts_keys = _aligned_ts_keys(hdg_idx, bsp_idx, twa_idx)
+
+    if len(ts_keys) < config.detection_window_s + config.context_window_s:
+        return []
+
+    candidates = _find_maneuver_candidates(ts_keys, hdg_idx, config)
+    maneuvers: list[Maneuver] = []
+
+    for idx in candidates:
+        # Measure total HDG change in detection + recovery window
+        w = config.detection_window_s
+        end_idx = min(idx + w, len(ts_keys) - 1)
+        total_change = 0.0
+        for j in range(idx, end_idx):
+            h0 = float(hdg_idx[ts_keys[j]]["heading_deg"])
+            h1 = float(hdg_idx[ts_keys[j + 1]]["heading_deg"])
+            step = _hdg_change(h0, h1)
+            if abs(step) >= config.hdg_noise_threshold_deg:
+                total_change += abs(step)
+
+        if total_change < config.tack_hdg_threshold_deg:
+            continue
+
+        # Confirm upwind via TWA context
+        ctx = config.context_window_s
+        ctx_start = max(0, idx - ctx)
+        ctx_end = min(len(ts_keys), end_idx + ctx)
+        ctx_keys = ts_keys[ctx_start:ctx_end]
+        twa_values = [
+            v for k in ctx_keys if k in twa_idx and (v := _twa_from_row(twa_idx[k])) is not None
+        ]
+        if not twa_values:
+            continue
+        mean_twa = sum(twa_values) / len(twa_values)
+        if mean_twa >= 90.0:
+            continue  # downwind — not a tack
+
+        m = _build_maneuver(idx, ts_keys, hdg_idx, bsp_idx, twa_idx, "tack", config)
+        if m is not None:
+            maneuvers.append(m)
+            logger.debug("Tack detected at {}", ts_keys[idx])
+
+    return maneuvers
+
+
+async def detect_gybes(
+    hdg: list[dict[str, Any]],
+    bsp: list[dict[str, Any]],
+    twa: list[dict[str, Any]],
+    config: ManeuverConfig | None = None,
+) -> list[Maneuver]:
+    """Detect gybes from aligned 1 Hz heading, BSP, and TWA series.
+
+    A gybe is a heading change >= ``gybe_hdg_threshold_deg`` with mean TWA >= 90°.
+    """
+    if config is None:
+        config = ManeuverConfig()
+
+    hdg_idx = _index_by_ts(hdg)
+    bsp_idx = _index_by_ts(bsp)
+    twa_idx = _index_by_ts(twa)
+    ts_keys = _aligned_ts_keys(hdg_idx, bsp_idx, twa_idx)
+
+    if len(ts_keys) < config.detection_window_s + config.context_window_s:
+        return []
+
+    candidates = _find_maneuver_candidates(ts_keys, hdg_idx, config)
+    maneuvers: list[Maneuver] = []
+
+    for idx in candidates:
+        w = config.detection_window_s
+        end_idx = min(idx + w, len(ts_keys) - 1)
+        total_change = 0.0
+        for j in range(idx, end_idx):
+            h0 = float(hdg_idx[ts_keys[j]]["heading_deg"])
+            h1 = float(hdg_idx[ts_keys[j + 1]]["heading_deg"])
+            step = _hdg_change(h0, h1)
+            if abs(step) >= config.hdg_noise_threshold_deg:
+                total_change += abs(step)
+
+        if total_change < config.gybe_hdg_threshold_deg:
+            continue
+
+        # Confirm downwind via TWA context
+        ctx = config.context_window_s
+        ctx_start = max(0, idx - ctx)
+        ctx_end = min(len(ts_keys), end_idx + ctx)
+        ctx_keys = ts_keys[ctx_start:ctx_end]
+        twa_values = [
+            v for k in ctx_keys if k in twa_idx and (v := _twa_from_row(twa_idx[k])) is not None
+        ]
+        if not twa_values:
+            continue
+        mean_twa = sum(twa_values) / len(twa_values)
+        if mean_twa < 90.0:
+            continue  # upwind — not a gybe
+
+        m = _build_maneuver(idx, ts_keys, hdg_idx, bsp_idx, twa_idx, "gybe", config)
+        if m is not None:
+            maneuvers.append(m)
+            logger.debug("Gybe detected at {}", ts_keys[idx])
+
+    return maneuvers
+
+
+async def detect_maneuvers(
+    storage: Storage,
+    session_id: int,
+    config: ManeuverConfig | None = None,
+) -> list[Maneuver]:
+    """Detect all maneuvers in a session and persist them to the maneuvers table.
+
+    Fetches heading, speed, and wind data for the session from SQLite, runs
+    tack and gybe detection, then writes results using
+    ``storage.replace_maneuvers_for_session`` (idempotent — replaces any
+    previous detection run for this session).
+
+    Returns the detected maneuvers list.
+    """
+    if config is None:
+        config = ManeuverConfig()
+
+    db = storage._conn()
+    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    row = await cur.fetchone()
+    if row is None:
+        logger.warning("detect_maneuvers: session {} not found", session_id)
+        return []
+
+    try:
+        start = datetime.fromisoformat(str(row["start_utc"])).replace(tzinfo=UTC)
+        end_raw = row["end_utc"]
+        fallback_end = start + timedelta(hours=4)
+        end = datetime.fromisoformat(str(end_raw)).replace(tzinfo=UTC) if end_raw else fallback_end
+    except ValueError:
+        logger.warning("detect_maneuvers: session {} has bad timestamps", session_id)
+        return []
+
+    hdg = await storage.query_range("headings", start, end)
+    bsp = await storage.query_range("speeds", start, end)
+    winds_raw = await storage.query_range("winds", start, end)
+    # Keep only true wind (reference 0 or 4)
+    twa = [w for w in winds_raw if int(w.get("reference", -1)) in (_WIND_REF_BOAT, _WIND_REF_NORTH)]
+
+    logger.info(
+        "detect_maneuvers: session={} hdg={} bsp={} wind={}",
+        session_id,
+        len(hdg),
+        len(bsp),
+        len(twa),
+    )
+
+    tacks = await detect_tacks(hdg, bsp, twa, config)
+    gybes = await detect_gybes(hdg, bsp, twa, config)
+    all_maneuvers = sorted(tacks + gybes, key=lambda m: m.ts)
+
+    rows = [
+        {
+            "type": m.type,
+            "ts": m.ts.isoformat(),
+            "end_ts": m.end_ts.isoformat() if m.end_ts else None,
+            "duration_sec": m.duration_sec,
+            "loss_kts": m.loss_kts,
+            "vmg_loss_kts": m.vmg_loss_kts,
+            "tws_bin": m.tws_bin,
+            "twa_bin": m.twa_bin,
+            "details": m.details,
+        }
+        for m in all_maneuvers
+    ]
+    await storage.replace_maneuvers_for_session(session_id, rows)
+    logger.info(
+        "detect_maneuvers: session={} detected {} tacks, {} gybes",
+        session_id,
+        len(tacks),
+        len(gybes),
+    )
+    return all_maneuvers

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -71,7 +71,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 28
+_CURRENT_VERSION: int = 29
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -574,6 +574,24 @@ _MIGRATIONS: dict[int, str] = {
         );
         CREATE INDEX IF NOT EXISTS idx_deployment_log_started
             ON deployment_log(started_at);
+    """,
+    29: """
+        -- Maneuver detection (#232)
+        CREATE TABLE IF NOT EXISTS maneuvers (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id   INTEGER NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+            type         TEXT    NOT NULL,
+            ts           TEXT    NOT NULL,
+            end_ts       TEXT,
+            duration_sec REAL,
+            loss_kts     REAL,
+            vmg_loss_kts REAL,
+            tws_bin      INTEGER,
+            twa_bin      INTEGER,
+            details      TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_maneuvers_session ON maneuvers(session_id);
+        CREATE INDEX IF NOT EXISTS idx_maneuvers_type    ON maneuvers(type);
     """,
     28: """
         -- Federation Phase 1: identity, co-op membership, session sharing
@@ -2602,6 +2620,52 @@ class Storage:
                     row["session_count"],
                     row["sample_count"],
                     built_at,
+                ),
+            )
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Maneuvers
+    # ------------------------------------------------------------------
+
+    async def list_maneuvers_for_session(self, session_id: int) -> list[dict[str, Any]]:
+        """Return all maneuver rows for a session, ordered by ts."""
+        cur = await self._conn().execute(
+            "SELECT id, session_id, type, ts, end_ts, duration_sec, loss_kts,"
+            " vmg_loss_kts, tws_bin, twa_bin, details"
+            " FROM maneuvers WHERE session_id = ? ORDER BY ts",
+            (session_id,),
+        )
+        rows = await cur.fetchall()
+        return [dict(row) for row in rows]
+
+    async def replace_maneuvers_for_session(
+        self,
+        session_id: int,
+        maneuvers: list[dict[str, Any]],
+    ) -> None:
+        """Replace all maneuvers for a session atomically."""
+        import json as _json
+
+        db = self._conn()
+        await db.execute("DELETE FROM maneuvers WHERE session_id = ?", (session_id,))
+        for m in maneuvers:
+            await db.execute(
+                "INSERT INTO maneuvers"
+                " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+                "  vmg_loss_kts, tws_bin, twa_bin, details)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    session_id,
+                    m["type"],
+                    m["ts"],
+                    m.get("end_ts"),
+                    m.get("duration_sec"),
+                    m.get("loss_kts"),
+                    m.get("vmg_loss_kts"),
+                    m.get("tws_bin"),
+                    m.get("twa_bin"),
+                    _json.dumps(m.get("details", {})),
                 ),
             )
         await db.commit()

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -1630,6 +1630,41 @@ def create_app(
         return JSONResponse({"type": "FeatureCollection", "features": [feature]})
 
     # ------------------------------------------------------------------
+    # /api/sessions/{id}/maneuvers  (maneuver detection, #232)
+    # ------------------------------------------------------------------
+
+    @app.get("/api/sessions/{session_id}/maneuvers")
+    async def api_session_maneuvers(
+        session_id: int,
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> JSONResponse:
+        """Return detected maneuvers for a session."""
+        rows = await storage.list_maneuvers_for_session(session_id)
+        return JSONResponse({"session_id": session_id, "maneuvers": rows})
+
+    @app.post("/api/sessions/{session_id}/detect-maneuvers", status_code=200)
+    async def api_detect_maneuvers(
+        session_id: int,
+        _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    ) -> JSONResponse:
+        """Trigger (or re-trigger) maneuver detection for a session."""
+        from helmlog.maneuver_detector import ManeuverConfig, detect_maneuvers
+
+        db = storage._conn()
+        cur = await db.execute("SELECT id FROM races WHERE id = ?", (session_id,))
+        if await cur.fetchone() is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        maneuvers = await detect_maneuvers(storage, session_id, ManeuverConfig())
+        return JSONResponse(
+            {
+                "session_id": session_id,
+                "detected": len(maneuvers),
+                "tacks": sum(1 for m in maneuvers if m.type == "tack"),
+                "gybes": sum(1 for m in maneuvers if m.type == "gybe"),
+            }
+        )
+
+    # ------------------------------------------------------------------
     # /api/sessions/{id}  (single session detail)
     # ------------------------------------------------------------------
 

--- a/tests/test_maneuver_detector.py
+++ b/tests/test_maneuver_detector.py
@@ -1,0 +1,465 @@
+"""Tests for maneuver_detector.py — tack/gybe detection from 1 Hz instrument data."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from helmlog.maneuver_detector import (
+    Maneuver,
+    ManeuverConfig,
+    _hdg_change,
+    _twa_bin,
+    _tws_bin,
+    detect_gybes,
+    detect_maneuvers,
+    detect_tacks,
+)
+from helmlog.storage import Storage, StorageConfig
+
+# ---------------------------------------------------------------------------
+# Helpers to build synthetic 1 Hz series
+# ---------------------------------------------------------------------------
+
+_BASE = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _ts(offset_s: int) -> str:
+    return (_BASE + timedelta(seconds=offset_s)).isoformat()
+
+
+def _hdg_series(values: list[float], start_s: int = 0) -> list[dict[str, Any]]:
+    """Build synthetic heading rows."""
+    return [
+        {"ts": _ts(start_s + i), "heading_deg": v, "source_addr": 0} for i, v in enumerate(values)
+    ]
+
+
+def _bsp_series(values: list[float], start_s: int = 0) -> list[dict[str, Any]]:
+    """Build synthetic BSP rows."""
+    return [
+        {"ts": _ts(start_s + i), "speed_kts": v, "source_addr": 0} for i, v in enumerate(values)
+    ]
+
+
+def _twa_series(values: list[float], start_s: int = 0) -> list[dict[str, Any]]:
+    """Build synthetic TWA rows (reference=0, boat-referenced)."""
+    return [
+        {
+            "ts": _ts(start_s + i),
+            "wind_angle_deg": v,
+            "wind_speed_kts": 12.0,
+            "reference": 0,
+            "source_addr": 0,
+        }
+        for i, v in enumerate(values)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHdgChange:
+    def test_straight_ahead(self) -> None:
+        assert _hdg_change(45.0, 45.0) == pytest.approx(0.0)
+
+    def test_turn_right(self) -> None:
+        assert _hdg_change(10.0, 80.0) == pytest.approx(70.0)
+
+    def test_turn_left(self) -> None:
+        assert _hdg_change(80.0, 10.0) == pytest.approx(-70.0)
+
+    def test_wrap_around_north_positive(self) -> None:
+        """350° → 010° is a 20° right turn, not a 340° left turn."""
+        assert _hdg_change(350.0, 10.0) == pytest.approx(20.0)
+
+    def test_wrap_around_north_negative(self) -> None:
+        """010° → 350° is a 20° left turn."""
+        assert _hdg_change(10.0, 350.0) == pytest.approx(-20.0)
+
+    def test_exactly_180(self) -> None:
+        result = _hdg_change(0.0, 180.0)
+        assert abs(result) == pytest.approx(180.0)
+
+
+class TestBinHelpers:
+    def test_tws_bin_floor(self) -> None:
+        assert _tws_bin(12.9) == 12
+
+    def test_tws_bin_zero(self) -> None:
+        assert _tws_bin(0.0) == 0
+
+    def test_twa_bin_port_starboard_symmetry(self) -> None:
+        assert _twa_bin(45.0) == _twa_bin(-45.0)
+
+    def test_twa_bin_five_degree_steps(self) -> None:
+        assert _twa_bin(47.0) == 45
+
+    def test_twa_bin_reflex_folded(self) -> None:
+        """TWA 200° folds to 160° (360-200)."""
+        assert _twa_bin(200.0) == 160
+
+
+# ---------------------------------------------------------------------------
+# Pure detector tests (no storage)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectTacks:
+    """Synthetic tests for detect_tacks() with known HDG/BSP/TWA series."""
+
+    def _tack_series(
+        self,
+        pre_hdg: float = 40.0,
+        post_hdg: float = 320.0,
+        pre_bsp: float = 6.0,
+        min_bsp: float = 2.0,
+        twa: float = 42.0,
+        pre_s: int = 30,
+        tack_s: int = 10,
+        post_s: int = 30,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+        """Build a synthetic tack sequence: steady → tack → recovery."""
+        hdg_vals = [pre_hdg] * pre_s
+        bsp_vals = [pre_bsp] * pre_s
+        # During tack: heading gradually changes via shortest arc, BSP dips
+        delta = ((post_hdg - pre_hdg) + 360) % 360
+        if delta > 180:
+            delta -= 360  # take short path
+        tack_hdgs = [(pre_hdg + delta * i / tack_s) % 360 for i in range(tack_s)]
+        tack_bsps = [
+            pre_bsp - (pre_bsp - min_bsp) * (1 - abs(i - tack_s / 2) / (tack_s / 2))
+            for i in range(tack_s)
+        ]
+        hdg_vals += tack_hdgs
+        bsp_vals += tack_bsps
+        hdg_vals += [post_hdg] * post_s
+        bsp_vals += [pre_bsp * 0.95] * post_s  # slight permanent loss is ok
+        twa_vals = [twa] * len(hdg_vals)
+
+        hdg = _hdg_series(hdg_vals)
+        bsp = _bsp_series(bsp_vals)
+        twa = _twa_series(twa_vals)
+        return hdg, bsp, twa
+
+    @pytest.mark.asyncio
+    async def test_detects_single_tack(self) -> None:
+        hdg, bsp, twa = self._tack_series()
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert len(maneuvers) == 1
+        assert maneuvers[0].type == "tack"
+
+    @pytest.mark.asyncio
+    async def test_tack_has_required_fields(self) -> None:
+        hdg, bsp, twa = self._tack_series()
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        m = maneuvers[0]
+        assert m.ts is not None
+        assert m.loss_kts is not None
+        assert m.loss_kts >= 0
+        assert m.twa_bin is not None
+        assert m.tws_bin is not None
+
+    @pytest.mark.asyncio
+    async def test_steady_state_no_tacks(self) -> None:
+        """No heading change → no tack detected."""
+        hdg = _hdg_series([45.0] * 120)
+        bsp = _bsp_series([6.0] * 120)
+        twa = _twa_series([42.0] * 120)
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert maneuvers == []
+
+    @pytest.mark.asyncio
+    async def test_noisy_hdg_no_false_positives(self) -> None:
+        """±2° random-ish noise around 45° shouldn't trigger a tack."""
+        import math
+
+        noise = [45.0 + 2.0 * math.sin(i * 0.7) for i in range(120)]
+        hdg = _hdg_series(noise)
+        bsp = _bsp_series([6.0] * 120)
+        twa = _twa_series([42.0] * 120)
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert maneuvers == []
+
+    @pytest.mark.asyncio
+    async def test_hdg_wraparound_detected(self) -> None:
+        """Tack crossing 0°/360° boundary (e.g. 50° → 330°, -80° turn) is detected."""
+        # delta = (330-50+360)%360 = 280 → -80° (crosses 0°: 50→42→...→2→354→...→330)
+        hdg, bsp, twa = self._tack_series(pre_hdg=50.0, post_hdg=330.0)
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert len(maneuvers) == 1
+        assert maneuvers[0].type == "tack"
+
+    @pytest.mark.asyncio
+    async def test_downwind_hdg_change_not_tack(self) -> None:
+        """Large HDG change downwind (TWA=150°) should NOT be a tack."""
+        hdg, bsp, twa_rows = self._tack_series(twa=150.0)
+        maneuvers = await detect_tacks(hdg, bsp, twa_rows)
+        assert maneuvers == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_tacks_detected(self) -> None:
+        """Two sequential tacks → two Maneuver objects returned."""
+        hdg1, bsp1, twa1 = self._tack_series(pre_hdg=40.0, post_hdg=320.0)
+        hdg2, bsp2, twa2 = self._tack_series(pre_hdg=320.0, post_hdg=40.0, pre_s=30)
+        # Offset the second sequence in time
+        offset = len(hdg1)
+        hdg2_shifted = [{**r, "ts": _ts(offset + i)} for i, r in enumerate(hdg2)]
+        bsp2_shifted = [{**r, "ts": _ts(offset + i)} for i, r in enumerate(bsp2)]
+        twa2_shifted = [{**r, "ts": _ts(offset + i)} for i, r in enumerate(twa2)]
+        all_hdg = hdg1 + hdg2_shifted
+        all_bsp = bsp1 + bsp2_shifted
+        all_twa = twa1 + twa2_shifted
+        maneuvers = await detect_tacks(all_hdg, all_bsp, all_twa)
+        assert len(maneuvers) == 2
+
+    @pytest.mark.asyncio
+    async def test_bsp_loss_calculation(self) -> None:
+        """BSP loss is non-negative and less than pre-maneuver BSP."""
+        hdg, bsp, twa = self._tack_series(pre_bsp=6.5, min_bsp=1.5)
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert len(maneuvers) == 1
+        loss = maneuvers[0].loss_kts
+        assert loss is not None
+        assert 0 < loss < 6.5
+
+    @pytest.mark.asyncio
+    async def test_tws_twa_bins_match_polar_convention(self) -> None:
+        """Bin values use the same convention as polar.py."""
+        from helmlog.polar import _twa_bin as polar_twa_bin
+        from helmlog.polar import _tws_bin as polar_tws_bin
+
+        hdg, bsp, twa = self._tack_series(twa=42.0)
+        maneuvers = await detect_tacks(hdg, bsp, twa)
+        assert len(maneuvers) == 1
+        m = maneuvers[0]
+        assert m.twa_bin == polar_twa_bin(42.0)
+        assert m.tws_bin == polar_tws_bin(12.0)  # default TWS in _twa_series
+
+
+class TestDetectGybes:
+    """Synthetic tests for detect_gybes() — downwind maneuvers."""
+
+    @pytest.mark.asyncio
+    async def test_detects_single_gybe(self) -> None:
+        """60°+ downwind HDG change → classified as gybe, not tack."""
+        pre_hdg = 180.0
+        post_hdg = 120.0
+        hdg_vals = [pre_hdg] * 30
+        bsp_vals = [7.0] * 30
+        twa_vals = [160.0] * 30
+        for i in range(10):
+            hdg_vals.append(pre_hdg + (post_hdg - pre_hdg) * i / 10)
+            bsp_vals.append(7.0 - 2.0 * (1 - abs(i - 5) / 5))
+            twa_vals.append(160.0)
+        hdg_vals += [post_hdg] * 30
+        bsp_vals += [6.8] * 30
+        twa_vals += [160.0] * 30
+
+        hdg = _hdg_series(hdg_vals)
+        bsp = _bsp_series(bsp_vals)
+        twa = _twa_series(twa_vals)
+        maneuvers = await detect_gybes(hdg, bsp, twa)
+        assert len(maneuvers) == 1
+        assert maneuvers[0].type == "gybe"
+
+    @pytest.mark.asyncio
+    async def test_upwind_change_not_gybe(self) -> None:
+        """Upwind tack-like HDG change should NOT be classified as gybe."""
+        hdg_vals = [40.0] * 30
+        bsp_vals = [6.0] * 30
+        twa_vals = [42.0] * 30
+        for i in range(10):
+            hdg_vals.append(40.0 + (320.0 - 40.0) * i / 10)
+            bsp_vals.append(3.0)
+            twa_vals.append(42.0)
+        hdg_vals += [320.0] * 30
+        bsp_vals += [5.8] * 30
+        twa_vals += [42.0] * 30
+        hdg = _hdg_series(hdg_vals)
+        bsp = _bsp_series(bsp_vals)
+        twa = _twa_series(twa_vals)
+        maneuvers = await detect_gybes(hdg, bsp, twa)
+        assert maneuvers == []
+
+    @pytest.mark.asyncio
+    async def test_steady_state_no_gybes(self) -> None:
+        hdg = _hdg_series([180.0] * 120)
+        bsp = _bsp_series([7.0] * 120)
+        twa = _twa_series([160.0] * 120)
+        maneuvers = await detect_gybes(hdg, bsp, twa)
+        assert maneuvers == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with Storage
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def storage() -> Storage:  # type: ignore[misc]
+    s = Storage(StorageConfig(db_path=":memory:"))
+    await s.connect()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def seeded_session(storage: Storage) -> int:
+    """Create a race session with synthetic tack data in storage."""
+    from helmlog.nmea2000 import (
+        PGN_SPEED_THROUGH_WATER,
+        PGN_VESSEL_HEADING,
+        PGN_WIND_DATA,
+        HeadingRecord,
+        SpeedRecord,
+        WindRecord,
+    )
+
+    # Create race
+    db = storage._conn()
+    start = _BASE
+    end = _BASE + timedelta(minutes=5)
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("TestRace", "TestEvent", 1, "2024-06-15", start.isoformat(), end.isoformat(), "race"),
+    )
+    await db.commit()
+    session_id = cur.lastrowid
+    assert session_id is not None
+
+    # Write synthetic instrument data: tack at t=60s
+    total_s = 300
+    pre_hdg, post_hdg = 40.0, 320.0
+    for i in range(total_s):
+        ts = start + timedelta(seconds=i)
+        if i < 60:
+            hdg_val = pre_hdg
+        elif i < 70:
+            hdg_val = pre_hdg + (post_hdg - pre_hdg) * (i - 60) / 10
+        else:
+            hdg_val = post_hdg
+        bsp_val = 6.0 if i < 60 or i > 75 else 6.0 - 3.0 * (1 - abs((i - 65) / 5))
+        twa_val = 42.0
+
+        await storage.write(
+            HeadingRecord(
+                pgn=PGN_VESSEL_HEADING,
+                source_addr=0,
+                timestamp=ts,
+                heading_deg=hdg_val,
+                deviation_deg=None,
+                variation_deg=None,
+            )
+        )
+        await storage.write(
+            SpeedRecord(pgn=PGN_SPEED_THROUGH_WATER, source_addr=0, timestamp=ts, speed_kts=bsp_val)
+        )
+        await storage.write(
+            WindRecord(
+                pgn=PGN_WIND_DATA,
+                source_addr=0,
+                timestamp=ts,
+                wind_speed_kts=12.0,
+                wind_angle_deg=twa_val,
+                reference=0,
+            )
+        )
+
+    await storage._flush()
+    return int(session_id)
+
+
+class TestDetectManeuversIntegration:
+    @pytest.mark.asyncio
+    async def test_detect_and_store_maneuvers(self, seeded_session: int, storage: Storage) -> None:
+        """detect_maneuvers writes to storage and returns maneuvers list."""
+        maneuvers = await detect_maneuvers(storage, seeded_session)
+        assert len(maneuvers) >= 1
+        tacks = [m for m in maneuvers if m.type == "tack"]
+        assert len(tacks) == 1
+
+    @pytest.mark.asyncio
+    async def test_maneuvers_persisted_to_db(self, seeded_session: int, storage: Storage) -> None:
+        """After detect_maneuvers, rows appear in maneuvers table."""
+        await detect_maneuvers(storage, seeded_session)
+        db = storage._conn()
+        cur = await db.execute("SELECT * FROM maneuvers WHERE session_id = ?", (seeded_session,))
+        rows = await cur.fetchall()
+        assert len(rows) >= 1
+        assert rows[0]["type"] == "tack"
+
+    @pytest.mark.asyncio
+    async def test_detect_maneuvers_idempotent(self, seeded_session: int, storage: Storage) -> None:
+        """Re-running detection replaces previous results (same count)."""
+        await detect_maneuvers(storage, seeded_session)
+        await detect_maneuvers(storage, seeded_session)
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT COUNT(*) as n FROM maneuvers WHERE session_id = ?", (seeded_session,)
+        )
+        row = await cur.fetchone()
+        # Should be exactly 1 (not 2 from double run)
+        assert row["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_maneuvers(self, seeded_session: int, storage: Storage) -> None:
+        """list_maneuvers_for_session returns rows from the DB."""
+        await detect_maneuvers(storage, seeded_session)
+        rows = await storage.list_maneuvers_for_session(seeded_session)
+        assert len(rows) >= 1
+        assert rows[0]["type"] == "tack"
+
+    @pytest.mark.asyncio
+    async def test_missing_session_returns_empty(self, storage: Storage) -> None:
+        """detect_maneuvers on a non-existent session returns empty list."""
+        result = await detect_maneuvers(storage, 9999)
+        assert result == []
+
+
+class TestManeuverDataclass:
+    def test_frozen(self) -> None:
+        m = Maneuver(
+            type="tack",
+            ts=_BASE,
+            end_ts=None,
+            duration_sec=None,
+            loss_kts=None,
+            vmg_loss_kts=None,
+            tws_bin=None,
+            twa_bin=None,
+            details={},
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            m.type = "gybe"  # type: ignore[misc]
+
+    def test_defaults_none(self) -> None:
+        m = Maneuver(
+            type="gybe",
+            ts=_BASE,
+            end_ts=None,
+            duration_sec=None,
+            loss_kts=None,
+            vmg_loss_kts=None,
+            tws_bin=None,
+            twa_bin=None,
+            details={},
+        )
+        assert m.vmg_loss_kts is None
+
+
+class TestManeuverConfig:
+    def test_defaults(self) -> None:
+        cfg = ManeuverConfig()
+        assert cfg.tack_hdg_threshold_deg == 70.0
+        assert cfg.gybe_hdg_threshold_deg == 60.0
+
+    def test_custom_threshold(self) -> None:
+        cfg = ManeuverConfig(tack_hdg_threshold_deg=80.0)
+        assert cfg.tack_hdg_threshold_deg == 80.0


### PR DESCRIPTION
## Summary

Implements maneuver detection from 1 Hz SQLite instrument data (issue #232).

- **New module `maneuver_detector.py`**: event-based tack/gybe detection from HDG + BSP + TWA data
- **Schema v29 migration**: adds `maneuvers` table with session FK, type, timestamps, BSP loss, TWS/TWA bins, and JSON details
- **Storage helpers**: `list_maneuvers_for_session` and `replace_maneuvers_for_session` (idempotent)
- **API endpoints**:
  - `GET /api/sessions/{id}/maneuvers` — list detected maneuvers
  - `POST /api/sessions/{id}/detect-maneuvers` — trigger/re-trigger detection
- **32 new tests** covering pure helpers, tack/gybe detection, edge cases (HDG wrap-around, noisy data, steady-state), and storage integration

### Algorithm

1. Compute per-second heading deltas (filtered by noise threshold 3°)
2. Group consecutive active seconds into events (allowing ≤2 s gaps)
3. Events with cumulative change ≥ threshold (70° tack / 60° gybe) are candidates
4. Confirm upwind (TWA < 90°) → tack, downwind (TWA ≥ 90°) → gybe
5. Measure BSP loss (min during vs mean pre-window) and recovery time

Closes #232

## Test plan

- [x] `uv run pytest` — 738 tests pass
- [x] `uv run ruff check .` — lint clean
- [x] `uv run ruff format --check .` — format clean
- [x] `uv run mypy src/` — only pre-existing web.py errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)