### PR TITLE
feat: /diagnose skill — Pi troubleshooting runbook

### DIFF
--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: diagnose
+description: Systematic Pi troubleshooting runbook — checks all subsystems and reports health
+---
+
+# /diagnose — Pi Troubleshooting Runbook
+
+Systematically check the health of a HelmLog Pi deployment. Run this when the
+Pi is misbehaving (no data, CAN errors, audio issues, web UI down) instead of
+ad-hoc debugging.
+
+## Usage
+
+- `/diagnose` — run all subsystem checks
+- `/diagnose system` — system health only
+- `/diagnose services` — systemd services only
+- `/diagnose can` — CAN bus only
+- `/diagnose signalk` — Signal K only
+- `/diagnose audio` — audio subsystem only
+- `/diagnose database` — SQLite database only
+- `/diagnose network` — network and connectivity only
+- `/diagnose aihat` — AI HAT (Hailo) only
+
+The argument is available as `$ARGUMENTS`. If empty, run all subsystems.
+
+## Output Format
+
+For each check, report a status line:
+
+```
+[OK]   Check name — detail
+[WARN] Check name — detail → suggested fix
+[FAIL] Check name — detail → suggested fix
+```
+
+After all checks, print a summary: total checks, pass/warn/fail counts, and
+the most likely root cause if any failures were found.
+
+## Diagnostic Sequence
+
+Checks are ordered by dependency — earlier failures make later checks moot.
+If a dependency fails, skip dependent checks and note why.
+
+### 1. System Health
+
+```bash
+# Disk space (WARN >80%, FAIL >95%)
+df -h /
+
+# Memory (WARN >80% used, FAIL >95%)
+free -m
+
+# CPU temperature (WARN >70°C, FAIL >80°C)
+cat /sys/class/thermal/thermal_zone0/temp
+# Divide by 1000 for °C
+
+# SD card health — check for read-only filesystem
+touch /tmp/helmlog-health-check && rm /tmp/helmlog-health-check
+
+# Uptime and load average
+uptime
+```
+
+### 2. Services
+
+**Dependency:** System health must not be FAIL (read-only filesystem blocks
+everything).
+
+```bash
+# HelmLog service
+sudo systemctl is-active helmlog
+sudo systemctl status helmlog --no-pager -l
+# If failed: sudo journalctl -u helmlog -n 30 --no-pager
+
+# Signal K server
+sudo systemctl is-active signalk-server
+# If failed: sudo journalctl -u signalk-server -n 30 --no-pager
+
+# nginx (reverse proxy)
+sudo systemctl is-active nginx
+# If failed: sudo nginx -t
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `ModuleNotFoundError` | Stale venv | `cd ~/helmlog && uv sync` then restart |
+| `Address already in use` | Port conflict | `sudo lsof -i :3002` to find conflict |
+| `Permission denied: data/` | Ownership wrong | `sudo chown -R helmlog:helmlog data/` |
+
+### 3. CAN Bus
+
+**Dependency:** HelmLog service must be active.
+
+```bash
+# Interface present and UP
+ip link show can0
+
+# Message rate (should be >0 frames/sec when instruments on)
+# Read for 2 seconds and count frames
+timeout 2 candump can0 2>/dev/null | wc -l
+
+# Error frames and bus-off state
+ip -details -statistics link show can0
+# Look for: "bus-off", "error-warning", "error-passive"
+# tx_errors and rx_errors should be low (<100)
+
+# CAN state
+cat /sys/class/net/can0/operstate
+# Should be "up"; "stopped" or missing = interface down
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `Network is down` on can0 | Interface not brought up | `sudo ip link set can0 up type can bitrate 250000` |
+| `No buffer space available` | CAN TX queue full | `sudo ip link set can0 txqueuelen 1000` then restart interface |
+| High `rx_errors` / `tx_errors` | Bus noise or termination issue | Check CAN wiring and 120Ω termination resistors |
+| `bus-off` state | Severe bus errors, controller shut down | `sudo ip link set can0 down && sudo ip link set can0 up type can bitrate 250000` |
+
+### 4. Signal K
+
+**Dependency:** Signal K service must be active.
+
+```bash
+# WebSocket connectivity — attempt connection to Signal K
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/signalk/v1/api/
+
+# Delta message flow — check if deltas are arriving
+# Look in helmlog logs for recent SK messages
+sudo journalctl -u helmlog --since "2 minutes ago" --no-pager | grep -c "sk_reader"
+
+# Self endpoint (API health check)
+curl -s http://127.0.0.1:3000/signalk/v1/api/self
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `WebSocket connection closed` repeating | SK server dropping connections | Restart signalk-server: `sudo systemctl restart signalk-server` |
+| `connection refused` on :3000 | SK not listening | Check `systemctl status signalk-server` |
+| No deltas but SK is up | No CAN data reaching SK | Check CAN bus (subsystem 3) |
+| `401 Unauthorized` | Auth token expired | Check SK admin password in `~/.signalk-admin-pass.txt` |
+
+### 5. Audio
+
+**Dependency:** HelmLog service must be active.
+
+```bash
+# USB audio device presence
+arecord -l
+# Should list at least one capture device (e.g., Gordik USB Audio)
+
+# ALSA state — check for errors
+cat /proc/asound/cards
+
+# Quick recording test (1 second)
+timeout 1 arecord -D default -f S16_LE -r 16000 -c 1 /tmp/helmlog-audio-test.wav 2>&1
+# Check exit code: 0 = success
+rm -f /tmp/helmlog-audio-test.wav
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `no soundcards found` | USB device disconnected | Re-seat USB audio device, check `lsusb` |
+| `Device or resource busy` | Another process using device | `sudo lsof /dev/snd/*` to find conflicting process |
+| `Input/output error` on recording | Device error | Unplug and replug USB audio device |
+
+### 6. Database
+
+**Dependency:** None — can always check.
+
+```bash
+# SQLite integrity check
+sqlite3 data/logger.db "PRAGMA integrity_check;" 2>&1
+# Must return "ok"
+
+# WAL file size (WARN >100MB, FAIL >500MB)
+ls -lh data/logger.db-wal 2>/dev/null
+
+# Recent write timestamp — check last insert
+sqlite3 data/logger.db "SELECT MAX(timestamp) FROM headings;" 2>&1
+# If significantly old, data pipeline is stalled
+
+# Database file size
+ls -lh data/logger.db
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `database is locked` | Long-running transaction or WAL checkpoint stuck | Restart helmlog service |
+| `disk I/O error` | SD card failing | **Critical:** back up data immediately, replace SD card |
+| Integrity check ≠ "ok" | Corruption | Restore from backup; investigate SD card health |
+| WAL > 500MB | Checkpointing not running | `sqlite3 data/logger.db "PRAGMA wal_checkpoint(TRUNCATE);"` |
+
+### 7. Network
+
+**Dependency:** None — can always check.
+
+```bash
+# Tailscale status
+tailscale status
+
+# Peer connectivity (if peers configured)
+tailscale ping <peer-hostname> --timeout 5s 2>/dev/null
+
+# nginx upstream health
+curl -s -o /dev/null -w "%{http_code}" http://localhost/
+# Should return 200
+
+# DNS resolution
+host github.com
+
+# Internet connectivity
+curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://api.github.com
+```
+
+**Known failure patterns:**
+
+| Log signature | Meaning | Fix |
+|---|---|---|
+| `Tailscale is stopped` | Tailscale not running | `sudo tailscale up` |
+| `502 Bad Gateway` from nginx | Upstream service down | Restart helmlog: `sudo systemctl restart helmlog` |
+| `connection timed out` | Network unreachable | Check ethernet/WiFi: `ip addr`, `nmcli` |
+| `DERP` in tailscale ping | No direct connection, relayed | Check firewall/NAT; may be acceptable for remote debugging |
+
+### 8. AI HAT (Future)
+
+**Dependency:** HelmLog service must be active.
+
+```bash
+# Hailo device presence
+ls /dev/hailo*
+
+# Hailo runtime status
+hailortcli fw-control identify 2>/dev/null
+
+# Inference test (if available)
+# This section will be expanded when the AI HAT is integrated
+```
+
+**Note:** This subsystem is not yet deployed. Skip checks gracefully if Hailo
+device is not present — report `[OK] AI HAT — not installed (expected)`.
+
+## Dependency Graph
+
+```
+System Health
+  └── Services (skip if filesystem read-only)
+        ├── CAN Bus (skip if helmlog service down)
+        ├── Signal K (skip if signalk-server down)
+        └── Audio (skip if helmlog service down)
+Database (independent)
+Network (independent)
+AI HAT (skip if helmlog service down)
+```
+
+If a parent check fails, skip its children and report:
+```
+[SKIP] CAN Bus — skipped because helmlog service is not running
+```
+
+## Root Cause Heuristics
+
+After running all checks, if failures exist, suggest the most likely root cause
+based on the failure pattern:
+
+| Failure pattern | Likely root cause |
+|---|---|
+| System FAIL + all services down | SD card failure or power issue |
+| Services FAIL + everything else OK | Bad deploy or stale venv — run `uv sync` and restart |
+| CAN FAIL + Signal K no deltas | CAN bus wiring or interface not up |
+| Signal K FAIL + CAN OK | Signal K server issue — restart signalk-server |
+| Audio FAIL only | USB device disconnected or conflict |
+| Database FAIL only | SD card degradation or WAL bloat |
+| Network FAIL only | Tailscale or connectivity issue |
+| No failures but "no data" symptom | Instruments not powered on or CAN bus silent |

--- a/.claude/skills/diagnose/evals/cases.yaml
+++ b/.claude/skills/diagnose/evals/cases.yaml
@@ -1,0 +1,88 @@
+# Eval cases for /diagnose skill
+# Tests whether the skill follows the structured diagnostic sequence,
+# respects dependency ordering, and produces actionable output.
+
+- name: no-data-full-diagnosis
+  description: Runs full diagnostic when user reports "no data showing up"
+  type: capability
+  scenario: |
+    The user is SSH'd into the Pi and reports that the web UI shows no new
+    instrument data. They don't know where the problem is. No subsystem
+    argument is provided, so all checks should run.
+  mock_input: |
+    The web UI isn't showing any new data. Can you figure out what's wrong?
+  expected:
+    - criterion: "Must run system health checks first (disk, memory, temperature)"
+      weight: critical
+    - criterion: "Must check systemd service status for helmlog and signalk-server"
+      weight: critical
+    - criterion: "Must check CAN bus interface state and message rate"
+      weight: critical
+    - criterion: "Must check Signal K WebSocket connectivity and delta flow"
+      weight: critical
+    - criterion: "Must report each check with a status (OK/WARN/FAIL) and detail"
+      weight: critical
+    - criterion: "Must print a summary with total checks and pass/warn/fail counts"
+      weight: important
+    - criterion: "Must suggest a root cause based on the failure pattern observed"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT skip subsystems without a dependency-based reason"
+      weight: critical
+    - criterion: "Must NOT suggest fixes without first identifying the failure"
+      weight: important
+  tags: [full-diagnosis, no-data, dependency-order]
+
+- name: targeted-can-bus-check
+  description: Runs only CAN bus checks when subsystem argument is provided
+  type: capability
+  scenario: |
+    The user suspects a CAN bus issue and runs /diagnose can to check just
+    that subsystem. The skill should run only CAN-related checks but still
+    verify dependencies (helmlog service must be active).
+  mock_input: |
+    /diagnose can
+  expected:
+    - criterion: "Must check CAN bus interface presence (ip link show can0)"
+      weight: critical
+    - criterion: "Must check CAN message rate or frame count"
+      weight: critical
+    - criterion: "Must check for error frames, bus-off state, and error counters"
+      weight: critical
+    - criterion: "Must verify helmlog service is running as a dependency before CAN checks"
+      weight: important
+    - criterion: "Must report known failure patterns if errors are found (e.g., bus-off fix)"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT run unrelated subsystem checks (audio, database, network)"
+      weight: critical
+    - criterion: "Must NOT skip the dependency check on helmlog service status"
+      weight: important
+  tags: [targeted, can-bus, dependency-check]
+
+- name: dependency-skip-cascading
+  description: Skips dependent checks when a parent subsystem fails
+  type: capability
+  scenario: |
+    The helmlog systemd service is not running (systemctl is-active returns
+    "inactive"). CAN bus, Signal K, and Audio checks depend on this service.
+    The skill must skip those dependent checks and explain why.
+  mock_input: |
+    Everything seems broken on the Pi, run a full diagnosis.
+  expected:
+    - criterion: "Must detect that helmlog service is not active"
+      weight: critical
+    - criterion: "Must skip CAN bus checks with a message like '[SKIP] ... because helmlog service is not running'"
+      weight: critical
+    - criterion: "Must skip Audio checks for the same dependency reason"
+      weight: critical
+    - criterion: "Must still run independent checks (Database, Network) even though services failed"
+      weight: critical
+    - criterion: "Must suggest restarting the helmlog service or checking journalctl for the failure cause"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT attempt CAN/Audio/Signal K checks when their dependency (helmlog service) is down"
+      weight: critical
+    - criterion: "Must NOT skip Database or Network checks — they are independent"
+      weight: important
+  tags: [dependency-skip, cascading-failure, service-down]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,3 +421,4 @@ The spec is posted as a GitHub issue comment for review before code is written.
 | `/release-notes` | Draft a RELEASES.md entry from commits since last stage tag |
 | `/skill-eval` | Run evaluation test cases against a skill to measure quality and detect regressions |
 | `/domain` | Sailing instrument domain reference — Signal K paths, NMEA 2000 PGNs, instrument relationships, racing concepts |
+| `/diagnose` | Systematic Pi troubleshooting runbook — checks all subsystems and reports health |


### PR DESCRIPTION
## Summary

- Adds `/diagnose` skill — a structured runbook for systematically checking Pi health
- Covers 8 subsystems: system health, services, CAN bus, Signal K, audio, database, network, AI HAT (future)
- Checks are dependency-ordered (e.g., if helmlog service is down, skip CAN/audio/SK checks)
- Each subsystem includes commands, thresholds, known failure patterns with log signatures, and suggested fixes
- Root cause heuristics suggest the most likely issue based on the failure pattern
- Supports targeted mode (`/diagnose can`) or full sweep (`/diagnose`)
- 3 eval test cases: full diagnosis, targeted subsystem, dependency-skip cascading
- Registered in CLAUDE.md skills table

Closes #351

## Test plan

- [ ] Run `/skill-eval diagnose` to verify eval cases pass
- [ ] Run `/diagnose` on a live Pi to confirm commands execute correctly
- [ ] Run `/diagnose can` to verify targeted mode skips unrelated subsystems
- [ ] Verify dependency skip behavior when helmlog service is stopped

🤖 Generated with [Claude Code](https://claude.ai/code)