### PR TITLE
fix: make helmlog service account the owner of data/

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -576,14 +576,15 @@ info "$PROJECT_DIR/data (SQLite DB)"
 info "$PROJECT_DIR/data/audio (WAV recordings)"
 info "$PROJECT_DIR/data/notes (photo notes)"
 
-# Shared ownership: deploy user owns, deploy user's group is shared with helmlog.
+# Shared ownership: helmlog service account owns (so the service can always write
+# its own DB), deploy user's group enables write access for admin CLI commands.
 # setgid ensures new files/dirs inherit the group so both users can always read/write.
-sudo chown -R "$CURRENT_USER:$CURRENT_USER" "$PROJECT_DIR/data"
+sudo chown -R "helmlog:$CURRENT_USER" "$PROJECT_DIR/data"
 sudo chmod -R g+ws "$PROJECT_DIR/data"
 # Default POSIX ACL: new files created in data/ (e.g. by `helmlog add-user`)
 # automatically get group rw regardless of the creating user's umask.
 sudo setfacl -R -d -m g::rw "$PROJECT_DIR/data"
-info "data/ owned by $CURRENT_USER, group-writable + default ACL (helmlog is a member)."
+info "data/ owned by helmlog:$CURRENT_USER, group-writable + default ACL."
 
 # ---------------------------------------------------------------------------
 # i) netdev group (allows non-root SocketCAN access)


### PR DESCRIPTION
## Summary

- Change `data/` ownership from `weaties:weaties` to `helmlog:weaties` in `setup.sh`
- The helmlog service account (which runs the DB) is now the owner, so it can always write — no longer dependent on group-write + setgid + POSIX ACLs all working correctly
- Deploy user (weaties) retains write access via group permissions + setgid

## Root cause

After `reset-pi.sh` + `bootstrap.sh`, the service hit `sqlite3.OperationalError: attempt to write a readonly database` because `data/` was owned by `weaties:weaties` and the group-write chain broke for the `helmlog` service user. This prevented DB schema migrations from running, which meant the `invitations` table never existed, causing "invalid or expired invitation" errors.

## Test plan

- [ ] Run `reset-pi.sh --confirm` then `bootstrap.sh` on a test Pi
- [ ] Verify `ls -la data/` shows `helmlog:weaties` ownership
- [ ] Verify the invite URL from bootstrap output works on first try
- [ ] Verify `helmlog add-user` still works as the deploy user (via group write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)