### PR TITLE
Add customizable color scheme system with sunlight-optimized presets

### DIFF
--- a/src/helmlog/static/base.css
+++ b/src/helmlog/static/base.css
@@ -4,6 +4,22 @@
    ========================================================================== */
 
 /* --------------------------------------------------------------------------
+   CSS Custom Properties — defaults match Ocean Dark preset.
+   Overridden per-user by a server-rendered <style> block in base.html.
+   -------------------------------------------------------------------------- */
+
+:root {
+  --bg-primary: #0a1628;
+  --text-primary: #e8eaf0;
+  --accent: #7eb8f7;
+  --bg-secondary: #131f35;
+  --text-secondary: #8892a4;
+  --border: #1e3a5f;
+  --bg-input: #0a1628;
+  --accent-strong: #2563eb;
+}
+
+/* --------------------------------------------------------------------------
    Reset & Body Defaults
    -------------------------------------------------------------------------- */
 
@@ -15,8 +31,8 @@
 
 body {
   font-family: system-ui, sans-serif;
-  background: #0a1628;
-  color: #e8eaf0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: clamp(0.85rem, 2vw, 1rem);
 }
 
@@ -49,13 +65,13 @@ body {
 h1 {
   font-size: 1.3rem;
   font-weight: 700;
-  color: #7eb8f7;
+  color: var(--accent);
   margin-bottom: 2px;
 }
 
 .sub {
   font-size: 0.9rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   margin-bottom: 20px;
 }
 
@@ -64,7 +80,7 @@ h1 {
    -------------------------------------------------------------------------- */
 
 .card {
-  background: #131f35;
+  background: var(--bg-secondary);
   border-radius: 12px;
   padding: 16px;
   margin-bottom: 16px;
@@ -78,7 +94,7 @@ h1 {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #8892a4;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 
@@ -120,12 +136,12 @@ h1 {
 }
 
 .btn-secondary {
-  background: #1e3a5f;
-  color: #7eb8f7;
-  border: 1px solid #2563eb;
+  background: var(--border);
+  color: var(--accent);
+  border: 1px solid var(--accent-strong);
 }
 .btn-secondary:active {
-  background: #163252;
+  background: var(--bg-secondary);
 }
 
 .btn-danger {
@@ -165,12 +181,12 @@ h1 {
 }
 
 .btn-note {
-  background: #1a3a4e;
-  color: #7eb8f7;
-  border: 1px solid #2563eb;
+  background: var(--border);
+  color: var(--accent);
+  border: 1px solid var(--accent-strong);
 }
 .btn-note:active {
-  background: #163252;
+  background: var(--bg-secondary);
 }
 
 /* --------------------------------------------------------------------------
@@ -179,10 +195,10 @@ h1 {
 
 .btn-export {
   padding: 8px 12px;
-  border: 1px solid #2563eb;
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
-  background: #131f35;
-  color: #7eb8f7;
+  background: var(--bg-secondary);
+  color: var(--accent);
   font-size: 0.8rem;
   cursor: pointer;
   text-decoration: none;
@@ -211,18 +227,18 @@ h1 {
 
 .btn-sm {
   padding: 8px 12px;
-  border: 1px solid #374151;
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: #0a1628;
+  background: var(--bg-primary);
   font-size: 0.78rem;
   cursor: pointer;
   min-height: 36px;
-  color: #e8eaf0;
+  color: var(--text-primary);
 }
 
 .btn-edit {
-  color: #7eb8f7;
-  border-color: #2563eb;
+  color: var(--accent);
+  border-color: var(--accent-strong);
 }
 
 .btn-del {
@@ -258,8 +274,8 @@ h1 {
 }
 
 .badge-race {
-  background: #1e3a5f;
-  color: #7eb8f7;
+  background: var(--border);
+  color: var(--accent);
 }
 
 .badge-practice {
@@ -316,10 +332,10 @@ h1 {
    -------------------------------------------------------------------------- */
 
 .field {
-  background: #0a1628;
-  border: 1px solid #2563eb;
+  background: var(--bg-input);
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
-  color: #e8eaf0;
+  color: var(--text-primary);
 }
 
 .event-row {
@@ -330,11 +346,11 @@ h1 {
 
 .event-input {
   flex: 1;
-  background: #0a1628;
-  border: 1px solid #2563eb;
+  background: var(--bg-input);
+  border: 1px solid var(--accent-strong);
   border-radius: 8px;
   padding: 12px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 1rem;
 }
 
@@ -350,17 +366,17 @@ table {
 
 th {
   text-align: left;
-  color: #8892a4;
+  color: var(--text-secondary);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 6px 8px;
-  border-bottom: 1px solid #1e3a5f;
+  border-bottom: 1px solid var(--border);
 }
 
 td {
   padding: 7px 8px;
-  border-bottom: 1px solid #0d1a2e;
+  border-bottom: 1px solid var(--bg-secondary);
   vertical-align: middle;
 }
 
@@ -369,7 +385,7 @@ tr:last-child td {
 }
 
 .empty {
-  color: #8892a4;
+  color: var(--text-secondary);
   text-align: center;
   padding: 20px 0;
 }
@@ -383,7 +399,7 @@ nav.site-nav {
   align-items: center;
   padding: 6px 0;
   margin-bottom: 8px;
-  border-bottom: 1px solid #1e3a5f;
+  border-bottom: 1px solid var(--border);
   position: relative;
 }
 
@@ -393,9 +409,9 @@ nav.site-nav {
   align-items: center;
   justify-content: center;
   background: none;
-  border: 1px solid #2563eb;
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
-  color: #7eb8f7;
+  color: var(--accent);
   font-size: 1.1rem;
   width: 36px;
   height: 36px;
@@ -404,7 +420,7 @@ nav.site-nav {
 }
 
 .nav-hamburger:active {
-  background: #1e3a5f;
+  background: var(--border);
 }
 
 /* Nav links container — collapsed on mobile by default */
@@ -415,8 +431,8 @@ nav.site-nav {
   top: 100%;
   left: 0;
   right: 0;
-  background: #131f35;
-  border: 1px solid #1e3a5f;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
   border-radius: 0 0 8px 8px;
   z-index: 100;
   padding: 4px 0;
@@ -427,11 +443,11 @@ nav.site-nav {
 }
 
 .nav-links a {
-  color: #8892a4;
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 0.9rem;
   padding: 10px 14px;
-  border-bottom: 1px solid #0d1a2e;
+  border-bottom: 1px solid var(--bg-primary);
 }
 
 .nav-links a:last-child {
@@ -440,13 +456,13 @@ nav.site-nav {
 
 .nav-links a:hover,
 .nav-links a:focus {
-  color: #e8eaf0;
-  background: #1e3a5f;
+  color: var(--text-primary);
+  background: var(--border);
   outline: none;
 }
 
 .nav-links a.active {
-  color: #7eb8f7;
+  color: var(--accent);
   font-weight: 600;
 }
 
@@ -498,13 +514,13 @@ nav.site-nav {
 .race-name {
   font-size: 1rem;
   font-weight: 600;
-  color: #e8eaf0;
+  color: var(--text-primary);
   margin-bottom: 4px;
 }
 
 .race-meta {
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
 }
 
 .status-dot {
@@ -541,7 +557,7 @@ nav.site-nav {
   -webkit-user-select: none;
   user-select: none;
   padding: 8px 0;
-  border-bottom: 1px solid #1e3a5f;
+  border-bottom: 1px solid var(--border);
 }
 
 .setup-cat-header:last-of-type {
@@ -551,13 +567,13 @@ nav.site-nav {
 .setup-cat-label {
   font-size: 0.8rem;
   font-weight: 600;
-  color: #7eb8f7;
+  color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
 .setup-cat-chevron {
-  color: #8892a4;
+  color: var(--text-secondary);
   font-size: 0.8rem;
   transition: transform 0.15s;
 }
@@ -576,24 +592,24 @@ nav.site-nav {
 .setup-label {
   min-width: 110px;
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
 .setup-input {
   flex: 1;
-  background: #0a1628;
-  border: 1px solid #374151;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 10px 10px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.95rem;
   min-width: 0;
   -webkit-appearance: none;
 }
 
 .setup-input:focus {
-  border-color: #2563eb;
+  border-color: var(--accent-strong);
   outline: none;
 }
 
@@ -603,7 +619,7 @@ nav.site-nav {
 
 .setup-unit {
   font-size: 0.75rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   min-width: 28px;
   text-align: right;
   flex-shrink: 0;
@@ -611,11 +627,11 @@ nav.site-nav {
 
 .setup-select {
   flex: 1;
-  background: #0a1628;
-  border: 1px solid #374151;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 10px 10px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.95rem;
   min-width: 0;
   -webkit-appearance: none;
@@ -627,7 +643,7 @@ nav.site-nav {
 }
 
 .setup-select:focus {
-  border-color: #2563eb;
+  border-color: var(--accent-strong);
   outline: none;
 }
 
@@ -649,18 +665,18 @@ nav.site-nav {
 
 .bs-label {
   min-width: 110px;
-  color: #8892a4;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
 .bs-value {
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-variant-numeric: tabular-nums;
 }
 
 .bs-unit {
   font-size: 0.72rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
@@ -720,26 +736,26 @@ nav.site-nav {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: #8892a4;
+  color: var(--text-secondary);
 }
 
 .inst-value {
   font-size: 1.3rem;
   font-weight: 700;
-  color: #7eb8f7;
+  color: var(--accent);
   font-variant-numeric: tabular-nums;
 }
 
 .inst-unit {
   font-size: 0.75rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   margin-left: 2px;
 }
 
 .inst-time {
   font-size: 1rem;
   font-weight: 600;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-variant-numeric: tabular-nums;
   margin-bottom: 8px;
 }
@@ -776,28 +792,28 @@ nav.site-nav {
 .crew-pos {
   min-width: 48px;
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
 .crew-input {
   flex: 1;
-  background: #0a1628;
-  border: 1px solid #2563eb;
+  background: var(--bg-input);
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
   padding: 8px 10px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.9rem;
 }
 
 .crew-select {
   flex: 1;
-  background: #0a1628;
-  border: 1px solid #374151;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 10px 10px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.95rem;
   min-width: 0;
   -webkit-appearance: none;
@@ -809,7 +825,7 @@ nav.site-nav {
 }
 
 .crew-select:focus {
-  border-color: #2563eb;
+  border-color: var(--accent-strong);
   outline: none;
 }
 
@@ -820,11 +836,11 @@ nav.site-nav {
 .crew-weight {
   width: 68px;
   flex-shrink: 0;
-  background: #0a1628;
-  border: 1px solid #374151;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px 6px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.8rem;
   text-align: right;
   -moz-appearance: textfield;
@@ -837,27 +853,27 @@ nav.site-nav {
 }
 
 .crew-weight:focus {
-  border-color: #2563eb;
+  border-color: var(--accent-strong);
   outline: none;
 }
 
 .crew-total-weight {
   font-size: 0.85rem;
-  color: #e0e6ed;
+  color: var(--text-primary);
   margin-top: 10px;
   padding: 8px 10px;
-  background: #0d1829;
-  border: 1px solid #1e3a5f;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
   border-radius: 6px;
   display: none;
 }
 
 .sailor-chip {
   padding: 6px 12px;
-  border: 1px solid #2563eb;
+  border: 1px solid var(--accent-strong);
   border-radius: 16px;
-  background: #0a1628;
-  color: #7eb8f7;
+  background: var(--bg-primary);
+  color: var(--accent);
   font-size: 0.82rem;
   cursor: pointer;
   white-space: nowrap;
@@ -865,12 +881,12 @@ nav.site-nav {
 }
 
 .sailor-chip:active {
-  background: #1e3a5f;
+  background: var(--border);
 }
 
 .race-item-crew {
   font-size: 0.75rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   margin-top: 2px;
 }
 
@@ -880,7 +896,7 @@ nav.site-nav {
 
 .results-section {
   margin-top: 8px;
-  border-top: 1px solid #1e3a5f;
+  border-top: 1px solid var(--border);
   padding-top: 6px;
 }
 
@@ -892,7 +908,7 @@ nav.site-nav {
   -webkit-user-select: none;
   user-select: none;
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
 }
 
 .results-header:active {
@@ -904,7 +920,7 @@ nav.site-nav {
   align-items: center;
   gap: 6px;
   padding: 4px 0;
-  border-bottom: 1px solid #0d1a2e;
+  border-bottom: 1px solid var(--bg-secondary);
 }
 
 .results-row:last-child {
@@ -915,7 +931,7 @@ nav.site-nav {
   min-width: 22px;
   font-size: 0.82rem;
   font-weight: 700;
-  color: #7eb8f7;
+  color: var(--accent);
 }
 
 .results-boat {
@@ -925,10 +941,10 @@ nav.site-nav {
 
 .flag-btn {
   padding: 2px 7px;
-  border: 1px solid #374151;
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: #0a1628;
-  color: #8892a4;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
   font-size: 0.72rem;
   cursor: pointer;
 }
@@ -947,9 +963,9 @@ nav.site-nav {
 
 .btn-del-result {
   padding: 2px 7px;
-  border: 1px solid #374151;
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: #0a1628;
+  background: var(--bg-primary);
   color: #ef4444;
   font-size: 0.72rem;
   cursor: pointer;
@@ -961,11 +977,11 @@ nav.site-nav {
 
 .boat-picker-input {
   width: 100%;
-  background: #0a1628;
-  border: 1px solid #374151;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 6px 9px;
-  color: #e8eaf0;
+  color: var(--text-primary);
   font-size: 0.82rem;
 }
 
@@ -974,8 +990,8 @@ nav.site-nav {
   top: calc(100% + 2px);
   left: 0;
   right: 0;
-  background: #131f35;
-  border: 1px solid #2563eb;
+  background: var(--bg-secondary);
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
   max-height: 190px;
   overflow-y: auto;
@@ -987,7 +1003,7 @@ nav.site-nav {
   padding: 8px 12px;
   font-size: 0.82rem;
   cursor: pointer;
-  border-bottom: 1px solid #1e3a5f;
+  border-bottom: 1px solid var(--border);
 }
 
 .boat-option:last-child {
@@ -995,7 +1011,7 @@ nav.site-nav {
 }
 
 .boat-option:active {
-  background: #1e3a5f;
+  background: var(--border);
 }
 
 .boat-option-new {
@@ -1008,16 +1024,16 @@ nav.site-nav {
 
 .note-tab {
   padding: 5px 12px;
-  border: 1px solid #2563eb;
+  border: 1px solid var(--accent-strong);
   border-radius: 6px;
-  background: #131f35;
-  color: #8892a4;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   font-size: 0.8rem;
   cursor: pointer;
 }
 
 .note-tab.active {
-  background: #2563eb;
+  background: var(--accent-strong);
   color: #fff;
 }
 
@@ -1028,18 +1044,18 @@ nav.site-nav {
 .session-name {
   font-size: 1rem;
   font-weight: 600;
-  color: #e8eaf0;
+  color: var(--text-primary);
   margin-bottom: 2px;
 }
 
 .session-meta {
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
 }
 
 .session-crew {
   font-size: 0.78rem;
-  color: #8892a4;
+  color: var(--text-secondary);
   margin-top: 2px;
 }
 
@@ -1052,7 +1068,7 @@ nav.site-nav {
 
 .session-results {
   margin-top: 8px;
-  border-top: 1px solid #1e3a5f;
+  border-top: 1px solid var(--border);
   padding-top: 8px;
 }
 
@@ -1062,7 +1078,7 @@ nav.site-nav {
 
 .race-item {
   padding: 10px 0;
-  border-bottom: 1px solid #1e3a5f;
+  border-bottom: 1px solid var(--border);
 }
 
 .race-item:last-child {
@@ -1077,7 +1093,7 @@ nav.site-nav {
 
 .race-item-time {
   font-size: 0.8rem;
-  color: #8892a4;
+  color: var(--text-secondary);
 }
 
 .race-exports {
@@ -1100,18 +1116,18 @@ nav.site-nav {
 
 .filter-btn {
   padding: 5px 14px;
-  border: 1px solid #374151;
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: #0a1628;
-  color: #8892a4;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
   font-size: 0.82rem;
   cursor: pointer;
 }
 
 .filter-btn.active {
-  border-color: #2563eb;
-  color: #7eb8f7;
-  background: #1e3a5f;
+  border-color: var(--accent-strong);
+  color: var(--accent);
+  background: var(--border);
 }
 
 .pager {
@@ -1123,7 +1139,7 @@ nav.site-nav {
 }
 
 .pager-info {
-  color: #8892a4;
+  color: var(--text-secondary);
   font-size: 0.85rem;
 }
 
@@ -1135,5 +1151,5 @@ footer {
   text-align: center;
   padding: 12px 0 8px;
   font-size: 0.7rem;
-  color: #4a5568;
+  color: var(--text-secondary);
 }

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -125,7 +125,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 46
+_CURRENT_VERSION: int = 47
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1054,6 +1054,19 @@ _MIGRATIONS: dict[int, str] = {
             event               TEXT    NOT NULL,
             session_type        TEXT    NOT NULL DEFAULT 'race',
             created_at          TEXT    NOT NULL
+        );
+    """,
+    47: """
+        -- Customizable color schemes (#347)
+        ALTER TABLE users ADD COLUMN color_scheme TEXT;
+        CREATE TABLE IF NOT EXISTS color_schemes (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            name        TEXT    NOT NULL,
+            bg          TEXT    NOT NULL,
+            text_color  TEXT    NOT NULL,
+            accent      TEXT    NOT NULL,
+            created_by  INTEGER REFERENCES users(id),
+            created_at  TEXT    NOT NULL
         );
     """,
 }
@@ -3975,7 +3988,7 @@ class Storage:
 
     _USER_COLS = (
         "id, email, name, role, created_at, last_seen,"
-        " avatar_path, is_developer, is_active, weight_lbs"
+        " avatar_path, is_developer, is_active, weight_lbs, color_scheme"
     )
 
     async def get_user_by_id(self, user_id: int) -> dict[str, Any] | None:
@@ -4514,6 +4527,80 @@ class Storage:
         )
         rows = await cur.fetchall()
         return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Color schemes (#347)
+    # ------------------------------------------------------------------
+
+    async def create_color_scheme(
+        self,
+        name: str,
+        bg: str,
+        text_color: str,
+        accent: str,
+        created_by: int | None,
+    ) -> int:
+        """Insert a new custom color scheme. Returns the new row id."""
+        from datetime import UTC
+        from datetime import datetime as _datetime
+
+        now = _datetime.now(UTC).isoformat()
+        db = self._conn()
+        cur = await db.execute(
+            "INSERT INTO color_schemes (name, bg, text_color, accent, created_by, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (name, bg, text_color, accent, created_by, now),
+        )
+        await db.commit()
+        assert cur.lastrowid is not None
+        return cur.lastrowid
+
+    async def update_color_scheme(
+        self, scheme_id: int, name: str, bg: str, text_color: str, accent: str
+    ) -> bool:
+        """Update an existing custom color scheme. Returns True if found."""
+        db = self._conn()
+        cur = await db.execute(
+            "UPDATE color_schemes SET name = ?, bg = ?, text_color = ?, accent = ?"
+            " WHERE id = ?",
+            (name, bg, text_color, accent, scheme_id),
+        )
+        await db.commit()
+        return cur.rowcount > 0
+
+    async def delete_color_scheme(self, scheme_id: int) -> bool:
+        """Delete a custom color scheme. Returns True if found."""
+        db = self._conn()
+        cur = await db.execute("DELETE FROM color_schemes WHERE id = ?", (scheme_id,))
+        await db.commit()
+        return cur.rowcount > 0
+
+    async def get_color_scheme(self, scheme_id: int) -> dict[str, Any] | None:
+        """Return a custom color scheme row by id, or None."""
+        cur = await self._conn().execute(
+            "SELECT id, name, bg, text_color, accent, created_by, created_at"
+            " FROM color_schemes WHERE id = ?",
+            (scheme_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+    async def list_color_schemes(self) -> list[dict[str, Any]]:
+        """Return all custom color schemes ordered by name."""
+        cur = await self._conn().execute(
+            "SELECT id, name, bg, text_color, accent, created_by, created_at"
+            " FROM color_schemes ORDER BY name"
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def set_user_color_scheme(self, user_id: int, scheme: str | None) -> None:
+        """Set or clear a user's personal color scheme override."""
+        db = self._conn()
+        await db.execute(
+            "UPDATE users SET color_scheme = ? WHERE id = ?",
+            (scheme, user_id),
+        )
+        await db.commit()
 
     # ------------------------------------------------------------------
     # Session deletion (#194)

--- a/src/helmlog/templates/admin/settings.html
+++ b/src/helmlog/templates/admin/settings.html
@@ -2,27 +2,43 @@
 {% block title %}Settings — HelmLog{% endblock %}
 {% block extra_css %}
 <style>
-.card{background:#131f35;border-radius:12px;padding:16px;margin-bottom:12px}
-.label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:#8892a4;margin-bottom:8px}
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:12px}
+.label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);margin-bottom:8px}
 .setting{margin-bottom:18px}
 .setting label{display:block;font-weight:600;margin-bottom:4px;font-size:.9rem}
-.setting .help{font-size:.75rem;color:#8892a4;margin-top:2px}
-.setting input,.setting select{width:100%;max-width:480px;padding:7px 10px;border:1px solid #374151;border-radius:4px;background:#0a1628;color:#e8eaf0;font-size:.85rem}
+.setting .help{font-size:.75rem;color:var(--text-secondary);margin-top:2px}
+.setting input,.setting select{width:100%;max-width:480px;padding:7px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.85rem}
 .setting input[type=number]{max-width:120px}
 .source-badge{display:inline-block;font-size:.65rem;text-transform:uppercase;letter-spacing:.06em;padding:2px 6px;border-radius:3px;margin-left:8px;vertical-align:middle}
-.source-db{background:#1e3a5f;color:#60a5fa}
+.source-db{background:var(--border);color:var(--accent)}
 .source-env{background:#1a3329;color:#4ade80}
 .source-default{background:#2a2033;color:#c084fc}
 .btn-row{display:flex;gap:8px;margin-top:18px;flex-wrap:wrap}
-.btn{padding:8px 18px;border:1px solid #374151;border-radius:6px;background:#1e293b;color:#e8eaf0;font-size:.85rem;cursor:pointer}
-.btn:hover{background:#253449}
-.btn-primary{background:#2563eb;border-color:#2563eb;color:#fff}
-.btn-primary:hover{background:#1d4ed8}
+.btn{padding:8px 18px;border:1px solid var(--border);border-radius:6px;background:var(--border);color:var(--text-primary);font-size:.85rem;cursor:pointer}
+.btn:hover{background:var(--bg-secondary)}
+.btn-primary{background:var(--accent-strong);border-color:var(--accent-strong);color:#fff}
+.btn-primary:hover{opacity:.9}
 .btn-reset{color:#f87171;border-color:#7f1d1d;font-size:.75rem;padding:4px 10px}
 .btn-reset:hover{background:#1f1215}
 .status{margin-top:12px;padding:8px;border-radius:6px;font-size:.85rem;display:none}
 .status.ok{display:block;background:#0d2818;color:#4ade80;border:1px solid #16a34a}
 .status.err{display:block;background:#1f1215;color:#f87171;border:1px solid #7f1d1d}
+/* Color scheme section */
+.cs-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:12px}
+@media(min-width:500px){.cs-grid{grid-template-columns:repeat(3,1fr)}}
+.cs-preset{border:2px solid var(--border);border-radius:8px;padding:10px 8px;cursor:pointer;text-align:center;font-size:.8rem;transition:border-color .15s}
+.cs-preset.selected{border-color:var(--accent-strong)}
+.cs-swatch{height:28px;border-radius:4px;margin-bottom:4px;border:1px solid var(--border)}
+.cs-custom-row{display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap}
+.cs-input{padding:7px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.85rem}
+.cs-name-input{flex:2;min-width:100px}
+.cs-color-input{width:50px;height:34px;padding:2px;cursor:pointer}
+.contrast-badge{font-size:.72rem;padding:2px 6px;border-radius:4px;display:inline-block}
+.contrast-aa{background:#0d2818;color:#4ade80;border:1px solid #16a34a}
+.contrast-aaa{background:#0d2818;color:#4ade80;border:1px solid #22c55e}
+.contrast-fail{background:#1f1215;color:#f87171;border:1px solid #7f1d1d}
+.cs-list-item{display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--border)}
+.cs-list-item:last-child{border-bottom:none}
 </style>
 {% endblock %}
 {% block content %}
@@ -36,9 +52,196 @@
     </div>
   </form>
 </div>
+
+<div class="card">
+  <div class="label">Color Scheme — Boat Default</div>
+  <div id="cs-status" class="status"></div>
+  <p style="font-size:.82rem;color:var(--text-secondary);margin-bottom:12px">Applies to all crew who haven't set a personal override. Select a preset or create a custom scheme below.</p>
+
+  <div class="cs-grid" id="preset-grid">
+    {% for p in preset_schemes %}
+    <div class="cs-preset{% if boat_default == p.id %} selected{% endif %}" id="preset-{{ p.id }}" onclick="selectScheme('{{ p.id }}')">
+      <div class="cs-swatch" id="swatch-{{ p.id }}"></div>
+      <div>{{ p.name }}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  {% if custom_schemes %}
+  <div style="font-size:.8rem;font-weight:600;color:var(--text-secondary);margin-bottom:6px;text-transform:uppercase;letter-spacing:.06em">Custom Schemes</div>
+  <div id="custom-list">
+    {% for cs in custom_schemes %}
+    <div class="cs-list-item">
+      <div style="display:flex;gap:4px">
+        <div style="width:18px;height:18px;border-radius:3px;border:1px solid var(--border);background:{{ cs.bg }}"></div>
+        <div style="width:18px;height:18px;border-radius:3px;border:1px solid var(--border);background:{{ cs.text_color }}"></div>
+        <div style="width:18px;height:18px;border-radius:3px;border:1px solid var(--border);background:{{ cs.accent }}"></div>
+      </div>
+      <span style="flex:1;font-size:.85rem">{{ cs.name }}</span>
+      <button class="btn{% if boat_default == 'custom:' ~ cs.id|string %} btn-primary{% endif %}"
+              onclick="selectScheme('custom:{{ cs.id }}')" style="padding:4px 10px;font-size:.78rem">
+        {% if boat_default == 'custom:' ~ cs.id|string %}Default ✓{% else %}Set default{% endif %}
+      </button>
+      <button class="btn btn-reset" onclick="deleteCustom({{ cs.id }})">Delete</button>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div style="margin-top:12px">
+    <span id="selected-scheme-label" style="font-size:.85rem;color:var(--text-secondary)">
+      Current default: <strong>{% if boat_default %}{{ boat_default }}{% else %}Ocean Dark (system){% endif %}</strong>
+    </span>
+  </div>
+  <div class="btn-row">
+    <button class="btn btn-primary" onclick="saveDefault()">Save Default</button>
+    <button class="btn btn-reset" onclick="clearDefault()">Clear (use system default)</button>
+  </div>
+</div>
+
+<div class="card">
+  <div class="label">Create Custom Scheme</div>
+  <p style="font-size:.82rem;color:var(--text-secondary);margin-bottom:12px">Define custom colors for your boat. The live contrast ratio is shown below.</p>
+  <div class="cs-custom-row">
+    <input type="text" class="cs-input cs-name-input" id="cs-name" placeholder="Scheme name (e.g. Corvo Colors)" oninput="updateCustomPreview()"/>
+  </div>
+  <div class="cs-custom-row">
+    <label style="font-size:.82rem;color:var(--text-secondary);min-width:60px">Background</label>
+    <input type="color" class="cs-color-input" id="cs-bg" value="#000000" oninput="updateCustomPreview()"/>
+    <input type="text" class="cs-input" id="cs-bg-text" value="#000000" style="width:90px" oninput="syncColor('cs-bg','cs-bg-text');updateCustomPreview()"/>
+  </div>
+  <div class="cs-custom-row">
+    <label style="font-size:.82rem;color:var(--text-secondary);min-width:60px">Text</label>
+    <input type="color" class="cs-color-input" id="cs-text" value="#FFD600" oninput="updateCustomPreview()"/>
+    <input type="text" class="cs-input" id="cs-text-text" value="#FFD600" style="width:90px" oninput="syncColor('cs-text','cs-text-text');updateCustomPreview()"/>
+  </div>
+  <div class="cs-custom-row">
+    <label style="font-size:.82rem;color:var(--text-secondary);min-width:60px">Accent</label>
+    <input type="color" class="cs-color-input" id="cs-accent" value="#FFD600" oninput="updateCustomPreview()"/>
+    <input type="text" class="cs-input" id="cs-accent-text" value="#FFD600" style="width:90px" oninput="syncColor('cs-accent','cs-accent-text');updateCustomPreview()"/>
+  </div>
+  <div id="custom-preview" style="margin:10px 0;padding:10px;border-radius:6px;font-size:.9rem"></div>
+  <div id="custom-contrast"></div>
+  <div class="btn-row">
+    <button class="btn btn-primary" onclick="createCustom()">Create Scheme</button>
+  </div>
+</div>
 {% endblock %}
 {% block scripts %}
 <script>
+const PRESET_COLORS = {
+  'ocean_dark':     {bg:'#0a1628', text:'#e8eaf0', accent:'#7eb8f7'},
+  'sunlight':       {bg:'#FFFFFF', text:'#000000', accent:'#0055AA'},
+  'racing_yellow':  {bg:'#000000', text:'#FFD600', accent:'#FFD600'},
+  'sunset_red':     {bg:'#1a0000', text:'#FFB4A8', accent:'#FF5722'},
+  'reef_green':     {bg:'#001A0A', text:'#A8FFD0', accent:'#00E676'},
+  'daylight_amber': {bg:'#FFFDE7', text:'#3E2723', accent:'#FF8F00'},
+};
+
+let selectedScheme = '{{ boat_default }}';
+
+// Populate swatch backgrounds
+Object.entries(PRESET_COLORS).forEach(([id, c]) => {
+  const sw = document.getElementById('swatch-'+id);
+  if (sw) sw.style.background = `linear-gradient(135deg, ${c.bg} 50%, ${c.text} 50%)`;
+});
+
+function selectScheme(id) {
+  selectedScheme = id;
+  document.querySelectorAll('.cs-preset').forEach(el => el.classList.remove('selected'));
+  const el = document.getElementById('preset-'+id);
+  if (el) el.classList.add('selected');
+}
+
+async function saveDefault() {
+  const r = await fetch('/api/color-schemes/default', {
+    method:'PUT', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({scheme_id: selectedScheme})
+  });
+  if (r.ok) { showCsStatus('Default saved — reload to see the change','ok'); setTimeout(()=>location.reload(),1200); }
+  else { const d = await r.json().catch(()=>({})); showCsStatus(d.detail||'Save failed','err'); }
+}
+
+async function clearDefault() {
+  const r = await fetch('/api/color-schemes/default', {
+    method:'PUT', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({scheme_id: ''})
+  });
+  if (r.ok) { showCsStatus('Default cleared','ok'); setTimeout(()=>location.reload(),1200); }
+  else showCsStatus('Clear failed','err');
+}
+
+async function deleteCustom(id) {
+  if (!confirm('Delete this custom scheme?')) return;
+  const r = await fetch('/api/color-schemes/'+id, {method:'DELETE'});
+  if (r.ok || r.status===204) location.reload();
+  else { const d = await r.json().catch(()=>({})); showCsStatus(d.detail||'Delete failed','err'); }
+}
+
+function relLum(hex) {
+  const h = hex.replace('#','');
+  const r = parseInt(h.slice(0,2),16)/255, g = parseInt(h.slice(2,4),16)/255, b = parseInt(h.slice(4,6),16)/255;
+  const lin = c => c <= 0.04045 ? c/12.92 : Math.pow((c+0.055)/1.055, 2.4);
+  return 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b);
+}
+function contrast(fg, bg) {
+  const l1 = relLum(fg), l2 = relLum(bg);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function syncColor(colorInputId, textInputId) {
+  const textEl = document.getElementById(textInputId);
+  const colorEl = document.getElementById(colorInputId);
+  // Determine which triggered
+  if (document.activeElement === textEl) {
+    const v = textEl.value;
+    if (/^#[0-9a-fA-F]{6}$/.test(v)) colorEl.value = v;
+  } else {
+    textEl.value = colorEl.value;
+  }
+}
+
+function updateCustomPreview() {
+  // Sync text inputs → color pickers
+  ['bg','text','accent'].forEach(k => {
+    const textEl = document.getElementById('cs-'+k+'-text');
+    const colorEl = document.getElementById('cs-'+k);
+    if (document.activeElement === colorEl) textEl.value = colorEl.value;
+    else if (/^#[0-9a-fA-F]{6}$/.test(textEl.value)) colorEl.value = textEl.value;
+  });
+  const bg = document.getElementById('cs-bg').value;
+  const text = document.getElementById('cs-text').value;
+  const accent = document.getElementById('cs-accent').value;
+  const name = document.getElementById('cs-name').value || 'Preview';
+  const prev = document.getElementById('custom-preview');
+  prev.style.background = bg;
+  prev.style.color = text;
+  prev.style.border = `2px solid ${accent}`;
+  prev.innerHTML = `<strong style="color:${accent}">${name}</strong> — Sample text in this color scheme. <em>Accent color.</em>`;
+  const ratio = contrast(text, bg).toFixed(1);
+  let cls = ratio >= 7 ? 'contrast-aaa' : ratio >= 4.5 ? 'contrast-aa' : 'contrast-fail';
+  let lbl = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA ✓' : 'Below AA ⚠';
+  document.getElementById('custom-contrast').innerHTML = `<span class="contrast-badge ${cls}">Contrast ${ratio}:1 ${lbl}</span>`;
+}
+
+async function createCustom() {
+  const name = document.getElementById('cs-name').value.trim();
+  const bg = document.getElementById('cs-bg').value;
+  const text_color = document.getElementById('cs-text').value;
+  const accent = document.getElementById('cs-accent').value;
+  if (!name) { showCsStatus('Scheme name is required','err'); return; }
+  const r = await fetch('/api/color-schemes', {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({name, bg, text_color, accent})
+  });
+  if (r.ok || r.status===201) { showCsStatus('Custom scheme created','ok'); setTimeout(()=>location.reload(),800); }
+  else { const d = await r.json().catch(()=>({})); showCsStatus(d.detail||'Create failed','err'); }
+}
+
+function showCsStatus(msg,cls){const el=document.getElementById('cs-status');el.textContent=msg;el.className='status '+cls;setTimeout(()=>{el.className='status'},4000)}
+
+// --- Existing settings logic ---
 let DEFS=[], loaded={};
 async function init(){
   const r=await fetch('/api/settings');
@@ -88,5 +291,6 @@ async function resetKey(key){
 }
 function showStatus(msg,cls){const el=document.getElementById('status');el.textContent=msg;el.className='status '+cls;setTimeout(()=>{el.className='status'},4000)}
 init();
+updateCustomPreview();
 </script>
 {% endblock %}

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>{% block title %}HelmLog{% endblock %}</title>
 <link rel="stylesheet" href="/static/base.css"/>
+{% if theme_css %}<style>{{ theme_css }}</style>{% endif %}
 {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/src/helmlog/templates/profile.html
+++ b/src/helmlog/templates/profile.html
@@ -2,35 +2,45 @@
 {% block title %}HelmLog — Profile{% endblock %}
 {% block extra_css %}
 <style>
-h1{font-size:1.3rem;font-weight:700;color:#7eb8f7;margin-bottom:12px}
-.p-card{background:#131f35;border-radius:12px;padding:24px;text-align:center}
+h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:12px}
+.p-card{background:var(--bg-secondary);border-radius:12px;padding:24px;text-align:center}
 .p-avatar{width:128px;height:128px;border-radius:50%;object-fit:cover;cursor:pointer;border:3px solid {{ role_color }};margin-bottom:16px}
-.p-avatar-hint{color:#6b7a90;font-size:.75rem;margin-top:-10px;margin-bottom:12px}
-.p-email{color:#8892a4;font-size:.9rem;margin-bottom:8px}
+.p-avatar-hint{color:var(--text-secondary);font-size:.75rem;margin-top:-10px;margin-bottom:12px}
+.p-email{color:var(--text-secondary);font-size:.9rem;margin-bottom:8px}
 .p-role{background:{{ role_color }}22;color:{{ role_color }};padding:2px 10px;border-radius:4px;font-size:.8rem;display:inline-block}
 .p-field{text-align:left;margin-top:24px}
-.p-field-label{color:#8892a4;font-size:.9rem;display:block;margin-bottom:6px}
+.p-field-label{color:var(--text-secondary);font-size:.9rem;display:block;margin-bottom:6px}
 .p-input{
   display:block;width:100%;padding:14px 12px;border-radius:8px;
-  border:1px solid #2a3a5c;background:#0d1829;color:#e0e6ed;
+  border:1px solid var(--border);background:var(--bg-input);color:var(--text-primary);
   font-size:1.1rem;box-sizing:border-box;min-height:48px;
 }
-.p-input:focus{border-color:#2563eb;outline:none}
+.p-input:focus{border-color:var(--accent-strong);outline:none}
 .p-row{display:flex;gap:10px;align-items:stretch;margin-top:6px}
 .p-row .p-input{flex:1 1 0;min-width:0;width:auto}
 .p-row .p-btn{
   flex-shrink:0;min-height:48px;padding:12px 20px;font-size:.95rem;
   display:flex;align-items:center;justify-content:center;
-  background:#1e3a5c;color:#e0e6ed;border:1px solid #2a3a5c;border-radius:8px;
+  background:var(--border);color:var(--text-primary);border:1px solid var(--border);border-radius:8px;
   cursor:pointer;font-weight:600;
 }
-.p-row .p-btn:active{background:#2563eb}
+.p-row .p-btn:active{background:var(--accent-strong);color:#fff}
 .p-consent{
   display:flex;align-items:center;gap:8px;margin-top:8px;
-  color:#8892a4;font-size:.9rem;cursor:pointer;padding:8px 0;
+  color:var(--text-secondary);font-size:.9rem;cursor:pointer;padding:8px 0;
 }
 .p-consent input[type="checkbox"]{width:20px;height:20px;cursor:pointer}
-.p-note{color:#6b7a90;font-size:.8rem;margin:6px 0 0;line-height:1.4}
+.p-note{color:var(--text-secondary);font-size:.8rem;margin:6px 0 0;line-height:1.4}
+/* Color scheme picker */
+.scheme-select{width:100%;padding:10px 12px;border-radius:8px;border:1px solid var(--border);background:var(--bg-input);color:var(--text-primary);font-size:1rem;box-sizing:border-box}
+.scheme-preview{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap}
+.scheme-swatch{width:28px;height:28px;border-radius:4px;border:2px solid var(--border)}
+.contrast-badge{font-size:.75rem;padding:2px 7px;border-radius:4px;margin-top:6px;display:inline-block}
+.contrast-aa{background:#0d2818;color:#4ade80;border:1px solid #16a34a}
+.contrast-aaa{background:#0d2818;color:#4ade80;border:1px solid #22c55e}
+.contrast-fail{background:#1f1215;color:#f87171;border:1px solid #7f1d1d}
+.scheme-reset-btn{background:none;border:1px solid var(--border);border-radius:6px;color:var(--text-secondary);padding:5px 12px;font-size:.82rem;cursor:pointer;margin-top:8px}
+.scheme-reset-btn:active{background:var(--border)}
 </style>
 {% endblock %}
 {% block content %}
@@ -62,37 +72,97 @@ h1{font-size:1.3rem;font-weight:700;color:#7eb8f7;margin-bottom:12px}
       <button type="button" class="p-btn" onclick="saveWeight()">Save</button>
     </div>
   </div>
+
+  <div class="p-field">
+    <label class="p-field-label" for="scheme-select">Color Scheme</label>
+    <p class="p-note">Optimized for phone screens in bright sunlight. Overrides the boat default.</p>
+    <select id="scheme-select" class="scheme-select" onchange="onSchemeChange()">
+      <option value="">— Boat default{% if boat_default %} ({{ boat_default }}){% endif %} —</option>
+      {% for p in preset_schemes %}
+      <option value="{{ p.id }}"{% if current_scheme == p.id %} selected{% endif %}>{{ p.name }}</option>
+      {% endfor %}
+      {% if custom_schemes %}
+      <optgroup label="Custom">
+        {% for cs in custom_schemes %}
+        <option value="custom:{{ cs.id }}"{% if current_scheme == 'custom:' ~ cs.id|string %} selected{% endif %}>{{ cs.name }}</option>
+        {% endfor %}
+      </optgroup>
+      {% endif %}
+    </select>
+    <div class="scheme-preview" id="scheme-preview"></div>
+    <div id="contrast-badge"></div>
+    <div>
+      <button type="button" class="p-btn" style="margin-top:10px;width:auto;display:inline-flex" onclick="saveScheme()">Apply</button>
+      <button type="button" class="scheme-reset-btn" onclick="resetScheme()">Reset to boat default</button>
+    </div>
+  </div>
 </div>
 {% endblock %}
 {% block scripts %}
 <script>
+const PRESET_COLORS = {
+  'ocean_dark':     {bg:'#0a1628', text:'#e8eaf0', accent:'#7eb8f7'},
+  'sunlight':       {bg:'#FFFFFF', text:'#000000', accent:'#0055AA'},
+  'racing_yellow':  {bg:'#000000', text:'#FFD600', accent:'#FFD600'},
+  'sunset_red':     {bg:'#1a0000', text:'#FFB4A8', accent:'#FF5722'},
+  'reef_green':     {bg:'#001A0A', text:'#A8FFD0', accent:'#00E676'},
+  'daylight_amber': {bg:'#FFFDE7', text:'#3E2723', accent:'#FF8F00'},
+};
+const CUSTOM_COLORS = {
+  {% for cs in custom_schemes %}'custom:{{ cs.id }}': {bg: '{{ cs.bg }}', text: '{{ cs.text_color }}', accent: '{{ cs.accent }}'},
+  {% endfor %}
+};
+
+function relLum(hex) {
+  const h = hex.replace('#','');
+  const r = parseInt(h.slice(0,2),16)/255, g = parseInt(h.slice(2,4),16)/255, b = parseInt(h.slice(4,6),16)/255;
+  const lin = c => c <= 0.04045 ? c/12.92 : Math.pow((c+0.055)/1.055, 2.4);
+  return 0.2126*lin(r) + 0.7152*lin(g) + 0.0722*lin(b);
+}
+function contrast(fg, bg) {
+  const l1 = relLum(fg), l2 = relLum(bg);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function onSchemeChange() {
+  const sel = document.getElementById('scheme-select').value;
+  const colors = PRESET_COLORS[sel] || CUSTOM_COLORS[sel];
+  const preview = document.getElementById('scheme-preview');
+  const badge = document.getElementById('contrast-badge');
+  if (!colors) { preview.innerHTML = ''; badge.innerHTML = ''; return; }
+  preview.innerHTML =
+    `<div class="scheme-swatch" style="background:${colors.bg}"></div>` +
+    `<div class="scheme-swatch" style="background:${colors.text}"></div>` +
+    `<div class="scheme-swatch" style="background:${colors.accent}"></div>` +
+    `<span style="font-size:.8rem;color:var(--text-secondary);align-self:center">${colors.bg} / ${colors.text} / ${colors.accent}</span>`;
+  const ratio = contrast(colors.text, colors.bg).toFixed(1);
+  let cls = ratio >= 7 ? 'contrast-aaa' : ratio >= 4.5 ? 'contrast-aa' : 'contrast-fail';
+  let lbl = ratio >= 7 ? 'AAA' : ratio >= 4.5 ? 'AA ✓' : 'Below AA ⚠';
+  badge.innerHTML = `<span class="contrast-badge ${cls}">${ratio}:1 ${lbl}</span>`;
+}
+
 document.getElementById('file').addEventListener('change', async e => {
   const f = e.target.files[0];
   if (!f) return;
   const fd = new FormData();
   fd.append('file', f);
   const r = await fetch('/profile/avatar', {method:'POST', body:fd});
-  if (r.ok) {
-    window.location.reload();
-  } else {
-    const d = await r.json();
-    alert(d.detail || 'Upload failed');
-  }
+  if (r.ok) { window.location.reload(); }
+  else { const d = await r.json(); alert(d.detail || 'Upload failed'); }
 });
+
 async function saveName() {
   const name = document.getElementById('name-input').value.trim();
   if (!name) { alert('Name must not be blank.'); return; }
   const r = await fetch('/api/me/name', {
-    method:'PATCH',
-    headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({name: name})
+    method:'PATCH', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({name})
   });
   if (r.ok) window.location.reload();
-  else {
-    const d = await r.json().catch(() => ({}));
-    alert(d.detail || 'Failed to save name');
-  }
+  else { const d = await r.json().catch(() => ({})); alert(d.detail || 'Failed to save name'); }
 }
+
 async function saveWeight() {
   const v = document.getElementById('weight-input').value;
   const weight = v ? parseFloat(v) : null;
@@ -101,22 +171,34 @@ async function saveWeight() {
     alert('Please check the biometric consent box before saving weight.');
     return;
   }
-  /* Grant or revoke biometric consent to match the checkbox */
   await fetch('/api/crew/{{ user_id }}/consents', {
-    method:'PUT',
-    headers:{'Content-Type':'application/json'},
+    method:'PUT', headers:{'Content-Type':'application/json'},
     body: JSON.stringify({consent_type:'biometric', granted: consentBox.checked})
   });
   const r = await fetch('/api/me/weight', {
-    method:'PATCH',
-    headers:{'Content-Type':'application/json'},
+    method:'PATCH', headers:{'Content-Type':'application/json'},
     body: JSON.stringify({weight_lbs: weight})
   });
   if (r.ok) alert('Weight saved');
-  else {
-    const d = await r.json().catch(() => ({}));
-    alert(d.detail || 'Failed to save weight');
-  }
+  else { const d = await r.json().catch(() => ({})); alert(d.detail || 'Failed to save weight'); }
 }
+
+async function saveScheme() {
+  const sel = document.getElementById('scheme-select').value;
+  const r = await fetch('/api/me/color-scheme', {
+    method:'PATCH', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({scheme_id: sel || null})
+  });
+  if (r.ok) window.location.reload();
+  else { const d = await r.json().catch(() => ({})); alert(d.detail || 'Failed to save color scheme'); }
+}
+
+async function resetScheme() {
+  await fetch('/api/me/color-scheme', {method:'DELETE'});
+  window.location.reload();
+}
+
+// Show preview for current selection on load
+onSchemeChange();
 </script>
 {% endblock %}

--- a/src/helmlog/themes.py
+++ b/src/helmlog/themes.py
@@ -1,0 +1,267 @@
+"""Color scheme / theming system (#347).
+
+Server-side theme resolution and CSS variable generation.  CSS variables are
+injected via a ``<style>`` block in ``base.html`` on every page load — no
+JavaScript theme-switching required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Preset registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ThemeColors:
+    """All CSS custom-property values for one color scheme."""
+
+    id: str
+    name: str
+    bg_primary: str  # --bg-primary  (page background)
+    text_primary: str  # --text-primary (body text)
+    accent: str  # --accent      (links, highlights)
+    bg_secondary: str  # --bg-secondary (cards/panels)
+    text_secondary: str  # --text-secondary (muted text)
+    border: str  # --border      (dividers)
+    bg_input: str  # --bg-input    (form fields)
+    accent_strong: str  # --accent-strong (buttons, focus rings)
+
+
+PRESETS: dict[str, ThemeColors] = {
+    tc.id: tc
+    for tc in [
+        ThemeColors(
+            id="ocean_dark",
+            name="Ocean Dark",
+            bg_primary="#0a1628",
+            text_primary="#e8eaf0",
+            accent="#7eb8f7",
+            bg_secondary="#131f35",
+            text_secondary="#8892a4",
+            border="#1e3a5f",
+            bg_input="#0a1628",
+            accent_strong="#2563eb",
+        ),
+        ThemeColors(
+            id="sunlight",
+            name="Sunlight High-Contrast",
+            bg_primary="#FFFFFF",
+            text_primary="#000000",
+            accent="#0055AA",
+            bg_secondary="#F5F5F5",
+            text_secondary="#555555",
+            border="#CCCCCC",
+            bg_input="#FFFFFF",
+            accent_strong="#0055AA",
+        ),
+        ThemeColors(
+            id="racing_yellow",
+            name="Racing Yellow",
+            bg_primary="#000000",
+            text_primary="#FFD600",
+            accent="#FFD600",
+            bg_secondary="#111111",
+            text_secondary="#BBAA00",
+            border="#333300",
+            bg_input="#0a0a00",
+            accent_strong="#FFD600",
+        ),
+        ThemeColors(
+            id="sunset_red",
+            name="Sunset Red",
+            bg_primary="#1a0000",
+            text_primary="#FFB4A8",
+            accent="#FF5722",
+            bg_secondary="#2a0808",
+            text_secondary="#CC8880",
+            border="#440000",
+            bg_input="#1a0000",
+            accent_strong="#FF5722",
+        ),
+        ThemeColors(
+            id="reef_green",
+            name="Reef Green",
+            bg_primary="#001A0A",
+            text_primary="#A8FFD0",
+            accent="#00E676",
+            bg_secondary="#0a2a10",
+            text_secondary="#88CCAA",
+            border="#003310",
+            bg_input="#001A0A",
+            accent_strong="#00E676",
+        ),
+        ThemeColors(
+            id="daylight_amber",
+            name="Daylight Amber",
+            bg_primary="#FFFDE7",
+            text_primary="#3E2723",
+            accent="#FF8F00",
+            bg_secondary="#FFF8C8",
+            text_secondary="#6E4C3E",
+            border="#D9C8A0",
+            bg_input="#FFFDE7",
+            accent_strong="#FF8F00",
+        ),
+    ]
+}
+
+SYSTEM_DEFAULT_ID = "ocean_dark"
+PRESET_ORDER = ["sunlight", "racing_yellow", "ocean_dark", "sunset_red", "reef_green", "daylight_amber"]
+
+
+# ---------------------------------------------------------------------------
+# WCAG 2.1 contrast ratio
+# ---------------------------------------------------------------------------
+
+
+def _relative_luminance(hex_color: str) -> float:
+    """Compute WCAG 2.1 relative luminance for a hex color."""
+    h = hex_color.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    r_raw, g_raw, b_raw = (int(h[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+
+    def _lin(c: float) -> float:
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * _lin(r_raw) + 0.7152 * _lin(g_raw) + 0.0722 * _lin(b_raw)
+
+
+def wcag_contrast(fg: str, bg: str) -> float:
+    """Return the WCAG 2.1 contrast ratio between two hex colors (1.0–21.0)."""
+    l1 = _relative_luminance(fg)
+    l2 = _relative_luminance(bg)
+    lighter, darker = (l1, l2) if l1 >= l2 else (l2, l1)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+# ---------------------------------------------------------------------------
+# Custom scheme helpers
+# ---------------------------------------------------------------------------
+
+
+def _hex_to_rgb(h: str) -> tuple[int, int, int]:
+    h = h.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def _rgb_to_hex(r: int, g: int, b: int) -> str:
+    return f"#{r:02X}{g:02X}{b:02X}"
+
+
+def _adjust_brightness(hex_color: str, delta: float) -> str:
+    """Nudge all RGB channels by delta×255 (positive = lighter)."""
+    r, g, b = _hex_to_rgb(hex_color)
+    bump = int(delta * 255)
+    return _rgb_to_hex(
+        max(0, min(255, r + bump)),
+        max(0, min(255, g + bump)),
+        max(0, min(255, b + bump)),
+    )
+
+
+def _dim_color(hex_color: str, factor: float) -> str:
+    """Blend hex_color toward its gray equivalent (factor=1 → original, 0 → gray)."""
+    r, g, b = _hex_to_rgb(hex_color)
+    avg = (r + g + b) // 3
+    return _rgb_to_hex(
+        int(r * factor + avg * (1 - factor)),
+        int(g * factor + avg * (1 - factor)),
+        int(b * factor + avg * (1 - factor)),
+    )
+
+
+def _custom_to_theme(cs: dict[str, Any]) -> ThemeColors:
+    """Convert a custom scheme DB row into a ThemeColors instance."""
+    bg = cs["bg"]
+    text = cs["text_color"]
+    accent = cs["accent"]
+    return ThemeColors(
+        id=f"custom:{cs['id']}",
+        name=cs["name"],
+        bg_primary=bg,
+        text_primary=text,
+        accent=accent,
+        bg_secondary=_adjust_brightness(bg, 0.05),
+        text_secondary=_dim_color(text, 0.6),
+        border=_dim_color(text, 0.25),
+        bg_input=bg,
+        accent_strong=accent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Theme resolution (decision table from spec)
+# ---------------------------------------------------------------------------
+
+
+def resolve_theme(
+    user_scheme: str | None,
+    boat_default: str | None,
+    custom_schemes: list[dict[str, Any]],
+) -> ThemeColors:
+    """Resolve the active theme per the spec decision table.
+
+    Resolution order:
+    1. User's personal override (if the referenced scheme still exists)
+    2. Boat default (if set and the referenced scheme still exists)
+    3. System default (ocean_dark)
+
+    Custom scheme IDs are stored as ``"custom:<integer id>"``.
+    """
+    custom_map: dict[str, dict[str, Any]] = {
+        f"custom:{cs['id']}": cs for cs in custom_schemes
+    }
+
+    def _lookup(scheme: str | None) -> ThemeColors | None:
+        if not scheme:
+            return None
+        if scheme in PRESETS:
+            return PRESETS[scheme]
+        cs = custom_map.get(scheme)
+        if cs is not None:
+            return _custom_to_theme(cs)
+        return None  # scheme references a deleted / unknown entry
+
+    # 1. User override
+    if user_scheme:
+        t = _lookup(user_scheme)
+        if t is not None:
+            return t
+
+    # 2. Boat default
+    if boat_default:
+        t = _lookup(boat_default)
+        if t is not None:
+            return t
+
+    # 3. System default
+    return PRESETS[SYSTEM_DEFAULT_ID]
+
+
+# ---------------------------------------------------------------------------
+# CSS generation
+# ---------------------------------------------------------------------------
+
+
+def theme_to_css(theme: ThemeColors) -> str:
+    """Return a minified CSS ``:root`` block that sets all theme variables."""
+    return (
+        ":root{"
+        f"--bg-primary:{theme.bg_primary};"
+        f"--text-primary:{theme.text_primary};"
+        f"--accent:{theme.accent};"
+        f"--bg-secondary:{theme.bg_secondary};"
+        f"--text-secondary:{theme.text_secondary};"
+        f"--border:{theme.border};"
+        f"--bg-input:{theme.bg_input};"
+        f"--accent-strong:{theme.accent_strong};"
+        "}"
+    )

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -361,8 +361,36 @@ def create_app(
     app.state.peer_limiter = peer_limiter
     app.include_router(peer_router)
 
+    # -- Theme middleware: injects resolved CSS variables into request.state --
+    # NOTE: inject_theme_css is registered BEFORE auth_middleware.  In Starlette's
+    # LIFO middleware stack, auth_middleware runs first (outermost), so
+    # request.state.user is already populated when inject_theme_css executes.
+    from helmlog.themes import resolve_theme, theme_to_css
+
+    @app.middleware("http")
+    async def inject_theme_css(request: Request, call_next: Any) -> Any:  # noqa: ANN401
+        """Resolve the active color scheme and store the CSS in request.state."""
+        accept = request.headers.get("accept", "")
+        if "text/html" in accept:
+            user: dict[str, Any] | None = getattr(request.state, "user", None)
+            user_scheme: str | None = user.get("color_scheme") if user else None
+            boat_default = await storage.get_setting("color_scheme_default")
+            custom_schemes = await storage.list_color_schemes()
+            theme = resolve_theme(user_scheme, boat_default, custom_schemes)
+            request.state.theme_css = theme_to_css(theme)
+        else:
+            request.state.theme_css = ""
+        return await call_next(request)
+
     def _tpl_ctx(request: Request, page: str, **extra: Any) -> dict[str, Any]:  # noqa: ANN401
-        return {"request": request, "active_page": page, "git_info": _GIT_INFO, **extra}
+        theme_css: str = getattr(request.state, "theme_css", "")
+        return {
+            "request": request,
+            "active_page": page,
+            "git_info": _GIT_INFO,
+            "theme_css": theme_css,
+            **extra,
+        }
 
     from helmlog.auth import (
         _is_auth_disabled,
@@ -1326,8 +1354,21 @@ def create_app(
         request: Request,
         _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
     ) -> Response:
+        from helmlog.themes import PRESET_ORDER, PRESETS
+
+        preset_list = [{"id": pid, "name": PRESETS[pid].name} for pid in PRESET_ORDER if pid in PRESETS]
+        custom_list = await storage.list_color_schemes()
+        boat_default = await storage.get_setting("color_scheme_default") or ""
         return _templates.TemplateResponse(
-            request, "admin/settings.html", _tpl_ctx(request, "/admin/settings")
+            request,
+            "admin/settings.html",
+            _tpl_ctx(
+                request,
+                "/admin/settings",
+                preset_schemes=preset_list,
+                custom_schemes=custom_list,
+                boat_default=boat_default,
+            ),
         )
 
     @app.get("/api/settings")
@@ -4855,6 +4896,160 @@ def create_app(
         return JSONResponse(tags)
 
     # ------------------------------------------------------------------
+    # Color schemes (#347)
+    # ------------------------------------------------------------------
+
+    @app.get("/api/color-schemes")
+    async def api_list_color_schemes(
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> JSONResponse:
+        """Return all available color schemes (presets + custom)."""
+        from helmlog.themes import PRESET_ORDER, PRESETS
+
+        presets = [
+            {"id": pid, "name": PRESETS[pid].name, "type": "preset"}
+            for pid in PRESET_ORDER
+            if pid in PRESETS
+        ]
+        custom = [
+            {**cs, "type": "custom", "id": f"custom:{cs['id']}"}
+            for cs in await storage.list_color_schemes()
+        ]
+        boat_default = await storage.get_setting("color_scheme_default") or ""
+        return JSONResponse(
+            {"presets": presets, "custom": custom, "boat_default": boat_default}
+        )
+
+    @app.post("/api/color-schemes", status_code=201)
+    async def api_create_color_scheme(
+        request: Request,
+        _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+    ) -> JSONResponse:
+        """Create a new custom color scheme (admin only)."""
+        body = await request.json()
+        name = str(body.get("name", "")).strip()
+        bg = str(body.get("bg", "")).strip()
+        text_color = str(body.get("text_color", "")).strip()
+        accent = str(body.get("accent", "")).strip()
+        if not all([name, bg, text_color, accent]):
+            raise HTTPException(422, detail="name, bg, text_color, accent are required")
+        scheme_id = await storage.create_color_scheme(
+            name, bg, text_color, accent, _user.get("id")
+        )
+        await _audit(
+            request, "color_scheme.create", detail=f"name={name!r}", user=_user
+        )
+        return JSONResponse({"id": scheme_id, "name": name}, status_code=201)
+
+    # NOTE: /default must be registered before /{scheme_id} to avoid route shadowing.
+    @app.put("/api/color-schemes/default")
+    async def api_set_color_scheme_default(
+        request: Request,
+        _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+    ) -> JSONResponse:
+        """Set the boat-wide default color scheme (admin only). Body: {scheme_id: str}."""
+        body = await request.json()
+        scheme = str(body.get("scheme_id", "")).strip()
+        if not scheme:
+            # Clear the default
+            await storage.delete_setting("color_scheme_default")
+            await _audit(request, "color_scheme.default.clear", user=_user)
+            return JSONResponse({"ok": True})
+        # Validate the scheme exists
+        from helmlog.themes import PRESETS
+
+        if not scheme.startswith("custom:") and scheme not in PRESETS:
+            raise HTTPException(422, detail=f"Unknown scheme: {scheme!r}")
+        if scheme.startswith("custom:"):
+            cs_id_str = scheme.removeprefix("custom:")
+            if not cs_id_str.isdigit():
+                raise HTTPException(422, detail="Invalid custom scheme id")
+            cs = await storage.get_color_scheme(int(cs_id_str))
+            if cs is None:
+                raise HTTPException(404, detail="Custom color scheme not found")
+        await storage.set_setting("color_scheme_default", scheme)
+        await _audit(
+            request, "color_scheme.default.set", detail=f"scheme={scheme!r}", user=_user
+        )
+        return JSONResponse({"ok": True})
+
+    @app.put("/api/color-schemes/{scheme_id}")
+    async def api_update_color_scheme(
+        request: Request,
+        scheme_id: int,
+        _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+    ) -> JSONResponse:
+        """Update a custom color scheme (admin only)."""
+        body = await request.json()
+        name = str(body.get("name", "")).strip()
+        bg = str(body.get("bg", "")).strip()
+        text_color = str(body.get("text_color", "")).strip()
+        accent = str(body.get("accent", "")).strip()
+        if not all([name, bg, text_color, accent]):
+            raise HTTPException(422, detail="name, bg, text_color, accent are required")
+        ok = await storage.update_color_scheme(scheme_id, name, bg, text_color, accent)
+        if not ok:
+            raise HTTPException(404, detail="Color scheme not found")
+        await _audit(
+            request, "color_scheme.update", detail=f"id={scheme_id} name={name!r}", user=_user
+        )
+        return JSONResponse({"id": scheme_id, "name": name})
+
+    @app.delete("/api/color-schemes/{scheme_id}", status_code=204)
+    async def api_delete_color_scheme(
+        request: Request,
+        scheme_id: int,
+        _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+    ) -> None:
+        """Delete a custom color scheme (admin only)."""
+        ok = await storage.delete_color_scheme(scheme_id)
+        if not ok:
+            raise HTTPException(404, detail="Color scheme not found")
+        # If the deleted scheme was the boat default, clear it
+        boat_default = await storage.get_setting("color_scheme_default")
+        if boat_default == f"custom:{scheme_id}":
+            await storage.delete_setting("color_scheme_default")
+        await _audit(
+            request, "color_scheme.delete", detail=f"id={scheme_id}", user=_user
+        )
+
+    @app.patch("/api/me/color-scheme")
+    async def api_set_my_color_scheme(
+        request: Request,
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> JSONResponse:
+        """Set the calling user's personal color scheme override. Body: {scheme_id: str}."""
+        body = await request.json()
+        scheme = str(body.get("scheme_id", "")).strip() or None
+        user_id = _user.get("id")
+        if user_id is None:
+            raise HTTPException(400, detail="Cannot set scheme for unauthenticated user")
+        if scheme is not None:
+            from helmlog.themes import PRESETS
+
+            if not scheme.startswith("custom:") and scheme not in PRESETS:
+                raise HTTPException(422, detail=f"Unknown scheme: {scheme!r}")
+            if scheme.startswith("custom:"):
+                cs_id_str = scheme.removeprefix("custom:")
+                if not cs_id_str.isdigit():
+                    raise HTTPException(422, detail="Invalid custom scheme id")
+                cs = await storage.get_color_scheme(int(cs_id_str))
+                if cs is None:
+                    raise HTTPException(404, detail="Custom color scheme not found")
+        await storage.set_user_color_scheme(user_id, scheme)
+        return JSONResponse({"ok": True})
+
+    @app.delete("/api/me/color-scheme", status_code=204)
+    async def api_reset_my_color_scheme(
+        _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+    ) -> None:
+        """Reset the calling user's color scheme to the boat default."""
+        user_id = _user.get("id")
+        if user_id is None:
+            raise HTTPException(400, detail="Cannot reset scheme for unauthenticated user")
+        await storage.set_user_color_scheme(user_id, None)
+
+    # ------------------------------------------------------------------
     # Profile & Avatars (#100)
     # ------------------------------------------------------------------
 
@@ -4865,11 +5060,17 @@ def create_app(
     ) -> Response:
         import time
 
+        from helmlog.themes import PRESET_ORDER, PRESETS
+
         user_id = _user.get("id") or 0
         role = _user.get("role", "viewer")
         role_colors = {"admin": "#f59e0b", "crew": "#34d399", "viewer": "#60a5fa"}
         consents = await storage.get_crew_consents(user_id) if user_id else []
         bio_consent = any(c["consent_type"] == "biometric" and c["granted"] for c in consents)
+        preset_list = [{"id": pid, "name": PRESETS[pid].name} for pid in PRESET_ORDER if pid in PRESETS]
+        custom_list = await storage.list_color_schemes()
+        boat_default = await storage.get_setting("color_scheme_default") or ""
+        current_scheme = _user.get("color_scheme") or ""
         return _templates.TemplateResponse(
             request,
             "profile.html",
@@ -4884,6 +5085,10 @@ def create_app(
                 weight_lbs=_user.get("weight_lbs"),
                 bio_consent=bio_consent,
                 user_id=user_id,
+                preset_schemes=preset_list,
+                custom_schemes=custom_list,
+                boat_default=boat_default,
+                current_scheme=current_scheme,
             ),
         )
 
@@ -6661,7 +6866,7 @@ def create_app(
         """Notification dashboard page."""
         return _templates.TemplateResponse(
             "attention.html",
-            {"request": request, "active_page": "/attention", "git_info": _GIT_INFO},
+            _tpl_ctx(request, "/attention"),
         )
 
     return app

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,0 +1,337 @@
+"""Tests for the color scheme / theming system (#347)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from helmlog.themes import (
+    PRESETS,
+    SYSTEM_DEFAULT_ID,
+    ThemeColors,
+    resolve_theme,
+    theme_to_css,
+    wcag_contrast,
+)
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> httpx.AsyncClient:  # type: ignore[misc]
+    """Authenticated admin client (auth disabled via env)."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# WCAG contrast ratio
+# ---------------------------------------------------------------------------
+
+
+def test_wcag_contrast_white_black() -> None:
+    """White on black should return 21:1."""
+    ratio = wcag_contrast("#FFFFFF", "#000000")
+    assert abs(ratio - 21.0) < 0.01
+
+
+def test_wcag_contrast_identical() -> None:
+    """Same color should return 1:1."""
+    assert wcag_contrast("#123456", "#123456") == pytest.approx(1.0, abs=0.01)
+
+
+def test_all_presets_pass_wcag_aa() -> None:
+    """All built-in presets must meet WCAG AA (4.5:1) for text on background."""
+    for preset_id, theme in PRESETS.items():
+        ratio = wcag_contrast(theme.text_primary, theme.bg_primary)
+        assert ratio >= 4.5, (
+            f"Preset {preset_id!r}: contrast ratio {ratio:.1f} is below AA (4.5:1)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Theme resolution — decision table
+# ---------------------------------------------------------------------------
+
+
+def _custom(id_: int, name: str = "Test") -> dict[str, Any]:
+    return {"id": id_, "name": name, "bg": "#001122", "text_color": "#EEEEFF", "accent": "#4488FF"}
+
+
+def test_no_config_returns_system_default() -> None:
+    """Row 9: no user, no boat default → ocean_dark."""
+    theme = resolve_theme(None, None, [])
+    assert theme.id == SYSTEM_DEFAULT_ID
+
+
+def test_boat_default_preset_applied_when_no_user_override() -> None:
+    """Row 6: user has no override, boat default is a valid preset."""
+    theme = resolve_theme(None, "sunlight", [])
+    assert theme.id == "sunlight"
+
+
+def test_user_override_preset_beats_boat_default() -> None:
+    """Row 1: user override (preset) takes precedence over boat default."""
+    theme = resolve_theme("racing_yellow", "sunlight", [])
+    assert theme.id == "racing_yellow"
+
+
+def test_user_override_custom_scheme() -> None:
+    """Row 2: user has a custom scheme override."""
+    custom = [_custom(7, "My Scheme")]
+    theme = resolve_theme("custom:7", None, custom)
+    assert theme.id == "custom:7"
+    assert theme.name == "My Scheme"
+
+
+def test_user_override_deleted_scheme_falls_back_to_boat_default() -> None:
+    """Row 3: user override references a deleted custom scheme → boat default."""
+    custom: list[dict[str, Any]] = []  # scheme deleted
+    theme = resolve_theme("custom:99", "sunlight", custom)
+    assert theme.id == "sunlight"
+
+
+def test_user_override_deleted_boat_default_also_deleted_returns_system_default() -> None:
+    """Row 5: user override and boat default both deleted → system default."""
+    theme = resolve_theme("custom:99", "custom:100", [])
+    assert theme.id == SYSTEM_DEFAULT_ID
+
+
+def test_boat_default_deleted_returns_system_default() -> None:
+    """Row 8: no user override, boat default references deleted custom → system default."""
+    theme = resolve_theme(None, "custom:99", [])
+    assert theme.id == SYSTEM_DEFAULT_ID
+
+
+def test_user_override_deleted_boat_default_valid() -> None:
+    """Row 3 variant: user references deleted scheme, boat default is valid preset."""
+    theme = resolve_theme("custom:0", "racing_yellow", [])
+    assert theme.id == "racing_yellow"
+
+
+def test_unknown_preset_id_treated_as_deleted() -> None:
+    """An unrecognized non-custom scheme falls through to boat default."""
+    theme = resolve_theme("nonexistent_scheme", "sunlight", [])
+    assert theme.id == "sunlight"
+
+
+# ---------------------------------------------------------------------------
+# CSS generation
+# ---------------------------------------------------------------------------
+
+
+def test_theme_to_css_contains_all_variables() -> None:
+    """theme_to_css output contains all 8 CSS custom properties."""
+    css = theme_to_css(PRESETS["ocean_dark"])
+    assert "--bg-primary" in css
+    assert "--text-primary" in css
+    assert "--accent" in css
+    assert "--bg-secondary" in css
+    assert "--text-secondary" in css
+    assert "--border" in css
+    assert "--bg-input" in css
+    assert "--accent-strong" in css
+
+
+def test_theme_to_css_uses_root_selector() -> None:
+    """:root must be the selector."""
+    css = theme_to_css(PRESETS["sunlight"])
+    assert css.startswith(":root{")
+
+
+# ---------------------------------------------------------------------------
+# Storage — color scheme CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_color_scheme(storage: Storage) -> None:
+    """create_color_scheme and list_color_schemes round-trip."""
+    scheme_id = await storage.create_color_scheme("Test", "#000", "#fff", "#aaa", None)
+    schemes = await storage.list_color_schemes()
+    assert any(s["id"] == scheme_id and s["name"] == "Test" for s in schemes)
+
+
+@pytest.mark.asyncio
+async def test_update_color_scheme(storage: Storage) -> None:
+    sid = await storage.create_color_scheme("Old", "#000", "#fff", "#aaa", None)
+    ok = await storage.update_color_scheme(sid, "New", "#111", "#eee", "#bbb")
+    assert ok is True
+    cs = await storage.get_color_scheme(sid)
+    assert cs is not None
+    assert cs["name"] == "New"
+    assert cs["bg"] == "#111"
+
+
+@pytest.mark.asyncio
+async def test_delete_color_scheme(storage: Storage) -> None:
+    sid = await storage.create_color_scheme("Del", "#000", "#fff", "#aaa", None)
+    ok = await storage.delete_color_scheme(sid)
+    assert ok is True
+    assert await storage.get_color_scheme(sid) is None
+    # second delete returns False
+    assert await storage.delete_color_scheme(sid) is False
+
+
+@pytest.mark.asyncio
+async def test_set_user_color_scheme(storage: Storage) -> None:
+    """set_user_color_scheme persists and is readable via get_user_by_id."""
+    user_id = await storage.create_user("cs@test.com", name="CS Tester", role="viewer")
+    await storage.set_user_color_scheme(user_id, "racing_yellow")
+    user = await storage.get_user_by_id(user_id)
+    assert user is not None
+    assert user["color_scheme"] == "racing_yellow"
+
+
+@pytest.mark.asyncio
+async def test_reset_user_color_scheme(storage: Storage) -> None:
+    """set_user_color_scheme(None) clears the preference."""
+    user_id = await storage.create_user("cs2@test.com", name="CS2", role="viewer")
+    await storage.set_user_color_scheme(user_id, "sunlight")
+    await storage.set_user_color_scheme(user_id, None)
+    user = await storage.get_user_by_id(user_id)
+    assert user is not None
+    assert user["color_scheme"] is None
+
+
+# ---------------------------------------------------------------------------
+# API — color scheme endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_list_color_schemes(client: httpx.AsyncClient) -> None:
+    """GET /api/color-schemes returns presets and custom list."""
+    resp = await client.get("/api/color-schemes")
+    assert resp.status_code == 200
+    data = resp.json()
+    preset_ids = [p["id"] for p in data["presets"]]
+    assert "ocean_dark" in preset_ids
+    assert "sunlight" in preset_ids
+    assert "racing_yellow" in preset_ids
+    assert "custom" in data
+    assert "boat_default" in data
+
+
+@pytest.mark.asyncio
+async def test_api_create_custom_scheme(client: httpx.AsyncClient) -> None:
+    """POST /api/color-schemes creates a custom scheme."""
+    resp = await client.post(
+        "/api/color-schemes",
+        json={"name": "Corvo Colors", "bg": "#000000", "text_color": "#FFD600", "accent": "#FFD600"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Corvo Colors"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_api_create_scheme_missing_fields_422(client: httpx.AsyncClient) -> None:
+    """POST /api/color-schemes with missing fields returns 422."""
+    resp = await client.post("/api/color-schemes", json={"name": "Oops"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_api_set_boat_default_preset(client: httpx.AsyncClient) -> None:
+    """PUT /api/color-schemes/default sets a preset as boat default."""
+    resp = await client.put(
+        "/api/color-schemes/default", json={"scheme_id": "racing_yellow"}
+    )
+    assert resp.status_code == 200
+    # Verify it shows up in the list
+    list_resp = await client.get("/api/color-schemes")
+    assert list_resp.json()["boat_default"] == "racing_yellow"
+
+
+@pytest.mark.asyncio
+async def test_api_set_boat_default_unknown_scheme_422(client: httpx.AsyncClient) -> None:
+    """PUT /api/color-schemes/default with unknown scheme returns 422."""
+    resp = await client.put(
+        "/api/color-schemes/default", json={"scheme_id": "bogus_scheme"}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_api_delete_custom_scheme(client: httpx.AsyncClient) -> None:
+    """DELETE /api/color-schemes/{id} removes the scheme."""
+    create = await client.post(
+        "/api/color-schemes",
+        json={"name": "Temp", "bg": "#111", "text_color": "#eee", "accent": "#aaa"},
+    )
+    assert create.status_code == 201
+    sid = create.json()["id"]
+    # delete it
+    del_resp = await client.delete(f"/api/color-schemes/{sid}")
+    assert del_resp.status_code == 204
+    # confirm gone
+    list_resp = await client.get("/api/color-schemes")
+    custom_ids = [c["id"] for c in list_resp.json()["custom"]]
+    assert f"custom:{sid}" not in custom_ids
+
+
+@pytest.mark.asyncio
+async def test_api_set_and_reset_user_color_scheme(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PATCH + DELETE /api/me/color-scheme sets and resets user override."""
+    from helmlog.web import create_app
+
+    # Create a real user and set AUTH_DISABLED so the mock admin is replaced with a real user
+    # by directly testing via storage — and test the endpoints with a real user via storage.
+    user_id = await storage.create_user("scheme@test.com", name="Scheme Tester", role="viewer")
+    await storage.set_user_color_scheme(user_id, "sunlight")
+    user = await storage.get_user_by_id(user_id)
+    assert user is not None
+    assert user["color_scheme"] == "sunlight"
+
+    # Reset via storage
+    await storage.set_user_color_scheme(user_id, None)
+    user2 = await storage.get_user_by_id(user_id)
+    assert user2 is not None
+    assert user2["color_scheme"] is None
+
+    # Verify the API endpoints exist and return expected codes for the mock admin
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        # Mock admin has id=None → endpoint returns 400 (handled gracefully)
+        resp = await c.patch("/api/me/color-scheme", json={"scheme_id": "sunlight"})
+        assert resp.status_code == 400
+
+        reset_resp = await c.delete("/api/me/color-scheme")
+        assert reset_resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_api_profile_page_200(client: httpx.AsyncClient) -> None:
+    """GET /profile returns 200 and includes color scheme selector."""
+    resp = await client.get("/profile", headers={"accept": "text/html"})
+    assert resp.status_code == 200
+    assert "Color Scheme" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_api_admin_settings_page_200(client: httpx.AsyncClient) -> None:
+    """GET /admin/settings returns 200 and includes color scheme section."""
+    resp = await client.get("/admin/settings", headers={"accept": "text/html"})
+    assert resp.status_code == 200
+    assert "Color Scheme" in resp.text


### PR DESCRIPTION
Implements a user-selectable color scheme system per #347.

## Summary
- 6 built-in presets tuned for sunlight readability (all meet WCAG AA 4.5:1 contrast)
- Admins set boat-wide default in Admin → Settings; can also create custom schemes
- Users override on Profile page with live WCAG contrast feedback
- Server-side CSS variable injection via HTTP middleware — no JS theme-switching needed
- Schema migration v47: `color_schemes` table + `users.color_scheme` column

Closes #347

Generated with [Claude Code](https://claude.ai/code)