### PR TITLE
docs: add uv sync dependency guidance

### DIFF
--- a/.claude/skills/deploy-pi/SKILL.md
+++ b/.claude/skills/deploy-pi/SKILL.md
@@ -71,6 +71,7 @@ git checkout <previous-commit>
 |---------|-----|
 | Service won't start | Check `journalctl -u helmlog -n 50` for errors |
 | `uv` not found | Ensure `UV_CACHE_DIR` is set in systemd unit |
+| `ModuleNotFoundError` for a dep in pyproject.toml | Run `uv sync` — the venv is stale. The service uses `--no-sync` and trusts the venv. Never use `uv pip install` as a workaround |
 | Permission denied on `data/` | Run `sudo chown -R helmlog:helmlog data/` |
 | Signal K unreachable | Check `systemctl status signalk-server` |
 | Web UI 502 | Service crashed — `sudo systemctl restart helmlog` |

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -43,8 +43,14 @@ If the module needs API endpoints or admin UI:
 - Pass to `_web_loop()` / `create_app()` if needed
 - Add CLI subcommand if applicable
 
-### 6. Update config
+### 6. Sync dependencies
+If the module requires new packages:
+- Add with `uv add <package>` (never edit pyproject.toml manually for deps)
+- Run `uv sync` and verify the import works
+- Never use `uv pip install` — it bypasses the lockfile and won't persist
+
+### 7. Update config
 - Add new env vars to `.env.example` with comments
 - Update `CLAUDE.md` project structure tree
 
-### 7. Run `/pr-checklist`
+### 8. Run `/pr-checklist`

--- a/.claude/skills/pr-checklist/SKILL.md
+++ b/.claude/skills/pr-checklist/SKILL.md
@@ -92,7 +92,14 @@ Key items to check:
 - No gambling/betting facilitation
 - Audit logging on co-op data access
 
-## 8. Documentation updates
+## 8. Dependency check
+
+If any dependencies were added (via `uv add`), verify:
+- The dependency is in `pyproject.toml` and `uv.lock`
+- `uv sync` installs it cleanly (the import works)
+- **Never** use `uv pip install` for project dependencies — it bypasses the lockfile and won't persist. The helmlog service runs with `--no-sync`, so the venv must be correct at deploy time.
+
+## 9. Documentation updates
 
 If the change involved any of these, update accordingly:
 - **New module** → update project structure tree in `CLAUDE.md`
@@ -101,8 +108,9 @@ If the change involved any of these, update accordingly:
 - **New stack tool** → update Stack & Tooling table in `CLAUDE.md`
 - **Schema migration** → update schema version in `CLAUDE.md` Stack table
 - **Data handling changes** → verify against `docs/data-licensing.md`
+- **New dependency** → verify it's in `pyproject.toml` and installs via `uv sync`
 
-## 9. Commit and push
+## 10. Commit and push
 
 ```bash
 git add <files>
@@ -110,7 +118,7 @@ git commit -m "feat: description (#issue)"
 git push -u origin <branch>
 ```
 
-## 10. Create PR
+## 11. Create PR
 
 ```bash
 gh pr create --title "..." --body "..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,8 @@ Use `/data-license` to review code changes against the full policy.
 - Write tests for all decoding and export logic
 - Run integration tests (`uv run pytest tests/integration/ -v`) for any federation/co-op/peer API changes
 - Use `uv add <package>` to add dependencies — never edit `pyproject.toml` manually for deps
+- **After adding a dependency**, always run `uv sync` to install it, then verify the import works. On the Pi, also restart the helmlog service (`sudo systemctl restart helmlog`). Never use `uv pip install` for project dependencies — it bypasses the lockfile
+- **After pulling or switching branches**, always run `uv sync` (or `./scripts/deploy.sh` on the Pi) to ensure new dependencies are installed. The helmlog service runs with `--no-sync` and trusts the venv is already correct
 - Keep the SQLite schema versioned with simple integer migrations in `storage.py`
 - Log every read error and decode failure with `loguru` at `WARNING` or above
 
@@ -245,6 +247,7 @@ Use `/data-license` to review code changes against the full policy.
 - Don't hardcode device paths (e.g., `/dev/can0`) — use config or environment variables
 - Don't mix business logic into `main.py` — it should only wire things together and start the loop
 - Don't commit the `data/` directory or any `.db` files
+- Don't use `uv pip install` to install project dependencies — always use `uv add` (to add) or `uv sync` (to install from lockfile). `uv pip install` bypasses the lockfile and won't persist across `uv sync` runs
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds guidance to CLAUDE.md, deploy-pi, pr-checklist, and new-module skills to always use `uv sync` (never `uv pip install`) for project dependencies
- Triggered by a production `ModuleNotFoundError: No module named 'shapely'` — the dep was in pyproject.toml but never installed because `uv sync` wasn't run after switching to a branch that added it
- The helmlog service runs with `--no-sync` and trusts the venv, so a stale venv means 500 errors at runtime

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify skill step numbering is sequential after inserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)