### PR TITLE
fix: raise nginx body size limit for photo uploads

### DIFF
--- a/scripts/nginx/helmlog.conf
+++ b/scripts/nginx/helmlog.conf
@@ -25,6 +25,9 @@ server {
     listen [::]:80 default_server;
     server_name _;
 
+    # Allow photo uploads up to 20 MB (nginx default is 1 MB)
+    client_max_body_size 20m;
+
     # helmlog — root path
     location / {
         proxy_pass http://helmlog;

--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -1344,7 +1344,14 @@ async function _savePhotoNote(sessionId) {
   if (!input.files || !input.files[0]) return;
   const fd = new FormData();
   fd.append('file', input.files[0]);
-  await fetch('/api/sessions/' + sessionId + '/notes/photo', {method: 'POST', body: fd});
+  const resp = await fetch('/api/sessions/' + sessionId + '/notes/photo', {method: 'POST', body: fd});
+  if (!resp.ok) {
+    const mb = (input.files[0].size / 1048576).toFixed(1);
+    alert(resp.status === 413
+      ? 'Photo too large (' + mb + ' MB). Maximum upload size is 20 MB.'
+      : 'Photo upload failed (HTTP ' + resp.status + '). Please try again.');
+    return;
+  }
   input.value = '';
   document.getElementById('photo-preview').innerHTML = '';
   _closeNotePanel(sessionId);


### PR DESCRIPTION
## Summary

- nginx's default `client_max_body_size` is 1MB, but iPhone photos are typically 2–5MB. All photo uploads were silently rejected with HTTP 413.
- The JS `_savePhotoNote()` had no error handling — the UI closed the note panel as if the upload succeeded, giving no indication of failure.
- Add `client_max_body_size 20m` to the nginx server block
- Add error handling in `_savePhotoNote()` to alert the user on failure (with a specific message for 413)

**Root cause evidence** — nginx error log on corvopi-live showed 8 rejected uploads during racing on 2026-04-08:
```
client intended to send too large body: 3757598 bytes, ... "POST /api/sessions/16/notes/photo"
client intended to send too large body: 4117038 bytes, ... "POST /api/sessions/17/notes/photo"
...
```

Fixes #440

## Test plan

- [ ] Deploy to Pi (`deploy.sh` copies nginx config and reloads)
- [ ] Upload a photo from iPhone during an active session — verify it appears in notes
- [ ] Verify the alert appears if a photo exceeds 20MB (or if the server is unreachable)

🤖 Generated with [Claude Code](https://claude.ai/code)