### PR TITLE
Fix bootstrap add-user running as wrong user, causing read-only DB

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -166,8 +166,11 @@ bootstrap() {
         warn "Check: sudo journalctl -u helmlog --no-pager -n 20"
     fi
 
-    # Create the admin user and capture the login URL
-    ADD_USER_OUTPUT=$("$UV_BIN" run --project "$HELMLOG_DIR" helmlog add-user \
+    # Create the admin user and capture the login URL.
+    # Must run as helmlog user so any DB writes have correct ownership.
+    ADD_USER_OUTPUT=$(sudo -u helmlog \
+        env UV_CACHE_DIR=/var/cache/helmlog HOME=/var/cache/helmlog \
+        "$UV_BIN" run --no-sync --project "$HELMLOG_DIR" helmlog add-user \
         --email "$ADMIN_EMAIL" --name "Admin" --role admin 2>&1) || true
 
     LOGIN_URL=$(echo "$ADD_USER_OUTPUT" | grep -oE 'http[s]?://[^ ]+/login\?token=[^ ]+' | head -1)


### PR DESCRIPTION
## Summary

- `helmlog add-user` in `bootstrap.sh` ran as the shell user (`weaties`), causing `data/logger.db` to be owned by `weaties:weaties`
- The helmlog systemd service runs as `helmlog:helmlog` and gets `sqlite3.OperationalError: attempt to write a readonly database` after reboot
- Fix: run `add-user` via `sudo -u helmlog` with the same env vars the service uses

Fixes #243

## Test plan

- [ ] Run `reset-pi` + bootstrap curl on corvopi-tst1
- [ ] Verify `ls -la data/logger.db` shows `helmlog:helmlog` ownership
- [ ] Reboot and confirm login URL works without internal server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)