### PR TITLE
Fix: create loki/promtail groups before chown

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -684,6 +684,13 @@ sudo cp "$SCRIPT_DIR/loki/loki-config.yaml" /etc/loki/loki-config.yaml
 sudo mkdir -p /etc/promtail
 sudo cp "$SCRIPT_DIR/loki/promtail-config.yaml" /etc/promtail/promtail-config.yaml
 
+# Ensure loki/promtail groups exist (Debian packages create the users with
+# nogroup as primary group, but don't always create a matching group).
+getent group loki    >/dev/null 2>&1 || sudo groupadd -r loki
+getent group promtail >/dev/null 2>&1 || sudo groupadd -r promtail
+id -gn loki    | grep -qx loki    || sudo usermod -g loki    loki
+id -gn promtail | grep -qx promtail || sudo usermod -g promtail promtail
+
 # Data directories
 sudo mkdir -p /var/lib/loki /var/lib/promtail
 sudo chown loki:loki /var/lib/loki


### PR DESCRIPTION
## Summary
- The Loki Debian package creates `loki`/`promtail` users with `nogroup` as primary group but doesn't create matching groups
- `chown loki:loki /var/lib/loki` fails, aborting the entire bootstrap after the Loki install step
- Added idempotent group creation and user reassignment before the `chown` calls

Fixes #260

## Test plan
- [ ] Run `scripts/setup.sh` on a fresh Pi (or after `scripts/reset-pi.sh`)
- [ ] Verify `getent group loki` and `getent group promtail` both return results
- [ ] Verify `/var/lib/loki` is owned by `loki:loki` and `/var/lib/promtail` by `promtail:promtail`
- [ ] Verify `systemctl status loki promtail` shows both services active

🤖 Generated with [Claude Code](https://claude.com/claude-code)