### PR TITLE
Fix bootstrap hanging at setup.sh configuration wizard

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -63,7 +63,11 @@ info()  { echo -e "${CYAN}    $*${NC}"; }
 
 step "Running configuration wizard..."
 if [[ -f "$SCRIPT_DIR/configure.sh" ]]; then
-    bash "$SCRIPT_DIR/configure.sh"
+    if [[ -f "$HOME/.helmlog/config.env" ]]; then
+        bash "$SCRIPT_DIR/configure.sh" --non-interactive
+    else
+        bash "$SCRIPT_DIR/configure.sh"
+    fi
 else
     warn "scripts/configure.sh not found — skipping configuration wizard."
 fi


### PR DESCRIPTION
## Summary
- `setup.sh` always ran `configure.sh` in interactive mode, even when called from `bootstrap.sh` which had already written `~/.helmlog/config.env` via `--non-interactive`
- This caused the bootstrap pipeline to hang waiting for terminal input on the second `configure.sh` invocation
- Now `setup.sh` checks for an existing `config.env` and passes `--non-interactive` when one is found

## Test plan
- [ ] Run `curl ... | ADMIN_EMAIL=... bash` bootstrap — should complete without hanging
- [ ] Run `setup.sh` standalone on a fresh Pi (no `~/.helmlog/config.env`) — interactive wizard should still appear

🤖 Generated with [Claude Code](https://claude.ai/code)