### PR TITLE
feat: add Signal K auth token support to sk_reader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ LOG_LEVEL=INFO
 DATA_SOURCE=signalk
 SK_HOST=localhost
 SK_PORT=3000
+# Signal K authentication (required when SK security is enabled)
+# SK_TOKEN=                    # pre-existing JWT token (takes priority)
+# SK_USERNAME=admin            # auto-login credentials
+# SK_PASSWORD=
+# Falls back to reading ~/.signalk-admin-pass.txt if no env vars set
 # Audio recording (Gordik 2T1R or any USB Audio Class device)
 # AUDIO_DEVICE=Gordik
 AUDIO_DIR=data/audio

--- a/src/helmlog/sk_reader.py
+++ b/src/helmlog/sk_reader.py
@@ -12,6 +12,7 @@ import math
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -49,11 +50,15 @@ class SKReaderConfig:
     """Configuration for the Signal K WebSocket reader.
 
     Values fall back to environment variables SK_HOST / SK_PORT if not set.
+    Auth waterfall: SK_TOKEN → SK_USERNAME/SK_PASSWORD → ~/.signalk-admin-pass.txt.
     """
 
     host: str = field(default_factory=lambda: os.environ.get("SK_HOST", "localhost"))
     port: int = field(default_factory=lambda: int(os.environ.get("SK_PORT", "3000")))
     reconnect_delay_s: float = 5.0
+    token: str | None = field(default_factory=lambda: os.environ.get("SK_TOKEN"))
+    username: str | None = field(default_factory=lambda: os.environ.get("SK_USERNAME"))
+    password: str | None = field(default_factory=lambda: os.environ.get("SK_PASSWORD"))
 
 
 # ---------------------------------------------------------------------------
@@ -259,9 +264,58 @@ class SKReader:
         self._config = config
         self._buf: dict[str, float] = {}
         self._self_context: str | None = None
+        self._token: str | None = None
 
     def __aiter__(self) -> AsyncIterator[PGNRecord]:
         return self._stream()
+
+    async def _resolve_token(self) -> str | None:
+        """Resolve a Signal K auth token using the waterfall:
+
+        1. Explicit token from config (SK_TOKEN env var)
+        2. Login with username/password (SK_USERNAME / SK_PASSWORD env vars)
+        3. Read password from ~/.signalk-admin-pass.txt (written by setup.sh)
+        4. None (unauthenticated — works only if SK security is disabled)
+        """
+        import httpx
+
+        config = self._config
+
+        # 1. Explicit token
+        if config.token:
+            self._token = config.token
+            logger.info("SK: using explicit auth token")
+            return self._token
+
+        # 2. Credentials from config/env, or 3. fall back to password file
+        username = config.username
+        password = config.password
+        if not username or not password:
+            pass_file = Path.home() / ".signalk-admin-pass.txt"
+            try:
+                password = pass_file.read_text().strip()
+                username = "admin"
+                logger.debug("SK: read password from {}", pass_file)
+            except FileNotFoundError:
+                logger.debug("SK: no password file at {}", pass_file)
+                return None
+
+        # Login via SK REST API
+        url = f"http://{config.host}:{config.port}/signalk/v1/auth/login"
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    url, json={"username": username, "password": password}, timeout=5.0
+                )
+                resp.raise_for_status()
+                self._token = resp.json().get("token")
+                if self._token:
+                    logger.info("SK: authenticated as {!r}", username)
+                    return self._token
+                logger.warning("SK: login response missing token field")
+        except Exception as exc:
+            logger.warning("SK: auth login failed: {}", exc)
+        return None
 
     async def _resolve_self_context(self) -> str | None:
         """Fetch the self-vessel context from the Signal K REST API."""
@@ -269,9 +323,12 @@ class SKReader:
 
         config = self._config
         url = f"http://{config.host}:{config.port}/signalk/v1/api/self"
+        headers: dict[str, str] = {}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
         try:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(url, timeout=5.0)
+                resp = await client.get(url, timeout=5.0, headers=headers)
                 resp.raise_for_status()
                 # Response is a JSON string like "vessels.urn:mrn:signalk:uuid:..."
                 ctx = resp.json()
@@ -284,14 +341,18 @@ class SKReader:
 
     async def _stream(self) -> AsyncGenerator[PGNRecord, None]:
         config = self._config
-        uri = f"ws://{config.host}:{config.port}/signalk/v1/stream?subscribe=all"
+        base_uri = f"ws://{config.host}:{config.port}/signalk/v1/stream?subscribe=all"
         delay = 1.0
         while True:
             try:
+                # Resolve auth token if not yet obtained
+                if self._token is None:
+                    await self._resolve_token()
                 # Resolve self-vessel context on first connect or if not yet known
                 if self._self_context is None:
                     self._self_context = await self._resolve_self_context()
-                logger.info("SK: connecting to {}", uri)
+                uri = f"{base_uri}&token={self._token}" if self._token else base_uri
+                logger.info("SK: connecting to {}", base_uri)
                 async with _ws_connect(uri) as ws:
                     delay = 1.0
                     logger.info("SK: connected")

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -8,8 +8,9 @@ import json
 import math
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from helmlog.nmea2000 import (
@@ -25,6 +26,7 @@ from helmlog.sk_reader import SK_SOURCE_ADDR, SKReader, SKReaderConfig, process_
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -32,6 +34,7 @@ if TYPE_CHECKING:
 
 _TS = "2025-08-10T14:05:30.000Z"
 _TS_DT = datetime(2025, 8, 10, 14, 5, 30, tzinfo=UTC)
+_FAKE_REQUEST = httpx.Request("GET", "http://test")
 
 
 def _delta(path: str, value: object, ts: str = _TS) -> str:
@@ -463,3 +466,222 @@ class TestSKReaderReconnect:
                 await task
 
         assert connect_calls[0] >= 2
+
+
+# ---------------------------------------------------------------------------
+# TestSKReaderConfigAuth — auth fields on SKReaderConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSKReaderConfigAuth:
+    """Auth-related fields on SKReaderConfig."""
+
+    def test_token_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SK_TOKEN", "abc123")
+        cfg = SKReaderConfig()
+        assert cfg.token == "abc123"
+
+    def test_username_password_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SK_USERNAME", "admin")
+        monkeypatch.setenv("SK_PASSWORD", "secret")
+        cfg = SKReaderConfig()
+        assert cfg.username == "admin"
+        assert cfg.password == "secret"
+
+    def test_defaults_none_when_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SK_TOKEN", raising=False)
+        monkeypatch.delenv("SK_USERNAME", raising=False)
+        monkeypatch.delenv("SK_PASSWORD", raising=False)
+        cfg = SKReaderConfig()
+        assert cfg.token is None
+        assert cfg.username is None
+        assert cfg.password is None
+
+
+# ---------------------------------------------------------------------------
+# TestTokenResolution — _resolve_token waterfall
+# ---------------------------------------------------------------------------
+
+
+class TestTokenResolution:
+    """Token resolution waterfall: explicit token → login → password file → None."""
+
+    async def test_uses_explicit_token(self) -> None:
+        """SK_TOKEN takes priority — no HTTP call made."""
+        reader = SKReader(SKReaderConfig(token="pre-existing"))
+        token = await reader._resolve_token()
+        assert token == "pre-existing"
+
+    async def test_login_with_username_password(self) -> None:
+        """Auto-login via SK REST API when credentials provided."""
+        cfg = SKReaderConfig(username="admin", password="secret")
+        reader = SKReader(cfg)
+
+        async def mock_post(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            return httpx.Response(200, json={"token": "jwt-from-login"}, request=_FAKE_REQUEST)
+
+        with patch.object(httpx.AsyncClient, "post", mock_post):
+            token = await reader._resolve_token()
+        assert token == "jwt-from-login"
+
+    async def test_login_fallback_to_password_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reads ~/.signalk-admin-pass.txt when no env vars set."""
+        pass_file = tmp_path / ".signalk-admin-pass.txt"
+        pass_file.write_text("file-password\n")
+        monkeypatch.setattr("helmlog.sk_reader.Path.home", staticmethod(lambda: tmp_path))
+
+        cfg = SKReaderConfig()
+        reader = SKReader(cfg)
+
+        async def mock_post(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            return httpx.Response(200, json={"token": "jwt-from-file"}, request=_FAKE_REQUEST)
+
+        with patch.object(httpx.AsyncClient, "post", mock_post):
+            token = await reader._resolve_token()
+        assert token == "jwt-from-file"
+
+    async def test_no_credentials_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No token, no creds, no file — returns None."""
+        monkeypatch.setattr("helmlog.sk_reader.Path.home", staticmethod(lambda: tmp_path))
+        cfg = SKReaderConfig()
+        reader = SKReader(cfg)
+        token = await reader._resolve_token()
+        assert token is None
+
+    async def test_login_failure_returns_none(self) -> None:
+        """Bad credentials log a warning and return None."""
+        cfg = SKReaderConfig(username="admin", password="wrong")
+        reader = SKReader(cfg)
+
+        async def mock_post(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            return httpx.Response(401, text="Unauthorized", request=_FAKE_REQUEST)
+
+        with patch.object(httpx.AsyncClient, "post", mock_post):
+            token = await reader._resolve_token()
+        assert token is None
+
+    async def test_password_file_missing_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing password file is not an error — returns None."""
+        monkeypatch.setattr("helmlog.sk_reader.Path.home", staticmethod(lambda: tmp_path))
+        cfg = SKReaderConfig()
+        reader = SKReader(cfg)
+        token = await reader._resolve_token()
+        assert token is None
+
+
+# ---------------------------------------------------------------------------
+# TestAuthPlumbing — token passed to HTTP and WebSocket connections
+# ---------------------------------------------------------------------------
+
+
+class TestAuthPlumbing:
+    """Token is plumbed to HTTP headers and WebSocket URI."""
+
+    async def test_resolve_self_context_sends_bearer_header(self) -> None:
+        """HTTP GET /api/self includes Authorization header when token is set."""
+        reader = SKReader(SKReaderConfig(token="my-jwt"))
+        reader._token = "my-jwt"
+        captured_headers: dict[str, str] = {}
+
+        async def mock_get(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            headers = kwargs.get("headers", {})
+            assert isinstance(headers, dict)
+            captured_headers.update(headers)
+            return httpx.Response(200, json="vessels.self")
+
+        with patch.object(httpx.AsyncClient, "get", mock_get):
+            await reader._resolve_self_context()
+
+        assert captured_headers.get("Authorization") == "Bearer my-jwt"
+
+    async def test_resolve_self_context_no_header_when_no_token(self) -> None:
+        """No auth header sent when token is None."""
+        reader = SKReader(SKReaderConfig())
+        reader._token = None
+        captured_headers: dict[str, str] = {}
+
+        async def mock_get(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            headers = kwargs.get("headers", {})
+            assert isinstance(headers, dict)
+            captured_headers.update(headers)
+            return httpx.Response(200, json="vessels.self")
+
+        with patch.object(httpx.AsyncClient, "get", mock_get):
+            await reader._resolve_self_context()
+
+        assert "Authorization" not in captured_headers
+
+    async def test_websocket_uri_includes_token_param(self) -> None:
+        """WS URI has &token=<jwt> when authenticated."""
+        reader = SKReader(SKReaderConfig())
+        reader._token = "ws-jwt"
+
+        captured_uris: list[str] = []
+
+        class FakeWS:
+            def __init__(self, uri: str) -> None:
+                captured_uris.append(uri)
+
+            async def __aenter__(self) -> FakeWS:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            def __aiter__(self) -> AsyncGenerator[str, None]:
+                return self._gen()
+
+            async def _gen(self) -> AsyncGenerator[str, None]:
+                yield _delta("navigation.headingTrue", 1.0)
+
+        with (
+            patch("helmlog.sk_reader._ws_connect", lambda uri, **kw: FakeWS(uri)),
+            patch.object(SKReader, "_resolve_self_context", AsyncMock(return_value=None)),
+            patch.object(SKReader, "_resolve_token", AsyncMock(return_value="ws-jwt")),
+        ):
+            async for _ in reader:
+                break
+
+        assert len(captured_uris) >= 1
+        assert "&token=ws-jwt" in captured_uris[0]
+
+    async def test_websocket_uri_no_token_when_none(self) -> None:
+        """WS URI is unchanged when no token."""
+        reader = SKReader(SKReaderConfig())
+        reader._token = None
+
+        captured_uris: list[str] = []
+
+        class FakeWS:
+            def __init__(self, uri: str) -> None:
+                captured_uris.append(uri)
+
+            async def __aenter__(self) -> FakeWS:
+                return self
+
+            async def __aexit__(self, *_: object) -> None:
+                pass
+
+            def __aiter__(self) -> AsyncGenerator[str, None]:
+                return self._gen()
+
+            async def _gen(self) -> AsyncGenerator[str, None]:
+                yield _delta("navigation.headingTrue", 1.0)
+
+        with (
+            patch("helmlog.sk_reader._ws_connect", lambda uri, **kw: FakeWS(uri)),
+            patch.object(SKReader, "_resolve_self_context", AsyncMock(return_value=None)),
+            patch.object(SKReader, "_resolve_token", AsyncMock(return_value=None)),
+        ):
+            async for _ in reader:
+                break
+
+        assert len(captured_uris) >= 1
+        assert "token=" not in captured_uris[0]
+        assert captured_uris[0].endswith("subscribe=all")


### PR DESCRIPTION
## Summary

- Add three-tier auth token waterfall to `sk_reader.py`: `SK_TOKEN` env var → `SK_USERNAME`/`SK_PASSWORD` login → `~/.signalk-admin-pass.txt` fallback
- Token passed as `&token=` query param on WebSocket URI and `Authorization: Bearer` header on HTTP requests
- Backward compatible — when no auth is configured, behavior is unchanged
- Document new env vars in `.env.example`

Required now that SK security is fully enabled after #417 added `secretKey` to `security.json`.

## Test plan

- [x] 13 new tests: config fields, token waterfall, HTTP/WS auth plumbing, backward compat
- [x] All 39 sk_reader tests pass (94% coverage)
- [x] Lint, format, mypy clean
- [x] Live verification: helmlog connects without "Missing access token" errors

🤖 Generated with [Claude Code](https://claude.ai/code)