### PR TITLE
feat: add /skill-compare for blind A/B testing of skill versions

### DIFF
--- a/.claude/skills/skill-compare/SKILL.md
+++ b/.claude/skills/skill-compare/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: skill-compare
+description: Blind A/B comparison of two skill versions using eval cases — measures relative improvement across correctness, completeness, conciseness, and actionability
+---
+
+# Skill Comparator — Blind A/B Testing
+
+Run the same eval prompts against two versions of a skill and blind-score which
+produces better results. Proves that a skill change is an improvement, not just
+a change.
+
+## Usage
+
+```
+/skill-compare <skill-name>                # compare current branch vs main
+/skill-compare <skill-name> --file         # compare SKILL.md vs SKILL.md.new
+/skill-compare <skill-name> <case-name>    # compare a single case only
+```
+
+## Prerequisites
+
+The target skill must have eval cases in `<skill-dir>/evals/cases.yaml` (see
+`/skill-eval` for the case format). If no cases exist, stop with:
+"No eval cases found for <skill>. Run `/skill-eval` to add cases first."
+
+## Workflow
+
+### 1. Load the two versions
+
+**Git-based (default):** Compare the current branch's SKILL.md against main's.
+
+```bash
+# Version A — main branch
+git show main:<relative-path-to-SKILL.md>
+
+# Version B — current working tree
+# Read the file directly
+```
+
+**File-based (`--file`):** Compare `SKILL.md` against `SKILL.md.new` in the
+same skill directory. The `.new` file contains the proposed revision.
+
+Assign each version a random label — either "Alpha" / "Beta" or "Left" / "Right".
+**Do not use "old" / "new" or "A" / "B" to avoid biasing the scoring.** Record
+the mapping privately (e.g., Alpha = main, Beta = branch) but do not reveal it
+until the final report.
+
+If the two versions are identical, stop with:
+"Versions are identical — nothing to compare."
+
+### 2. Show the diff
+
+Before running cases, display a concise diff of the two skill versions so the
+user can see what changed:
+
+```
+### Skill diff: <skill-name>
+<unified diff between version Alpha and version Beta>
+```
+
+### 3. Run each eval case
+
+For each case in `evals/cases.yaml` (or the single named case):
+
+**a. Generate outputs from both versions:**
+
+For each version, mentally apply that version's SKILL.md instructions to the
+case's `scenario` + `mock_input`, and produce the output the skill would
+generate. Keep the two outputs separate.
+
+**b. Blind-score on four dimensions:**
+
+Score each output on a 1–5 scale for each dimension, **without knowing which
+version produced it** (use the randomized labels from step 1):
+
+| Dimension | What to evaluate | 1 (poor) | 5 (excellent) |
+|---|---|---|---|
+| **Correctness** | Does the output meet the case's `expected` criteria and avoid `anti_expected`? | Misses critical criteria | Hits all criteria |
+| **Completeness** | Are all relevant aspects of the scenario covered? | Major gaps | Thorough coverage |
+| **Conciseness** | Is the output appropriately scoped — not bloated, not skeletal? | Padded / rambling OR missing key content | Right-sized for the task |
+| **Actionability** | Can the user act on the output without further clarification? | Vague, requires follow-up | Clear next steps, no ambiguity |
+
+**c. Pick a winner for this case:**
+
+For each case, determine: Alpha wins, Beta wins, or Tie. A tie requires scores
+within 1 point on all four dimensions. Otherwise, the version with the higher
+total score wins the case.
+
+**d. Record the eval-criteria pass/fail too:**
+
+Also check each output against the case's `expected` and `anti_expected`
+criteria (as `/skill-eval` does). This lets you see whether the new version
+passes more criteria, not just whether it "feels" better.
+
+### 4. Aggregate results
+
+Compute:
+
+- **Case wins:** Alpha X, Beta Y, Ties Z
+- **Dimension averages:** mean score per dimension per version
+- **Criteria pass rate:** % of eval criteria met per version
+- **Overall winner:** version with more case wins (or tie if equal)
+
+### 5. Report results
+
+Output the report in this format:
+
+```
+## Skill Compare: <skill-name>
+Date: <date>
+Versions: Alpha = <source>, Beta = <source>
+Cases: <N>
+
+### Summary
+
+| Metric | Alpha | Beta |
+|---|---|---|
+| Cases won | X | Y |
+| Ties | — | Z |
+| Avg correctness | 3.8 | 4.2 |
+| Avg completeness | 4.0 | 4.1 |
+| Avg conciseness | 3.5 | 4.0 |
+| Avg actionability | 3.9 | 4.3 |
+| Criteria pass rate | 85% | 92% |
+
+**Winner: Beta (branch) — wins X/N cases, +0.4 avg score**
+(or: **Tie — neither version is clearly better**)
+
+### Per-case breakdown
+
+| Case | Alpha | Beta | Winner | Notes |
+|---|---|---|---|---|
+| case-name-1 | 16/20 | 18/20 | Beta | Beta catches PII edge case |
+| case-name-2 | 17/20 | 17/20 | Tie | |
+
+### Dimension details
+
+#### Correctness
+- Alpha: [per-case scores]
+- Beta: [per-case scores]
+- Verdict: <which is more correct and why>
+
+#### Completeness
+...
+
+#### Conciseness
+...
+
+#### Actionability
+...
+
+### Criteria diff
+
+Cases where the two versions differ on specific eval criteria:
+
+| Case | Criterion | Alpha | Beta |
+|---|---|---|---|
+| case-name-1 | "Must flag PII exposure" | FAIL | PASS |
+```
+
+### 6. Log results
+
+Append a summary to `.claude/skills/<skill-name>/evals/compare-log.md`:
+
+```markdown
+### <date> — <branch-or-file> vs <base>
+
+| Metric | Alpha (<source>) | Beta (<source>) |
+|---|---|---|
+| Cases won | X | Y |
+| Criteria pass rate | 85% | 92% |
+| Avg total score | 15.2/20 | 16.6/20 |
+
+Winner: Beta
+```
+
+Create the file if it doesn't exist. This log provides a historical record of
+how skill refinements have performed over time.
+
+## Scoring Guidelines
+
+### Avoiding bias
+
+- **Randomize label assignment** every run — don't always map main → Alpha
+- **Score each output independently** before comparing — don't look at one
+  output while scoring the other
+- **Anchor to the eval criteria** — the case's `expected` and `anti_expected`
+  are the ground truth, not subjective preference
+- **When in doubt, tie** — a genuine tie is more honest than a forced winner
+
+### Interpreting results
+
+| Result | What it means | Action |
+|---|---|---|
+| Beta wins 70%+ cases | Strong improvement — ship it | Merge the skill change |
+| Beta wins 50–70% cases | Marginal improvement — review dimensions | Check if conciseness regressed while correctness improved |
+| Tie (within 1 case) | No clear winner | The change may not be worth the diff complexity |
+| Alpha wins | Regression — the change made things worse | Revert or rethink the approach |
+
+### Dimension trade-offs
+
+Common trade-off patterns to watch for:
+
+- **Correctness up, conciseness down:** Skill got more thorough but also more
+  verbose. May be acceptable if the extra content is high-signal.
+- **Completeness up, actionability down:** Skill covers more ground but buries
+  the key takeaway. Usually a net negative — users need clear next steps.
+- **All dimensions flat:** The change is a lateral move. Only worth shipping if
+  it improves maintainability of the skill itself.
+
+## Tips
+
+- Start with the priority skills: `/data-license`, `/pr-checklist`, `/spec`,
+  `/domain` — these benefit most from measured iteration.
+- Run comparisons before and after a skill change, not just after. The "before"
+  run establishes whether the eval cases themselves are stable (no flaky scores).
+- If a comparison shows a tie but you believe the change is better, the eval
+  cases may be too coarse. Add more cases that target the specific improvement.
+- Small, focused skill changes are easier to compare than large rewrites.
+  If a rewrite touches five aspects of a skill, it's hard to attribute wins to
+  any specific change.

--- a/.claude/skills/skill-compare/evals/cases.yaml
+++ b/.claude/skills/skill-compare/evals/cases.yaml
@@ -1,0 +1,163 @@
+# Eval cases for /skill-compare skill
+# Tests whether the comparator correctly runs blind A/B comparisons
+# and produces useful, unbiased reports.
+
+- name: detects-improvement-in-correctness
+  description: Identifies that a revised skill version catches more eval criteria
+  type: capability
+  scenario: |
+    The user has modified the /data-license skill to add explicit guidance about
+    biometric data consent. The main branch version does not mention biometrics.
+    The branch version adds a section on biometric PII. The eval cases include
+    a case about biometric data exposure that the old version would miss.
+  mock_input: |
+    /skill-compare data-license
+  expected:
+    - criterion: "Must load both versions of the skill (main vs current branch)"
+      weight: critical
+    - criterion: "Must run eval cases from data-license/evals/cases.yaml against both versions"
+      weight: critical
+    - criterion: "Must score outputs on all four dimensions (correctness, completeness, conciseness, actionability)"
+      weight: critical
+    - criterion: "Must use randomized labels (not 'old'/'new') to avoid bias"
+      weight: critical
+    - criterion: "Must produce a summary table showing which version won"
+      weight: critical
+    - criterion: "Must show per-case breakdown with winner and notes"
+      weight: important
+    - criterion: "Must show criteria diff where the two versions diverge on specific eval criteria"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT reveal the version mapping before scoring is complete"
+      weight: critical
+    - criterion: "Must NOT skip the diff display between versions"
+      weight: important
+  tags: [correctness, improvement-detection, data-license]
+
+- name: reports-tie-when-versions-identical
+  description: Correctly reports identical versions as a tie with no comparison
+  type: capability
+  scenario: |
+    The user runs /skill-compare on the /tdd skill, but the SKILL.md on the
+    current branch is identical to main. No changes have been made to the skill.
+  mock_input: |
+    /skill-compare tdd
+  expected:
+    - criterion: "Must detect that the two versions are identical"
+      weight: critical
+    - criterion: "Must stop with a clear message like 'Versions are identical — nothing to compare'"
+      weight: critical
+  anti_expected:
+    - criterion: "Must NOT run eval cases when versions are identical"
+      weight: critical
+    - criterion: "Must NOT report a winner when there is no difference"
+      weight: critical
+  tags: [edge-case, identical-versions]
+
+- name: catches-regression-conciseness
+  description: Detects when a skill revision improves correctness but regresses on conciseness
+  type: capability
+  scenario: |
+    The user revised /pr-checklist to add more detailed verification steps.
+    The new version is much more thorough (better completeness) but also
+    significantly more verbose — the output doubled in length with redundant
+    explanations. The eval cases test both coverage and output length.
+  mock_input: |
+    /skill-compare pr-checklist
+  expected:
+    - criterion: "Must score completeness higher for the more thorough version"
+      weight: important
+    - criterion: "Must score conciseness lower for the more verbose version"
+      weight: important
+    - criterion: "Must surface the dimension trade-off in the report (e.g., completeness up but conciseness down)"
+      weight: critical
+    - criterion: "Must show per-dimension averages so the user can see the trade-off quantitatively"
+      weight: critical
+  anti_expected:
+    - criterion: "Must NOT declare a winner based solely on one dimension — must consider all four"
+      weight: critical
+  tags: [regression, trade-off, conciseness, pr-checklist]
+
+- name: file-based-comparison
+  description: Supports comparing SKILL.md vs SKILL.md.new when --file flag is used
+  type: capability
+  scenario: |
+    The user has created a SKILL.md.new file in the /spec skill directory
+    containing a proposed revision. They want to compare it against the
+    current SKILL.md without committing to a branch.
+  mock_input: |
+    /skill-compare spec --file
+  expected:
+    - criterion: "Must read SKILL.md as one version and SKILL.md.new as the other"
+      weight: critical
+    - criterion: "Must still randomize labels and score blind"
+      weight: critical
+    - criterion: "Must produce the same report format as git-based comparison"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT attempt git-based comparison when --file flag is present"
+      weight: critical
+  tags: [file-based, alternative-mode, spec]
+
+- name: logs-results-for-history
+  description: Appends comparison results to the skill's compare-log.md
+  type: capability
+  scenario: |
+    The user runs a successful comparison on /domain. After displaying the
+    report, the skill should append a summary to the compare log for
+    historical tracking.
+  mock_input: |
+    /skill-compare domain
+  expected:
+    - criterion: "Must append results to <skill-dir>/evals/compare-log.md"
+      weight: critical
+    - criterion: "Must create compare-log.md if it doesn't exist"
+      weight: important
+    - criterion: "Must include date, source labels, case wins, criteria pass rates, and winner in the log entry"
+      weight: important
+  anti_expected:
+    - criterion: "Must NOT overwrite existing compare-log.md entries — must append"
+      weight: critical
+  tags: [logging, history, persistence]
+
+- name: no-evals-graceful-error
+  description: Reports a clear error when the skill has no eval cases
+  type: capability
+  scenario: |
+    The user runs /skill-compare on the /deploy-pi skill, which does not
+    have an evals/cases.yaml file.
+  mock_input: |
+    /skill-compare deploy-pi
+  expected:
+    - criterion: "Must check for evals/cases.yaml existence before proceeding"
+      weight: critical
+    - criterion: "Must report a clear error message mentioning that no eval cases were found"
+      weight: critical
+    - criterion: "Must suggest running /skill-eval to add cases"
+      weight: nice-to-have
+  anti_expected:
+    - criterion: "Must NOT attempt to run a comparison without eval cases"
+      weight: critical
+    - criterion: "Must NOT crash or produce an unclear error"
+      weight: critical
+  tags: [edge-case, error-handling, no-evals]
+
+- name: single-case-comparison
+  description: Supports running comparison on a single named case
+  type: capability
+  scenario: |
+    The user wants to compare only a specific eval case for /data-license,
+    not the full suite. They specify the case name on the command line.
+  mock_input: |
+    /skill-compare data-license pii-leak-crew-emails-in-coop-api
+  expected:
+    - criterion: "Must run only the named case, not the full suite"
+      weight: critical
+    - criterion: "Must still produce all four dimension scores for that case"
+      weight: important
+    - criterion: "Must still log the result (even for a single case)"
+      weight: nice-to-have
+  anti_expected:
+    - criterion: "Must NOT run all eval cases when a specific case is named"
+      weight: important
+  tags: [single-case, targeted-comparison]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,3 +423,4 @@ The spec is posted as a GitHub issue comment for review before code is written.
 | `/domain` | Sailing instrument domain reference — Signal K paths, NMEA 2000 PGNs, instrument relationships, racing concepts |
 | `/architecture` | Codebase comprehension — module map, data flow, complexity hotspots, risk tier overlay. Full snapshot or delta briefing |
 | `/diagnose` | Systematic Pi troubleshooting runbook — checks all subsystems and reports health |
+| `/skill-compare` | Blind A/B comparison of two skill versions — measures relative improvement across multiple dimensions |


### PR DESCRIPTION
## Summary

- Adds `/skill-compare` skill for blind A/B comparison of two skill versions using existing eval cases
- Supports git-based (current branch vs main) and file-based (SKILL.md vs SKILL.md.new) comparison modes
- Scores outputs on four dimensions: correctness, completeness, conciseness, actionability
- Includes 7 eval cases for the comparator skill itself
- Logs results to `compare-log.md` for historical tracking

Closes #354

## Test plan

- [ ] Run `/skill-compare` on a skill with eval cases and verify blind scoring works
- [ ] Verify identical versions produce "nothing to compare" message
- [ ] Verify `--file` mode reads SKILL.md.new correctly
- [ ] Verify single-case mode runs only the named case
- [ ] Verify results are appended to compare-log.md
- [ ] Run `/skill-eval skill-compare` to validate the comparator's own eval cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)