### PR TITLE
feat: session deletion UI with active-session guard

### DIFF
--- a/docs/ideation-log.md
+++ b/docs/ideation-log.md
@@ -1711,7 +1711,7 @@ Dave on *Aria*, not with `fingerprint:a3b7c9...`.
 
 - **Date captured:** 2026-03-22
 - **Origin:** Conversation about data management capabilities; user noted this could be promoted to an actionable issue
-- **Status:** `raw`
+- **Status:** `promoted` → [#409](https://github.com/weaties/helmlog/issues/409)
 - **Related:** Data licensing policy (`docs/data-licensing.md`), `storage.py`, `web.py`, `transcribe.py`, `audio.py`
 
 **Description:**
@@ -1746,6 +1746,10 @@ the policy states that the boat owns its data and has deletion rights over PII
   and effort is estimable. The main blocker is resolving the design questions above,
   particularly cascade behavior and co-op retraction. Could be promoted to a GitHub
   issue once those are settled.
+- *2026-03-23:* Promoted to #409. Design decisions: hard delete (not soft),
+  admin-only (admin = boat owner), active session guard (409), cascade via
+  `delete_race_session()`, co-op sharing rows cascade via FK, audit logged.
+  UI delete button on session detail page.
 
 ---
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -797,10 +797,14 @@ async def api_delete_session(
 ) -> None:
     """Delete a session and all related data (admin only)."""
     storage = get_storage(request)
-    cur = await storage._conn().execute("SELECT name FROM races WHERE id = ?", (session_id,))
+    cur = await storage._conn().execute(
+        "SELECT name, end_utc FROM races WHERE id = ?", (session_id,)
+    )
     row = await cur.fetchone()
     if row is None:
         raise HTTPException(status_code=404, detail="Session not found")
+    if row["end_utc"] is None:
+        raise HTTPException(status_code=409, detail="Cannot delete an active session")
     files = await storage.delete_race_session(session_id)
     # Clean up physical files
     for f in files:

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -53,6 +53,35 @@ async function init() {
   loadSharing();
   loadMatch();
   renderExports();
+  renderDangerZone();
+}
+
+// ---------------------------------------------------------------------------
+// Danger zone — session deletion (#409)
+// ---------------------------------------------------------------------------
+
+function renderDangerZone() {
+  const role = cfg.dataset.userRole;
+  if (role !== 'admin') return;
+  if (!_session.end_utc) return; // active session — cannot delete
+  document.getElementById('danger-zone').style.display = '';
+}
+
+async function deleteSession() {
+  const name = _session.name || 'this session';
+  if (!confirm('Delete "' + name + '"?\n\nThis will permanently remove all data, audio, and files. This cannot be undone.')) return;
+  const btn = document.getElementById('delete-session-btn');
+  btn.disabled = true;
+  btn.textContent = 'Deleting\u2026';
+  const r = await fetch('/api/sessions/' + SESSION_ID, { method: 'DELETE' });
+  if (r.ok) {
+    window.location.href = '/history';
+  } else {
+    btn.disabled = false;
+    btn.textContent = 'Delete Session';
+    const data = await r.json().catch(() => null);
+    alert('Delete failed: ' + (data && data.detail ? data.detail : r.statusText));
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -193,6 +193,14 @@
   <div class="section-title">Audio</div>
   <div id="audio-body"></div>
 </div>
+
+<div id="danger-zone" class="card" style="display:none;border-color:var(--danger)">
+  <div class="section-title" style="color:var(--danger)">Danger Zone</div>
+  <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+    <div style="font-size:.82rem;color:var(--text-secondary)">Permanently delete this session and all related data (audio, notes, instrument data). This cannot be undone.</div>
+    <button id="delete-session-btn" onclick="deleteSession()" style="white-space:nowrap;background:var(--danger);color:#fff;border:none;border-radius:4px;padding:6px 14px;font-size:.8rem;cursor:pointer">Delete Session</button>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/tests/test_session_delete.py
+++ b/tests/test_session_delete.py
@@ -1,0 +1,284 @@
+"""Tests for session deletion (#409) — decision table + guard conditions."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from helmlog.auth import generate_token, session_expires_at
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_START = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+_END = datetime(2026, 3, 1, 13, 0, 0, tzinfo=UTC)
+
+
+async def _create_user(storage: Storage, role: str) -> tuple[int, str]:
+    email = f"{role}@test.com"
+    user_id = await storage.create_user(email, f"Test {role}", role)
+    session_id = generate_token()
+    await storage.create_session(session_id, user_id, session_expires_at())
+    return user_id, session_id
+
+
+async def _create_ended_session(storage: Storage) -> int:
+    """Create a completed (ended) race session. Returns race id."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Test Race", "Regatta", 1, "2026-03-01", _START.isoformat(), _END.isoformat(), "race"),
+    )
+    race_id = cur.lastrowid
+    assert race_id is not None
+    await db.commit()
+    return race_id
+
+
+async def _create_active_session(storage: Storage) -> int:
+    """Create an active (no end_utc) race session. Returns race id."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("Active Race", "Regatta", 2, "2026-03-01", _START.isoformat(), None, "race"),
+    )
+    race_id = cur.lastrowid
+    assert race_id is not None
+    await db.commit()
+    return race_id
+
+
+@pytest_asyncio.fixture
+async def admin_client(storage: Storage) -> tuple[httpx.AsyncClient, int, str]:  # type: ignore[misc]
+    """Return (client, user_id, auth_session_id) for an admin user."""
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            yield client, _, session_id
+
+
+# ---------------------------------------------------------------------------
+# Decision table row 1: viewer cannot delete (403)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_delete_session(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    _, session_id = await _create_user(storage, "viewer")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Decision table row 2: crew cannot delete (403)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crew_cannot_delete_session(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    _, session_id = await _create_user(storage, "crew")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Decision table row 3: admin cannot delete active session (409)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_delete_active_session(storage: Storage) -> None:
+    race_id = await _create_active_session(storage)
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 409
+    assert "active" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Decision table row 4: admin deletes ended session (no co-op) → 204
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_deletes_ended_session(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 204
+
+    # Verify session is gone
+    db = storage._conn()
+    cur = await db.execute("SELECT id FROM races WHERE id = ?", (race_id,))
+    assert await cur.fetchone() is None
+
+
+# ---------------------------------------------------------------------------
+# Decision table row 5: admin deletes ended session (shared with co-op) → 204
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_deletes_shared_session(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    # Insert a co-op sharing row (shared_by is INTEGER FK to users, nullable)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO session_sharing (session_id, co_op_id, shared_at, shared_by)"
+        " VALUES (?, ?, ?, ?)",
+        (race_id, "test-coop-id", _END.isoformat(), None),
+    )
+    await db.commit()
+
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 204
+
+    # Both session and sharing row should be gone (FK cascade)
+    cur = await db.execute("SELECT id FROM races WHERE id = ?", (race_id,))
+    assert await cur.fetchone() is None
+    cur = await db.execute("SELECT * FROM session_sharing WHERE session_id = ?", (race_id,))
+    assert await cur.fetchone() is None
+
+
+# ---------------------------------------------------------------------------
+# Guard: delete nonexistent session → 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_session_returns_404(storage: Storage) -> None:
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete("/api/sessions/99999")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Guard: cascade completeness — instrument data deleted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_cascades_instrument_data(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    db = storage._conn()
+
+    # Insert instrument data within session time range
+    ts = datetime(2026, 3, 1, 12, 30, 0, tzinfo=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+        (ts, 0, 180.0),
+    )
+    await db.execute(
+        "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+        (ts, 0, 5.5),
+    )
+    await db.commit()
+
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 204
+
+    # Instrument data within the session's time range should be deleted
+    cur = await db.execute("SELECT COUNT(*) FROM headings WHERE ts = ?", (ts,))
+    row = await cur.fetchone()
+    assert row[0] == 0
+
+    cur = await db.execute("SELECT COUNT(*) FROM speeds WHERE ts = ?", (ts,))
+    row = await cur.fetchone()
+    assert row[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Guard: audit log entry created
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_creates_audit_entry(storage: Storage) -> None:
+    race_id = await _create_ended_session(storage)
+    _, session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+        ) as client:
+            resp = await client.delete(f"/api/sessions/{race_id}")
+    assert resp.status_code == 204
+
+    db = storage._conn()
+    cur = await db.execute("SELECT action, detail FROM audit_log WHERE action = 'session.delete'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert "Test Race" in row["detail"]


### PR DESCRIPTION
## Summary

- Adds active-session guard (409 Conflict) to `DELETE /api/sessions/{id}` — prevents deleting a session that is currently recording
- Adds "Danger Zone" card with delete button on session detail page, visible only to admin users for ended sessions
- Updates IDX-029 in ideation log from `raw` to `promoted` with link to #409

## Changes

| File | Change |
|---|---|
| `routes/sessions.py` | Check `end_utc IS NULL` → 409 before cascade delete |
| `templates/session.html` | Danger zone card with delete button |
| `static/session.js` | `renderDangerZone()` + `deleteSession()` with confirm dialog |
| `docs/ideation-log.md` | IDX-029 status → `promoted` |
| `tests/test_session_delete.py` | 8 tests from spec decision table |

## Test plan

- [x] 8 new tests covering all spec decision table rows + guard conditions
- [x] Full suite passes (1358 tests)
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] mypy clean
- [x] Visual check: delete button visible on ended session as admin, hidden for crew/viewer and active sessions

Closes #409

🤖 Generated with [Claude Code](https://claude.ai/code)