### PR TITLE
fix: boat setup values not reflected during/after session

### DIFF
--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -816,7 +816,9 @@ async function loadSetupCurrentValues() {
     for (const row of rows) {
       setupCurrentValues[row.parameter] = row.value;
       const el = document.getElementById('setup-' + row.parameter);
-      if (el) {
+      // Don't overwrite a field the user is actively editing or that has a
+      // pending save timer — their unsaved value would be lost.
+      if (el && document.activeElement !== el && !_setupSaveTimers[row.parameter]) {
         el.value = row.value;
         el.classList.toggle('has-value', !!row.value);
       }
@@ -847,6 +849,7 @@ function onSetupChange(paramName) {
 async function saveSetupValue(paramName, value) {
   // Manual UI settings are boat-level (race_id=null), not per-race.
   // Per-race settings come from transcript extraction with a race_id.
+  delete _setupSaveTimers[paramName];  // Clear pending-save guard so loadSetupCurrentValues can refresh this field
   const ts = new Date().toISOString();
   try {
     const resp = await fetch('/api/boat-settings', {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1919,8 +1919,9 @@ async function loadBoatSettings() {
     _bsParams = await r.json();
   } catch (e) { console.error('boat settings params error', e); return; }
 
-  // Resolve settings at race start time initially
-  const asOf = _session.end_utc || _session.start_utc;
+  // For completed sessions use end time; for active sessions use now so values
+  // entered during the session are visible rather than being filtered out.
+  const asOf = _session.end_utc || new Date().toISOString();
   await _fetchAndRenderBoatSettings(asOf);
 }
 


### PR DESCRIPTION
Two bugs caused manual boat setup edits to be invisible in the session view.

**Bug 1 — session.js**: for active sessions, `as_of` was `start_utc`, so values entered *during* the session were excluded by the `ts <= as_of` filter. Fixed by using `new Date().toISOString()` for sessions with no end time.

**Bug 2 — home.js**: the 10-second periodic `loadState` refresh overwrote input field values with the server value even while the user was typing, discarding unsaved changes. Fixed by skipping overwrite when the field is focused or has a pending save timer.

Closes #384

Generated with [Claude Code](https://claude.ai/code)