### PR TITLE
Add /release-notes skill and promote gate for RELEASES.md

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: release-notes
+description: Draft a curated RELEASES.md entry from commits since the last stage/* tag
+---
+
+# Release Notes: Draft Entry
+
+Draft a new RELEASES.md entry summarizing commits on `main` since the latest
+`stage/*` tag. Run this skill before promoting `main` to `stage`.
+
+## 1. Find the Commit Range
+
+Run `git tag -l 'stage/*' --sort=-creatordate | head -1` to find the latest
+stage tag. If no stage tags exist, use the initial commit as the base.
+
+Save the tag as `$LAST_TAG` and collect the commit range:
+
+```bash
+git log --oneline "$LAST_TAG"..HEAD
+```
+
+## 2. Filter Out Ideation-Log-Only Commits
+
+For each commit in the range, check which files it touches:
+
+```bash
+git diff-tree --no-commit-id --name-only -r <sha>
+```
+
+- **Exclude entirely:** Commits where every changed file is `docs/ideation-log.md`
+- **Include (code changes only):** Commits that touch `docs/ideation-log.md` AND
+  other files — describe only the non-ideation changes
+
+If no non-ideation commits remain after filtering, tell the user:
+> All commits since the last stage tag only touch the ideation log — nothing to
+> document. The promote workflow will allow this through automatically.
+
+And stop here.
+
+## 3. Analyze Changes and Group by Theme
+
+For each included commit, examine:
+- The commit message and any PR title (from `(#NNN)` references)
+- The files changed and the nature of the diff
+
+Group changes into logical themes (e.g., "Performance analysis", "Synthesizer
+improvements", "Deploy & infrastructure", "Bug fixes"). Use your judgment — aim
+for 2–5 groups. A single-commit release can have just one group.
+
+## 4. Draft the RELEASES.md Entry
+
+Read `RELEASES.md` to match the existing format. Draft a new entry following
+this pattern:
+
+```markdown
+## Title — Description (YYYY-MM-DD)
+
+Optional 1–2 sentence summary of the release.
+
+### Theme group
+- **Feature name** (#issue) — one-line description
+- **Feature name** (#issue) — one-line description with enough context to
+  understand the change without reading the code
+```
+
+Rules:
+- Use today's date (YYYY-MM-DD format)
+- Bold feature names, reference issue/PR numbers as `(#NNN)`
+- One bullet per logical change — merge related commits into a single bullet
+- Use sub-bullets only when a change needs a brief clarification
+- Do NOT mention ideation log updates anywhere in the entry
+
+## 5. Insert into RELEASES.md
+
+Prepend the new entry immediately after the `# Release Notes` heading (line 1),
+with a blank line separating it from the next entry. Do not modify existing
+entries.
+
+## 6. Present for Review
+
+Show the user the drafted entry and ask them to review and edit before
+committing. Do NOT commit automatically — the user will commit when satisfied.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -89,6 +89,53 @@ jobs:
           echo "| **Source tag** | \`${PREVIOUS_TAG}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Triggered by** | @${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Check RELEASES.md updated
+        if: "!inputs.rollback && inputs.target == 'stage'"
+        run: |
+          SOURCE="main"
+          TARGET="stage"
+
+          git fetch origin "$SOURCE" "$TARGET"
+
+          SOURCE_SHA=$(git rev-parse "origin/${SOURCE}")
+          TARGET_SHA=$(git rev-parse "origin/${TARGET}")
+
+          if [ "$SOURCE_SHA" = "$TARGET_SHA" ]; then
+            echo "::notice::No commits to check — already up to date"
+            exit 0
+          fi
+
+          # Check if ALL commits only touch docs/ideation-log.md
+          IDEATION_ONLY=true
+          for SHA in $(git rev-list "${TARGET_SHA}..${SOURCE_SHA}"); do
+            FILES=$(git diff-tree --no-commit-id --name-only -r "$SHA")
+            NON_IDEATION=$(echo "$FILES" | grep -v '^docs/ideation-log.md$' || true)
+            if [ -n "$NON_IDEATION" ]; then
+              IDEATION_ONLY=false
+              break
+            fi
+          done
+
+          if [ "$IDEATION_ONLY" = "true" ]; then
+            echo "::notice::All commits only touch ideation log — skipping RELEASES.md check"
+            exit 0
+          fi
+
+          # Verify RELEASES.md has a diff that adds a new ## heading
+          RELEASES_DIFF=$(git diff "${TARGET_SHA}..${SOURCE_SHA}" -- RELEASES.md)
+          if [ -z "$RELEASES_DIFF" ]; then
+            echo "::error::RELEASES.md has not been updated. Run /release-notes to draft an entry before promoting to stage."
+            exit 1
+          fi
+
+          NEW_HEADING=$(echo "$RELEASES_DIFF" | grep '^\+## ' || true)
+          if [ -z "$NEW_HEADING" ]; then
+            echo "::error::RELEASES.md was modified but no new ## heading was added. A new release entry is required — run /release-notes."
+            exit 1
+          fi
+
+          echo "::notice::RELEASES.md check passed — new entry found"
+
       - name: Promote
         if: "!inputs.rollback"
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,16 @@ When starting work on a GitHub issue:
 
 **All changes to `main` must come through merged PRs.** Never push directly to `main`.
 
+### Promote gate
+
+The `promote.yml` workflow gates `main → stage` promotion on RELEASES.md:
+- RELEASES.md must have a new `##` heading in the promoted commits (editing an
+  old entry doesn't count)
+- **Exemption:** if all commits only touch `docs/ideation-log.md`, the check is
+  skipped
+- `stage → live` has no RELEASES.md gate (it's a fast-forward of the same commit)
+- Run `/release-notes` before promoting to draft the entry
+
 ### Environment & Configuration
 
 All config is via environment variables or `.env`. The canonical reference
@@ -316,3 +326,4 @@ docker compose -f tests/integration/docker-compose.yml up --build --abort-on-con
 | `/data-license` | Review changes against the data licensing policy |
 | `/integration-test` | Run federation integration tests (Layer 1/2/3) |
 | `/ideate` | Capture half-baked ideas into the ideation log |
+| `/release-notes` | Draft a RELEASES.md entry from commits since last stage tag |


### PR DESCRIPTION
## Summary
- **`/release-notes` skill** — drafts a curated RELEASES.md entry from commits since the last `stage/*` tag, filtering out ideation-log-only commits and grouping changes by theme
- **Promote gate** — new `Check RELEASES.md updated` step in `promote.yml` that blocks `main → stage` promotion unless RELEASES.md has a new `##` heading (with an exemption when all commits only touch the ideation log)
- **CLAUDE.md updates** — skill added to the skills table; promote gate documented in the workflow section

Closes #302

## Test plan
- [ ] Run `/release-notes` with a mix of feature, fix, and ideation-log commits — verify ideation is excluded and format matches existing entries
- [ ] Run `/release-notes` when there are only ideation-log commits since last tag — verify it reports nothing to document
- [ ] Trigger promote `main → stage` without updating RELEASES.md — verify it fails with a clear error
- [ ] Trigger promote `main → stage` after only editing an old entry (no new `##`) — verify it fails
- [ ] Trigger promote `main → stage` with a proper new `##` entry — verify it passes
- [ ] Trigger promote `main → stage` with only ideation-log commits and no RELEASES.md update — verify it passes (exemption)
- [ ] Trigger promote `stage → live` — verify no RELEASES.md check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)