### PR TITLE
fix: request diarization when offloading to remote worker

### DIFF
--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -90,7 +90,10 @@ async def api_transcribe(
     from helmlog.transcribe import transcribe_session
 
     t_url = await get_effective_setting(storage, "TRANSCRIBE_URL")
-    diarize = bool(os.environ.get("HF_TOKEN"))
+    # When offloading to a remote worker, always request diarization —
+    # the worker has its own HF_TOKEN and decides locally.  Only gate on
+    # the Pi's HF_TOKEN when running the local fallback path.
+    diarize = True if t_url else bool(os.environ.get("HF_TOKEN"))
     asyncio.create_task(
         transcribe_session(
             storage,

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -614,9 +614,7 @@ class TestTokenResolution:
             token = await reader._resolve_token()
         assert token == "jwt-custom"
 
-    async def test_password_file_default_is_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_password_file_default_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without SK_PASSWORD_FILE env var, password_file defaults to None."""
         monkeypatch.delenv("SK_PASSWORD_FILE", raising=False)
         cfg = SKReaderConfig()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2647,6 +2647,40 @@ async def test_create_transcript_job_202(storage: Storage, tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_transcribe_requests_diarize_when_remote(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When TRANSCRIBE_URL is set, diarize=True even without local HF_TOKEN."""
+    from unittest.mock import AsyncMock, patch
+
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    session_id = await _create_audio_session(storage, tmp_path)
+    app = create_app(storage)
+
+    # Stub get_effective_setting to return a remote URL for TRANSCRIBE_URL
+    async def _fake_setting(st: object, key: str, default: str = "") -> str:
+        return "http://fake-mac:8321" if key == "TRANSCRIBE_URL" else default
+
+    mock_transcribe = AsyncMock()
+    with (
+        patch("helmlog.transcribe.transcribe_session", mock_transcribe),
+        patch("helmlog.storage.get_effective_setting", side_effect=_fake_setting),
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/audio/{session_id}/transcribe")
+        assert resp.status_code == 202
+
+        # Verify transcribe_session was called with diarize=True
+        mock_transcribe.assert_called_once()
+        _, kwargs = mock_transcribe.call_args
+        assert kwargs["diarize"] is True, (
+            "Expected diarize=True when TRANSCRIBE_URL is set (even without local HF_TOKEN)"
+        )
+
+
+@pytest.mark.asyncio
 async def test_transcript_done(storage: Storage, tmp_path: Path) -> None:
     """After transcription completes, GET returns {status:'done', text:...}."""
     from unittest.mock import patch


### PR DESCRIPTION
## Summary

- The transcribe endpoint (`POST /api/audio/{id}/transcribe`) decided `diarize` based on the Pi's local `HF_TOKEN` env var (line 93 of `routes/audio.py`)
- When `TRANSCRIBE_URL` is set (remote offload), the Pi doesn't need `HF_TOKEN` — the Mac worker has its own token and pyannote
- The Pi was sending `diarize=false` to the worker, which dutifully skipped diarization
- Fix: when `TRANSCRIBE_URL` is configured, always pass `diarize=True` and let the worker decide

**Evidence** from worker log:
```
Transcribing: audio.wav (201.6 MB) model=base diarize=False
```

## Test plan

- [x] New test: `test_transcribe_requests_diarize_when_remote` — verifies `diarize=True` when `TRANSCRIBE_URL` is set and `HF_TOKEN` is absent
- [x] All existing transcription tests pass
- [ ] Trigger transcription from web UI on corvopi-live — verify diarized segments appear

🤖 Generated with [Claude Code](https://claude.ai/code)