### PR TITLE
fix: add sudo to data dir removal in reset-pi.sh

### DIFF
--- a/scripts/reset-pi.sh
+++ b/scripts/reset-pi.sh
@@ -262,7 +262,7 @@ info "Removed helmlog wrapper and influx token file."
 
 step "Removing .env, data directory, and venv..."
 rm -f "$ENV_FILE"
-rm -rf "$PROJECT_DIR/data"
+sudo rm -rf "$PROJECT_DIR/data"
 sudo rm -rf "$PROJECT_DIR/.venv"
 info "Removed .env, data/, and .venv/"
 


### PR DESCRIPTION
## Summary
- Add missing `sudo` to `rm -rf "$PROJECT_DIR/data"` on line 265 of `reset-pi.sh`
- Files under `data/notes/` are created by the helmlog service account, so unprivileged `rm` fails with "Permission denied"

Fixes #290

## Test plan
- [ ] Run `./scripts/reset-pi.sh` (dry run) to verify no syntax errors
- [ ] Run `./scripts/reset-pi.sh --confirm` on corvopi-tst1 and confirm data dir is fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)