### PR TITLE
Add AGENTS.md conventions and strengthen CI/data-license checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,12 @@
 - [ ] New tests added for new functionality
 - [ ] Manual testing (describe below)
 
+## AI usage
+
+<!-- If you used AI tools, check the box and briefly describe how -->
+
+- [ ] AI-assisted (tool and scope: _e.g., Claude Code for test generation_)
+
 ## Checklist
 
 - [ ] Changes follow the [coding standards](CONTRIBUTING.md#coding-standards)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -63,6 +64,105 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: mypy
-        run: uv run mypy src/
-        continue-on-error: true  # pre-existing errors from aiosqlite/slowapi; track trend
+      - name: mypy (baseline enforcement)
+        run: |
+          # 110 pre-existing errors in storage.py and web.py (aiosqlite Row types,
+          # union-attr on Optional fields). Fail if new errors are introduced.
+          # Reduce this number as errors are fixed.
+          BASELINE=110
+          ERROR_COUNT=$(uv run mypy src/ 2>&1 | grep -c "^src/helmlog/.*: error:" || true)
+          echo "mypy errors: $ERROR_COUNT (baseline: $BASELINE)"
+          if [ "$ERROR_COUNT" -gt "$BASELINE" ]; then
+            echo "::error::mypy error count ($ERROR_COUNT) exceeds baseline ($BASELINE). New type errors introduced."
+            uv run mypy src/ 2>&1 | grep "^src/helmlog/.*: error:" | head -20
+            exit 1
+          fi
+          echo "mypy baseline check passed (no new errors introduced)"
+
+  data-license-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for data-sensitive file changes
+        id: check-files
+        run: |
+          # Files that handle user data, PII, or co-op sharing
+          SENSITIVE_PATTERNS=(
+            "src/helmlog/storage.py"
+            "src/helmlog/export.py"
+            "src/helmlog/peer_api.py"
+            "src/helmlog/peer_client.py"
+            "src/helmlog/federation.py"
+            "src/helmlog/transcribe.py"
+            "src/helmlog/audio.py"
+            "src/helmlog/auth.py"
+            "src/helmlog/web.py"
+          )
+
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null || echo "")
+          MATCHED_FILES=""
+
+          for pattern in "${SENSITIVE_PATTERNS[@]}"; do
+            if echo "$CHANGED_FILES" | grep -q "^${pattern}$"; then
+              MATCHED_FILES="${MATCHED_FILES}${pattern}\n"
+            fi
+          done
+
+          if [ -n "$MATCHED_FILES" ]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            echo -e "Data-sensitive files changed:\n${MATCHED_FILES}"
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo -e "$MATCHED_FILES" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            echo "No data-sensitive files changed"
+          fi
+
+      - name: Post data-license reminder
+        if: steps.check-files.outputs.matched == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = `${{ steps.check-files.outputs.files }}`.trim();
+            const body = `### Data Licensing Review Required
+
+            This PR modifies data-sensitive files:
+
+            \`\`\`
+            ${files}
+            \`\`\`
+
+            Please ensure changes comply with the [data licensing policy](docs/data-licensing.md):
+            - **PII handling**: audio, photos, emails, biometrics have deletion/anonymization rights
+            - **Co-op data**: view-only, no bulk export, audit logging required
+            - **Embargo**: check embargo timestamps before serving track data
+            - **Gambling/protest firewalls**: no betting facilitation or protest committee exports
+
+            Run \`/data-license\` in Claude Code to review, or manually check against \`docs/data-licensing.md\`.`;
+
+            // Check if we already posted this comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.data.find(c =>
+              c.body.includes('Data Licensing Review Required') &&
+              c.user.type === 'Bot'
+            );
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,30 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            Review with these project-specific priorities:
+
+            HIGH PRIORITY — always flag:
+            - Security issues in auth.py, peer_auth.py, federation.py (Critical tier modules)
+            - Data licensing violations: check docs/data-licensing.md — PII exposure, missing
+              deletion support, co-op data bulk export, gambling/protest firewall breaches
+            - Schema migration issues in storage.py: backwards compatibility, FK cascades
+            - Missing or broken type annotations (mypy must pass)
+            - Architecture violations: business logic in main.py, hardware imports outside
+              isolated modules, raw dicts instead of dataclasses/TypedDict
+            - Missing tests for new functionality (project follows TDD)
+
+            MEDIUM PRIORITY — flag if confident:
+            - Embargo enforcement gaps when serving co-op track data
+            - Export code that leaks GPS precision or serves data policy-restricted fields
+            - Auth decorator missing on new web.py endpoints
+            - Rate limiting missing on new API endpoints
+
+            DO NOT comment on:
+            - Code formatting or style — Ruff handles this in CI
+            - Line length — enforced by Ruff (100 chars, E501 suppressed in web.py)
+            - Import ordering — enforced by Ruff
+            - Pre-existing mypy errors in web.py (known issues with datetime | None and AudioRecorder | None)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md — HelmLog
+
+This file provides conventions for any AI coding agent working on HelmLog.
+Claude Code users: see `CLAUDE.md` for additional Claude-specific skills and workflows.
+
+---
+
+## Project Overview
+
+A Raspberry Pi-based sailing data logger that reads from a B&G instrument system via Signal K,
+stores time-series data in SQLite, and provides a web interface for race marking, history,
+debrief audio, and performance exports.
+
+**Stack:** Python 3.12+, FastAPI, SQLite (aiosqlite), uv (dependency management), Ruff (lint/format), mypy (types), pytest (tests).
+
+---
+
+## Essential Commands
+
+```bash
+uv sync                          # install dependencies (always run first)
+uv run pytest                    # run all tests
+uv run ruff check .              # lint
+uv run ruff format --check .     # format check
+uv run mypy src/                 # type check
+uv run pytest tests/integration/ -v  # federation integration tests
+```
+
+All four checks (tests, ruff check, ruff format, mypy) must pass before submitting a PR.
+
+---
+
+## Project Structure
+
+```
+src/helmlog/           # all source code
+  main.py              # CLI entry point (wiring only, no business logic)
+  web.py               # FastAPI routes and API endpoints
+  storage.py           # SQLite schema, migrations, read/write
+  sk_reader.py         # Signal K WebSocket reader (primary data source)
+  can_reader.py        # CAN bus reader (legacy path)
+  auth.py              # Magic-link authentication
+  federation.py        # Boat identity (Ed25519), co-op membership
+  peer_api.py          # Inter-boat peer API endpoints
+  peer_auth.py         # Ed25519 request signing/verification
+  peer_client.py       # Async HTTP client for peer boats
+  export.py            # CSV / GPX / JSON export
+  audio.py             # USB audio recording
+  transcribe.py        # Whisper transcription + diarization
+  polar.py             # Polar performance baseline
+  templates/           # Jinja2 HTML templates
+  static/              # CSS and JS
+
+tests/                 # pytest suite (no hardware required)
+tests/integration/     # federation integration tests
+```
+
+---
+
+## Coding Conventions
+
+- **Python 3.12+** — use modern syntax (`match`, `X | Y` unions, `tomllib`)
+- **Full type annotations** on all function signatures — mypy must pass
+- **Ruff** is the only linter/formatter — line length 100, `E501` suppressed only in `web.py`
+- **Loguru** for all logging — never use `print()`
+- **Dataclasses or TypedDict** for structured data — no raw dicts with unknown shapes
+- Modules stay under ~200 lines; split when they grow
+- Hardware-dependent code is isolated to its own module
+
+---
+
+## Architecture Rules
+
+- **Signal K is the primary data source** — `sk_reader.py` connects to Signal K WebSocket
+- **Hardware isolation** — hardware modules are only imported by `main.py`; other modules receive decoded data structures
+- **Decode early, store clean** — raw data is decoded to named dataclasses immediately on arrival
+- **SQLite is the single source of truth** — all data goes to SQLite; exports read from SQLite
+- **Timestamps are always UTC** — convert to local time only at display/export boundaries
+- **No business logic in `main.py`** — it only wires modules together
+
+---
+
+## Testing Requirements
+
+- Follow TDD: write a failing test first, then implement
+- Tests run without hardware — mock `audio.py`, `can_reader.py`, `sk_reader.py`, `cameras.py`
+- Use the `storage` fixture from `conftest.py` for in-memory SQLite
+- Use `httpx.AsyncClient` with `ASGITransport` for web route tests
+- Federation/co-op/peer API changes require integration tests (`tests/integration/`)
+
+---
+
+## Do NOT
+
+- Push directly to `main` — all changes go through PRs
+- Use `print()` — use loguru
+- Add raw dicts with string keys for structured data
+- Put business logic in `main.py`
+- Import hardware modules outside their isolated module
+- Use `uv pip install` — use `uv add` (to add deps) or `uv sync` (to install)
+- Commit `data/` directory or `.db` files
+- Hardcode device paths — use config/environment variables
+
+---
+
+## Risk Tiers
+
+Changes to these modules require extra care:
+
+| Tier | Modules | Extra requirements |
+|---|---|---|
+| **Critical** | `auth.py`, `peer_auth.py`, `federation.py`, `storage.py` (migrations), `can_reader.py` | Integration tests + data-license review |
+| **High** | `sk_reader.py`, `peer_api.py`, `peer_client.py`, `export.py`, `transcribe.py` | Integration tests where applicable |
+
+---
+
+## Data Licensing
+
+HelmLog has a data licensing policy (`docs/data-licensing.md`). Code handling user data,
+PII (audio, photos, emails, biometrics), co-op data sharing, or exports must comply.
+Key rules: boat owns its data, PII has deletion rights, co-op data is view-only,
+no gambling or protest committee exports.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with comprehensive coding conventions, architecture rules, and project structure for AI agents working on HelmLog
- Strengthen mypy enforcement in CI with baseline error tracking to prevent regressions
- Add automated data-license compliance check that flags PRs modifying sensitive files (auth, storage, export, federation, etc.) and posts reminder comments
- Update Claude Code review workflow with project-specific review priorities (security, data licensing, schema migrations, type safety, architecture)
- Update PR template to include AI usage disclosure

## Test plan

- [ ] `uv run pytest` — all tests pass
- [ ] `uv run ruff check .` — lint clean
- [ ] `uv run ruff format --check .` — format clean
- [ ] `uv run mypy src/` — types clean (no new errors)

## Checklist

- [x] Changes follow the [coding standards](CONTRIBUTING.md#coding-standards)
- [x] No secrets, credentials, or `.env` files committed
- [x] Documentation updated (AGENTS.md added; CI workflows and PR template updated)

## Notes

**AGENTS.md** documents:
- Project overview and essential commands
- Complete project structure with module responsibilities
- Coding conventions (Python 3.12+, type annotations, Ruff, Loguru, dataclasses)
- Architecture rules (Signal K primary source, hardware isolation, SQLite as source of truth, UTC timestamps)
- Testing requirements (TDD, mocking, fixtures, integration tests)
- Risk tiers for critical modules (auth, federation, storage, peer APIs)
- Data licensing policy reference

**CI improvements:**
- `mypy` now enforces a baseline (110 pre-existing errors) and fails if new errors are introduced, allowing gradual improvement
- New `data-license-check` job detects changes to 9 sensitive modules and posts a reminder comment with policy checklist
- Claude Code review prompt updated with HIGH/MEDIUM priority flags for security, data licensing, schema safety, types, and architecture

**PR template:** Added AI usage disclosure checkbox to track tool-assisted contributions.

https://claude.ai/code/session_01CePttiARqyLWCoqgksgtim