### PR TITLE
docs: capture idea IDX-034 — database replication and offline analysis

### DIFF
--- a/docs/ideation-log.md
+++ b/docs/ideation-log.md
@@ -2140,3 +2140,70 @@ data-licensing policy (co-op data is view-only, no bulk export).
   the ESP32 makes it richer but isn't strictly required to start. Could
   prototype the analysis on existing session data by using TWS/TWD changes
   as the trigger instead of sea state.
+
+---
+
+## IDX-034: Database replication and offline analysis — Pi → test Pi / Mac
+
+- **Date captured:** 2026-04-06
+- **Origin:** Conversation about needing offline analysis when the boat's Pi isn't online, plus backup
+- **Status:** `raw`
+- **Related:** SQLite storage (`storage.py`), audio recording (`audio.py`), ArUco images, federation
+
+**Description:**
+Replicate the SQLite database, WAV audio files, and ArUco images from
+corvopi-live to corvopi-tst and the MacBook Pro. This serves two purposes:
+
+1. **Offline analysis** — run debrief, export, and analysis workflows on
+   the Mac or test Pi without needing the boat's Pi online.
+2. **Backup** — a second copy of all data protects against SD card failure
+   or Pi damage on the boat.
+
+**Design questions:**
+
+1. **Replication mechanism** — options include:
+   - `rsync` over Tailscale (simplest; cron or on-demand)
+   - Litestream for continuous SQLite WAL streaming to S3 or a local target
+   - Custom `helmlog sync` CLI command that copies DB + media files
+   - SQLite backup API (`VACUUM INTO` or `.backup`) for consistent snapshots
+
+2. **Media files** — `data/audio/*.wav` and any ArUco images need to sync
+   alongside the database. rsync handles this naturally; Litestream only
+   covers the DB.
+
+3. **Conflict resolution** — replicas should be read-only to avoid divergence.
+   Only the live Pi writes. If the Mac or test Pi need to write (e.g., adding
+   notes during debrief), that's a harder problem — possibly write-back via
+   the Pi's API over Tailscale.
+
+4. **Trigger** — when does sync happen?
+   - On session end (race finish / debrief complete)
+   - Periodic (every N minutes while on home network)
+   - Manual (`helmlog sync` command)
+   - On deploy (as part of `deploy.sh`)
+
+5. **Partial sync** — for the Mac, do we want the full history or just
+   recent sessions? Full DB could be large over time. Could offer a
+   `--since` flag.
+
+6. **Security** — data in transit over Tailscale is encrypted. Data at rest
+   on the Mac should follow the same data-licensing rules (boat owns its
+   data, PII handling for audio/transcripts).
+
+7. **Read-only mode** — the Mac/test Pi instance should start in a read-only
+   mode that serves the web UI for analysis/export but doesn't try to
+   connect to Signal K or record audio.
+
+**Simplest starting point:**
+A `helmlog sync` CLI command that runs `rsync` over Tailscale to copy
+`data/logger.db`, `data/audio/`, and `data/notes/` to a target host.
+Combined with a read-only mode flag (`HELMLOG_READ_ONLY=true`) that
+disables Signal K, audio, and CAN readers.
+
+**Notes:**
+- *2026-04-06:* Initial capture. Motivated by wanting to do analysis on the
+  Mac without the boat being online. Also provides backup against Pi
+  hardware failure. rsync over Tailscale is the obvious first step — no new
+  infrastructure needed. Litestream is interesting for continuous streaming
+  but adds complexity. The read-only mode is important to prevent the
+  replica from trying to record data or connect to instruments.


### PR DESCRIPTION
## Summary

- Adds IDX-034 to the ideation log: replicate SQLite DB, WAV audio, and images from corvopi-live to corvopi-tst and MacBook Pro for offline analysis and backup
- Simplest starting point: `helmlog sync` CLI wrapping rsync over Tailscale + a `HELMLOG_READ_ONLY` mode for replicas

## Test plan
- [x] Ideation log entry follows template format
- [x] No duplicate/conflicting entries

🤖 Generated with [Claude Code](https://claude.ai/code)