### PR TITLE
fix: use leg-derived marks for wind field visualization

### DIFF
--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -1828,10 +1828,10 @@ def create_app(
         _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
     ) -> JSONResponse:
         from helmlog.courses import (
+            CourseMark,
             build_custom_course,
             build_triangle_course,
             build_wl_course,
-            compute_buoy_marks,
             validate_course_marks,
         )
         from helmlog.races import build_race_name, local_today
@@ -1880,10 +1880,13 @@ def create_app(
             raise HTTPException(status_code=422, detail=f"Unknown course_type: {course_type}")
 
         # Validate all course marks are in navigable water (>6 ft deep)
-        all_marks = {leg.target.name[:1]: leg.target for leg in legs}
-        if course_type != "custom":
-            buoy_marks = compute_buoy_marks(start_lat, start_lon, wind_dir, leg_nm)
-            all_marks.update(buoy_marks)
+        # Build marks from legs only — they already have correct overridden positions
+        # and only include marks actually used in the course (#264)
+        all_marks: dict[str, CourseMark] = {}
+        for leg in legs:
+            key = leg.target.name.split()[-1][0]
+            if key not in all_marks:
+                all_marks[key] = leg.target
         mark_warnings = validate_course_marks(all_marks)
 
         now = datetime.now(UTC)

--- a/tests/test_web_wind_field.py
+++ b/tests/test_web_wind_field.py
@@ -64,14 +64,54 @@ async def test_synthesize_persists_course_marks(storage: Storage) -> None:
         sid = await _synthesize_session(client)
 
     marks = await storage.get_synth_course_marks(sid)
-    assert len(marks) >= 3  # at least S, A, F
     keys = {m["mark_key"] for m in marks}
-    assert "S" in keys
-    assert "A" in keys
-    assert "F" in keys
+    # W/L 1-lap course rounds A, X, F — only these marks should be persisted (#264)
+    assert keys == {"A", "X", "F"}
+    # Must NOT include start (S), gybe (G), or offset (O) marks
+    assert "G" not in keys, "Gybe mark should not appear in W/L course marks"
+    assert "O" not in keys, "Offset mark should not appear in W/L course marks"
     for m in marks:
         assert m["lat"] != 0
         assert m["lon"] != 0
+
+
+@pytest.mark.asyncio
+async def test_synthesize_course_marks_use_overridden_positions(storage: Storage) -> None:
+    """Dragged mark positions must be persisted, not original computed positions (#264)."""
+    await storage.set_daily_event("2026-03-10", "TestRegatta")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Override the windward mark (A) to a noticeably different position
+        override_lat, override_lon = 47.65, -122.42
+        resp = await client.post(
+            "/api/sessions/synthesize",
+            json={
+                "course_type": "windward_leeward",
+                "wind_direction": 180,
+                "wind_speed_low": 10,
+                "wind_speed_high": 12,
+                "laps": 1,
+                "start_lat": 47.63,
+                "start_lon": -122.40,
+                "seed": 42,
+                "mark_overrides": {"A": {"lat": override_lat, "lon": override_lon}},
+            },
+        )
+        assert resp.status_code == 201
+        sid = resp.json()["id"]
+
+    marks = await storage.get_synth_course_marks(sid)
+    a_marks = [m for m in marks if m["mark_key"] == "A"]
+    assert len(a_marks) == 1
+    a_mark = a_marks[0]
+    assert abs(a_mark["lat"] - override_lat) < 1e-6, (
+        f"Windward mark lat should be overridden ({override_lat}), got {a_mark['lat']}"
+    )
+    assert abs(a_mark["lon"] - override_lon) < 1e-6, (
+        f"Windward mark lon should be overridden ({override_lon}), got {a_mark['lon']}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #264 — wind field shows duplicate and extra marks for synthesized W/L sessions.

- Remove `compute_buoy_marks()` overwrite in `api_synthesize_session` that clobbered user-dragged mark positions with original computed positions
- Build `synth_course_marks` from leg targets only, which already carry correct overridden positions and only include marks actually rounded in the course
- Fix mark key extraction (`name[:1]` → `name.split()[-1][0]`) to derive correct single-letter keys (A, X, F) from mark names like "Windward A"

## Test plan

- [x] New test: W/L course marks contain only A, X, F — no phantom G or O marks
- [x] New test: dragged mark override positions are persisted correctly
- [x] All 859 existing tests pass
- [x] Ruff lint + format clean
- [x] No new mypy errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)