### PR TITLE
fix: ensure helmlog stays running through bootstrap (#292)

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -153,7 +153,14 @@ bootstrap() {
         return 1
     fi
 
-    # Wait for helmlog to create/migrate the DB (service was started by setup.sh)
+    # Ensure helmlog is running — setup.sh may have started it earlier, but
+    # subsequent daemon-reload / apt activity can stop it before we get here.
+    if ! sudo systemctl is-active --quiet helmlog.service 2>/dev/null; then
+        info "helmlog not running — restarting..."
+        sudo systemctl restart helmlog.service
+    fi
+
+    # Wait for helmlog to create/migrate the DB
     DB_FILE="$HELMLOG_DIR/data/logger.db"
     info "Waiting for database..."
     for _i in {1..30}; do
@@ -178,6 +185,11 @@ bootstrap() {
     # -------------------------------------------------------------------
     # 6. Summary
     # -------------------------------------------------------------------
+
+    # Final safety net — make sure helmlog is running before we declare victory.
+    if ! sudo systemctl is-active --quiet helmlog.service 2>/dev/null; then
+        sudo systemctl restart helmlog.service
+    fi
 
     PI_HOSTNAME="$(hostname)"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -718,6 +718,13 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now loki promtail
 info "Loki (port 3100) + Promtail installed and running."
 
+# daemon-reload can deactivate helmlog — ensure it's still running.
+if sudo systemctl is-enabled --quiet helmlog.service 2>/dev/null &&
+   ! sudo systemctl is-active --quiet helmlog.service 2>/dev/null; then
+    sudo systemctl restart helmlog.service
+    info "Re-started helmlog after daemon-reload."
+fi
+
 # ---------------------------------------------------------------------------
 # k.2) nginx reverse proxy — single-port access to all services
 #      Proxies helmlog (/), Grafana (/grafana/), Signal K (/signalk/)


### PR DESCRIPTION
## Summary

- **setup.sh**: re-start helmlog after the loki/promtail `daemon-reload` if it got deactivated
- **bootstrap.sh**: explicitly check helmlog is running before the 60s DB wait, and again at the end before printing the success banner

Fixes #292

## Test plan

- [ ] Run `reset-pi.sh` followed by `bootstrap.sh` on corvopi-tst1
- [ ] Verify helmlog is `active (running)` at completion
- [ ] Verify admin login URL is printed
- [ ] Verify no 502 Bad Gateway when hitting `http://corvopi-tst1/`
- [ ] Reboot and confirm all services come up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)