### PR TITLE
fix: prevent .git/ ownership conflicts between service and deploy user

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -50,6 +50,22 @@ done
 cd "$PROJECT_DIR"
 
 # ---------------------------------------------------------------------------
+# Ensure .git/ is owned by the current user (fixes ownership conflicts when
+# the helmlog service account has run git commands in this directory)
+# ---------------------------------------------------------------------------
+REPO_OWNER="$(stat -c '%U' "$PROJECT_DIR")"
+if [[ "$(whoami)" != "$REPO_OWNER" ]]; then
+    echo "ERROR: deploy.sh must run as '$REPO_OWNER' (the repo owner), not '$(whoami)'." >&2
+    exit 1
+fi
+
+# Fix any mis-owned .git/ files (e.g. from a previous service-account git op)
+if find .git -not -user "$(whoami)" -print -quit 2>/dev/null | grep -q .; then
+    echo "==> Fixing .git/ ownership (some files owned by wrong user)..."
+    sudo chown -R "$(whoami):$(whoami)" .git/
+fi
+
+# ---------------------------------------------------------------------------
 # Resolve uv — not on PATH in non-interactive SSH sessions
 # ---------------------------------------------------------------------------
 if command -v uv &>/dev/null; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -829,6 +829,12 @@ ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart nginx.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status nginx
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/systemctl status nginx.service
 ${CURRENT_USER} ALL=(ALL) NOPASSWD: /usr/bin/cp ${PROJECT_DIR}/scripts/nginx/helmlog.conf /etc/nginx/sites-available/helmlog
+
+# .git/ ownership repair (deploy.sh may need to fix files owned by helmlog)
+${CURRENT_USER} ALL=(ALL) NOPASSWD: /bin/chown -R ${CURRENT_USER}\:${CURRENT_USER} ${PROJECT_DIR}/.git/
+
+# helmlog service account — git as repo owner for web-triggered deploys
+helmlog ALL=(${CURRENT_USER}) NOPASSWD: /usr/bin/git
 EOF
 sudo chmod 440 "$SUDOERS_FILE"
 

--- a/src/helmlog/deploy.py
+++ b/src/helmlog/deploy.py
@@ -102,11 +102,54 @@ def _uv_bin() -> str:
     return "uv"  # last resort — let it fail with a clear error
 
 
-def _git(args: list[str]) -> str:
-    """Run a git command in the project directory and return stripped stdout."""
+def _repo_owner() -> str:
+    """Return the username that owns the project directory.
+
+    Git operations that write to .git/ must run as this user to avoid
+    ownership conflicts between the service account and the deploy user.
+    """
     repo = _repo_dir()
+    st = os.stat(repo)
+    try:
+        import pwd
+
+        return pwd.getpwuid(st.st_uid).pw_name
+    except (ImportError, KeyError):
+        return str(st.st_uid)
+
+
+def _git(args: list[str], *, write: bool = False) -> str:
+    """Run a git command in the project directory and return stripped stdout.
+
+    When *write* is False (default) ``--no-optional-locks`` is added so that
+    read-only commands do not refresh the index or create lock files.
+
+    When *write* is True the command is executed via ``sudo -u <owner>`` if
+    the current process is not the repo owner, preventing .git/ files from
+    being created with the wrong ownership.
+    """
+    repo = _repo_dir()
+    git_base = ["git", "-c", f"safe.directory={repo}"]
+
+    if write:
+        owner = _repo_owner()
+        current_user = os.environ.get("USER", "")
+        if not current_user:
+            try:
+                import pwd
+
+                current_user = pwd.getpwuid(os.getuid()).pw_name
+            except (ImportError, KeyError):
+                current_user = str(os.getuid())
+        if current_user != owner:
+            cmd = ["sudo", "-n", "-u", owner, *git_base, *args]
+        else:
+            cmd = [*git_base, *args]
+    else:
+        cmd = [*git_base, "--no-optional-locks", *args]
+
     return subprocess.check_output(
-        ["git", "-c", f"safe.directory={repo}", *args],
+        cmd,
         cwd=repo,
         stderr=subprocess.DEVNULL,
         text=True,
@@ -116,7 +159,7 @@ def _git(args: list[str]) -> str:
 async def list_remote_branches() -> list[str]:
     """Return sorted list of remote branch names from origin."""
     try:
-        await asyncio.to_thread(_git, ["fetch", "--prune", "origin"])
+        await asyncio.to_thread(_git, ["fetch", "--prune", "origin"], write=True)
         raw = await asyncio.to_thread(_git, ["branch", "-r", "--format=%(refname:short)"])
     except Exception:  # noqa: BLE001
         return []
@@ -151,7 +194,7 @@ async def fetch_latest(config: DeployConfig) -> dict[str, Any] | None:
     Returns None if the fetch fails (offline, no remote, etc.).
     """
     try:
-        await asyncio.to_thread(_git, ["fetch", "origin", config.branch])
+        await asyncio.to_thread(_git, ["fetch", "origin", config.branch], write=True)
         sha = _git(["rev-parse", f"origin/{config.branch}"])
         short_sha = _git(["rev-parse", "--short=7", f"origin/{config.branch}"])
         commit_ts = _git(["log", "-1", "--format=%cI", f"origin/{config.branch}"])
@@ -285,10 +328,10 @@ async def execute_deploy(config: DeployConfig) -> dict[str, Any]:
     now = datetime.now(UTC).isoformat()
 
     try:
-        # git fetch + checkout + pull
-        await asyncio.to_thread(_git, ["fetch", "origin", config.branch])
-        await asyncio.to_thread(_git, ["checkout", config.branch])
-        await asyncio.to_thread(_git, ["pull", "origin", config.branch])
+        # git fetch + checkout + pull (as repo owner to preserve .git/ ownership)
+        await asyncio.to_thread(_git, ["fetch", "origin", config.branch], write=True)
+        await asyncio.to_thread(_git, ["checkout", config.branch], write=True)
+        await asyncio.to_thread(_git, ["pull", "origin", config.branch], write=True)
 
         # uv sync (best-effort — may fail on first run if deps changed)
         uv = _uv_bin()

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -44,7 +44,7 @@ def _get_git_info() -> str:
 
     try:
         _repo = str(Path(__file__).resolve().parents[2])
-        _git = ["git", "-c", f"safe.directory={_repo}"]
+        _git = ["git", "-c", f"safe.directory={_repo}", "--no-optional-locks"]
 
         def _run(args: list[str]) -> str:
             return subprocess.check_output(

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -76,6 +76,32 @@ class TestDeployWindow:
         assert in_deploy_window(config) is expected
 
 
+class TestRepoOwner:
+    def test_returns_current_user(self) -> None:
+        """_repo_owner() should return the owner of the project directory."""
+        from helmlog.deploy import _repo_owner
+
+        owner = _repo_owner()
+        assert isinstance(owner, str)
+        assert len(owner) > 0
+
+    def test_git_no_optional_locks_in_read_mode(self) -> None:
+        """Read-mode _git() should use --no-optional-locks."""
+        from helmlog.deploy import _git
+
+        # rev-parse is a pure read — should succeed with --no-optional-locks
+        sha = _git(["rev-parse", "--short=7", "HEAD"])
+        assert len(sha) == 7
+
+    def test_git_write_mode_same_user(self) -> None:
+        """Write-mode _git() should work when current user owns the repo."""
+        from helmlog.deploy import _git
+
+        # Should not use sudo when current user == repo owner
+        branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], write=True)
+        assert branch  # non-empty
+
+
 class TestGetRunningVersion:
     def test_returns_dict(self) -> None:
         from helmlog.deploy import get_running_version


### PR DESCRIPTION
## Summary

Closes #239

The `helmlog` systemd service runs as the `helmlog` user, but the git repo is owned by `weaties`. When the service runs git commands (deploy page, version footer), `.git/` files get created with `helmlog:helmlog` ownership, which then blocks `weaties` from running `deploy.sh` or any git operations:

```
$ ./scripts/deploy.sh
error: cannot open '.git/FETCH_HEAD': Permission denied
```

**Three-part fix:**

- **`deploy.py`**: Read-only git commands now use `--no-optional-locks` to prevent index writes. Write commands (`fetch`/`checkout`/`pull`) use `sudo -n -u <repo_owner>` when the current process user differs from the repo owner, ensuring `.git/` files are always created with correct ownership.

- **`web.py`**: `_get_git_info()` adds `--no-optional-locks` so the footer version display never writes to `.git/`.

- **`deploy.sh`**: Detects and auto-repairs mis-owned `.git/` files before git operations. Refuses to run as the wrong user with a clear error message.

- **`setup.sh`**: Adds scoped sudoers entries:
  - `helmlog` can run `git` as `weaties` (for web-triggered deploys)
  - `weaties` can `chown .git/` without a password (for deploy.sh repair)

## Test plan

- [x] All 677 existing tests pass
- [x] New tests for `_repo_owner()`, read-mode `_git()`, and write-mode `_git()`
- [x] Lint, format, and mypy clean
- [ ] Manual: deploy from web UI on Pi — verify `.git/` stays owned by `weaties`
- [ ] Manual: run `deploy.sh` via SSH after a web deploy — verify no permission errors
- [ ] Manual: run `setup.sh` to install new sudoers entries, then test web deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)