### PR TITLE
Default sail selection — boat-level defaults

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -763,6 +763,23 @@ async function loadSails() {
   });
   html += '<button class="btn-export" style="background:#2563eb;color:#fff;border-color:#2563eb;font-size:.78rem;margin-top:4px" onclick="saveSails()">Save Sails</button>';
   body.innerHTML = html;
+
+  // If no sails are set for this session, pre-select from boat-level defaults
+  const hasAnySail = slots.some(slot => current[slot] && current[slot].id);
+  if (!hasAnySail) {
+    try {
+      const defaultsResp = await fetch('/api/sails/defaults');
+      if (defaultsResp.ok) {
+        const defaults = await defaultsResp.json();
+        slots.forEach(slot => {
+          if (defaults[slot] && defaults[slot].id) {
+            const sel = document.getElementById('sail-select-' + slot);
+            if (sel) sel.value = String(defaults[slot].id);
+          }
+        });
+      }
+    } catch (_) { /* ignore — defaults are a convenience, not critical */ }
+  }
 }
 
 async function saveSails() {

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -125,7 +125,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 39
+_CURRENT_VERSION: int = 40
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -361,6 +361,12 @@ _MIGRATIONS: dict[int, str] = {
             UNIQUE(race_id, sail_id)
         );
         CREATE INDEX IF NOT EXISTS idx_race_sails_race_id ON race_sails(race_id);
+
+        CREATE TABLE IF NOT EXISTS sail_defaults (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            sail_id INTEGER NOT NULL REFERENCES sails(id) ON DELETE CASCADE,
+            UNIQUE(sail_id)
+        );
     """,
     15: """
         CREATE TABLE IF NOT EXISTS transcripts (
@@ -908,6 +914,14 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE sails ADD COLUMN point_of_sail TEXT NOT NULL DEFAULT 'both';
         UPDATE sails SET point_of_sail = 'upwind' WHERE type = 'jib';
         UPDATE sails SET point_of_sail = 'downwind' WHERE type = 'spinnaker';
+    """,
+    40: """
+        -- Default sail selection — boat-level defaults (#306)
+        CREATE TABLE IF NOT EXISTS sail_defaults (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            sail_id INTEGER NOT NULL REFERENCES sails(id) ON DELETE CASCADE,
+            UNIQUE(sail_id)
+        );
     """,
 }
 
@@ -3188,6 +3202,82 @@ class Storage:
                     "point_of_sail": row["point_of_sail"],
                 }
         return result
+
+    # ------------------------------------------------------------------
+    # Sail defaults (boat-level)
+    # ------------------------------------------------------------------
+
+    async def get_sail_defaults(self) -> dict[str, Any]:
+        """Return the boat-level default sail selection.
+
+        Returns a dict with keys ``main``, ``jib``, ``spinnaker``, each
+        containing the full sail row dict or ``None`` if not set.
+        """
+        db = self._conn()
+        cur = await db.execute(
+            "SELECT s.id, s.type, s.name, s.notes, s.active, s.point_of_sail"
+            " FROM sail_defaults sd"
+            " JOIN sails s ON s.id = sd.sail_id",
+        )
+        rows = await cur.fetchall()
+        result: dict[str, dict[str, Any] | None] = dict.fromkeys(_SAIL_TYPES)
+        for row in rows:
+            sail_type = row["type"]
+            if sail_type in result:
+                result[sail_type] = {
+                    "id": row["id"],
+                    "type": sail_type,
+                    "name": row["name"],
+                    "notes": row["notes"],
+                    "active": bool(row["active"]),
+                    "point_of_sail": row["point_of_sail"],
+                }
+        return result
+
+    async def set_sail_defaults(
+        self,
+        *,
+        main_id: int | None,
+        jib_id: int | None,
+        spinnaker_id: int | None,
+    ) -> None:
+        """Replace the boat-level default sail selection.
+
+        Existing defaults are deleted and the provided non-None sail ids
+        are re-inserted.  Validates that each sail exists and matches the
+        expected type.
+        """
+        db = self._conn()
+        slot_map: dict[str, int | None] = {
+            "main": main_id,
+            "jib": jib_id,
+            "spinnaker": spinnaker_id,
+        }
+        for slot_type, sail_id in slot_map.items():
+            if sail_id is None:
+                continue
+            cur = await db.execute(
+                "SELECT type FROM sails WHERE id = ?", (sail_id,)
+            )
+            row = await cur.fetchone()
+            if row is None:
+                msg = f"Sail id={sail_id} not found"
+                raise ValueError(msg)
+            if row["type"] != slot_type:
+                msg = (
+                    f"Sail id={sail_id} has type {row['type']!r},"
+                    f" expected {slot_type!r} for the {slot_type} slot"
+                )
+                raise ValueError(msg)
+        await db.execute("DELETE FROM sail_defaults")
+        for sail_id in (main_id, jib_id, spinnaker_id):
+            if sail_id is not None:
+                await db.execute(
+                    "INSERT OR IGNORE INTO sail_defaults (sail_id) VALUES (?)",
+                    (sail_id,),
+                )
+        await db.commit()
+        logger.debug("Sail defaults updated")
 
     # ------------------------------------------------------------------
     # Transcripts

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -4121,6 +4121,48 @@ def create_app(
             {"id": sail_id, "type": body.type, "name": body.name.strip()}, status_code=201
         )
 
+    @app.get("/api/sails/defaults")
+    async def api_get_sail_defaults(
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> JSONResponse:
+        """Return the boat-level default sail selection."""
+        defaults = await storage.get_sail_defaults()
+        return JSONResponse(defaults)
+
+    @app.put("/api/sails/defaults", status_code=200)
+    async def api_set_sail_defaults(
+        request: Request,
+        body: RaceSailsSet,
+        _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    ) -> JSONResponse:
+        """Set the boat-level default sail selection."""
+        # Validate that each supplied sail_id references a sail of the correct type
+        slot_map = {"main": body.main_id, "jib": body.jib_id, "spinnaker": body.spinnaker_id}
+        for slot_type, sail_id in slot_map.items():
+            if sail_id is None:
+                continue
+            all_sails = await storage.list_sails(include_inactive=True)
+            matched = next((s for s in all_sails if s["id"] == sail_id), None)
+            if matched is None:
+                raise HTTPException(status_code=422, detail=f"Sail id={sail_id} not found")
+            if matched["type"] != slot_type:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Sail id={sail_id} has type {matched['type']!r},"
+                        f" expected {slot_type!r} for the {slot_type} slot"
+                    ),
+                )
+
+        await storage.set_sail_defaults(
+            main_id=body.main_id,
+            jib_id=body.jib_id,
+            spinnaker_id=body.spinnaker_id,
+        )
+        defaults = await storage.get_sail_defaults()
+        await _audit(request, "sails.defaults.set", user=_user)
+        return JSONResponse(defaults)
+
     @app.patch("/api/sails/{sail_id}", status_code=200)
     async def api_update_sail(
         request: Request,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2144,6 +2144,131 @@ async def test_list_sails_includes_point_of_sail(storage: Storage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Sail defaults (#306)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sail_defaults_empty(storage: Storage) -> None:
+    """GET /api/sails/defaults returns all-None when no defaults are set."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sails/defaults")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"main": None, "jib": None, "spinnaker": None}
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_sail_defaults(storage: Storage) -> None:
+    """PUT /api/sails/defaults persists and GET returns them."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        main_id = await _add_sail(client, "main", "Full Main")
+        jib_id = await _add_sail(client, "jib", "J1")
+        resp = await client.put(
+            "/api/sails/defaults",
+            json={"main_id": main_id, "jib_id": jib_id, "spinnaker_id": None},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["main"]["id"] == main_id
+        assert data["jib"]["id"] == jib_id
+        assert data["spinnaker"] is None
+
+        # GET should return the same
+        resp2 = await client.get("/api/sails/defaults")
+        assert resp2.json() == data
+
+
+@pytest.mark.asyncio
+async def test_set_sail_defaults_invalid_id_422(storage: Storage) -> None:
+    """PUT /api/sails/defaults with non-existent sail returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.put(
+            "/api/sails/defaults", json={"main_id": 999}
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_set_sail_defaults_wrong_type_422(storage: Storage) -> None:
+    """PUT /api/sails/defaults with sail in wrong slot returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        jib_id = await _add_sail(client, "jib", "J1")
+        resp = await client.put(
+            "/api/sails/defaults", json={"main_id": jib_id}
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_clear_sail_defaults(storage: Storage) -> None:
+    """PUT /api/sails/defaults with all None clears defaults."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        main_id = await _add_sail(client, "main", "Full Main")
+        await client.put(
+            "/api/sails/defaults", json={"main_id": main_id}
+        )
+        # Clear
+        resp = await client.put(
+            "/api/sails/defaults",
+            json={"main_id": None, "jib_id": None, "spinnaker_id": None},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"main": None, "jib": None, "spinnaker": None}
+
+
+@pytest.mark.asyncio
+async def test_sail_defaults_do_not_affect_session_sails(storage: Storage) -> None:
+    """Session sails remain independent of defaults."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        main_id = await _add_sail(client, "main", "Full Main")
+        jib_id = await _add_sail(client, "jib", "J1")
+
+        # Set defaults to main only
+        await client.put("/api/sails/defaults", json={"main_id": main_id})
+
+        # Start a session and set sails to jib only
+        await _set_event(client)
+        race_resp = await client.post("/api/races/start")
+        session_id = race_resp.json()["id"]
+        await client.put(
+            f"/api/sessions/{session_id}/sails",
+            json={"main_id": None, "jib_id": jib_id, "spinnaker_id": None},
+        )
+
+        # Session sails should be jib only
+        sails_resp = await client.get(f"/api/sessions/{session_id}/sails")
+        sails = sails_resp.json()
+        assert sails["main"] is None
+        assert sails["jib"]["id"] == jib_id
+
+        # Defaults should still be main only
+        defaults_resp = await client.get("/api/sails/defaults")
+        defaults = defaults_resp.json()
+        assert defaults["main"]["id"] == main_id
+        assert defaults["jib"] is None
+
+
+# ---------------------------------------------------------------------------
 # Audio download / stream endpoints (#21)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `sail_defaults` table (migration v40) for boat-level default sail selection
- `GET /PUT /api/sails/defaults` endpoints to manage defaults (same shape as session sails)
- Session page pre-selects defaults when no sails are set (user must click Save to persist)
- Defaults and session sails are fully independent — changing one doesn't affect the other

## Dependencies
- Based on #316 (`308-point-of-sail` branch) for the `point_of_sail` column

## Test plan
- [x] GET /api/sails/defaults returns all-None when empty
- [x] PUT then GET round-trips correctly
- [x] Invalid sail ID returns 422
- [x] Wrong sail type in wrong slot returns 422
- [x] Clearing defaults (all None) works
- [x] Session sails and defaults are independent
- [x] All 259 tests pass

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)