### PR TITLE
docs: update release notes for pending promotion to live

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Pending promotion to live (main, 2026-03-10)
+## Promoted to live and stage from main, 2026-03-10
 
 ### Synthesize race sessions with interactive Leaflet map (#245, #252)
 


### PR DESCRIPTION
## Summary

- Add new "Pending promotion to live (main, 2026-03-10)" section covering all 17 merged PRs since the last release notes update
- Key features: federation phase 1, race session synthesizer with Leaflet map, deployment management/promotion workflow, data policy compliance, mobile hamburger nav
- Previous "Unreleased" section renamed to dated "2026-03-08" heading
- Infrastructure: GitHub Actions CI, Docker dev container, community contribution setup, Pi health monitor tuning

## Test plan

- [ ] Verify RELEASES.md renders correctly on GitHub
- [ ] Confirm all referenced PR numbers match merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)