### PR TITLE
feat: in-app bug report and feature request links

### DIFF
--- a/src/helmlog/static/base.css
+++ b/src/helmlog/static/base.css
@@ -1203,3 +1203,13 @@ footer {
   font-size: 0.7rem;
   color: var(--text-secondary);
 }
+
+footer a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}

--- a/src/helmlog/static/shared.js
+++ b/src/helmlog/static/shared.js
@@ -142,6 +142,54 @@ function parseVideoPosition(str) {
 // Grafana URL helpers
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// GitHub issue URL builder (in-app bug reports / feature requests)
+// ---------------------------------------------------------------------------
+
+function buildIssueUrl(kind) {
+  var version = '';
+  var meta = document.querySelector('meta[name="helmlog-version"]');
+  if (meta) version = meta.getAttribute('content') || '';
+
+  var page = location.pathname + location.search;
+  var screen = window.innerWidth + '×' + window.innerHeight;
+  var ua = navigator.userAgent;
+  var ts = new Date().toISOString();
+
+  // Extract session/race ID from URL if applicable
+  var idMatch = page.match(/\/(session|race)\/(\d+)/);
+  var idLine = idMatch ? '| ' + idMatch[1] + '_id | `' + idMatch[2] + '` |\n' : '';
+
+  var isBug = kind === 'bug';
+  var title = isBug ? '[Bug] ' : '[Feature] ';
+  var labels = isBug ? 'from-app,bug' : 'from-app,enhancement';
+
+  var body = isBug
+    ? '## Description\n\n<!-- Describe the bug -->\n\n'
+      + '## Steps to reproduce\n\n1. \n2. \n3. \n\n'
+      + '## Expected vs actual behavior\n\n<!-- What did you expect? What happened instead? -->\n\n'
+    : '## Description\n\n<!-- Describe the feature you\'d like -->\n\n'
+      + '## Use case\n\n<!-- Why is this needed? -->\n\n';
+
+  body += '---\n\n*Submitted from HelmLog UI*\n\n'
+    + '| | |\n|---|---|\n'
+    + '| Page | `' + page + '` |\n'
+    + '| Version | `' + version + '` |\n'
+    + '| Browser | `' + ua + '` |\n'
+    + '| Screen | `' + screen + '` |\n'
+    + idLine
+    + '| Time | `' + ts + '` |\n';
+
+  return 'https://github.com/weaties/helmlog/issues/new'
+    + '?title=' + encodeURIComponent(title)
+    + '&body=' + encodeURIComponent(body)
+    + '&labels=' + encodeURIComponent(labels);
+}
+
+// ---------------------------------------------------------------------------
+// Grafana URL helpers
+// ---------------------------------------------------------------------------
+
 function initGrafana(grafanaPort, grafanaUid, skPort) {
   const isDefaultPort = !location.port || location.port === '443' || location.port === '80';
   window.GRAFANA_BASE = isDefaultPort

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
+<meta name="helmlog-version" content="{{ git_sha }}"/>
 <title>{% block title %}HelmLog{% endblock %}</title>
 <link rel="stylesheet" href="/static/base.css"/>
 {% if theme_css %}<style>{{ theme_css }}</style>{% endif %}
@@ -31,7 +32,7 @@
   </div>
 </nav>
 {% block content %}{% endblock %}
-<footer>{{ git_info }}</footer>
+<footer>{{ git_info }}<span class="footer-sep"> · </span><a href="#" onclick="window.open(buildIssueUrl('bug'),'_blank');return false">Report a bug</a><span class="footer-sep"> · </span><a href="#" onclick="window.open(buildIssueUrl('feature'),'_blank');return false">Request a feature</a></footer>
 </div>
 {% endblock %}
 <script src="/static/shared.js"></script>

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -76,6 +76,8 @@ def _get_git_info() -> str:
 
 
 _GIT_INFO: str = _get_git_info()
+# Short SHA for version display in the UI (e.g. meta tag for issue reporting)
+_GIT_SHORT_SHA: str = ""
 # SHA the running process was started with — used to detect restart-needed
 _STARTUP_SHA: str = ""
 try:
@@ -88,6 +90,7 @@ try:
         text=True,
         stderr=_sp.DEVNULL,
     ).strip()
+    _GIT_SHORT_SHA = _STARTUP_SHA[:7]
     del _sp, _repo_dir
 except Exception:  # noqa: BLE001
     pass
@@ -388,6 +391,7 @@ def create_app(
             "request": request,
             "active_page": page,
             "git_info": _GIT_INFO,
+            "git_sha": _GIT_SHORT_SHA,
             "theme_css": theme_css,
             **extra,
         }

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -572,3 +572,26 @@ async def test_audit_logged_on_race_start(client: AsyncClient, storage: Storage)
     actions = [e["action"] for e in entries]
     assert "race.start" in actions
     assert "event.set" in actions
+
+
+# ---------------------------------------------------------------------------
+# In-app issue reporting (#369)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_version_meta_tag_present(client: AsyncClient) -> None:
+    """The helmlog-version meta tag should be rendered on every page."""
+    r = await client.get("/")
+    assert r.status_code == 200
+    assert 'name="helmlog-version"' in r.text
+
+
+@pytest.mark.asyncio
+async def test_footer_report_links_present(client: AsyncClient) -> None:
+    """Footer should contain bug report and feature request links."""
+    r = await client.get("/")
+    assert r.status_code == 200
+    assert "Report a bug" in r.text
+    assert "Request a feature" in r.text
+    assert "buildIssueUrl" in r.text


### PR DESCRIPTION
## Summary

- Adds "Report a bug" and "Request a feature" links to the footer on all pages
- Links open pre-populated GitHub issue URLs (new tab) with page context, HelmLog version, browser/OS, screen size, and timestamp
- Version is injected via a `<meta name="helmlog-version">` tag rendered server-side from the git short SHA
- Two link types: bug (with steps-to-reproduce template) and feature (with use-case template)
- Footer link styling matches existing theme variables

Closes #369

## Test plan

- [x] `test_version_meta_tag_present` — meta tag rendered on all pages
- [x] `test_footer_report_links_present` — both links present with correct JS handler
- [x] Full test suite passes (1129 tests)
- [ ] Visual check: footer links visible and styled correctly
- [ ] Click "Report a bug" → GitHub new issue opens with pre-populated context

🤖 Generated with [Claude Code](https://claude.ai/code)