### PR TITLE
fix: replace hardcoded hex colors with CSS variables across all templates

### DIFF
--- a/src/helmlog/templates/admin/audit.html
+++ b/src/helmlog/templates/admin/audit.html
@@ -6,7 +6,7 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:12px}
 .card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:16px}
 table{width:100%;border-collapse:collapse;font-size:.82rem}
 th{text-align:left;padding:6px 8px;color:var(--text-secondary);font-weight:500;border-bottom:1px solid var(--border)}
-td{padding:6px 8px;border-bottom:1px solid #0d1a2e}
+td{padding:6px 8px;border-bottom:1px solid var(--border)}
 code{background:var(--border);padding:1px 5px;border-radius:3px;font-size:.78rem}
 a{color:var(--accent);text-decoration:none}
 </style>

--- a/src/helmlog/templates/admin/boats.html
+++ b/src/helmlog/templates/admin/boats.html
@@ -10,18 +10,18 @@ background:var(--bg-secondary);color:var(--accent);font-size:.8rem;cursor:pointe
 .field{background:var(--bg-input);border:1px solid var(--accent-strong);border-radius:6px;
 padding:9px 12px;color:var(--text-primary);font-size:.9rem;width:100%}
 .btn-add{padding:9px 16px;border:none;border-radius:6px;background:var(--accent-strong);
-color:var(--text-primary);font-weight:700;cursor:pointer;font-size:.9rem}
+color:var(--bg-primary);font-weight:700;cursor:pointer;font-size:.9rem}
 .btn-sm{padding:8px 12px;border:1px solid var(--border);border-radius:4px;
 background:var(--bg-input);font-size:.78rem;cursor:pointer;min-height:36px}
 .table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
 .btn-edit{color:var(--accent);border-color:var(--accent-strong)}
-.btn-del{color:var(--danger);border-color:#7f1d1d}
+.btn-del{color:var(--danger);border-color:var(--danger)}
 .btn-save{color:var(--success);border-color:var(--success)}
 .btn-cancel{color:var(--text-secondary)}
 table{width:100%;border-collapse:collapse;font-size:.87rem}
 th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;letter-spacing:.06em;
 padding:6px 8px;border-bottom:1px solid var(--border)}
-td{padding:7px 8px;border-bottom:1px solid #0d1a2e;vertical-align:middle}
+td{padding:7px 8px;border-bottom:1px solid var(--border);vertical-align:middle}
 tr:last-child td{border-bottom:none}
 .empty{color:var(--text-secondary);text-align:center;padding:20px 0}
 </style>

--- a/src/helmlog/templates/admin/cameras.html
+++ b/src/helmlog/templates/admin/cameras.html
@@ -6,18 +6,18 @@
 .label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);margin-bottom:8px}
 table{width:100%;border-collapse:collapse;font-size:.87rem}
 th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;padding:6px 8px}
-td{padding:7px 8px;border-bottom:1px solid #0d1a2e}
+td{padding:7px 8px;border-bottom:1px solid var(--border)}
 .badge{padding:2px 8px;border-radius:4px;font-size:.78rem;font-weight:600}
-.badge-rec{background:#16a34a22;color:var(--success)}
+.badge-rec{background:var(--bg-secondary);color:var(--success)}
 .badge-idle{background:var(--border);color:var(--text-secondary)}
-.badge-err{background:#7f1d1d22;color:var(--danger)}
+.badge-err{background:var(--bg-secondary);color:var(--danger)}
 .btn-sm{padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.78rem;cursor:pointer}
 .btn-start{color:var(--success);border-color:var(--success)}
-.btn-stop{color:var(--danger);border-color:#7f1d1d}
+.btn-stop{color:var(--danger);border-color:var(--danger)}
 .btn-refresh{color:var(--accent);border-color:var(--accent-strong)}
 .btn-add{color:var(--success);border-color:var(--success)}
-.btn-edit{color:var(--warning);border-color:#92400e}
-.btn-del{color:var(--danger);border-color:#7f1d1d}
+.btn-edit{color:var(--warning);border-color:var(--warning)}
+.btn-del{color:var(--danger);border-color:var(--danger)}
 .form-row{display:flex;gap:8px;align-items:center;margin-top:12px;flex-wrap:wrap}
 .form-row input{padding:6px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.85rem}
 .form-row input::placeholder{color:var(--text-muted)}

--- a/src/helmlog/templates/admin/events.html
+++ b/src/helmlog/templates/admin/events.html
@@ -6,10 +6,10 @@
 .label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);margin-bottom:8px}
 table{width:100%;border-collapse:collapse;font-size:.87rem}
 th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;padding:6px 8px}
-td{padding:7px 8px;border-bottom:1px solid #0d1a2e}
+td{padding:7px 8px;border-bottom:1px solid var(--border)}
 .btn-sm{padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.78rem;cursor:pointer}
 .btn-add{color:var(--success);border-color:var(--success)}
-.btn-del{color:var(--danger);border-color:#7f1d1d}
+.btn-del{color:var(--danger);border-color:var(--danger)}
 .form-row{display:flex;gap:8px;align-items:center;margin-top:12px;flex-wrap:wrap}
 .form-row input,.form-row select{padding:6px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.85rem}
 .form-row input::placeholder{color:var(--text-muted)}

--- a/src/helmlog/templates/admin/federation.html
+++ b/src/helmlog/templates/admin/federation.html
@@ -10,17 +10,17 @@ h2{font-size:1rem;font-weight:600;color:var(--accent);margin:0 0 10px}
 padding:9px 12px;color:var(--text-primary);font-size:.9rem;width:100%;box-sizing:border-box}
 textarea.field{min-height:100px;font-family:monospace;font-size:.8rem;resize:vertical}
 .btn-add{padding:9px 16px;border:none;border-radius:6px;background:var(--accent-strong);
-color:var(--text-primary);font-weight:700;cursor:pointer;font-size:.9rem}
+color:var(--bg-primary);font-weight:700;cursor:pointer;font-size:.9rem}
 .btn-add:disabled{opacity:.5;cursor:not-allowed}
 .btn-sm{padding:8px 12px;border:1px solid var(--border);border-radius:4px;
 background:var(--bg-input);font-size:.78rem;cursor:pointer;min-height:36px}
 .btn-copy{color:var(--accent);border-color:var(--accent-strong)}
-.btn-del{color:var(--danger);border-color:#7f1d1d}
+.btn-del{color:var(--danger);border-color:var(--danger)}
 .table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
 table{width:100%;border-collapse:collapse;font-size:.87rem}
 th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;letter-spacing:.06em;
 padding:6px 8px;border-bottom:1px solid var(--border)}
-td{padding:7px 8px;border-bottom:1px solid #0d1a2e;vertical-align:middle}
+td{padding:7px 8px;border-bottom:1px solid var(--border);vertical-align:middle}
 tr:last-child td{border-bottom:none}
 .empty{color:var(--text-secondary);text-align:center;padding:20px 0}
 .kv{display:grid;grid-template-columns:auto 1fr;gap:4px 12px;font-size:.9rem;align-items:baseline}
@@ -30,12 +30,12 @@ tr:last-child td{border-bottom:none}
 .badge{display:inline-block;font-size:.7rem;text-transform:uppercase;letter-spacing:.06em;
 padding:2px 7px;border-radius:3px;margin-left:6px}
 .badge-admin{background:var(--border);color:var(--accent)}
-.badge-member{background:#1a3329;color:var(--success)}
-.badge-active{background:#0d2818;color:var(--success)}
-.badge-inactive{background:#1f1215;color:var(--danger)}
+.badge-member{background:var(--bg-secondary);color:var(--success)}
+.badge-active{background:var(--bg-secondary);color:var(--success)}
+.badge-inactive{background:var(--bg-secondary);color:var(--danger)}
 .status{margin-top:12px;padding:8px;border-radius:6px;font-size:.85rem;display:none}
-.status.ok{display:block;background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.status.err{display:block;background:#1f1215;color:var(--danger);border:1px solid #7f1d1d}
+.status.ok{display:block;background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.status.err{display:block;background:var(--bg-secondary);color:var(--danger);border:1px solid var(--danger)}
 .form-grid{display:grid;grid-template-columns:1fr;gap:8px;margin-bottom:10px}
 .peer-section{margin-top:12px;padding-top:10px;border-top:1px solid var(--border)}
 select.field{appearance:auto}

--- a/src/helmlog/templates/admin/settings.html
+++ b/src/helmlog/templates/admin/settings.html
@@ -11,18 +11,18 @@
 .setting input[type=number]{max-width:120px}
 .source-badge{display:inline-block;font-size:.65rem;text-transform:uppercase;letter-spacing:.06em;padding:2px 6px;border-radius:3px;margin-left:8px;vertical-align:middle}
 .source-db{background:var(--border);color:var(--accent)}
-.source-env{background:#1a3329;color:var(--success)}
-.source-default{background:#2a2033;color:#c084fc}
+.source-env{background:var(--bg-secondary);color:var(--success)}
+.source-default{background:var(--bg-secondary);color:var(--accent)}
 .btn-row{display:flex;gap:8px;margin-top:18px;flex-wrap:wrap}
 .btn{padding:8px 18px;border:1px solid var(--border);border-radius:6px;background:var(--border);color:var(--text-primary);font-size:.85rem;cursor:pointer}
 .btn:hover{background:var(--bg-secondary)}
-.btn-primary{background:var(--accent-strong);border-color:var(--accent-strong);color:#fff}
+.btn-primary{background:var(--accent-strong);border-color:var(--accent-strong);color:var(--bg-primary)}
 .btn-primary:hover{opacity:.9}
-.btn-reset{color:var(--danger);border-color:#7f1d1d;font-size:.75rem;padding:4px 10px}
-.btn-reset:hover{background:#1f1215}
+.btn-reset{color:var(--danger);border-color:var(--danger);font-size:.75rem;padding:4px 10px}
+.btn-reset:hover{background:var(--bg-secondary)}
 .status{margin-top:12px;padding:8px;border-radius:6px;font-size:.85rem;display:none}
-.status.ok{display:block;background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.status.err{display:block;background:#1f1215;color:var(--danger);border:1px solid #7f1d1d}
+.status.ok{display:block;background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.status.err{display:block;background:var(--bg-secondary);color:var(--danger);border:1px solid var(--danger)}
 /* Color scheme section */
 .cs-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:12px}
 @media(min-width:500px){.cs-grid{grid-template-columns:repeat(3,1fr)}}
@@ -34,9 +34,9 @@
 .cs-name-input{flex:2;min-width:100px}
 .cs-color-input{width:50px;height:34px;padding:2px;cursor:pointer}
 .contrast-badge{font-size:.72rem;padding:2px 6px;border-radius:4px;display:inline-block}
-.contrast-aa{background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.contrast-aaa{background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.contrast-fail{background:#1f1215;color:var(--danger);border:1px solid #7f1d1d}
+.contrast-aa{background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.contrast-aaa{background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.contrast-fail{background:var(--bg-secondary);color:var(--danger);border:1px solid var(--danger)}
 .cs-list-item{display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--border)}
 .cs-list-item:last-child{border-bottom:none}
 </style>

--- a/src/helmlog/templates/attention.html
+++ b/src/helmlog/templates/attention.html
@@ -7,7 +7,7 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:4px}
 .notif-list{list-style:none;padding:0;margin:0}
 .notif-item{display:flex;gap:12px;align-items:flex-start;padding:10px 0;border-bottom:1px solid var(--border);font-size:.85rem}
 .notif-item:last-child{border-bottom:none}
-.notif-item.unread{background:#0d1a2e;border-radius:6px;padding:10px;margin:0 -10px 4px;border-bottom:none}
+.notif-item.unread{background:var(--bg-secondary);border-radius:6px;padding:10px;margin:0 -10px 4px;border-bottom:none}
 .notif-dot{width:8px;height:8px;border-radius:50%;background:var(--accent-strong);flex-shrink:0;margin-top:6px}
 .notif-dot.read{background:transparent}
 .notif-body{flex:1;min-width:0}
@@ -22,14 +22,14 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:4px}
 .notif-thread{color:var(--warning);font-size:.78rem}
 .notif-type{font-size:.72rem;padding:2px 6px;border-radius:3px;font-weight:600}
 .notif-type.mention{background:var(--border);color:var(--accent)}
-.notif-type.reply{background:#1e3a2f;color:var(--success)}
-.notif-type.new_thread{background:#2e2a1f;color:var(--warning)}
-.notif-type.resolved{background:#1e2a3f;color:var(--accent)}
+.notif-type.reply{background:var(--bg-secondary);color:var(--success)}
+.notif-type.new_thread{background:var(--bg-secondary);color:var(--warning)}
+.notif-type.resolved{background:var(--bg-secondary);color:var(--accent)}
 .notif-snippet{color:var(--text-secondary);font-size:.78rem;margin-top:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:500px}
 .notif-actions{display:flex;gap:6px;flex-shrink:0;align-items:flex-start}
 .ubtn{cursor:pointer;background:none;border:1px solid var(--accent-strong);color:var(--accent);border-radius:4px;padding:4px 10px;font-size:.8rem;white-space:nowrap}
 .ubtn-sm{padding:2px 8px;font-size:.75rem}
-.btn{padding:8px 16px;border:none;border-radius:8px;font-size:.85rem;font-weight:700;cursor:pointer;background:var(--accent-strong);color:var(--text-primary);margin-bottom:12px}
+.btn{padding:8px 16px;border:none;border-radius:8px;font-size:.85rem;font-weight:700;cursor:pointer;background:var(--accent-strong);color:var(--bg-primary);margin-bottom:12px}
 .empty{color:var(--text-muted);font-size:.9rem;padding:20px 0;text-align:center}
 .session-group{margin-bottom:16px}
 .session-group-header{font-size:.9rem;color:var(--text-secondary);margin:0 0 6px}

--- a/src/helmlog/templates/profile.html
+++ b/src/helmlog/templates/profile.html
@@ -24,7 +24,7 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:12px}
   background:var(--border);color:var(--text-primary);border:1px solid var(--border);border-radius:8px;
   cursor:pointer;font-weight:600;
 }
-.p-row .p-btn:active{background:var(--accent-strong);color:#fff}
+.p-row .p-btn:active{background:var(--accent-strong);color:var(--bg-primary)}
 .p-consent{
   display:flex;align-items:center;gap:8px;margin-top:8px;
   color:var(--text-secondary);font-size:.9rem;cursor:pointer;padding:8px 0;
@@ -36,9 +36,9 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:12px}
 .scheme-preview{display:flex;gap:6px;margin-top:8px;flex-wrap:wrap}
 .scheme-swatch{width:28px;height:28px;border-radius:4px;border:2px solid var(--border)}
 .contrast-badge{font-size:.75rem;padding:2px 7px;border-radius:4px;margin-top:6px;display:inline-block}
-.contrast-aa{background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.contrast-aaa{background:#0d2818;color:var(--success);border:1px solid var(--success)}
-.contrast-fail{background:#1f1215;color:var(--danger);border:1px solid #7f1d1d}
+.contrast-aa{background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.contrast-aaa{background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.contrast-fail{background:var(--bg-secondary);color:var(--danger);border:1px solid var(--danger)}
 .scheme-reset-btn{background:none;border:1px solid var(--border);border-radius:6px;color:var(--text-secondary);padding:5px 12px;font-size:.82rem;cursor:pointer;margin-top:8px}
 .scheme-reset-btn:active{background:var(--border)}
 </style>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -19,10 +19,10 @@
 .back-link:hover{color:var(--accent)}
 .maneuver-table{width:100%;border-collapse:collapse;font-size:.78rem}
 .maneuver-table th{color:var(--text-secondary);font-weight:400;text-align:left;padding:3px 6px;border-bottom:1px solid var(--border)}
-.maneuver-table td{padding:3px 6px;border-bottom:1px solid #0d1a2e;color:var(--text-primary)}
-.maneuver-table tr.active-row td{background:#0d2040;color:var(--text-primary)}
+.maneuver-table td{padding:3px 6px;border-bottom:1px solid var(--border);color:var(--text-primary)}
+.maneuver-table tr.active-row td{background:var(--bg-secondary);color:var(--text-primary)}
 .badge-tack{color:var(--accent)}
-.badge-gybe{color:#fb923c}
+.badge-gybe{color:var(--warning)}
 .badge-rounding{color:var(--success)}
 .wf-mark-label{background:var(--bg-primary)!important;border:1px solid var(--warning)!important;color:var(--text-primary)!important;font-size:.7rem!important;padding:1px 4px!important;border-radius:3px!important;box-shadow:none!important}
 .wf-mark-label::before{border-right-color:var(--warning)!important}
@@ -30,13 +30,13 @@
 .thread-item:hover{border-color:var(--accent-strong)}
 .thread-item.resolved{opacity:.7}
 .thread-anchor{font-size:.7rem;color:var(--warning);margin-left:6px}
-.thread-unread{background:var(--accent-strong);color:var(--text-primary);font-size:.65rem;padding:1px 5px;border-radius:8px;margin-left:6px}
-.comment-item{padding:6px 0;border-bottom:1px solid #0d1a2e;font-size:.8rem}
-.comment-author{color:#7dd3fc;font-weight:600;font-size:.75rem}
+.thread-unread{background:var(--accent-strong);color:var(--bg-primary);font-size:.65rem;padding:1px 5px;border-radius:8px;margin-left:6px}
+.comment-item{padding:6px 0;border-bottom:1px solid var(--border);font-size:.8rem}
+.comment-author{color:var(--accent);font-weight:600;font-size:.75rem}
 .comment-time{color:var(--text-secondary);font-size:.7rem;margin-left:4px}
 .comment-edited{color:var(--text-secondary);font-size:.65rem;font-style:italic}
 .comment-body{color:var(--text-primary);margin-top:2px;white-space:pre-wrap}
-.thread-form input,.thread-form select,.thread-form textarea{background:#0d1929;border:1px solid var(--border);border-radius:4px;color:var(--text-primary);padding:4px 8px;font-size:.8rem;width:100%;box-sizing:border-box}
+.thread-form input,.thread-form select,.thread-form textarea{background:var(--bg-input);border:1px solid var(--border);border-radius:4px;color:var(--text-primary);padding:4px 8px;font-size:.8rem;width:100%;box-sizing:border-box}
 .thread-form textarea{resize:vertical;min-height:60px}
 .btn-thread{background:var(--border);color:var(--accent);border:none;border-radius:4px;padding:4px 12px;font-size:.78rem;cursor:pointer}
 .btn-thread:hover{background:var(--accent-strong);color:var(--text-primary)}
@@ -155,11 +155,11 @@
 <div class="card" id="tuning-extraction-card" style="display:none">
   <div style="display:flex;align-items:center;justify-content:space-between">
     <div class="section-title" style="margin-bottom:0" onclick="toggleSection('tuning-extraction')">
-      Tuning Extraction <span id="tuning-extraction-badge" style="font-size:.7rem;color:#60a5fa"></span>
+      Tuning Extraction <span id="tuning-extraction-badge" style="font-size:.7rem;color:var(--accent)"></span>
       <span id="tuning-extraction-toggle">&#9660;</span>
     </div>
     <button id="extract-tuning-btn" onclick="extractTuning()"
-      style="font-size:.72rem;color:#7eb8f7;background:none;border:none;cursor:pointer;padding:2px 0">
+      style="font-size:.72rem;color:var(--accent);background:none;border:none;cursor:pointer;padding:2px 0">
       &#8635; Extract
     </button>
   </div>


### PR DESCRIPTION
Fixes buttons, borders, badges, and status boxes appearing in wrong colors on non-default color schemes. All hardcoded hex colors replaced with CSS custom properties across 9 templates.

Closes #372

Generated with [Claude Code](https://claude.ai/code)