### PR TITLE
fix: generate secretKey in Signal K security.json during setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -540,12 +540,16 @@ if [[ ! -f "$SK_SECURITY_FILE" ]]; then
 
     # Hash via Signal K's own bcryptjs to ensure compatibility.
     # Signal K uses the field name 'username' (not 'userId') for login matching.
+    # secretKey is required for JWT signing (device tokens, access requests).
+    # Without it, device approval fails with "secretOrPrivateKey must have a value".
     node -e "
+const crypto = require('crypto');
 const bcrypt = require('/usr/lib/node_modules/signalk-server/node_modules/bcryptjs');
 const hash = bcrypt.hashSync(process.env.SK_ADMIN_PASS, 12);
 const data = {
   allowedCorsOrigins: '',
   immutableConfig: false,
+  secretKey: crypto.randomBytes(32).toString('hex'),
   acls: [],
   users: [
     { username: 'admin', type: 'admin', password: hash, roles: ['admin'] }


### PR DESCRIPTION
## Summary

- `setup.sh` creates `~/.signalk/security.json` directly (bypassing the Signal K setup wizard) but was missing the `secretKey` field required for JWT token signing
- Without `secretKey`, Signal K cannot issue device tokens — device approval fails with `secretOrPrivateKey must have a value`, the admin Devices tab crashes ("Something went wrong"), and external sensors (SensESP ESP-32) cannot authenticate for write access
- Generates a 32-byte random hex secret using Node's `crypto.randomBytes()` during setup

## Test plan

- [ ] Run `setup.sh` on a fresh Pi and verify `~/.signalk/security.json` contains a `secretKey` field
- [ ] Confirm Signal K admin UI Devices tab loads without error
- [ ] Confirm SensESP device access request can be approved through the admin UI
- [ ] Verify re-running `setup.sh` is idempotent (existing `security.json` is not overwritten)



🤖 Generated with [Claude Code](https://claude.ai/code)