### PR TITLE
fix: SK auth fails when helmlog runs with different HOME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ SK_PORT=3000
 # SK_TOKEN=                    # pre-existing JWT token (takes priority)
 # SK_USERNAME=admin            # auto-login credentials
 # SK_PASSWORD=
-# Falls back to reading ~/.signalk-admin-pass.txt if no env vars set
+# SK_PASSWORD_FILE=             # absolute path to password file (overrides ~/.signalk-admin-pass.txt)
+# Falls back to reading ~/.signalk-admin-pass.txt if no env/file vars set
 # Rudder angle storage rate (Hz) — ESP32 publishes at 10 Hz; default stores at 2 Hz
 # RUDDER_STORAGE_HZ=2
 # Audio recording (Gordik 2T1R or any USB Audio Class device)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -571,7 +571,7 @@ console.log(JSON.stringify(data, null, 2));
     info "Username: admin"
     info "Password: ${SK_ADMIN_PASS}"
     info "Password also saved to ~/.signalk-admin-pass.txt (chmod 600)"
-    unset SK_ADMIN_PASS
+    # Keep SK_ADMIN_PASS for .env injection below; unset after that.
 else
     info "~/.signalk/security.json already exists — skipping."
     info "Password is in ~/.signalk-admin-pass.txt (if this setup.sh created it)."
@@ -618,6 +618,19 @@ if [[ -n "$INFLUX_TOKEN" && "$INFLUX_TOKEN" != "REPLACE_WITH_INFLUX_TOKEN" ]]; t
         sed -i "s|^# INFLUX_BUCKET=.*|INFLUX_BUCKET=signalk|" "$ENV_FILE"
         info "InfluxDB connection configured in .env"
     fi
+fi
+
+# Populate Signal K credentials if we just created the admin account.
+# The helmlog service runs as a dedicated user with a different HOME, so it
+# cannot find ~/.signalk-admin-pass.txt.  Writing credentials into .env
+# (loaded via EnvironmentFile) ensures the service can authenticate.
+if [[ -n "${SK_ADMIN_PASS:-}" ]]; then
+    if grep -q '^# SK_USERNAME=' "$ENV_FILE" 2>/dev/null; then
+        sed -i "s|^# SK_USERNAME=.*|SK_USERNAME=admin|" "$ENV_FILE"
+        sed -i "s|^# SK_PASSWORD=.*|SK_PASSWORD=${SK_ADMIN_PASS}|" "$ENV_FILE"
+        info "Signal K credentials configured in .env"
+    fi
+    unset SK_ADMIN_PASS
 fi
 
 # Restrict .env so only weaties (and root via systemd EnvironmentFile) can read it

--- a/src/helmlog/sk_reader.py
+++ b/src/helmlog/sk_reader.py
@@ -52,7 +52,8 @@ class SKReaderConfig:
     """Configuration for the Signal K WebSocket reader.
 
     Values fall back to environment variables SK_HOST / SK_PORT if not set.
-    Auth waterfall: SK_TOKEN → SK_USERNAME/SK_PASSWORD → ~/.signalk-admin-pass.txt.
+    Auth waterfall: SK_TOKEN → SK_USERNAME/SK_PASSWORD →
+    SK_PASSWORD_FILE → ~/.signalk-admin-pass.txt.
     """
 
     host: str = field(default_factory=lambda: os.environ.get("SK_HOST", "localhost"))
@@ -61,6 +62,7 @@ class SKReaderConfig:
     token: str | None = field(default_factory=lambda: os.environ.get("SK_TOKEN"))
     username: str | None = field(default_factory=lambda: os.environ.get("SK_USERNAME"))
     password: str | None = field(default_factory=lambda: os.environ.get("SK_PASSWORD"))
+    password_file: str | None = field(default_factory=lambda: os.environ.get("SK_PASSWORD_FILE"))
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +300,11 @@ class SKReader:
         username = config.username
         password = config.password
         if not username or not password:
-            pass_file = Path.home() / ".signalk-admin-pass.txt"
+            # SK_PASSWORD_FILE overrides the default Path.home() lookup
+            if config.password_file:
+                pass_file = Path(config.password_file)
+            else:
+                pass_file = Path.home() / ".signalk-admin-pass.txt"
             try:
                 password = pass_file.read_text().strip()
                 username = "admin"

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -586,6 +586,42 @@ class TestTokenResolution:
         token = await reader._resolve_token()
         assert token is None
 
+    async def test_password_file_env_overrides_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SK_PASSWORD_FILE env var overrides Path.home() lookup."""
+        # Put password file in a non-home location
+        pass_file = tmp_path / "custom" / ".signalk-admin-pass.txt"
+        pass_file.parent.mkdir()
+        pass_file.write_text("custom-password\n")
+        monkeypatch.setenv("SK_PASSWORD_FILE", str(pass_file))
+
+        # Point Path.home() somewhere without the file — should not matter
+        empty_home = tmp_path / "empty-home"
+        empty_home.mkdir()
+        monkeypatch.setattr("helmlog.sk_reader.Path.home", staticmethod(lambda: empty_home))
+
+        cfg = SKReaderConfig()
+        assert cfg.password_file == str(pass_file)
+        reader = SKReader(cfg)
+
+        async def mock_post(self: httpx.AsyncClient, url: str, **kwargs: object) -> httpx.Response:
+            body = kwargs.get("json", {})
+            assert body.get("password") == "custom-password"  # type: ignore[union-attr]
+            return httpx.Response(200, json={"token": "jwt-custom"}, request=_FAKE_REQUEST)
+
+        with patch.object(httpx.AsyncClient, "post", mock_post):
+            token = await reader._resolve_token()
+        assert token == "jwt-custom"
+
+    async def test_password_file_default_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without SK_PASSWORD_FILE env var, password_file defaults to None."""
+        monkeypatch.delenv("SK_PASSWORD_FILE", raising=False)
+        cfg = SKReaderConfig()
+        assert cfg.password_file is None
+
 
 # ---------------------------------------------------------------------------
 # TestAuthPlumbing — token passed to HTTP and WebSocket connections


### PR DESCRIPTION
## Summary
- The helmlog systemd service runs as `User=helmlog` with `HOME=/var/cache/helmlog`, but `sk_reader.py` uses `Path.home()` to find `~/.signalk-admin-pass.txt` — which resolves to the wrong directory, causing a 401 auth loop and no instrument data
- Added `SK_PASSWORD_FILE` env var to `SKReaderConfig` for explicit password file path override
- `setup.sh` now writes `SK_USERNAME`/`SK_PASSWORD` directly into `.env` when creating the SK admin account, so the service authenticates via `EnvironmentFile` regardless of HOME
- Also patched the live Pi's `.env` and restarted — data is flowing again

Fixes #435

## Test plan
- [x] Existing auth waterfall tests pass (8 tests)
- [x] New test: `SK_PASSWORD_FILE` env var overrides `Path.home()` lookup
- [x] New test: `password_file` defaults to `None` without env var
- [x] Verified on corvopi-live: `SK: authenticated as 'admin'`, WebSocket connected, no more crash loop
- [ ] Run `setup.sh` on a fresh Pi to verify `.env` gets `SK_USERNAME`/`SK_PASSWORD` populated

🤖 Generated with [Claude Code](https://claude.ai/code)