### PR TITLE
feat: ESP32 string potentiometer sensor support

### DIFF
--- a/src/helmlog/routes/sensors.py
+++ b/src/helmlog/routes/sensors.py
@@ -158,6 +158,7 @@ async def api_list_sensors(
                 "last_seen_at": d.last_seen_at,
                 "last_battery_mv": d.last_battery_mv,
                 "last_rssi": d.last_rssi,
+                "last_raw_adc": d.last_raw_adc,
             }
             for d in devices
         ]

--- a/src/helmlog/routes/sensors.py
+++ b/src/helmlog/routes/sensors.py
@@ -1,0 +1,265 @@
+"""Route handlers for ESP32 string potentiometer sensors (#432)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from helmlog.auth import require_auth
+from helmlog.routes._helpers import audit, get_storage, limiter
+from helmlog.sensors import (
+    DeviceState,
+    ReadingRequest,
+    compute_mm_per_adc,
+    process_active_reading,
+    process_reading,
+    validate_mac,
+)
+
+router = APIRouter()
+
+
+@router.post("/api/sensor/reading")
+@limiter.limit("60/minute")
+async def api_sensor_reading(request: Request) -> JSONResponse:
+    """Accept a reading from an ESP32 sensor. No auth required."""
+    body = await request.json()
+
+    mac = body.get("mac", "")
+    if not validate_mac(mac):
+        raise HTTPException(status_code=422, detail="Invalid MAC format")
+
+    raw_adc = body.get("raw_adc")
+    if raw_adc is None or not isinstance(raw_adc, int):
+        raise HTTPException(status_code=422, detail="raw_adc is required and must be an integer")
+
+    reading_req = ReadingRequest(
+        mac=mac,
+        raw_adc=raw_adc,
+        battery_mv=body.get("battery_mv"),
+        rssi=body.get("rssi"),
+        button_pressed=bool(body.get("button_pressed", False)),
+        estimated_utc=body.get("estimated_utc"),
+    )
+
+    storage = get_storage(request)
+
+    # Look up or register the device
+    device = await storage.get_sensor_device(mac)
+    if device is None:
+        await storage.register_sensor_device(mac)
+        device = await storage.get_sensor_device(mac)
+        assert device is not None
+        logger.info("New sensor device registered: {}", mac)
+
+    # Get session state
+    session_active = storage.session_active
+    current_race = await storage.get_current_race() if session_active else None
+    current_session_id = current_race.id if current_race else None
+
+    # Get last stored reading for threshold comparison
+    last_stored_mm: float | None = None
+    if current_session_id is not None:
+        last_stored_mm = await storage.get_last_sensor_reading_mm(mac, current_session_id)
+
+    # Determine if device is in "active" mode (was promoted to active on a previous check-in)
+    # The device state in DB is always 'ready' — "active" is a runtime state
+    # driven by session_active. We track it via presence of readings in the current session.
+    is_runtime_active = (
+        device.state == DeviceState.READY
+        and current_session_id is not None
+        and last_stored_mm is not None
+    )
+
+    if is_runtime_active:
+        response, reading, updates = process_active_reading(
+            device, reading_req, session_active, current_session_id, last_stored_mm
+        )
+    else:
+        response, reading, updates = process_reading(
+            device, reading_req, session_active, current_session_id, last_stored_mm
+        )
+
+    # Apply device updates
+    if updates:
+        # Don't persist "active" as a DB state — it's runtime-only
+        db_updates = {k: v for k, v in updates.items() if not (k == "state" and v == "active")}
+        if db_updates:
+            await storage.update_sensor_device(mac, db_updates)
+
+    # Store reading if produced
+    if reading is not None:
+        await storage.store_sensor_reading(
+            session_id=reading.session_id,
+            mac=reading.mac,
+            timestamp_utc=reading.timestamp_utc,
+            raw_adc=reading.raw_adc,
+            position_mm=reading.position_mm,
+            battery_mv=reading.battery_mv,
+        )
+
+    # Log warnings for out-of-range ADC
+    if raw_adc < 0 or raw_adc > 4095:
+        logger.warning("Sensor {} reported out-of-range ADC: {}", mac, raw_adc)
+
+    return JSONResponse(
+        {
+            "state": response.state,
+            "sleep_seconds": response.sleep_seconds,
+            "session_active": response.session_active,
+            "server_time_utc": response.server_time_utc,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints for sensor management
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/sensors")
+async def api_list_sensors(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """List all registered sensor devices."""
+    storage = get_storage(request)
+    devices = await storage.list_sensor_devices()
+    return JSONResponse(
+        [
+            {
+                "mac": d.mac,
+                "line_name": d.line_name,
+                "friendly_name": d.friendly_name,
+                "state": d.state,
+                "mm_per_adc_count": d.mm_per_adc_count,
+                "total_travel_mm": d.total_travel_mm,
+                "zero_offset_adc": d.zero_offset_adc,
+                "last_zeroed_at": d.last_zeroed_at,
+                "sleep_idle_s": d.sleep_idle_s,
+                "sleep_active_s": d.sleep_active_s,
+                "report_threshold_mm": d.report_threshold_mm,
+                "last_seen_at": d.last_seen_at,
+                "last_battery_mv": d.last_battery_mv,
+                "last_rssi": d.last_rssi,
+            }
+            for d in devices
+        ]
+    )
+
+
+@router.put("/api/sensors/{mac}")
+async def api_update_sensor(
+    request: Request,
+    mac: str,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Update sensor device configuration."""
+    if not validate_mac(mac):
+        raise HTTPException(status_code=422, detail="Invalid MAC format")
+
+    storage = get_storage(request)
+    device = await storage.get_sensor_device(mac)
+    if device is None:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    body = await request.json()
+    updates: dict[str, object] = {}
+
+    # Editable fields
+    for field in (
+        "line_name",
+        "friendly_name",
+        "pulley_diameter_mm",
+        "cal_adc_a",
+        "cal_adc_b",
+        "cal_distance_mm",
+        "total_travel_mm",
+        "sleep_idle_s",
+        "sleep_active_s",
+        "report_threshold_mm",
+    ):
+        if field in body:
+            updates[field] = body[field]
+
+    # If line_name is being set on an unregistered device, transition to uncalibrated
+    if "line_name" in updates and updates["line_name"] and device.state == DeviceState.UNREGISTERED:
+        updates["state"] = DeviceState.UNCALIBRATED
+
+    # If calibration params changed, recompute mm_per_adc_count
+    cal_a_raw = updates.get("cal_adc_a", device.cal_adc_a)
+    cal_b_raw = updates.get("cal_adc_b", device.cal_adc_b)
+    cal_dist_raw = updates.get("cal_distance_mm", device.cal_distance_mm)
+
+    if cal_a_raw is not None and cal_b_raw is not None and cal_dist_raw is not None:
+        cal_a_int = int(str(cal_a_raw))
+        cal_b_int = int(str(cal_b_raw))
+        cal_dist_f = float(str(cal_dist_raw))
+        mm_per_adc = compute_mm_per_adc(cal_a_int, cal_b_int, cal_dist_f)
+        if mm_per_adc is not None:
+            updates["mm_per_adc_count"] = mm_per_adc
+            # If calibration just completed, transition to needs_zero
+            if device.state == DeviceState.UNCALIBRATED:
+                updates["state"] = DeviceState.NEEDS_ZERO
+        # If calibration params were edited on a calibrated device, invalidate
+        cal_fields_changed = any(
+            f in updates for f in ("cal_adc_a", "cal_adc_b", "cal_distance_mm")
+        )
+        if cal_fields_changed and device.state in (DeviceState.NEEDS_ZERO, DeviceState.READY):
+            updates["state"] = DeviceState.UNCALIBRATED
+            updates["zero_offset_adc"] = None
+            updates["last_zeroed_at"] = None
+
+    if updates:
+        await storage.update_sensor_device(mac, updates)
+        await audit(request, "sensors.update", detail=mac, user=_user)
+
+    updated = await storage.get_sensor_device(mac)
+    assert updated is not None
+    return JSONResponse({"mac": updated.mac, "state": updated.state})
+
+
+@router.delete("/api/sensors/{mac}")
+async def api_delete_sensor(
+    request: Request,
+    mac: str,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Delete a sensor device and all its readings."""
+    if not validate_mac(mac):
+        raise HTTPException(status_code=422, detail="Invalid MAC format")
+
+    storage = get_storage(request)
+    device = await storage.get_sensor_device(mac)
+    if device is None:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    await storage.delete_sensor_device(mac)
+    await audit(request, "sensors.delete", detail=mac, user=_user)
+    return JSONResponse({"ok": True})
+
+
+@router.get("/api/sensors/{mac}/readings")
+async def api_sensor_readings(
+    request: Request,
+    mac: str,
+    session_id: int | None = None,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return sensor readings, optionally filtered by session."""
+    if not validate_mac(mac):
+        raise HTTPException(status_code=422, detail="Invalid MAC format")
+
+    storage = get_storage(request)
+    if session_id is None:
+        # Get current session
+        race = await storage.get_current_race()
+        if race is None:
+            return JSONResponse([])
+        session_id = race.id
+
+    readings = await storage.get_sensor_readings_for_session(session_id, mac)
+    return JSONResponse(readings)

--- a/src/helmlog/routes/sensors.py
+++ b/src/helmlog/routes/sensors.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from loguru import logger
 
 from helmlog.auth import require_auth
-from helmlog.routes._helpers import audit, get_storage, limiter
+from helmlog.routes._helpers import audit, get_storage, limiter, templates, tpl_ctx
 from helmlog.sensors import (
     DeviceState,
     ReadingRequest,
@@ -20,6 +20,16 @@ from helmlog.sensors import (
 )
 
 router = APIRouter()
+
+
+@router.get("/admin/sensors", response_class=HTMLResponse, include_in_schema=False)
+async def admin_sensors_page(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    return templates.TemplateResponse(
+        request, "admin/sensors.html", tpl_ctx(request, "/admin/sensors")
+    )
 
 
 @router.post("/api/sensor/reading")
@@ -135,6 +145,9 @@ async def api_list_sensors(
                 "line_name": d.line_name,
                 "friendly_name": d.friendly_name,
                 "state": d.state,
+                "cal_adc_a": d.cal_adc_a,
+                "cal_adc_b": d.cal_adc_b,
+                "cal_distance_mm": d.cal_distance_mm,
                 "mm_per_adc_count": d.mm_per_adc_count,
                 "total_travel_mm": d.total_travel_mm,
                 "zero_offset_adc": d.zero_offset_adc,

--- a/src/helmlog/sensors.py
+++ b/src/helmlog/sensors.py
@@ -1,0 +1,325 @@
+"""ESP32 string potentiometer sensor support.
+
+Manages device registration, calibration, zeroing, ADC-to-mm conversion,
+and session-aware reading storage for ESP32-based control line sensors.
+
+The ESP32 is a dumb sensor — it reads a cleaned raw ADC value and posts it.
+HelmLog owns all intelligence: device state machine, calibration math,
+session control, and configuration.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+_MAC_RE = re.compile(r"^[0-9A-F]{2}(?::[0-9A-F]{2}){5}$")
+
+
+class DeviceState(StrEnum):
+    """Lifecycle states for a sensor device."""
+
+    UNREGISTERED = "unregistered"
+    UNCALIBRATED = "uncalibrated"
+    NEEDS_ZERO = "needs_zero"
+    READY = "ready"
+
+
+@dataclass(frozen=True)
+class SensorDevice:
+    """A registered ESP32 sensor device."""
+
+    mac: str
+    line_name: str | None
+    friendly_name: str | None
+    state: DeviceState
+    # Calibration
+    pulley_diameter_mm: float | None
+    cal_adc_a: int | None
+    cal_adc_b: int | None
+    cal_distance_mm: float | None
+    mm_per_adc_count: float | None
+    total_travel_mm: float | None
+    # Zeroing
+    zero_offset_adc: int | None
+    last_zeroed_at: str | None
+    # Config
+    sleep_idle_s: int
+    sleep_active_s: int
+    report_threshold_mm: float
+    # Status
+    last_seen_at: str | None
+    last_battery_mv: int | None
+    last_rssi: int | None
+    created_at: str
+
+
+@dataclass(frozen=True)
+class SensorReading:
+    """A single sensor reading to store."""
+
+    session_id: int
+    mac: str
+    timestamp_utc: str
+    raw_adc: int
+    position_mm: float
+    battery_mv: int | None
+
+
+@dataclass(frozen=True)
+class ReadingRequest:
+    """Parsed POST body from an ESP32 sensor."""
+
+    mac: str
+    raw_adc: int
+    battery_mv: int | None
+    rssi: int | None
+    button_pressed: bool
+    estimated_utc: str | None
+
+
+@dataclass(frozen=True)
+class ReadingResponse:
+    """Response sent back to the ESP32."""
+
+    state: str
+    sleep_seconds: int
+    session_active: bool
+    server_time_utc: str
+
+
+def validate_mac(mac: str) -> bool:
+    """Return True if *mac* matches ``XX:XX:XX:XX:XX:XX`` (uppercase hex)."""
+    return bool(_MAC_RE.match(mac))
+
+
+def compute_mm_per_adc(cal_adc_a: int, cal_adc_b: int, cal_distance_mm: float) -> float | None:
+    """Compute the calibration factor from two-point calibration data.
+
+    Returns ``None`` if the two ADC values are identical (division by zero).
+    """
+    diff = cal_adc_b - cal_adc_a
+    if diff == 0:
+        return None
+    return cal_distance_mm / diff
+
+
+def adc_to_mm(raw_adc: int, zero_offset_adc: int, mm_per_adc_count: float) -> float:
+    """Convert a raw ADC reading to millimetres using calibration + zero offset."""
+    return (raw_adc - zero_offset_adc) * mm_per_adc_count
+
+
+def process_reading(
+    device: SensorDevice,
+    request: ReadingRequest,
+    session_active: bool,
+    current_session_id: int | None,
+    last_stored_mm: float | None,
+) -> tuple[ReadingResponse, SensorReading | None, dict[str, object] | None]:
+    """Process an incoming sensor reading and determine the response.
+
+    Returns a tuple of:
+    - ReadingResponse to send back to the ESP32
+    - SensorReading to store (or None if no reading should be stored)
+    - dict of device field updates to apply (or None if no updates)
+    """
+    now_utc = datetime.now(UTC).isoformat()
+    status_updates: dict[str, object] = {
+        "last_seen_at": now_utc,
+        "last_battery_mv": request.battery_mv,
+        "last_rssi": request.rssi,
+    }
+
+    match device.state:
+        case DeviceState.UNREGISTERED:
+            return (
+                ReadingResponse(
+                    state="unregistered",
+                    sleep_seconds=device.sleep_idle_s,
+                    session_active=False,
+                    server_time_utc=now_utc,
+                ),
+                None,
+                status_updates,
+            )
+
+        case DeviceState.UNCALIBRATED:
+            if request.button_pressed:
+                return (
+                    ReadingResponse(
+                        state="calibrating",
+                        sleep_seconds=2,
+                        session_active=False,
+                        server_time_utc=now_utc,
+                    ),
+                    None,
+                    status_updates,
+                )
+            return (
+                ReadingResponse(
+                    state="uncalibrated",
+                    sleep_seconds=device.sleep_idle_s,
+                    session_active=False,
+                    server_time_utc=now_utc,
+                ),
+                None,
+                status_updates,
+            )
+
+        case DeviceState.NEEDS_ZERO:
+            if request.button_pressed:
+                status_updates["zero_offset_adc"] = request.raw_adc
+                status_updates["last_zeroed_at"] = now_utc
+                status_updates["state"] = DeviceState.READY
+                return (
+                    ReadingResponse(
+                        state="zeroing",
+                        sleep_seconds=2,
+                        session_active=False,
+                        server_time_utc=now_utc,
+                    ),
+                    None,
+                    status_updates,
+                )
+            return (
+                ReadingResponse(
+                    state="needs_zero",
+                    sleep_seconds=device.sleep_idle_s,
+                    session_active=False,
+                    server_time_utc=now_utc,
+                ),
+                None,
+                status_updates,
+            )
+
+        case DeviceState.READY:
+            if session_active and current_session_id is not None:
+                status_updates["state"] = "active"
+                reading = _maybe_store_reading(
+                    device, request, current_session_id, now_utc, last_stored_mm
+                )
+                return (
+                    ReadingResponse(
+                        state="active",
+                        sleep_seconds=device.sleep_active_s,
+                        session_active=True,
+                        server_time_utc=now_utc,
+                    ),
+                    reading,
+                    status_updates,
+                )
+            return (
+                ReadingResponse(
+                    state="ready",
+                    sleep_seconds=device.sleep_idle_s,
+                    session_active=False,
+                    server_time_utc=now_utc,
+                ),
+                None,
+                status_updates,
+            )
+
+    # Should not be reached — all states handled above
+    return (  # pragma: no cover
+        ReadingResponse(
+            state=device.state,
+            sleep_seconds=device.sleep_idle_s,
+            session_active=False,
+            server_time_utc=now_utc,
+        ),
+        None,
+        status_updates,
+    )
+
+
+def process_active_reading(
+    device: SensorDevice,
+    request: ReadingRequest,
+    session_active: bool,
+    current_session_id: int | None,
+    last_stored_mm: float | None,
+) -> tuple[ReadingResponse, SensorReading | None, dict[str, object] | None]:
+    """Process a reading for a device whose persisted state is 'ready' but is logically active.
+
+    This is called when the device was previously promoted to active (session was running)
+    and is checking in again.
+    """
+    now_utc = datetime.now(UTC).isoformat()
+    status_updates: dict[str, object] = {
+        "last_seen_at": now_utc,
+        "last_battery_mv": request.battery_mv,
+        "last_rssi": request.rssi,
+    }
+
+    if not session_active:
+        # Session ended — return to ready
+        return (
+            ReadingResponse(
+                state="ready",
+                sleep_seconds=device.sleep_idle_s,
+                session_active=False,
+                server_time_utc=now_utc,
+            ),
+            None,
+            status_updates,
+        )
+
+    # Session still active — store reading if threshold met
+    reading = (
+        _maybe_store_reading(device, request, current_session_id, now_utc, last_stored_mm)
+        if current_session_id is not None
+        else None
+    )
+    return (
+        ReadingResponse(
+            state="active",
+            sleep_seconds=device.sleep_active_s,
+            session_active=True,
+            server_time_utc=now_utc,
+        ),
+        reading,
+        status_updates,
+    )
+
+
+def _maybe_store_reading(
+    device: SensorDevice,
+    request: ReadingRequest,
+    session_id: int,
+    now_utc: str,
+    last_stored_mm: float | None,
+) -> SensorReading | None:
+    """Convert ADC → mm and decide whether to store a reading.
+
+    Returns a SensorReading if the position changed enough, else None.
+    """
+    if device.mm_per_adc_count is None or device.zero_offset_adc is None:
+        return None
+
+    position_mm = adc_to_mm(request.raw_adc, device.zero_offset_adc, device.mm_per_adc_count)
+
+    # First reading of session always stored
+    if last_stored_mm is None:
+        return SensorReading(
+            session_id=session_id,
+            mac=request.mac,
+            timestamp_utc=now_utc,
+            raw_adc=request.raw_adc,
+            position_mm=round(position_mm, 2),
+            battery_mv=request.battery_mv,
+        )
+
+    # Threshold-based noise suppression
+    if abs(position_mm - last_stored_mm) < device.report_threshold_mm:
+        return None
+
+    return SensorReading(
+        session_id=session_id,
+        mac=request.mac,
+        timestamp_utc=now_utc,
+        raw_adc=request.raw_adc,
+        position_mm=round(position_mm, 2),
+        battery_mv=request.battery_mv,
+    )

--- a/src/helmlog/sensors.py
+++ b/src/helmlog/sensors.py
@@ -147,9 +147,24 @@ def process_reading(
 
         case DeviceState.UNCALIBRATED:
             if request.button_pressed:
+                # Two-point calibration: capture point A, then point B
+                if device.cal_adc_a is None:
+                    status_updates["cal_adc_a"] = request.raw_adc
+                    return (
+                        ReadingResponse(
+                            state="calibrating_a",
+                            sleep_seconds=2,
+                            session_active=False,
+                            server_time_utc=now_utc,
+                        ),
+                        None,
+                        status_updates,
+                    )
+                # Point A already captured — capture point B
+                status_updates["cal_adc_b"] = request.raw_adc
                 return (
                     ReadingResponse(
-                        state="calibrating",
+                        state="calibrating_b",
                         sleep_seconds=2,
                         session_active=False,
                         server_time_utc=now_utc,

--- a/src/helmlog/sensors.py
+++ b/src/helmlog/sensors.py
@@ -53,6 +53,7 @@ class SensorDevice:
     last_seen_at: str | None
     last_battery_mv: int | None
     last_rssi: int | None
+    last_raw_adc: int | None
     created_at: str
 
 
@@ -130,6 +131,7 @@ def process_reading(
         "last_seen_at": now_utc,
         "last_battery_mv": request.battery_mv,
         "last_rssi": request.rssi,
+        "last_raw_adc": request.raw_adc,
     }
 
     match device.state:
@@ -266,6 +268,7 @@ def process_active_reading(
         "last_seen_at": now_utc,
         "last_battery_mv": request.battery_mv,
         "last_rssi": request.rssi,
+        "last_raw_adc": request.raw_adc,
     }
 
     if not session_active:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -132,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 57
+_CURRENT_VERSION: int = 58
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1312,6 +1312,10 @@ _MIGRATIONS: dict[int, str] = {
             ON sensor_readings(session_id, mac);
         CREATE INDEX IF NOT EXISTS idx_sensor_readings_ts
             ON sensor_readings(timestamp_utc);
+    """,
+    58: """
+        -- Track last raw ADC for UI-driven calibration capture (#432)
+        ALTER TABLE sensor_devices ADD COLUMN last_raw_adc INTEGER;
     """,
 }
 
@@ -7364,6 +7368,7 @@ class Storage:
             last_seen_at=row["last_seen_at"],
             last_battery_mv=row["last_battery_mv"],
             last_rssi=row["last_rssi"],
+            last_raw_adc=row["last_raw_adc"],
             created_at=row["created_at"],
         )
 
@@ -7449,6 +7454,7 @@ class Storage:
                 last_seen_at=r["last_seen_at"],
                 last_battery_mv=r["last_battery_mv"],
                 last_rssi=r["last_rssi"],
+                last_raw_adc=r["last_raw_adc"],
                 created_at=r["created_at"],
             )
             for r in rows

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from helmlog.audio import AudioSession
     from helmlog.external import TideReading, WeatherReading
     from helmlog.races import Race
+    from helmlog.sensors import SensorDevice
 
 from helmlog.nmea2000 import (
     COGSOGRecord,
@@ -131,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 56
+_CURRENT_VERSION: int = 57
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1273,6 +1274,44 @@ _MIGRATIONS: dict[int, str] = {
             label       TEXT NOT NULL,
             sort_order  INTEGER NOT NULL DEFAULT 0
         );
+    """,
+    57: """
+        -- ESP32 string potentiometer sensors (#432)
+        CREATE TABLE IF NOT EXISTS sensor_devices (
+            mac               TEXT PRIMARY KEY,
+            line_name         TEXT,
+            friendly_name     TEXT,
+            state             TEXT NOT NULL DEFAULT 'unregistered',
+            pulley_diameter_mm REAL,
+            cal_adc_a         INTEGER,
+            cal_adc_b         INTEGER,
+            cal_distance_mm   REAL,
+            mm_per_adc_count  REAL,
+            total_travel_mm   REAL,
+            zero_offset_adc   INTEGER,
+            last_zeroed_at    TEXT,
+            sleep_idle_s      INTEGER NOT NULL DEFAULT 30,
+            sleep_active_s    INTEGER NOT NULL DEFAULT 5,
+            report_threshold_mm REAL NOT NULL DEFAULT 2.0,
+            last_seen_at      TEXT,
+            last_battery_mv   INTEGER,
+            last_rssi         INTEGER,
+            created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS sensor_readings (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id    INTEGER NOT NULL REFERENCES races(id),
+            mac           TEXT NOT NULL REFERENCES sensor_devices(mac),
+            timestamp_utc TEXT NOT NULL,
+            raw_adc       INTEGER NOT NULL,
+            position_mm   REAL NOT NULL,
+            battery_mv    INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_sensor_readings_session_mac
+            ON sensor_readings(session_id, mac);
+        CREATE INDEX IF NOT EXISTS idx_sensor_readings_ts
+            ON sensor_readings(timestamp_utc);
     """,
 }
 
@@ -7292,6 +7331,157 @@ class Storage:
                 return float(ctrl["tolerance_mm"])
         val = await self.get_aruco_setting("tolerance_mm_default")
         return float(val) if val else 5.0
+
+    # ------------------------------------------------------------------
+    # Sensors (#432)
+    # ------------------------------------------------------------------
+
+    async def get_sensor_device(self, mac: str) -> SensorDevice | None:
+        """Return the sensor device for *mac*, or None if not registered."""
+        from helmlog.sensors import DeviceState, SensorDevice
+
+        db = self._read_conn()
+        cur = await db.execute("SELECT * FROM sensor_devices WHERE mac = ?", (mac,))
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return SensorDevice(
+            mac=row["mac"],
+            line_name=row["line_name"],
+            friendly_name=row["friendly_name"],
+            state=DeviceState(row["state"]),
+            pulley_diameter_mm=row["pulley_diameter_mm"],
+            cal_adc_a=row["cal_adc_a"],
+            cal_adc_b=row["cal_adc_b"],
+            cal_distance_mm=row["cal_distance_mm"],
+            mm_per_adc_count=row["mm_per_adc_count"],
+            total_travel_mm=row["total_travel_mm"],
+            zero_offset_adc=row["zero_offset_adc"],
+            last_zeroed_at=row["last_zeroed_at"],
+            sleep_idle_s=row["sleep_idle_s"],
+            sleep_active_s=row["sleep_active_s"],
+            report_threshold_mm=row["report_threshold_mm"],
+            last_seen_at=row["last_seen_at"],
+            last_battery_mv=row["last_battery_mv"],
+            last_rssi=row["last_rssi"],
+            created_at=row["created_at"],
+        )
+
+    async def register_sensor_device(self, mac: str) -> None:
+        """Create a new sensor device row in the unregistered state."""
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        db = self._conn()
+        await db.execute(
+            "INSERT OR IGNORE INTO sensor_devices (mac, state, created_at) VALUES (?, ?, ?)",
+            (mac, "unregistered", _datetime.now(_UTC).isoformat()),
+        )
+        await db.commit()
+
+    async def update_sensor_device(self, mac: str, updates: dict[str, object]) -> None:
+        """Apply a dict of column updates to a sensor device row."""
+        if not updates:
+            return
+        db = self._conn()
+        cols = ", ".join(f"{k} = ?" for k in updates)
+        vals = [*updates.values(), mac]
+        await db.execute(f"UPDATE sensor_devices SET {cols} WHERE mac = ?", vals)  # noqa: S608
+        await db.commit()
+
+    async def store_sensor_reading(
+        self,
+        session_id: int,
+        mac: str,
+        timestamp_utc: str,
+        raw_adc: int,
+        position_mm: float,
+        battery_mv: int | None,
+    ) -> int:
+        """Insert a sensor reading row and return the new row ID."""
+        db = self._conn()
+        cur = await db.execute(
+            "INSERT INTO sensor_readings"
+            " (session_id, mac, timestamp_utc, raw_adc, position_mm, battery_mv)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, mac, timestamp_utc, raw_adc, position_mm, battery_mv),
+        )
+        await db.commit()
+        assert cur.lastrowid is not None
+        return cur.lastrowid
+
+    async def get_last_sensor_reading_mm(
+        self, mac: str, session_id: int
+    ) -> float | None:
+        """Return the most recent position_mm for *mac* in *session_id*, or None."""
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT position_mm FROM sensor_readings"
+            " WHERE mac = ? AND session_id = ?"
+            " ORDER BY timestamp_utc DESC LIMIT 1",
+            (mac, session_id),
+        )
+        row = await cur.fetchone()
+        return float(row["position_mm"]) if row else None
+
+    async def list_sensor_devices(self) -> list[SensorDevice]:
+        """Return all registered sensor devices."""
+        from helmlog.sensors import DeviceState, SensorDevice
+
+        db = self._read_conn()
+        cur = await db.execute("SELECT * FROM sensor_devices ORDER BY created_at")
+        rows = await cur.fetchall()
+        return [
+            SensorDevice(
+                mac=r["mac"],
+                line_name=r["line_name"],
+                friendly_name=r["friendly_name"],
+                state=DeviceState(r["state"]),
+                pulley_diameter_mm=r["pulley_diameter_mm"],
+                cal_adc_a=r["cal_adc_a"],
+                cal_adc_b=r["cal_adc_b"],
+                cal_distance_mm=r["cal_distance_mm"],
+                mm_per_adc_count=r["mm_per_adc_count"],
+                total_travel_mm=r["total_travel_mm"],
+                zero_offset_adc=r["zero_offset_adc"],
+                last_zeroed_at=r["last_zeroed_at"],
+                sleep_idle_s=r["sleep_idle_s"],
+                sleep_active_s=r["sleep_active_s"],
+                report_threshold_mm=r["report_threshold_mm"],
+                last_seen_at=r["last_seen_at"],
+                last_battery_mv=r["last_battery_mv"],
+                last_rssi=r["last_rssi"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]
+
+    async def get_sensor_readings_for_session(
+        self, session_id: int, mac: str | None = None
+    ) -> list[dict[str, object]]:
+        """Return sensor readings for a session, optionally filtered by MAC."""
+        db = self._read_conn()
+        if mac:
+            cur = await db.execute(
+                "SELECT * FROM sensor_readings"
+                " WHERE session_id = ? AND mac = ?"
+                " ORDER BY timestamp_utc",
+                (session_id, mac),
+            )
+        else:
+            cur = await db.execute(
+                "SELECT * FROM sensor_readings"
+                " WHERE session_id = ? ORDER BY timestamp_utc",
+                (session_id,),
+            )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def delete_sensor_device(self, mac: str) -> None:
+        """Delete a sensor device and all its readings."""
+        db = self._conn()
+        await db.execute("DELETE FROM sensor_readings WHERE mac = ?", (mac,))
+        await db.execute("DELETE FROM sensor_devices WHERE mac = ?", (mac,))
+        await db.commit()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -5266,9 +5266,11 @@ class Storage:
                 files.append(row["photo_path"])
 
         # Cascade delete handles: race_crew, race_results, race_sails,
-        # race_videos, session_notes, camera_sessions, session_tags.
-        # audio_sessions → transcripts also cascades.
+        # race_videos, session_notes, session_tags, etc.
+        # Tables below lack ON DELETE CASCADE and must be deleted manually.
         await db.execute("DELETE FROM audio_sessions WHERE race_id = ?", (session_id,))
+        await db.execute("DELETE FROM camera_sessions WHERE session_id = ?", (session_id,))
+        await db.execute("DELETE FROM sensor_readings WHERE session_id = ?", (session_id,))
 
         # Delete instrument data in the time range of this session
         cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7410,9 +7410,7 @@ class Storage:
         assert cur.lastrowid is not None
         return cur.lastrowid
 
-    async def get_last_sensor_reading_mm(
-        self, mac: str, session_id: int
-    ) -> float | None:
+    async def get_last_sensor_reading_mm(self, mac: str, session_id: int) -> float | None:
         """Return the most recent position_mm for *mac* in *session_id*, or None."""
         db = self._read_conn()
         cur = await db.execute(
@@ -7470,8 +7468,7 @@ class Storage:
             )
         else:
             cur = await db.execute(
-                "SELECT * FROM sensor_readings"
-                " WHERE session_id = ? ORDER BY timestamp_utc",
+                "SELECT * FROM sensor_readings WHERE session_id = ? ORDER BY timestamp_utc",
                 (session_id,),
             )
         return [dict(r) for r in await cur.fetchall()]

--- a/src/helmlog/templates/admin/sensors.html
+++ b/src/helmlog/templates/admin/sensors.html
@@ -18,6 +18,7 @@ td{padding:7px 8px;border-bottom:1px solid var(--border)}
 .btn-edit{color:var(--accent);border-color:var(--accent)}
 .btn-del{color:var(--danger);border-color:var(--danger)}
 .btn-save{color:var(--success);border-color:var(--success)}
+.btn-reset{color:var(--warning);border-color:var(--warning)}
 .mono{font-family:monospace;font-size:.8rem}
 dialog{background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:520px;width:90%}
 dialog::backdrop{background:rgba(0,0,0,.6)}
@@ -27,6 +28,10 @@ dialog::backdrop{background:rgba(0,0,0,.6)}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:8px}
 .status-detail{font-size:.8rem;color:var(--text-secondary)}
 #err-msg{color:var(--danger);font-size:.8rem;margin-top:8px}
+.cal-status{padding:10px;border-radius:6px;background:var(--bg-input);border:1px solid var(--border);margin-bottom:10px;font-size:.85rem}
+.cal-step{color:var(--text-secondary);font-size:.8rem;margin-top:4px}
+.cal-value{font-family:monospace;color:var(--success)}
+.cal-pending{color:var(--warning)}
 </style>
 {% endblock %}
 {% block content %}
@@ -54,25 +59,31 @@ dialog::backdrop{background:rgba(0,0,0,.6)}
 <input id="edit-friendly" placeholder="e.g. Port halyard"/>
 </div>
 </div>
+
+<div class="cal-status" id="cal-status"></div>
+
 <div class="field-row">
 <div class="field">
 <label>Cal ADC Point A</label>
-<input id="edit-cal-a" type="number" placeholder="ADC at point A"/>
+<input id="edit-cal-a" type="number" placeholder="Press button on sensor" disabled/>
 </div>
 <div class="field">
 <label>Cal ADC Point B</label>
-<input id="edit-cal-b" type="number" placeholder="ADC at point B"/>
+<input id="edit-cal-b" type="number" placeholder="Press button on sensor" disabled/>
 </div>
 </div>
 <div class="field-row">
 <div class="field">
 <label>Cal Distance (mm)</label>
-<input id="edit-cal-dist" type="number" step="0.1" placeholder="Distance between A and B"/>
+<input id="edit-cal-dist" type="number" step="0.1" placeholder="Measured distance A→B"/>
 </div>
 <div class="field">
 <label>Total Travel (mm)</label>
 <input id="edit-travel" type="number" step="0.1" placeholder="Max useful range"/>
 </div>
+</div>
+<div style="display:flex;gap:8px;margin-bottom:10px">
+<button class="btn-sm btn-reset" onclick="resetCal()" type="button">Reset Calibration</button>
 </div>
 <div class="field-row">
 <div class="field">
@@ -90,8 +101,8 @@ dialog::backdrop{background:rgba(0,0,0,.6)}
 </div>
 <div id="err-msg"></div>
 <div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">
-<button class="btn-sm" onclick="document.getElementById('edit-dlg').close()">Cancel</button>
-<button class="btn-sm btn-save" onclick="saveSensor()">Save</button>
+<button class="btn-sm" onclick="document.getElementById('edit-dlg').close()" type="button">Cancel</button>
+<button class="btn-sm btn-save" onclick="saveSensor()" type="button">Save</button>
 </div>
 </form>
 </dialog>
@@ -102,24 +113,42 @@ const BADGE={ready:'badge-ready',active:'badge-active',unregistered:'badge-unreg
 function badge(state){return `<span class="badge ${BADGE[state]||'badge-offline'}">${state}</span>`}
 function ago(iso){if(!iso)return'\u2014';const s=Math.floor((Date.now()-new Date(iso).getTime())/1000);if(s<60)return s+'s ago';if(s<3600)return Math.floor(s/60)+'m ago';if(s<86400)return Math.floor(s/3600)+'h ago';return Math.floor(s/86400)+'d ago'}
 
+function calStatus(d){
+  const el=document.getElementById('cal-status');
+  if(d.state==='ready'||d.state==='needs_zero'){
+    el.innerHTML='<span class="cal-value">Calibrated</span> — mm/count: '+
+      (d.mm_per_adc_count!=null?d.mm_per_adc_count.toFixed(4):'?')+
+      (d.state==='needs_zero'?'<div class="cal-step">Press the button on the sensor at the reference (zero) position.</div>':'');
+    return;
+  }
+  if(d.cal_adc_a!=null&&d.cal_adc_b!=null){
+    el.innerHTML='<span class="cal-value">Both points captured</span> (A: '+d.cal_adc_a+', B: '+d.cal_adc_b+')'+
+      '<div class="cal-step">Enter the measured distance between A and B, then click Save.</div>';
+  } else if(d.cal_adc_a!=null){
+    el.innerHTML='<span class="cal-value">Point A captured</span>: ADC '+d.cal_adc_a+
+      '<div class="cal-step cal-pending">Move the line to position B and press the button on the sensor.</div>';
+  } else {
+    el.innerHTML='<span class="cal-pending">No calibration points captured</span>'+
+      '<div class="cal-step">Move the line to position A and press the button on the sensor.</div>';
+  }
+}
+
 async function loadSensors(){
   document.getElementById('sensor-table').textContent='Loading\u2026';
   const r=await fetch('/api/sensors');
   if(!r.ok){document.getElementById('sensor-table').textContent='Failed to load';return}
   const devs=await r.json();
   if(!devs.length){document.getElementById('sensor-table').innerHTML='<p style="color:var(--text-secondary)">No sensors detected. Power on an ESP32 sensor — it will appear here automatically on first check-in.</p>';return}
-  let h='<table><thead><tr><th>Line</th><th>MAC</th><th>State</th><th>Position</th><th>Battery</th><th>RSSI</th><th>Last Seen</th><th>Actions</th></tr></thead><tbody>';
+  let h='<table><thead><tr><th>Line</th><th>MAC</th><th>State</th><th>Battery</th><th>RSSI</th><th>Last Seen</th><th>Actions</th></tr></thead><tbody>';
   for(const d of devs){
     const name=d.line_name||'<span style="color:var(--text-muted)">unassigned</span>';
     const friendly=d.friendly_name?` <span style="color:var(--text-secondary);font-size:.8rem">(${d.friendly_name})</span>`:'';
     const batt=d.last_battery_mv!=null?Math.round(d.last_battery_mv/10)/100+'V':'\u2014';
     const rssi=d.last_rssi!=null?d.last_rssi+' dBm':'\u2014';
-    const pos=d.mm_per_adc_count!=null&&d.zero_offset_adc!=null?'calibrated':'\u2014';
     h+=`<tr>
       <td>${name}${friendly}</td>
       <td class="mono">${d.mac}</td>
       <td>${badge(d.state)}</td>
-      <td>${pos}</td>
       <td>${batt}</td>
       <td>${rssi}</td>
       <td class="status-detail">${ago(d.last_seen_at)}</td>
@@ -133,14 +162,34 @@ async function loadSensors(){
   document.getElementById('sensor-table').innerHTML=h;
 }
 
+let _pollTimer=null;
 async function editSensor(mac){
   const r=await fetch('/api/sensors');
   if(!r.ok)return;
   const devs=await r.json();
   const d=devs.find(x=>x.mac===mac);
   if(!d)return;
-  document.getElementById('edit-mac').value=mac;
-  document.getElementById('edit-mac-display').value=mac;
+  _fillDialog(d);
+  document.getElementById('edit-dlg').showModal();
+  // Poll for calibration updates while dialog is open
+  if(_pollTimer)clearInterval(_pollTimer);
+  _pollTimer=setInterval(async()=>{
+    if(!document.getElementById('edit-dlg').open){clearInterval(_pollTimer);_pollTimer=null;return}
+    const r2=await fetch('/api/sensors');
+    if(!r2.ok)return;
+    const devs2=await r2.json();
+    const d2=devs2.find(x=>x.mac===mac);
+    if(!d2)return;
+    // Update cal fields and status without overwriting user edits
+    document.getElementById('edit-cal-a').value=d2.cal_adc_a!=null?d2.cal_adc_a:'';
+    document.getElementById('edit-cal-b').value=d2.cal_adc_b!=null?d2.cal_adc_b:'';
+    calStatus(d2);
+  },3000);
+}
+
+function _fillDialog(d){
+  document.getElementById('edit-mac').value=d.mac;
+  document.getElementById('edit-mac-display').value=d.mac;
   document.getElementById('edit-line').value=d.line_name||'';
   document.getElementById('edit-friendly').value=d.friendly_name||'';
   document.getElementById('edit-cal-a').value=d.cal_adc_a!=null?d.cal_adc_a:'';
@@ -150,9 +199,18 @@ async function editSensor(mac){
   document.getElementById('edit-sleep-idle').value=d.sleep_idle_s;
   document.getElementById('edit-sleep-active').value=d.sleep_active_s;
   document.getElementById('edit-threshold').value=d.report_threshold_mm;
-  document.getElementById('dlg-title').textContent='Configure '+mac;
+  document.getElementById('dlg-title').textContent='Configure '+d.mac;
   document.getElementById('err-msg').textContent='';
-  document.getElementById('edit-dlg').showModal();
+  calStatus(d);
+}
+
+async function resetCal(){
+  const mac=document.getElementById('edit-mac').value;
+  if(!confirm('Reset calibration for '+mac+'? You will need to recapture both points.'))return;
+  const r=await fetch('/api/sensors/'+encodeURIComponent(mac),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({cal_adc_a:null,cal_adc_b:null,cal_distance_mm:null})});
+  if(!r.ok){document.getElementById('err-msg').textContent='Failed to reset';return}
+  // Reload dialog
+  editSensor(mac);
 }
 
 async function saveSensor(){
@@ -162,10 +220,6 @@ async function saveSensor(){
   if(line)body.line_name=line;
   const friendly=document.getElementById('edit-friendly').value.trim();
   body.friendly_name=friendly||null;
-  const calA=document.getElementById('edit-cal-a').value;
-  if(calA!=='')body.cal_adc_a=parseInt(calA);
-  const calB=document.getElementById('edit-cal-b').value;
-  if(calB!=='')body.cal_adc_b=parseInt(calB);
   const calDist=document.getElementById('edit-cal-dist').value;
   if(calDist!=='')body.cal_distance_mm=parseFloat(calDist);
   const travel=document.getElementById('edit-travel').value;
@@ -176,6 +230,7 @@ async function saveSensor(){
   body.report_threshold_mm=parseFloat(document.getElementById('edit-threshold').value)||2.0;
   const r=await fetch('/api/sensors/'+encodeURIComponent(mac),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
   if(!r.ok){const d=await r.json();document.getElementById('err-msg').textContent=d.detail||'Failed';return}
+  if(_pollTimer){clearInterval(_pollTimer);_pollTimer=null}
   document.getElementById('edit-dlg').close();
   loadSensors();
 }

--- a/src/helmlog/templates/admin/sensors.html
+++ b/src/helmlog/templates/admin/sensors.html
@@ -1,0 +1,192 @@
+{% extends "base.html" %}
+{% block title %}Sensors — HelmLog{% endblock %}
+{% block extra_css %}
+<style>
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:12px}
+.label{font-size:.75rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);margin-bottom:8px}
+table{width:100%;border-collapse:collapse;font-size:.87rem}
+th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;padding:6px 8px}
+td{padding:7px 8px;border-bottom:1px solid var(--border)}
+.badge{padding:2px 8px;border-radius:4px;font-size:.78rem;font-weight:600}
+.badge-ready{background:var(--bg-secondary);color:var(--success)}
+.badge-active{background:var(--bg-secondary);color:var(--accent)}
+.badge-unreg{background:var(--border);color:var(--text-secondary)}
+.badge-uncal{background:var(--bg-secondary);color:var(--warning)}
+.badge-zero{background:var(--bg-secondary);color:var(--warning)}
+.badge-offline{background:var(--border);color:var(--danger)}
+.btn-sm{padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.78rem;cursor:pointer}
+.btn-edit{color:var(--accent);border-color:var(--accent)}
+.btn-del{color:var(--danger);border-color:var(--danger)}
+.btn-save{color:var(--success);border-color:var(--success)}
+.mono{font-family:monospace;font-size:.8rem}
+dialog{background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:520px;width:90%}
+dialog::backdrop{background:rgba(0,0,0,.6)}
+.field{margin-bottom:10px}
+.field label{display:block;font-size:.78rem;color:var(--text-secondary);margin-bottom:3px}
+.field input,.field select{width:100%;padding:6px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary);font-size:.85rem;box-sizing:border-box}
+.field-row{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.status-detail{font-size:.8rem;color:var(--text-secondary)}
+#err-msg{color:var(--danger);font-size:.8rem;margin-top:8px}
+</style>
+{% endblock %}
+{% block content %}
+<h1>Sensors</h1>
+<div class="card">
+<div class="label">ESP32 String Potentiometer Sensors</div>
+<div id="sensor-table">Loading…</div>
+</div>
+
+<dialog id="edit-dlg">
+<h3 style="margin:0 0 12px" id="dlg-title">Configure Sensor</h3>
+<form id="edit-form" onsubmit="return false">
+<input type="hidden" id="edit-mac"/>
+<div class="field">
+<label>MAC Address</label>
+<input id="edit-mac-display" disabled class="mono"/>
+</div>
+<div class="field-row">
+<div class="field">
+<label>Control Line</label>
+<input id="edit-line" placeholder="e.g. backstay"/>
+</div>
+<div class="field">
+<label>Friendly Name</label>
+<input id="edit-friendly" placeholder="e.g. Port halyard"/>
+</div>
+</div>
+<div class="field-row">
+<div class="field">
+<label>Cal ADC Point A</label>
+<input id="edit-cal-a" type="number" placeholder="ADC at point A"/>
+</div>
+<div class="field">
+<label>Cal ADC Point B</label>
+<input id="edit-cal-b" type="number" placeholder="ADC at point B"/>
+</div>
+</div>
+<div class="field-row">
+<div class="field">
+<label>Cal Distance (mm)</label>
+<input id="edit-cal-dist" type="number" step="0.1" placeholder="Distance between A and B"/>
+</div>
+<div class="field">
+<label>Total Travel (mm)</label>
+<input id="edit-travel" type="number" step="0.1" placeholder="Max useful range"/>
+</div>
+</div>
+<div class="field-row">
+<div class="field">
+<label>Sleep Idle (s)</label>
+<input id="edit-sleep-idle" type="number" value="30"/>
+</div>
+<div class="field">
+<label>Sleep Active (s)</label>
+<input id="edit-sleep-active" type="number" value="5"/>
+</div>
+</div>
+<div class="field">
+<label>Report Threshold (mm)</label>
+<input id="edit-threshold" type="number" step="0.1" value="2.0"/>
+</div>
+<div id="err-msg"></div>
+<div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">
+<button class="btn-sm" onclick="document.getElementById('edit-dlg').close()">Cancel</button>
+<button class="btn-sm btn-save" onclick="saveSensor()">Save</button>
+</div>
+</form>
+</dialog>
+{% endblock %}
+{% block scripts %}
+<script>
+const BADGE={ready:'badge-ready',active:'badge-active',unregistered:'badge-unreg',uncalibrated:'badge-uncal',needs_zero:'badge-zero'};
+function badge(state){return `<span class="badge ${BADGE[state]||'badge-offline'}">${state}</span>`}
+function ago(iso){if(!iso)return'\u2014';const s=Math.floor((Date.now()-new Date(iso).getTime())/1000);if(s<60)return s+'s ago';if(s<3600)return Math.floor(s/60)+'m ago';if(s<86400)return Math.floor(s/3600)+'h ago';return Math.floor(s/86400)+'d ago'}
+
+async function loadSensors(){
+  document.getElementById('sensor-table').textContent='Loading\u2026';
+  const r=await fetch('/api/sensors');
+  if(!r.ok){document.getElementById('sensor-table').textContent='Failed to load';return}
+  const devs=await r.json();
+  if(!devs.length){document.getElementById('sensor-table').innerHTML='<p style="color:var(--text-secondary)">No sensors detected. Power on an ESP32 sensor — it will appear here automatically on first check-in.</p>';return}
+  let h='<table><thead><tr><th>Line</th><th>MAC</th><th>State</th><th>Position</th><th>Battery</th><th>RSSI</th><th>Last Seen</th><th>Actions</th></tr></thead><tbody>';
+  for(const d of devs){
+    const name=d.line_name||'<span style="color:var(--text-muted)">unassigned</span>';
+    const friendly=d.friendly_name?` <span style="color:var(--text-secondary);font-size:.8rem">(${d.friendly_name})</span>`:'';
+    const batt=d.last_battery_mv!=null?Math.round(d.last_battery_mv/10)/100+'V':'\u2014';
+    const rssi=d.last_rssi!=null?d.last_rssi+' dBm':'\u2014';
+    const pos=d.mm_per_adc_count!=null&&d.zero_offset_adc!=null?'calibrated':'\u2014';
+    h+=`<tr>
+      <td>${name}${friendly}</td>
+      <td class="mono">${d.mac}</td>
+      <td>${badge(d.state)}</td>
+      <td>${pos}</td>
+      <td>${batt}</td>
+      <td>${rssi}</td>
+      <td class="status-detail">${ago(d.last_seen_at)}</td>
+      <td style="display:flex;gap:4px">
+        <button class="btn-sm btn-edit" onclick="editSensor('${d.mac}')">Edit</button>
+        <button class="btn-sm btn-del" onclick="delSensor('${d.mac}')">Delete</button>
+      </td>
+    </tr>`;
+  }
+  h+='</tbody></table>';
+  document.getElementById('sensor-table').innerHTML=h;
+}
+
+async function editSensor(mac){
+  const r=await fetch('/api/sensors');
+  if(!r.ok)return;
+  const devs=await r.json();
+  const d=devs.find(x=>x.mac===mac);
+  if(!d)return;
+  document.getElementById('edit-mac').value=mac;
+  document.getElementById('edit-mac-display').value=mac;
+  document.getElementById('edit-line').value=d.line_name||'';
+  document.getElementById('edit-friendly').value=d.friendly_name||'';
+  document.getElementById('edit-cal-a').value=d.cal_adc_a!=null?d.cal_adc_a:'';
+  document.getElementById('edit-cal-b').value=d.cal_adc_b!=null?d.cal_adc_b:'';
+  document.getElementById('edit-cal-dist').value=d.cal_distance_mm!=null?d.cal_distance_mm:'';
+  document.getElementById('edit-travel').value=d.total_travel_mm!=null?d.total_travel_mm:'';
+  document.getElementById('edit-sleep-idle').value=d.sleep_idle_s;
+  document.getElementById('edit-sleep-active').value=d.sleep_active_s;
+  document.getElementById('edit-threshold').value=d.report_threshold_mm;
+  document.getElementById('dlg-title').textContent='Configure '+mac;
+  document.getElementById('err-msg').textContent='';
+  document.getElementById('edit-dlg').showModal();
+}
+
+async function saveSensor(){
+  const mac=document.getElementById('edit-mac').value;
+  const body={};
+  const line=document.getElementById('edit-line').value.trim();
+  if(line)body.line_name=line;
+  const friendly=document.getElementById('edit-friendly').value.trim();
+  body.friendly_name=friendly||null;
+  const calA=document.getElementById('edit-cal-a').value;
+  if(calA!=='')body.cal_adc_a=parseInt(calA);
+  const calB=document.getElementById('edit-cal-b').value;
+  if(calB!=='')body.cal_adc_b=parseInt(calB);
+  const calDist=document.getElementById('edit-cal-dist').value;
+  if(calDist!=='')body.cal_distance_mm=parseFloat(calDist);
+  const travel=document.getElementById('edit-travel').value;
+  if(travel!=='')body.total_travel_mm=parseFloat(travel);
+  else body.total_travel_mm=null;
+  body.sleep_idle_s=parseInt(document.getElementById('edit-sleep-idle').value)||30;
+  body.sleep_active_s=parseInt(document.getElementById('edit-sleep-active').value)||5;
+  body.report_threshold_mm=parseFloat(document.getElementById('edit-threshold').value)||2.0;
+  const r=await fetch('/api/sensors/'+encodeURIComponent(mac),{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+  if(!r.ok){const d=await r.json();document.getElementById('err-msg').textContent=d.detail||'Failed';return}
+  document.getElementById('edit-dlg').close();
+  loadSensors();
+}
+
+async function delSensor(mac){
+  if(!confirm('Delete sensor '+mac+'? All readings will be lost.'))return;
+  const r=await fetch('/api/sensors/'+encodeURIComponent(mac),{method:'DELETE'});
+  if(!r.ok){alert('Failed to delete');return}
+  loadSensors();
+}
+
+loadSensors();
+</script>
+{% endblock %}

--- a/src/helmlog/templates/admin/sensors.html
+++ b/src/helmlog/templates/admin/sensors.html
@@ -62,14 +62,24 @@ dialog::backdrop{background:rgba(0,0,0,.6)}
 
 <div class="cal-status" id="cal-status"></div>
 
+<div class="field">
+<label>Live ADC</label>
+<span id="live-adc" class="mono" style="font-size:.95rem">—</span>
+</div>
 <div class="field-row">
 <div class="field">
 <label>Cal ADC Point A</label>
-<input id="edit-cal-a" type="number" placeholder="Press button on sensor" disabled/>
+<div style="display:flex;gap:4px">
+<input id="edit-cal-a" type="number" placeholder="Move line to A" style="flex:1"/>
+<button class="btn-sm btn-edit" onclick="captureA()" type="button">Capture</button>
+</div>
 </div>
 <div class="field">
 <label>Cal ADC Point B</label>
-<input id="edit-cal-b" type="number" placeholder="Press button on sensor" disabled/>
+<div style="display:flex;gap:4px">
+<input id="edit-cal-b" type="number" placeholder="Move line to B" style="flex:1"/>
+<button class="btn-sm btn-edit" onclick="captureB()" type="button">Capture</button>
+</div>
 </div>
 </div>
 <div class="field-row">
@@ -115,21 +125,58 @@ function ago(iso){if(!iso)return'\u2014';const s=Math.floor((Date.now()-new Date
 
 function calStatus(d){
   const el=document.getElementById('cal-status');
+  // Update live ADC display
+  document.getElementById('live-adc').textContent=d.last_raw_adc!=null?d.last_raw_adc:'—';
   if(d.state==='ready'||d.state==='needs_zero'){
     el.innerHTML='<span class="cal-value">Calibrated</span> — mm/count: '+
       (d.mm_per_adc_count!=null?d.mm_per_adc_count.toFixed(4):'?')+
-      (d.state==='needs_zero'?'<div class="cal-step">Press the button on the sensor at the reference (zero) position.</div>':'');
+      (d.state==='needs_zero'?'<div class="cal-step">Move the line to the reference (zero) position and click Capture on a cal point, or use the Zero button below.</div>':'');
     return;
   }
-  if(d.cal_adc_a!=null&&d.cal_adc_b!=null){
-    el.innerHTML='<span class="cal-value">Both points captured</span> (A: '+d.cal_adc_a+', B: '+d.cal_adc_b+')'+
+  const calA=document.getElementById('edit-cal-a').value;
+  const calB=document.getElementById('edit-cal-b').value;
+  if(calA&&calB){
+    el.innerHTML='<span class="cal-value">Both points set</span> (A: '+calA+', B: '+calB+')'+
       '<div class="cal-step">Enter the measured distance between A and B, then click Save.</div>';
-  } else if(d.cal_adc_a!=null){
-    el.innerHTML='<span class="cal-value">Point A captured</span>: ADC '+d.cal_adc_a+
-      '<div class="cal-step cal-pending">Move the line to position B and press the button on the sensor.</div>';
+  } else if(calA){
+    el.innerHTML='<span class="cal-value">Point A set</span>: ADC '+calA+
+      '<div class="cal-step cal-pending">Move the line to position B and click Capture.</div>';
   } else {
-    el.innerHTML='<span class="cal-pending">No calibration points captured</span>'+
-      '<div class="cal-step">Move the line to position A and press the button on the sensor.</div>';
+    el.innerHTML='<span class="cal-pending">No calibration points set</span>'+
+      '<div class="cal-step">Move the line to position A and click Capture.</div>';
+  }
+}
+
+function captureA(){
+  const adc=document.getElementById('live-adc').textContent;
+  if(adc==='\u2014'){document.getElementById('err-msg').textContent='No ADC reading yet — wait for sensor to check in';return}
+  document.getElementById('edit-cal-a').value=adc;
+  document.getElementById('err-msg').textContent='';
+  // Refresh cal status display
+  const calB=document.getElementById('edit-cal-b').value;
+  const el=document.getElementById('cal-status');
+  if(calB){
+    el.innerHTML='<span class="cal-value">Both points set</span> (A: '+adc+', B: '+calB+')'+
+      '<div class="cal-step">Enter the measured distance between A and B, then click Save.</div>';
+  } else {
+    el.innerHTML='<span class="cal-value">Point A set</span>: ADC '+adc+
+      '<div class="cal-step cal-pending">Move the line to position B and click Capture.</div>';
+  }
+}
+
+function captureB(){
+  const adc=document.getElementById('live-adc').textContent;
+  if(adc==='\u2014'){document.getElementById('err-msg').textContent='No ADC reading yet — wait for sensor to check in';return}
+  document.getElementById('edit-cal-b').value=adc;
+  document.getElementById('err-msg').textContent='';
+  const calA=document.getElementById('edit-cal-a').value;
+  const el=document.getElementById('cal-status');
+  if(calA){
+    el.innerHTML='<span class="cal-value">Both points set</span> (A: '+calA+', B: '+adc+')'+
+      '<div class="cal-step">Enter the measured distance between A and B, then click Save.</div>';
+  } else {
+    el.innerHTML='<span class="cal-value">Point B set</span>: ADC '+adc+
+      '<div class="cal-step cal-pending">Move the line to position A and click Capture.</div>';
   }
 }
 
@@ -180,10 +227,8 @@ async function editSensor(mac){
     const devs2=await r2.json();
     const d2=devs2.find(x=>x.mac===mac);
     if(!d2)return;
-    // Update cal fields and status without overwriting user edits
-    document.getElementById('edit-cal-a').value=d2.cal_adc_a!=null?d2.cal_adc_a:'';
-    document.getElementById('edit-cal-b').value=d2.cal_adc_b!=null?d2.cal_adc_b:'';
-    calStatus(d2);
+    // Only update live ADC — don't overwrite user-entered cal values
+    document.getElementById('live-adc').textContent=d2.last_raw_adc!=null?d2.last_raw_adc:'\u2014';
   },3000);
 }
 
@@ -220,6 +265,10 @@ async function saveSensor(){
   if(line)body.line_name=line;
   const friendly=document.getElementById('edit-friendly').value.trim();
   body.friendly_name=friendly||null;
+  const calA=document.getElementById('edit-cal-a').value;
+  if(calA!=='')body.cal_adc_a=parseInt(calA);
+  const calB=document.getElementById('edit-cal-b').value;
+  if(calB!=='')body.cal_adc_b=parseInt(calB);
   const calDist=document.getElementById('edit-cal-dist').value;
   if(calDist!=='')body.cal_distance_mm=parseFloat(calDist);
   const travel=document.getElementById('edit-travel').value;

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -27,6 +27,7 @@
     <a href="/admin/cameras" class="admin-link{% if active_page == "/admin/cameras" %} active{% endif %}">Cameras</a>
     <a href="/admin/aruco" class="admin-link{% if active_page == "/admin/aruco" %} active{% endif %}">ArUco</a>
     <a href="/admin/devices" class="admin-link{% if active_page == "/admin/devices" %} active{% endif %}">Devices</a>
+    <a href="/admin/sensors" class="admin-link{% if active_page == "/admin/sensors" %} active{% endif %}">Sensors</a>
     <a href="/admin/network" class="admin-link{% if active_page == "/admin/network" %} active{% endif %}">Network</a>
     <a href="/admin/events" class="admin-link{% if active_page == "/admin/events" %} active{% endif %}">Events</a>
     <a href="/admin/settings" class="admin-link{% if active_page == "/admin/settings" %} active{% endif %}">Settings</a>

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -156,7 +156,7 @@ def create_app(
 
             request.state.user = _MOCK_ADMIN
             return await call_next(request)  # type: ignore[no-any-return]
-        if path in _PUBLIC_PATHS or path.startswith(("/static/", "/co-op/", "/auth/")):
+        if path in _PUBLIC_PATHS or path.startswith(("/static/", "/co-op/", "/auth/", "/api/sensor/")):
             return await call_next(request)  # type: ignore[no-any-return]
 
         # Try device bearer token auth first (#423)
@@ -213,6 +213,7 @@ def create_app(
         polar,
         races,
         sails,
+        sensors,
         sessions,
         settings,
         tags,
@@ -241,6 +242,7 @@ def create_app(
         notes,
         videos,
         boat_settings,
+        sensors,
         comments,
         tags,
         settings,

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -156,7 +156,9 @@ def create_app(
 
             request.state.user = _MOCK_ADMIN
             return await call_next(request)  # type: ignore[no-any-return]
-        if path in _PUBLIC_PATHS or path.startswith(("/static/", "/co-op/", "/auth/", "/api/sensor/")):
+        if path in _PUBLIC_PATHS or path.startswith(
+            ("/static/", "/co-op/", "/auth/", "/api/sensor/")
+        ):
             return await call_next(request)  # type: ignore[no-any-return]
 
         # Try device bearer token auth first (#423)

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -165,11 +165,68 @@ class TestProcessReadingUncalibrated:
         assert resp.state == "uncalibrated"
         assert reading is None
 
-    def test_uncalibrated_button_pressed(self) -> None:
+    def test_uncalibrated_button_captures_point_a(self) -> None:
         dev = _device(state=DeviceState.UNCALIBRATED)
-        resp, reading, _ = process_reading(dev, _request(button_pressed=True), False, None, None)
-        assert resp.state == "calibrating"
+        # No cal_adc_a yet — should capture point A
+        dev_no_cal = SensorDevice(
+            mac=dev.mac,
+            line_name=dev.line_name,
+            friendly_name=dev.friendly_name,
+            state=DeviceState.UNCALIBRATED,
+            pulley_diameter_mm=None,
+            cal_adc_a=None,
+            cal_adc_b=None,
+            cal_distance_mm=None,
+            mm_per_adc_count=None,
+            total_travel_mm=None,
+            zero_offset_adc=None,
+            last_zeroed_at=None,
+            sleep_idle_s=30,
+            sleep_active_s=5,
+            report_threshold_mm=2.0,
+            last_seen_at=None,
+            last_battery_mv=None,
+            last_rssi=None,
+            created_at="2026-04-06T09:00:00+00:00",
+        )
+        resp, reading, updates = process_reading(
+            dev_no_cal, _request(raw_adc=1000, button_pressed=True), False, None, None
+        )
+        assert resp.state == "calibrating_a"
         assert resp.sleep_seconds == 2
+        assert updates is not None
+        assert updates["cal_adc_a"] == 1000
+        assert reading is None
+
+    def test_uncalibrated_button_captures_point_b(self) -> None:
+        # cal_adc_a already set — should capture point B
+        dev_with_a = SensorDevice(
+            mac="AA:BB:CC:DD:EE:FF",
+            line_name="backstay",
+            friendly_name=None,
+            state=DeviceState.UNCALIBRATED,
+            pulley_diameter_mm=None,
+            cal_adc_a=1000,
+            cal_adc_b=None,
+            cal_distance_mm=None,
+            mm_per_adc_count=None,
+            total_travel_mm=None,
+            zero_offset_adc=None,
+            last_zeroed_at=None,
+            sleep_idle_s=30,
+            sleep_active_s=5,
+            report_threshold_mm=2.0,
+            last_seen_at=None,
+            last_battery_mv=None,
+            last_rssi=None,
+            created_at="2026-04-06T09:00:00+00:00",
+        )
+        resp, reading, updates = process_reading(
+            dev_with_a, _request(raw_adc=2000, button_pressed=True), False, None, None
+        )
+        assert resp.state == "calibrating_b"
+        assert updates is not None
+        assert updates["cal_adc_b"] == 2000
         assert reading is None
 
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,567 @@
+"""Tests for ESP32 string potentiometer sensor support (#432)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.sensors import (
+    DeviceState,
+    ReadingRequest,
+    SensorDevice,
+    adc_to_mm,
+    compute_mm_per_adc,
+    process_active_reading,
+    process_reading,
+    validate_mac,
+)
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = "2026-04-06T18:30:00+00:00"
+
+
+def _device(
+    *,
+    state: DeviceState = DeviceState.READY,
+    mm_per_adc_count: float | None = 0.1,
+    zero_offset_adc: int | None = 1000,
+    sleep_idle_s: int = 30,
+    sleep_active_s: int = 5,
+    report_threshold_mm: float = 2.0,
+    total_travel_mm: float | None = 500.0,
+) -> SensorDevice:
+    return SensorDevice(
+        mac="AA:BB:CC:DD:EE:FF",
+        line_name="backstay",
+        friendly_name=None,
+        state=state,
+        pulley_diameter_mm=None,
+        cal_adc_a=1000,
+        cal_adc_b=2000,
+        cal_distance_mm=100.0,
+        mm_per_adc_count=mm_per_adc_count,
+        total_travel_mm=total_travel_mm,
+        zero_offset_adc=zero_offset_adc,
+        last_zeroed_at="2026-04-06T10:00:00+00:00",
+        sleep_idle_s=sleep_idle_s,
+        sleep_active_s=sleep_active_s,
+        report_threshold_mm=report_threshold_mm,
+        last_seen_at=None,
+        last_battery_mv=None,
+        last_rssi=None,
+        created_at="2026-04-06T09:00:00+00:00",
+    )
+
+
+def _request(
+    *,
+    raw_adc: int = 1500,
+    button_pressed: bool = False,
+    battery_mv: int = 3850,
+    rssi: int = -62,
+) -> ReadingRequest:
+    return ReadingRequest(
+        mac="AA:BB:CC:DD:EE:FF",
+        raw_adc=raw_adc,
+        battery_mv=battery_mv,
+        rssi=rssi,
+        button_pressed=button_pressed,
+        estimated_utc="2026-04-06T18:30:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — validate_mac
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMac:
+    def test_valid_mac(self) -> None:
+        assert validate_mac("AA:BB:CC:DD:EE:FF") is True
+
+    def test_lowercase_rejected(self) -> None:
+        assert validate_mac("aa:bb:cc:dd:ee:ff") is False
+
+    def test_missing_colons(self) -> None:
+        assert validate_mac("AABBCCDDEEFF") is False
+
+    def test_too_short(self) -> None:
+        assert validate_mac("AA:BB:CC") is False
+
+    def test_empty(self) -> None:
+        assert validate_mac("") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — compute_mm_per_adc
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMmPerAdc:
+    def test_normal_calibration(self) -> None:
+        result = compute_mm_per_adc(1000, 2000, 100.0)
+        assert result == pytest.approx(0.1)
+
+    def test_identical_adc_returns_none(self) -> None:
+        assert compute_mm_per_adc(1000, 1000, 100.0) is None
+
+    def test_negative_direction(self) -> None:
+        result = compute_mm_per_adc(2000, 1000, 100.0)
+        assert result == pytest.approx(-0.1)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — adc_to_mm
+# ---------------------------------------------------------------------------
+
+
+class TestAdcToMm:
+    def test_zero_offset(self) -> None:
+        assert adc_to_mm(1500, 1000, 0.1) == pytest.approx(50.0)
+
+    def test_at_zero(self) -> None:
+        assert adc_to_mm(1000, 1000, 0.1) == pytest.approx(0.0)
+
+    def test_negative_position(self) -> None:
+        assert adc_to_mm(500, 1000, 0.1) == pytest.approx(-50.0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — process_reading state machine
+# ---------------------------------------------------------------------------
+
+
+class TestProcessReadingUnregistered:
+    def test_unregistered_returns_unregistered(self) -> None:
+        dev = _device(state=DeviceState.UNREGISTERED)
+        resp, reading, updates = process_reading(dev, _request(), False, None, None)
+        assert resp.state == "unregistered"
+        assert resp.session_active is False
+        assert resp.sleep_seconds == 30
+        assert reading is None
+
+    def test_unregistered_with_session_still_unregistered(self) -> None:
+        dev = _device(state=DeviceState.UNREGISTERED)
+        resp, reading, _ = process_reading(dev, _request(), True, 1, None)
+        assert resp.state == "unregistered"
+        assert resp.session_active is False
+        assert reading is None
+
+
+class TestProcessReadingUncalibrated:
+    def test_uncalibrated_no_button(self) -> None:
+        dev = _device(state=DeviceState.UNCALIBRATED)
+        resp, reading, _ = process_reading(dev, _request(), False, None, None)
+        assert resp.state == "uncalibrated"
+        assert reading is None
+
+    def test_uncalibrated_button_pressed(self) -> None:
+        dev = _device(state=DeviceState.UNCALIBRATED)
+        resp, reading, _ = process_reading(dev, _request(button_pressed=True), False, None, None)
+        assert resp.state == "calibrating"
+        assert resp.sleep_seconds == 2
+        assert reading is None
+
+
+class TestProcessReadingNeedsZero:
+    def test_needs_zero_no_button(self) -> None:
+        dev = _device(state=DeviceState.NEEDS_ZERO, zero_offset_adc=None)
+        resp, reading, updates = process_reading(dev, _request(), False, None, None)
+        assert resp.state == "needs_zero"
+        assert reading is None
+
+    def test_needs_zero_button_transitions_to_ready(self) -> None:
+        dev = _device(state=DeviceState.NEEDS_ZERO, zero_offset_adc=None)
+        resp, reading, updates = process_reading(
+            dev, _request(raw_adc=2000, button_pressed=True), False, None, None
+        )
+        assert resp.state == "zeroing"
+        assert resp.sleep_seconds == 2
+        assert updates is not None
+        assert updates["zero_offset_adc"] == 2000
+        assert updates["state"] == DeviceState.READY
+        assert reading is None
+
+
+class TestProcessReadingReady:
+    def test_ready_no_session(self) -> None:
+        dev = _device()
+        resp, reading, _ = process_reading(dev, _request(), False, None, None)
+        assert resp.state == "ready"
+        assert resp.sleep_seconds == 30
+        assert resp.session_active is False
+        assert reading is None
+
+    def test_ready_with_session_transitions_to_active(self) -> None:
+        dev = _device()
+        resp, reading, updates = process_reading(dev, _request(), True, 1, None)
+        assert resp.state == "active"
+        assert resp.sleep_seconds == 5
+        assert resp.session_active is True
+        # First reading of session should be stored
+        assert reading is not None
+        assert reading.session_id == 1
+        assert reading.position_mm == pytest.approx(50.0)
+
+
+class TestProcessActiveReading:
+    def test_active_session_still_running(self) -> None:
+        dev = _device()
+        resp, reading, _ = process_active_reading(dev, _request(), True, 1, 45.0)
+        assert resp.state == "active"
+        assert resp.session_active is True
+        # position_mm = (1500 - 1000) * 0.1 = 50.0, delta from 45.0 = 5.0 >= 2.0
+        assert reading is not None
+        assert reading.position_mm == pytest.approx(50.0)
+
+    def test_active_below_threshold_suppressed(self) -> None:
+        dev = _device()
+        # last_stored = 49.5, new = 50.0, delta = 0.5 < 2.0
+        resp, reading, _ = process_active_reading(dev, _request(), True, 1, 49.5)
+        assert resp.state == "active"
+        assert reading is None
+
+    def test_active_session_ends(self) -> None:
+        dev = _device()
+        resp, reading, _ = process_active_reading(dev, _request(), False, None, 50.0)
+        assert resp.state == "ready"
+        assert resp.session_active is False
+        assert reading is None
+
+    def test_active_first_reading_always_stored(self) -> None:
+        dev = _device()
+        resp, reading, _ = process_reading(dev, _request(), True, 1, None)
+        assert reading is not None
+
+    def test_no_calibration_no_reading(self) -> None:
+        dev = _device(mm_per_adc_count=None, zero_offset_adc=None)
+        resp, reading, _ = process_reading(dev, _request(), True, 1, None)
+        assert resp.state == "active"
+        assert reading is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — API endpoint via ASGI transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_unknown_mac_registers(storage: Storage) -> None:
+    """POST /api/sensor/reading with unknown MAC creates a new device."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/sensor/reading",
+            json={
+                "mac": "AA:BB:CC:DD:EE:01",
+                "raw_adc": 2000,
+                "battery_mv": 3800,
+                "rssi": -55,
+                "button_pressed": False,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "unregistered"
+    assert data["session_active"] is False
+    assert "server_time_utc" in data
+
+    # Verify device was persisted
+    device = await storage.get_sensor_device("AA:BB:CC:DD:EE:01")
+    assert device is not None
+    assert device.state == DeviceState.UNREGISTERED
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_invalid_mac_returns_422(storage: Storage) -> None:
+    """POST /api/sensor/reading with invalid MAC returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/sensor/reading",
+            json={"mac": "invalid", "raw_adc": 2000},
+        )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_missing_adc_returns_422(storage: Storage) -> None:
+    """POST /api/sensor/reading without raw_adc returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/sensor/reading",
+            json={"mac": "AA:BB:CC:DD:EE:01"},
+        )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_during_session_stores_reading(storage: Storage) -> None:
+    """Active session + calibrated device should store a sensor reading."""
+    app = create_app(storage)
+    mac = "AA:BB:CC:DD:EE:02"
+
+    # Register + calibrate + zero the device
+    await storage.register_sensor_device(mac)
+    await storage.update_sensor_device(
+        mac,
+        {
+            "state": "ready",
+            "line_name": "backstay",
+            "cal_adc_a": 1000,
+            "cal_adc_b": 2000,
+            "cal_distance_mm": 100.0,
+            "mm_per_adc_count": 0.1,
+            "zero_offset_adc": 1000,
+            "last_zeroed_at": "2026-04-06T10:00:00+00:00",
+        },
+    )
+
+    # Start a session
+    await storage.start_race(
+        event="TestRegatta",
+        start_utc=datetime(2026, 4, 6, 18, 0, 0, tzinfo=UTC),
+        date_str="2026-04-06",
+        race_num=1,
+        name="2026-04-06 TestRegatta 1",
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/sensor/reading",
+            json={
+                "mac": mac,
+                "raw_adc": 1500,
+                "battery_mv": 3850,
+                "rssi": -62,
+                "button_pressed": False,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "active"
+    assert data["session_active"] is True
+
+    # Verify reading was stored
+    readings = await storage.get_sensor_readings_for_session(1, mac)
+    assert len(readings) == 1
+    assert readings[0]["position_mm"] == pytest.approx(50.0)
+
+
+@pytest.mark.asyncio
+async def test_sensor_reading_threshold_suppression(storage: Storage) -> None:
+    """Readings below report_threshold_mm should not be stored."""
+    app = create_app(storage)
+    mac = "AA:BB:CC:DD:EE:03"
+
+    await storage.register_sensor_device(mac)
+    await storage.update_sensor_device(
+        mac,
+        {
+            "state": "ready",
+            "line_name": "cunningham",
+            "cal_adc_a": 0,
+            "cal_adc_b": 4095,
+            "cal_distance_mm": 409.5,
+            "mm_per_adc_count": 0.1,
+            "zero_offset_adc": 0,
+            "report_threshold_mm": 5.0,
+        },
+    )
+
+    await storage.start_race(
+        event="TestRegatta",
+        start_utc=datetime(2026, 4, 6, 18, 0, 0, tzinfo=UTC),
+        date_str="2026-04-06",
+        race_num=1,
+        name="2026-04-06 TestRegatta 1",
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # First reading — always stored
+        resp1 = await client.post(
+            "/api/sensor/reading",
+            json={"mac": mac, "raw_adc": 100, "battery_mv": 3800, "rssi": -60},
+        )
+        assert resp1.status_code == 200
+
+        # Second reading — within threshold (delta = 1mm < 5mm), should NOT store
+        resp2 = await client.post(
+            "/api/sensor/reading",
+            json={"mac": mac, "raw_adc": 110, "battery_mv": 3800, "rssi": -60},
+        )
+        assert resp2.status_code == 200
+
+        # Third reading — exceeds threshold (delta = 100mm > 5mm), should store
+        resp3 = await client.post(
+            "/api/sensor/reading",
+            json={"mac": mac, "raw_adc": 1100, "battery_mv": 3800, "rssi": -60},
+        )
+        assert resp3.status_code == 200
+
+    readings = await storage.get_sensor_readings_for_session(1, mac)
+    assert len(readings) == 2  # first + third
+
+
+@pytest.mark.asyncio
+async def test_sensor_zeroing_via_button(storage: Storage) -> None:
+    """Button press in needs_zero state sets zero offset and transitions to ready."""
+    app = create_app(storage)
+    mac = "AA:BB:CC:DD:EE:04"
+
+    await storage.register_sensor_device(mac)
+    await storage.update_sensor_device(
+        mac,
+        {
+            "state": "needs_zero",
+            "line_name": "outhaul",
+            "cal_adc_a": 0,
+            "cal_adc_b": 4095,
+            "cal_distance_mm": 409.5,
+            "mm_per_adc_count": 0.1,
+        },
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/api/sensor/reading",
+            json={
+                "mac": mac,
+                "raw_adc": 2048,
+                "battery_mv": 3900,
+                "rssi": -50,
+                "button_pressed": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "zeroing"
+
+    # Verify device transitioned
+    device = await storage.get_sensor_device(mac)
+    assert device is not None
+    assert device.state == DeviceState.READY
+    assert device.zero_offset_adc == 2048
+
+
+@pytest.mark.asyncio
+async def test_sensor_admin_update_transitions_state(storage: Storage) -> None:
+    """Assigning line_name transitions unregistered → uncalibrated."""
+    mac = "AA:BB:CC:DD:EE:05"
+    await storage.register_sensor_device(mac)
+
+    await storage.update_sensor_device(mac, {"line_name": "vang", "state": "uncalibrated"})
+
+    device = await storage.get_sensor_device(mac)
+    assert device is not None
+    assert device.state == DeviceState.UNCALIBRATED
+    assert device.line_name == "vang"
+
+
+# ---------------------------------------------------------------------------
+# Storage method tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_storage_sensor_device_lifecycle(storage: Storage) -> None:
+    """Register, update, list, and delete a sensor device."""
+    mac = "AA:BB:CC:DD:EE:10"
+
+    # Register
+    await storage.register_sensor_device(mac)
+    device = await storage.get_sensor_device(mac)
+    assert device is not None
+    assert device.state == DeviceState.UNREGISTERED
+
+    # Update
+    await storage.update_sensor_device(mac, {"line_name": "backstay", "state": "uncalibrated"})
+    device = await storage.get_sensor_device(mac)
+    assert device is not None
+    assert device.line_name == "backstay"
+    assert device.state == DeviceState.UNCALIBRATED
+
+    # List
+    devices = await storage.list_sensor_devices()
+    assert len(devices) == 1
+    assert devices[0].mac == mac
+
+    # Delete
+    await storage.delete_sensor_device(mac)
+    device = await storage.get_sensor_device(mac)
+    assert device is None
+
+
+@pytest.mark.asyncio
+async def test_storage_sensor_readings(storage: Storage) -> None:
+    """Store and retrieve sensor readings."""
+    mac = "AA:BB:CC:DD:EE:11"
+
+    await storage.register_sensor_device(mac)
+
+    # Start a race for session_id
+    race = await storage.start_race(
+        event="Test",
+        start_utc=datetime(2026, 4, 6, 18, 0, 0, tzinfo=UTC),
+        date_str="2026-04-06",
+        race_num=1,
+        name="2026-04-06 Test 1",
+    )
+
+    # Store readings
+    await storage.store_sensor_reading(
+        session_id=race.id,
+        mac=mac,
+        timestamp_utc="2026-04-06T18:00:01+00:00",
+        raw_adc=1500,
+        position_mm=50.0,
+        battery_mv=3850,
+    )
+    await storage.store_sensor_reading(
+        session_id=race.id,
+        mac=mac,
+        timestamp_utc="2026-04-06T18:00:06+00:00",
+        raw_adc=1600,
+        position_mm=60.0,
+        battery_mv=3840,
+    )
+
+    # Get last reading
+    last_mm = await storage.get_last_sensor_reading_mm(mac, race.id)
+    assert last_mm == pytest.approx(60.0)
+
+    # Get all readings
+    readings = await storage.get_sensor_readings_for_session(race.id, mac)
+    assert len(readings) == 2
+
+    # Get all readings without mac filter
+    all_readings = await storage.get_sensor_readings_for_session(race.id)
+    assert len(all_readings) == 2

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -59,6 +59,7 @@ def _device(
         last_seen_at=None,
         last_battery_mv=None,
         last_rssi=None,
+        last_raw_adc=None,
         created_at="2026-04-06T09:00:00+00:00",
     )
 
@@ -187,6 +188,7 @@ class TestProcessReadingUncalibrated:
             last_seen_at=None,
             last_battery_mv=None,
             last_rssi=None,
+            last_raw_adc=None,
             created_at="2026-04-06T09:00:00+00:00",
         )
         resp, reading, updates = process_reading(
@@ -219,6 +221,7 @@ class TestProcessReadingUncalibrated:
             last_seen_at=None,
             last_battery_mv=None,
             last_rssi=None,
+            last_raw_adc=None,
             created_at="2026-04-06T09:00:00+00:00",
         )
         resp, reading, updates = process_reading(


### PR DESCRIPTION
## Summary

- Add ESP32 string potentiometer sensor support for tracking control line positions (backstay, halyards, cunningham, outhaul, etc.)
- New `sensors.py` module with device state machine, ADC→mm conversion, calibration math, and threshold-based noise suppression
- `POST /api/sensor/reading` endpoint (unauthenticated, rate-limited) for ESP32 check-ins, plus admin CRUD endpoints for device management
- Schema v57 with `sensor_devices` and `sensor_readings` tables
- 33 tests covering MAC validation, calibration math, all state transitions, API integration, and storage methods

Closes #432

## Architecture

**ESP32 (dumb sensor):** reads ADC + button state, posts to HelmLog
**HelmLog (brain):** device registration, calibration workflow, zeroing, ADC→mm conversion, session-aware storage

Device lifecycle: `unregistered → uncalibrated → needs_zero → ready ⇄ active`

Readings are only stored during active sessions, with threshold-based noise suppression to avoid storing redundant data.

## Files changed

| File | Change |
|---|---|
| `src/helmlog/sensors.py` | **New** — dataclasses, state machine, conversion logic |
| `src/helmlog/routes/sensors.py` | **New** — API endpoints |
| `src/helmlog/storage.py` | Schema v57 migration + sensor CRUD methods |
| `src/helmlog/web.py` | Wire sensors router + public path for `/api/sensor/` |
| `tests/test_sensors.py` | 33 tests |

## Test plan

- [x] All 33 sensor tests pass
- [x] Full test suite (306 tests) passes
- [x] Ruff lint clean
- [x] Mypy type-check clean
- [ ] Manual test with ESP32 sensor on Pi (post-merge)

🤖 Generated with [Claude Code](https://claude.ai/code)