### PR TITLE
fix: OAuth login 500 — add SessionMiddleware and init_oauth (#279)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ AVATAR_DIR=data/avatars
 # SMTP_FROM=helmlog@example.com
 # Authentication (#268 — invitation + flexible auth)
 # AUTH_DISABLED=true          # bypass auth entirely — local/LAN dev only
+# SESSION_SECRET=             # secret key for session cookie signing (OAuth state); auto-generated if unset
 # How long session cookies stay valid (days)
 AUTH_SESSION_TTL_DAYS=90
 # OAuth providers (optional — only providers with configured vars are enabled)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "types-shapely>=2.1.0.20250917",
     "authlib>=1.3",
     "argon2-cffi>=23.1",
+    "itsdangerous>=2.2.0",
 ]
 
 [project.scripts]

--- a/src/helmlog/oauth.py
+++ b/src/helmlog/oauth.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any
 
 from authlib.integrations.starlette_client import OAuth
 from loguru import logger
@@ -89,7 +88,6 @@ def enabled_providers() -> list[str]:
     return providers
 
 
-def init_oauth(app: Any) -> None:  # noqa: ANN401
-    """Initialize OAuth with the FastAPI/Starlette app."""
+def init_oauth() -> None:
+    """Register OAuth providers that have env vars configured."""
     _configure_providers()
-    oauth.init_app(app)

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -310,6 +310,25 @@ def create_app(
     app = FastAPI(title="HelmLog", docs_url=None, redoc_url=None)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+    # SessionMiddleware is required by Authlib's OAuth integration (request.session)
+    from starlette.middleware.sessions import SessionMiddleware
+
+    session_secret = os.getenv("SESSION_SECRET", "")
+    if not session_secret:
+        from helmlog.auth import generate_token
+
+        session_secret = generate_token()
+        logger.warning(
+            "SESSION_SECRET not set — generated an ephemeral key (OAuth state will not survive restarts)"
+        )
+    app.add_middleware(SessionMiddleware, secret_key=session_secret)
+
+    # Initialize OAuth providers
+    from helmlog.oauth import init_oauth
+
+    init_oauth()
+
     app.state.storage = storage
     _audio_session_id: int | None = None
     _debrief_audio_session_id: int | None = None
@@ -771,29 +790,51 @@ def create_app(
         if client is None:
             raise HTTPException(status_code=404, detail=f"Unknown OAuth provider: {provider}")
 
-        tok = await client.authorize_access_token(request)
+        try:
+            tok = await client.authorize_access_token(request)
+        except Exception as exc:
+            logger.warning("OAuth token exchange failed for {}: {}", provider, exc)
+            return HTMLResponse(
+                "<h1>OAuth login failed.</h1><p>Could not complete sign-in. Please try again.</p>",
+                status_code=400,
+            )
+
         if provider == "google":
             user_info = tok.get("userinfo", {})
             provider_email = user_info.get("email", "")
             provider_uid = user_info.get("sub", "")
             provider_name = user_info.get("name")
         elif provider == "github":
-            resp = await client.get("user")
-            user_info = resp.json()
-            provider_email = user_info.get("email", "")
-            provider_uid = str(user_info.get("id", ""))
-            provider_name = user_info.get("name")
-            if not provider_email:
-                email_resp = await client.get("user/emails")
-                for e in email_resp.json():
-                    if e.get("primary"):
-                        provider_email = e["email"]
-                        break
+            try:
+                resp = await client.get("user")
+                user_info = resp.json()
+                provider_email = user_info.get("email", "")
+                provider_uid = str(user_info.get("id", ""))
+                provider_name = user_info.get("name")
+                if not provider_email:
+                    email_resp = await client.get("user/emails")
+                    for e in email_resp.json():
+                        if e.get("primary"):
+                            provider_email = e["email"]
+                            break
+            except Exception as exc:
+                logger.warning("GitHub API call failed: {}", exc)
+                return HTMLResponse(
+                    "<h1>OAuth login failed.</h1><p>Could not retrieve GitHub profile. Please try again.</p>",
+                    status_code=400,
+                )
         else:  # apple
             user_info = tok.get("userinfo", {})
             provider_email = user_info.get("email", "")
             provider_uid = user_info.get("sub", "")
             provider_name = user_info.get("name")
+
+        if not provider_uid:
+            logger.warning("OAuth provider {} returned empty user ID", provider)
+            return HTMLResponse(
+                "<h1>OAuth login failed.</h1><p>Provider did not return a user identifier.</p>",
+                status_code=400,
+            )
 
         # Look up existing credential
         cred = await storage.get_credential_by_provider_uid(provider, provider_uid)

--- a/uv.lock
+++ b/uv.lock
@@ -1134,6 +1134,7 @@ dependencies = [
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
     { name = "influxdb-client" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "loguru" },
     { name = "pillow" },
@@ -1176,6 +1177,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "influxdb-client", specifier = ">=1.44.0" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -1339,6 +1341,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Add `SessionMiddleware`** to the FastAPI app — OAuth routes use `request.session` which requires it; without it, Starlette raises `AssertionError` → 500
- **Call `init_oauth()`** in `create_app()` — providers were never registered, so `create_client()` always returned `None`
- **Fix `init_oauth()`** — removed broken `oauth.init_app(app)` call (Authlib's Starlette `OAuth` has no `init_app` method)
- **Add `itsdangerous`** dependency — required by Starlette's `SessionMiddleware`
- **Add error handling** around `authorize_access_token()` and GitHub API calls — unhandled exceptions now return 400 with a user-friendly message instead of 500
- **Validate `provider_uid`** is non-empty before querying the database

Closes #279

## Test plan
- [x] All 900 existing tests pass
- [ ] Test OAuth login with Google/GitHub/Apple providers configured
- [ ] Test OAuth login with denied permissions returns friendly error page
- [ ] Test OAuth login without `SESSION_SECRET` env var (ephemeral key fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)