### PR TITLE
feat: auto-start recording at a preset race start time

### DIFF
--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -9,6 +9,7 @@ let tickInterval = null;
 let curRaceStartMs = null;
 let debriefStartMs = null;
 let lastInstrumentDataMs = 0;
+let scheduleCountdownInterval = null;
 
 async function loadState() {
   try {
@@ -110,6 +111,33 @@ function render(s) {
   }
 
   btnStartRace.textContent = `▶ START RACE ${s.next_race_num}`;
+
+  // --- Scheduled start (#345) ---
+  const btnSchedule = document.getElementById('btn-schedule-toggle');
+  const schedPanel = document.getElementById('schedule-panel');
+  const schedCountdown = document.getElementById('schedule-countdown');
+  if (s.scheduled_start && isIdle) {
+    // Active countdown
+    btnSchedule.classList.add('hidden');
+    btnStartRace.classList.add('hidden');
+    btnStartPractice.classList.add('hidden');
+    schedPanel.classList.add('hidden');
+    schedCountdown.classList.remove('hidden');
+    const fireAt = new Date(s.scheduled_start.scheduled_start_utc);
+    document.getElementById('schedule-countdown-event').textContent =
+      s.scheduled_start.event + ' (' + s.scheduled_start.session_type + ')';
+    _startScheduleCountdown(fireAt);
+  } else if (isIdle) {
+    // No schedule — show the button
+    btnSchedule.classList.remove('hidden');
+    schedCountdown.classList.add('hidden');
+    _stopScheduleCountdown();
+  } else {
+    btnSchedule.classList.add('hidden');
+    schedPanel.classList.add('hidden');
+    schedCountdown.classList.add('hidden');
+    _stopScheduleCountdown();
+  }
 
   // --- Debrief last race button: show when idle, has recorder, and finished races exist ---
   const lastFinished = (s.today_races || []).filter(r => r.end_utc).slice(-1)[0];
@@ -932,6 +960,76 @@ async function startDebriefLast() {
 async function stopDebrief() {
   await fetch('/api/debrief/stop', {method: 'POST'});
   await loadState();
+}
+
+// --- Scheduled start (#345) ---
+
+function toggleSchedulePanel() {
+  const panel = document.getElementById('schedule-panel');
+  panel.classList.toggle('hidden');
+  if (!panel.classList.contains('hidden')) {
+    // Pre-fill with a time 5 minutes from now
+    const d = new Date(Date.now() + 5 * 60000);
+    const pad = n => String(n).padStart(2, '0');
+    const local = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    document.getElementById('schedule-time').value = local;
+  }
+}
+
+async function submitSchedule() {
+  const input = document.getElementById('schedule-time');
+  if (!input.value) { alert('Please set a start time'); return; }
+  const localDate = new Date(input.value);
+  const utcIso = localDate.toISOString();
+  try {
+    const resp = await fetch('/api/races/schedule', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({scheduled_start_utc: utcIso})
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => null);
+      alert(err && err.detail ? err.detail : 'Failed to schedule start');
+      return;
+    }
+    document.getElementById('schedule-panel').classList.add('hidden');
+    await loadState();
+  } catch(e) {
+    console.error('submitSchedule error', e);
+    alert('Error: ' + e.message);
+  }
+}
+
+async function cancelSchedule() {
+  await fetch('/api/races/schedule', {method: 'DELETE'});
+  await loadState();
+}
+
+function _startScheduleCountdown(fireAt) {
+  _stopScheduleCountdown();
+  const el = document.getElementById('schedule-countdown-time');
+  function update() {
+    const diff = Math.max(0, Math.floor((fireAt - Date.now()) / 1000));
+    if (diff <= 0) {
+      el.textContent = 'Starting...';
+      _stopScheduleCountdown();
+      // Poll state to pick up the new race
+      setTimeout(() => loadState(), 2000);
+      return;
+    }
+    const m = Math.floor(diff / 60);
+    const s = diff % 60;
+    el.textContent = `${m}:${String(s).padStart(2, '0')}`;
+  }
+  update();
+  scheduleCountdownInterval = setInterval(update, 1000);
+}
+
+function _stopScheduleCountdown() {
+  if (scheduleCountdownInterval) {
+    clearInterval(scheduleCountdownInterval);
+    scheduleCountdownInterval = null;
+  }
 }
 
 async function saveEvent() {

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -125,7 +125,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 45
+_CURRENT_VERSION: int = 46
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1046,6 +1046,16 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE races ADD COLUMN centroid_lat REAL;
         ALTER TABLE races ADD COLUMN centroid_lon REAL;
     """,
+    46: """
+        -- Scheduled race starts (#345)
+        CREATE TABLE IF NOT EXISTS scheduled_starts (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            scheduled_start_utc TEXT    NOT NULL,
+            event               TEXT    NOT NULL,
+            session_type        TEXT    NOT NULL DEFAULT 'race',
+            created_at          TEXT    NOT NULL
+        );
+    """,
 }
 
 
@@ -1934,6 +1944,63 @@ class Storage:
         await db.commit()
         self._session_active = False
         logger.info("Race {} ended at {}", race_id, end_utc.isoformat())
+
+    # -- Scheduled starts (#345) ------------------------------------------
+
+    async def schedule_start(
+        self,
+        scheduled_start_utc: datetime,
+        event: str,
+        session_type: str = "race",
+    ) -> int:
+        """Set (or replace) the scheduled start. Returns the row id."""
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        db = self._conn()
+        await db.execute("DELETE FROM scheduled_starts")
+        cur = await db.execute(
+            "INSERT INTO scheduled_starts (scheduled_start_utc, event, session_type, created_at)"
+            " VALUES (?, ?, ?, ?)",
+            (
+                scheduled_start_utc.isoformat(),
+                event,
+                session_type,
+                _datetime.now(_UTC).isoformat(),
+            ),
+        )
+        await db.commit()
+        assert cur.lastrowid is not None
+        logger.info("Scheduled start set for {} ({})", scheduled_start_utc.isoformat(), event)
+        return cur.lastrowid
+
+    async def get_scheduled_start(self) -> dict[str, str] | None:
+        """Return the pending scheduled start row, or None."""
+        db = self._conn()
+        cur = await db.execute(
+            "SELECT id, scheduled_start_utc, event, session_type, created_at"
+            " FROM scheduled_starts LIMIT 1"
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "scheduled_start_utc": row["scheduled_start_utc"],
+            "event": row["event"],
+            "session_type": row["session_type"],
+            "created_at": row["created_at"],
+        }
+
+    async def cancel_scheduled_start(self) -> bool:
+        """Delete the pending scheduled start. Returns True if a row was deleted."""
+        db = self._conn()
+        cur = await db.execute("DELETE FROM scheduled_starts")
+        await db.commit()
+        deleted = cur.rowcount > 0
+        if deleted:
+            logger.info("Scheduled start cancelled")
+        return deleted
 
     async def has_source_id(self, source: str, source_id: str) -> bool:
         """Check if a race with this source/source_id already exists (dedup)."""

--- a/src/helmlog/templates/home.html
+++ b/src/helmlog/templates/home.html
@@ -156,9 +156,29 @@
 <div id="controls">
   <button class="btn btn-primary"  id="btn-start-race"     onclick="startSession('race')">&#9654; START RACE 1</button>
   <button class="btn btn-practice" id="btn-start-practice" onclick="startSession('practice')">&#9654; START PRACTICE</button>
+  <button class="btn btn-schedule hidden" id="btn-schedule-toggle" onclick="toggleSchedulePanel()" style="background:#2563eb;color:#fff">&#9200; SET START TIME</button>
   <button class="btn btn-synthesize hidden" id="btn-synthesize" onclick="toggleSynthPanel()">&#9881; SYNTHESIZE RACE</button>
   <button class="btn btn-debrief hidden" id="btn-debrief-last" onclick="startDebriefLast()">DEBRIEF LAST RACE</button>
   <button class="btn btn-danger hidden" id="btn-end" onclick="confirmEndRace()">&#9632; END RACE</button>
+</div>
+
+<div id="schedule-panel" class="card hidden">
+  <div class="label">Schedule Start Time</div>
+  <div class="field">
+    <label for="schedule-time">Start time (local)</label>
+    <input id="schedule-time" type="datetime-local" style="width:100%;padding:6px;border-radius:6px;border:1px solid #333;background:#1a1a2e;color:#e0e0e0"/>
+  </div>
+  <div style="display:flex;gap:8px;margin-top:8px">
+    <button class="btn btn-primary" onclick="submitSchedule()" style="flex:1">Schedule</button>
+    <button class="btn" onclick="toggleSchedulePanel()" style="flex:1;background:#333">Cancel</button>
+  </div>
+</div>
+
+<div id="schedule-countdown" class="card hidden" style="text-align:center">
+  <div style="font-size:.78rem;color:#8892a4">Scheduled start</div>
+  <div id="schedule-countdown-time" style="font-size:1.6rem;font-weight:700;font-variant-numeric:tabular-nums"></div>
+  <div id="schedule-countdown-event" style="font-size:.82rem;color:#8892a4;margin-top:2px"></div>
+  <button class="btn" onclick="cancelSchedule()" style="margin-top:8px;background:#333;font-size:.78rem">Cancel scheduled start</button>
 </div>
 
 <div id="synth-panel" class="card hidden">

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1829,6 +1829,21 @@ def create_app(
         current_dict = await _race_dict(current) if current else None
         today_race_dicts = [await _race_dict(r) for r in today_races]
 
+        # Scheduled start info (#345)
+        sched_row = await storage.get_scheduled_start()
+        scheduled_start_dict: dict[str, Any] | None = None
+        if sched_row is not None:
+            fire_at = datetime.fromisoformat(sched_row["scheduled_start_utc"])
+            if fire_at.tzinfo is None:
+                fire_at = fire_at.replace(tzinfo=UTC)
+            secs = max(0, int((fire_at - now).total_seconds()))
+            scheduled_start_dict = {
+                "scheduled_start_utc": sched_row["scheduled_start_utc"],
+                "event": sched_row["event"],
+                "session_type": sched_row["session_type"],
+                "seconds_until_start": secs,
+            }
+
         return JSONResponse(
             {
                 "date": date_str,
@@ -1841,6 +1856,7 @@ def create_app(
                 "next_practice_num": next_practice_num,
                 "today_races": today_race_dicts,
                 "has_recorder": recorder is not None,
+                "scheduled_start": scheduled_start_dict,
                 "current_debrief": {
                     "race_id": _debrief_race_id,
                     "race_name": _debrief_race_name,
@@ -1963,6 +1979,196 @@ def create_app(
         await _audit(request, "event_rule.delete", detail=_WEEKDAY_NAMES[weekday], user=_user)
 
     # ------------------------------------------------------------------
+    # /api/races/schedule  (#345 — scheduled race starts)
+    # ------------------------------------------------------------------
+
+    _schedule_task: asyncio.Task[None] | None = None
+    _schedule_first_check_done: bool = False
+
+    async def _schedule_fire_loop() -> None:
+        """Background task: poll for a pending scheduled start and fire when due."""
+        nonlocal _schedule_first_check_done
+        while True:
+            try:
+                row = await storage.get_scheduled_start()
+                if row is not None:
+                    fire_at = datetime.fromisoformat(row["scheduled_start_utc"])
+                    if fire_at.tzinfo is None:
+                        fire_at = fire_at.replace(tzinfo=UTC)
+                    now = datetime.now(UTC)
+                    if now >= fire_at:
+                        if not _schedule_first_check_done:
+                            # First check after startup — missed start, don't fire
+                            logger.warning(
+                                "Scheduled start at {} was missed — system was not running",
+                                row["scheduled_start_utc"],
+                            )
+                            await storage.cancel_scheduled_start()
+                        else:
+                            # Normal operation — fire the scheduled start
+                            current = await storage.get_current_race()
+                            if current is not None:
+                                await storage.cancel_scheduled_start()
+                                logger.warning(
+                                    "Scheduled start cancelled — race {} already active",
+                                    current.name,
+                                )
+                            else:
+                                await storage.cancel_scheduled_start()
+                                await _do_scheduled_start(row["event"], row["session_type"])
+                _schedule_first_check_done = True
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Schedule fire loop error: {}", exc)
+            await asyncio.sleep(1)
+
+    async def _do_scheduled_start(event: str, session_type: str) -> None:
+        """Fire a scheduled start — equivalent to pressing Start."""
+        nonlocal _audio_session_id
+        from helmlog.races import build_race_name, local_today
+
+        now = datetime.now(UTC)
+        today = local_today()
+        date_str = today.isoformat()
+        race_num = await storage.count_sessions_for_date(date_str, session_type) + 1
+        name = build_race_name(event, today, race_num, session_type)
+        try:
+            race = await storage.start_race(event, now, date_str, race_num, name, session_type)
+            logger.info("Scheduled start fired: {} (id={})", race.name, race.id)
+
+            # Auto-apply sail defaults
+            try:
+                sail_defaults = await storage.get_sail_defaults()
+                has_any = any(sail_defaults[t] is not None for t in ("main", "jib", "spinnaker"))
+                if has_any:
+                    await storage.insert_sail_change(
+                        race.id,
+                        race.start_utc.isoformat(),
+                        main_id=sail_defaults["main"]["id"] if sail_defaults["main"] else None,
+                        jib_id=sail_defaults["jib"]["id"] if sail_defaults["jib"] else None,
+                        spinnaker_id=(
+                            sail_defaults["spinnaker"]["id"] if sail_defaults["spinnaker"] else None
+                        ),
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Sail defaults failed for scheduled race {}: {}", name, exc)
+
+            # Start audio if recorder is available
+            if recorder is not None and audio_config is not None:
+                from helmlog.audio import AudioDeviceNotFoundError
+
+                try:
+                    session = await recorder.start(audio_config, name=race.name)
+                    _audio_session_id = await storage.write_audio_session(
+                        session,
+                        race_id=race.id,
+                        session_type=session_type,
+                        name=race.name,
+                    )
+                except AudioDeviceNotFoundError as exc:
+                    logger.warning("Audio unavailable for scheduled race {}: {}", name, exc)
+
+            await storage.log_action("race.scheduled_start", detail=race.name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Scheduled start failed: {}", exc)
+
+    @app.on_event("startup")
+    async def _start_schedule_loop() -> None:
+        nonlocal _schedule_task
+        _schedule_task = asyncio.create_task(_schedule_fire_loop())
+
+    @app.on_event("shutdown")
+    async def _stop_schedule_loop() -> None:
+        if _schedule_task is not None:
+            _schedule_task.cancel()
+
+    @app.post("/api/races/schedule", status_code=201)
+    async def api_schedule_start(
+        request: Request,
+        _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    ) -> JSONResponse:
+        body = await request.json()
+        raw_ts = body.get("scheduled_start_utc")
+        event = body.get("event")
+        session_type = body.get("session_type", "race")
+        if not raw_ts:
+            raise HTTPException(422, detail="scheduled_start_utc is required")
+
+        try:
+            fire_at = datetime.fromisoformat(raw_ts)
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(422, detail=f"Invalid timestamp: {exc}") from exc
+        if fire_at.tzinfo is None:
+            fire_at = fire_at.replace(tzinfo=UTC)
+
+        now = datetime.now(UTC)
+        if fire_at <= now + timedelta(seconds=5):
+            raise HTTPException(
+                422, detail="scheduled_start_utc must be in the future (> now + 5s)"
+            )
+
+        if session_type not in ("race", "practice"):
+            raise HTTPException(422, detail="session_type must be 'race' or 'practice'")
+
+        # If no event provided, resolve from rules / daily override
+        if not event:
+            from helmlog.races import default_event_for_date, local_today
+
+            today = local_today()
+            date_str = today.isoformat()
+            rules = {r["weekday"]: r["event_name"] for r in await storage.list_event_rules()}
+            default_ev = default_event_for_date(today, rules)
+            custom_ev = await storage.get_daily_event(date_str)
+            event = custom_ev or default_ev
+            if event is None:
+                raise HTTPException(422, detail="No event set for today. POST /api/event first.")
+
+        row_id = await storage.schedule_start(fire_at, event, session_type)
+        await _audit(request, "race.schedule", detail=fire_at.isoformat(), user=_user)
+        seconds_until = max(0, int((fire_at - now).total_seconds()))
+        return JSONResponse(
+            {
+                "id": row_id,
+                "scheduled_start_utc": fire_at.isoformat(),
+                "event": event,
+                "session_type": session_type,
+                "seconds_until_start": seconds_until,
+            },
+            status_code=201,
+        )
+
+    @app.get("/api/races/schedule")
+    async def api_get_schedule(
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> JSONResponse:
+        row = await storage.get_scheduled_start()
+        if row is None:
+            raise HTTPException(404, detail="No scheduled start")
+        fire_at = datetime.fromisoformat(row["scheduled_start_utc"])
+        if fire_at.tzinfo is None:
+            fire_at = fire_at.replace(tzinfo=UTC)
+        now = datetime.now(UTC)
+        seconds_until = max(0, int((fire_at - now).total_seconds()))
+        return JSONResponse(
+            {
+                "id": row["id"],
+                "scheduled_start_utc": row["scheduled_start_utc"],
+                "event": row["event"],
+                "session_type": row["session_type"],
+                "seconds_until_start": seconds_until,
+            }
+        )
+
+    @app.delete("/api/races/schedule", status_code=204)
+    async def api_cancel_schedule(
+        request: Request,
+        _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    ) -> None:
+        await storage.cancel_scheduled_start()
+        await _audit(request, "race.schedule_cancel", user=_user)
+
+    # ------------------------------------------------------------------
     # /api/races/start
     # ------------------------------------------------------------------
 
@@ -2001,6 +2207,9 @@ def create_app(
                 status_code=422,
                 detail="No event set for today. POST /api/event first.",
             )
+
+        # Cancel any pending scheduled start (#345)
+        await storage.cancel_scheduled_start()
 
         # Auto-stop any active debrief before starting a new session
         if _debrief_audio_session_id is not None:

--- a/tests/test_scheduled_start.py
+++ b/tests/test_scheduled_start.py
@@ -1,0 +1,391 @@
+"""Tests for scheduled race start (#345)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _set_event(client: httpx.AsyncClient, name: str = "TestRegatta") -> None:
+    resp = await client.post("/api/event", json={"event_name": name})
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# POST /api/races/schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_returns_201(storage: Storage) -> None:
+    """POST /api/races/schedule with a valid future time returns 201."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        resp = await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future},
+        )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "id" in data
+    assert data["event"] == "TestRegatta"
+    assert data["session_type"] == "race"
+    assert data["seconds_until_start"] > 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_rejects_past_time(storage: Storage) -> None:
+    """POST /api/races/schedule with a past time returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        past = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        resp = await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": past},
+        )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_rejects_missing_timestamp(storage: Storage) -> None:
+    """POST /api/races/schedule without a timestamp returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        resp = await client.post("/api/races/schedule", json={})
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_replaces_existing(storage: Storage) -> None:
+    """Scheduling a second start replaces the first one."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        t1 = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        t2 = (datetime.now(UTC) + timedelta(minutes=20)).isoformat()
+        await client.post("/api/races/schedule", json={"scheduled_start_utc": t1})
+        resp = await client.post("/api/races/schedule", json={"scheduled_start_utc": t2})
+
+    assert resp.status_code == 201
+    # Only one row should exist
+    row = await storage.get_scheduled_start()
+    assert row is not None
+    assert row["scheduled_start_utc"] == datetime.fromisoformat(t2).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_no_event_returns_422(storage: Storage) -> None:
+    """POST /api/races/schedule without an event configured returns 422."""
+    from unittest.mock import patch
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        with patch("helmlog.races.default_event_for_date", return_value=None):
+            future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+            resp = await client.post(
+                "/api/races/schedule",
+                json={"scheduled_start_utc": future},
+            )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_with_explicit_event(storage: Storage) -> None:
+    """POST /api/races/schedule with an explicit event succeeds."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        resp = await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future, "event": "CustomEvent"},
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["event"] == "CustomEvent"
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_practice_session_type(storage: Storage) -> None:
+    """POST /api/races/schedule with session_type=practice works."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        resp = await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future, "session_type": "practice"},
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["session_type"] == "practice"
+
+
+@pytest.mark.asyncio
+async def test_schedule_start_invalid_session_type(storage: Storage) -> None:
+    """POST /api/races/schedule with invalid session_type returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        resp = await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future, "session_type": "invalid"},
+        )
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/races/schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_returns_404_when_empty(storage: Storage) -> None:
+    """GET /api/races/schedule returns 404 when nothing is scheduled."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/races/schedule")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_returns_scheduled_start(storage: Storage) -> None:
+    """GET /api/races/schedule returns the scheduled start when one exists."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future},
+        )
+        resp = await client.get("/api/races/schedule")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["event"] == "TestRegatta"
+    assert data["seconds_until_start"] > 0
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/races/schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_schedule_returns_204(storage: Storage) -> None:
+    """DELETE /api/races/schedule cancels the scheduled start."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future},
+        )
+        resp = await client.delete("/api/races/schedule")
+
+    assert resp.status_code == 204
+    assert await storage.get_scheduled_start() is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_schedule_idempotent(storage: Storage) -> None:
+    """DELETE /api/races/schedule returns 204 even when nothing is scheduled."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.delete("/api/races/schedule")
+
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Manual start cancels schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_start_cancels_schedule(storage: Storage) -> None:
+    """POST /api/races/start cancels any pending scheduled start."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future},
+        )
+        # Verify schedule exists
+        assert await storage.get_scheduled_start() is not None
+
+        # Manual start should cancel the schedule
+        resp = await client.post("/api/races/start")
+
+    assert resp.status_code == 201
+    assert await storage.get_scheduled_start() is None
+
+
+# ---------------------------------------------------------------------------
+# State endpoint includes scheduled_start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_includes_scheduled_start(storage: Storage) -> None:
+    """GET /api/state includes scheduled_start when one is set."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        await client.post(
+            "/api/races/schedule",
+            json={"scheduled_start_utc": future},
+        )
+        resp = await client.get("/api/state")
+
+    data = resp.json()
+    assert data["scheduled_start"] is not None
+    assert data["scheduled_start"]["event"] == "TestRegatta"
+    assert data["scheduled_start"]["seconds_until_start"] > 0
+
+
+@pytest.mark.asyncio
+async def test_state_scheduled_start_null_when_none(storage: Storage) -> None:
+    """GET /api/state has scheduled_start as null when none is set."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/state")
+
+    data = resp.json()
+    assert data["scheduled_start"] is None
+
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_storage_schedule_start(storage: Storage) -> None:
+    """Storage.schedule_start stores and retrieves the scheduled start."""
+    ts = datetime.now(UTC) + timedelta(minutes=10)
+    row_id = await storage.schedule_start(ts, "TestRegatta")
+    assert row_id > 0
+
+    row = await storage.get_scheduled_start()
+    assert row is not None
+    assert row["event"] == "TestRegatta"
+    assert row["session_type"] == "race"
+
+
+@pytest.mark.asyncio
+async def test_storage_schedule_replaces_existing(storage: Storage) -> None:
+    """Storage.schedule_start replaces any existing row."""
+    t1 = datetime.now(UTC) + timedelta(minutes=10)
+    t2 = datetime.now(UTC) + timedelta(minutes=20)
+    await storage.schedule_start(t1, "Event1")
+    await storage.schedule_start(t2, "Event2")
+
+    row = await storage.get_scheduled_start()
+    assert row is not None
+    assert row["event"] == "Event2"
+
+
+@pytest.mark.asyncio
+async def test_storage_cancel_scheduled_start(storage: Storage) -> None:
+    """Storage.cancel_scheduled_start deletes the row."""
+    ts = datetime.now(UTC) + timedelta(minutes=10)
+    await storage.schedule_start(ts, "TestRegatta")
+    deleted = await storage.cancel_scheduled_start()
+    assert deleted is True
+    assert await storage.get_scheduled_start() is None
+
+
+@pytest.mark.asyncio
+async def test_storage_cancel_no_row(storage: Storage) -> None:
+    """Storage.cancel_scheduled_start returns False when nothing exists."""
+    deleted = await storage.cancel_scheduled_start()
+    assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# Missed start recovery (startup)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_schedule_not_in_state(storage: Storage) -> None:
+    """GET /api/state still returns the expired schedule row until the loop clears it.
+
+    The real missed-start cleanup is done by the background loop's first check.
+    Here we verify the storage layer correctly persists and retrieves expired rows.
+    """
+    # Insert a scheduled start in the past directly
+    past = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO scheduled_starts (scheduled_start_utc, event, session_type, created_at)"
+        " VALUES (?, ?, ?, ?)",
+        (past, "TestRegatta", "race", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+
+    # Verify the row is retrievable
+    row = await storage.get_scheduled_start()
+    assert row is not None
+    assert row["event"] == "TestRegatta"
+
+    # Cancel simulates what the fire loop's first check does
+    await storage.cancel_scheduled_start()
+    assert await storage.get_scheduled_start() is None
+    # No race should have been created
+    current = await storage.get_current_race()
+    assert current is None


### PR DESCRIPTION
## Summary

- Users can schedule a future start time via the home page UI or `POST /api/races/schedule`
- Background task polls every 1s and fires `start_race()` when the clock reaches the scheduled time
- Manual start (`POST /api/races/start`) atomically cancels any pending schedule
- Missed starts (system was down when the scheduled time passed) are detected and cleared — no retroactive recording
- `GET /api/state` includes `scheduled_start` with countdown seconds for the UI
- Home page shows a countdown card when a start is scheduled, with cancel button

## Changes

| File | Change |
|---|---|
| `storage.py` | Schema v46 (`scheduled_starts` table), `schedule_start()`, `get_scheduled_start()`, `cancel_scheduled_start()` |
| `web.py` | `POST/GET/DELETE /api/races/schedule`, background fire loop, missed-start detection, state endpoint enrichment, manual-start cancellation |
| `home.html` | Schedule button, time input panel, countdown card |
| `home.js` | `toggleSchedulePanel()`, `submitSchedule()`, `cancelSchedule()`, countdown timer |
| `test_scheduled_start.py` | 20 tests: API validation, storage CRUD, state integration, manual-start interaction, edge cases |

## Test plan

- [x] `uv run pytest tests/test_scheduled_start.py -v` — 20/20 pass
- [x] `uv run pytest` — 1136 tests pass (no regressions)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — no new errors (pre-existing only)
- [ ] Manual: deploy to Pi, set a start time 2 minutes in the future, verify countdown and auto-start
- [ ] Manual: set a start time, then manually start before it fires — verify schedule is cancelled
- [ ] Manual: set a start time, restart helmlog service before it fires — verify missed-start warning in logs

Closes #345

🤖 Generated with [Claude Code](https://claude.ai/code)