### PR TITLE
feat: diarized transcript playback, crew ID, and voice learning

### DIFF
--- a/docs/ideation-log.md
+++ b/docs/ideation-log.md
@@ -988,7 +988,8 @@ the opposite of performative broadcasting.
 
 - **Date captured:** 2026-03-14
 - **Origin:** Conversation about keeping user feedback in context with what they're seeing in the app
-- **Status:** `raw`
+- **Status:** `promoted`
+- **Promoted to:** #369
 - **Related:** GitHub Issues, `web.py`, `auth.py`
 
 **Description:**

--- a/scripts/transcribe_worker.py
+++ b/scripts/transcribe_worker.py
@@ -55,7 +55,6 @@ async def transcribe(
 
         from helmlog.transcribe import (
             _pyannote_available,
-            _run_whisper,
             _run_with_diarization,
         )
 

--- a/scripts/transcribe_worker.py
+++ b/scripts/transcribe_worker.py
@@ -59,7 +59,17 @@ async def transcribe(
             _run_with_diarization,
         )
 
-        use_diarize = want_diarize and bool(os.environ.get("HF_TOKEN")) and _pyannote_available()
+        has_token = bool(os.environ.get("HF_TOKEN"))
+        has_pyannote = _pyannote_available()
+        use_diarize = want_diarize and has_token and has_pyannote
+
+        if want_diarize and not use_diarize:
+            reasons = []
+            if not has_token:
+                reasons.append("HF_TOKEN not set")
+            if not has_pyannote:
+                reasons.append("pyannote.audio not installed")
+            logger.warning("Diarization requested but unavailable: {}", ", ".join(reasons))
 
         if use_diarize:
             text, segments_json_str = _run_with_diarization(
@@ -67,11 +77,21 @@ async def transcribe(
             )
             segments: list[dict[str, Any]] = json.loads(segments_json_str)
         else:
-            text = _run_whisper(file_path=tmp_path, model_size=model_size)
-            segments = [{"start": 0.0, "end": 0.0, "text": text}]
+            from helmlog.transcribe import _run_whisper_segments
 
-        logger.info("Done: {} chars, {} segments", len(text), len(segments))
-        return JSONResponse({"text": text, "segments": segments})
+            raw_segs = _run_whisper_segments(file_path=tmp_path, model_size=model_size)
+            text = " ".join(t for _, _, t in raw_segs).strip()
+            segments = [{"start": s, "end": e, "text": t} for s, e, t in raw_segs]
+
+        logger.info(
+            "Done: {} chars, {} segments, diarized={}",
+            len(text), len(segments), use_diarize,
+        )
+        return JSONResponse({
+            "text": text,
+            "segments": segments,
+            "diarized": use_diarize,
+        })
     finally:
         os.unlink(tmp_path)
 

--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -126,6 +126,9 @@ async def api_get_transcript(
     del t["segments_json"]
     # Remove internal anon map from response
     t.pop("speaker_anon_map", None)
+    # Expose speaker_map for UI (crew labels, auto-match info)
+    raw_map = t.pop("speaker_map", None)
+    t["speaker_map"] = _json.loads(raw_map) if raw_map else {}
     return JSONResponse(t)
 
 
@@ -145,6 +148,48 @@ async def api_delete_audio(
         await asyncio.to_thread(p.unlink)
         logger.info("Deleted audio file: {}", p)
     await audit(request, "audio.delete", detail=str(session_id), user=_user)
+
+
+@router.post("/api/audio/{session_id}/transcript/assign-speaker", status_code=200)
+@limiter.limit("30/minute")
+async def api_assign_speaker(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> JSONResponse:
+    """Assign a speaker label to a crew member in a diarized transcript."""
+    storage = get_storage(request)
+    body = await request.json()
+    speaker_label = (body.get("speaker_label") or "").strip()
+    user_id = body.get("user_id")
+    if not speaker_label:
+        raise HTTPException(status_code=422, detail="speaker_label is required")
+    if user_id is None:
+        raise HTTPException(status_code=422, detail="user_id is required")
+    t = await storage.get_transcript(session_id)
+    if t is None:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    # Look up the user name
+    db = storage._conn()
+    cur = await db.execute("SELECT name FROM users WHERE id = ?", (user_id,))
+    row = await cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    name = row["name"] or f"User {user_id}"
+    found = await storage.assign_speaker_crew(t["id"], speaker_label, user_id, name)
+    if not found:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    await audit(
+        request,
+        "transcript.assign_speaker",
+        detail=f"session={session_id} speaker={speaker_label} user={user_id}",
+        user=_user,
+    )
+    # Trigger voice profile build check in background (non-blocking)
+    from helmlog.transcribe import maybe_build_voice_profile
+
+    asyncio.create_task(maybe_build_voice_profile(storage, user_id))
+    return JSONResponse({"speaker_label": speaker_label, "user_id": user_id, "name": name})
 
 
 @router.post("/api/audio/{session_id}/transcript/anonymize-speaker", status_code=200)

--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -90,7 +90,10 @@ async def api_transcribe(
     from helmlog.transcribe import transcribe_session
 
     t_url = await get_effective_setting(storage, "TRANSCRIBE_URL")
-    diarize = bool(os.environ.get("HF_TOKEN"))
+    # When offloading to a remote worker, always request diarization —
+    # the worker has its own HF_TOKEN and decides locally.  Only gate on
+    # the Pi's HF_TOKEN when running the local fallback path.
+    diarize = True if t_url else bool(os.environ.get("HF_TOKEN"))
     asyncio.create_task(
         transcribe_session(
             storage,
@@ -131,7 +134,10 @@ async def api_retranscribe(
     from helmlog.transcribe import transcribe_session
 
     t_url = await get_effective_setting(storage, "TRANSCRIBE_URL")
-    diarize = bool(os.environ.get("HF_TOKEN"))
+    # When offloading to a remote worker, always request diarization —
+    # the worker has its own HF_TOKEN and decides locally.  Only gate on
+    # the Pi's HF_TOKEN when running the local fallback path.
+    diarize = True if t_url else bool(os.environ.get("HF_TOKEN"))
     asyncio.create_task(
         transcribe_session(
             storage,

--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -105,6 +105,47 @@ async def api_transcribe(
     return JSONResponse({"status": "accepted", "transcript_id": transcript_id}, status_code=202)
 
 
+@router.post("/api/audio/{session_id}/retranscribe", status_code=202)
+@limiter.limit("5/minute")
+async def api_retranscribe(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> JSONResponse:
+    """Delete existing transcript and retranscribe with current settings.
+
+    Useful when a transcript was created without diarization and needs to be
+    redone with speaker identification enabled.
+    """
+    storage = get_storage(request)
+    row = await storage.get_audio_session_row(session_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Audio session not found")
+    # Delete the existing transcript (and any linked extraction runs)
+    await storage.delete_transcript(session_id)
+    # Create a new job
+    model = os.environ.get("WHISPER_MODEL", "base")
+    transcript_id = await storage.create_transcript_job(session_id, model)
+
+    from helmlog.storage import get_effective_setting
+    from helmlog.transcribe import transcribe_session
+
+    t_url = await get_effective_setting(storage, "TRANSCRIBE_URL")
+    diarize = bool(os.environ.get("HF_TOKEN"))
+    asyncio.create_task(
+        transcribe_session(
+            storage,
+            session_id,
+            transcript_id,
+            model_size=model,
+            diarize=diarize,
+            transcribe_url=t_url,
+        )
+    )
+    await audit(request, "transcribe.retranscribe", detail=str(session_id), user=_user)
+    return JSONResponse({"status": "accepted", "transcript_id": transcript_id}, status_code=202)
+
+
 @router.get("/api/audio/{session_id}/transcript")
 async def api_get_transcript(
     request: Request,

--- a/src/helmlog/routes/crew.py
+++ b/src/helmlog/routes/crew.py
@@ -346,12 +346,19 @@ async def api_set_consent(
     storage = get_storage(request)
     body = await request.json()
     consent_type = (body.get("consent_type") or "").strip()
-    if consent_type not in ("audio", "video", "name", "photo", "biometric"):
+    valid = ("audio", "video", "name", "photo", "biometric", "voice_profile")
+    if consent_type not in valid:
         raise HTTPException(
-            status_code=422, detail="consent_type must be audio/video/name/photo/biometric"
+            status_code=422,
+            detail=f"consent_type must be one of: {', '.join(valid)}",
         )
     granted = bool(body.get("granted", True))
-    row_id = await storage.set_crew_consent(user_id, consent_type, granted)
+    # Revoking voice_profile consent triggers hard delete of biometric data
+    if consent_type == "voice_profile" and not granted:
+        await storage.revoke_voice_profile_consent(user_id)
+    else:
+        await storage.set_crew_consent(user_id, consent_type, granted)
+    row_id = 0  # consent id not critical for response
     action = "consent.grant" if granted else "consent.revoke"
     await audit(request, action, detail=f"user={user_id}/{consent_type}", user=_user)
     return JSONResponse(
@@ -362,6 +369,20 @@ async def api_set_consent(
             "granted": granted,
         }
     )
+
+
+@router.delete("/api/crew/{user_id:int}/voice-profile", status_code=204)
+async def api_delete_voice_profile(
+    request: Request,
+    user_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> None:
+    """Delete a crew member's voice profile."""
+    storage = get_storage(request)
+    deleted = await storage.delete_voice_profile(user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Voice profile not found")
+    await audit(request, "voice_profile.delete", detail=f"user={user_id}", user=_user)
 
 
 @router.post("/api/crew/{user_id:int}/anonymize", status_code=200)

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -789,9 +789,10 @@ async function _loadTranscript(sessionId, audioSessionId, el) {
     ).join('');
     el.innerHTML = '<div id="' + uid + '" style="max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + html + '</div>';
   } else {
-    // legacy: plain text fallback
+    // legacy: plain text fallback — offer retranscribe with diarization
     const text = t.text ? t.text.replace(/</g,'&lt;') : '(empty)';
-    el.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:200px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>';
+    el.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:200px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>'
+      + '<div style="margin-top:8px"><button class="btn-export" style="font-size:.75rem" onclick="retranscribeHistory(' + audioSessionId + ',' + sessionId + ')" title="Re-run with speaker diarization">&#8635; Retranscribe with diarization</button></div>';
   }
 }
 
@@ -892,6 +893,14 @@ async function assignHistorySpeaker(speakerLabel, userId, audioSessionId) {
 async function startTranscript(sessionId, audioSessionId) {
   const r = await fetch('/api/audio/' + audioSessionId + '/transcribe', {method: 'POST'});
   if (!r.ok) { alert('Failed to start transcription'); return; }
+  const el = document.getElementById('hist-transcript-' + sessionId);
+  await _loadTranscript(sessionId, audioSessionId, el);
+}
+
+async function retranscribeHistory(audioSessionId, sessionId) {
+  if (!confirm('Re-run transcription with diarization? The existing transcript will be replaced.')) return;
+  const r = await fetch('/api/audio/' + audioSessionId + '/retranscribe', {method: 'POST'});
+  if (!r.ok) { alert('Failed to start retranscription'); return; }
   const el = document.getElementById('hist-transcript-' + sessionId);
   await _loadTranscript(sessionId, audioSessionId, el);
 }

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -755,8 +755,10 @@ async function _loadTranscript(sessionId, audioSessionId, el) {
     return;
   }
   const speakerMap = t.speaker_map || {};
-  // status === 'done'
-  if (t.segments && t.segments.length > 0) {
+  // status === 'done' — check for diarized (speaker-labeled) segments
+  const hasDiarizedSegments = t.segments && t.segments.length > 0
+    && t.segments.some(s => s.speaker);
+  if (hasDiarizedSegments) {
     // merge consecutive same-speaker segments for readability
     const blocks = [];
     for (const seg of t.segments) {

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -841,7 +841,7 @@ async function openHistorySpeakerPicker(speakerLabel, audioSessionId) {
   try {
     const r = await fetch('/api/crew/users');
     if (!r.ok) return;
-    users = await r.json();
+    users = (await r.json()).users || [];
   } catch { return; }
 
   const old = document.getElementById('speaker-picker');

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -754,6 +754,7 @@ async function _loadTranscript(sessionId, audioSessionId, el) {
     el.innerHTML = '<span style="color:var(--danger);font-size:.8rem">Error: ' + (t.error_msg || 'unknown') + '</span>';
     return;
   }
+  const speakerMap = t.speaker_map || {};
   // status === 'done'
   if (t.segments && t.segments.length > 0) {
     // merge consecutive same-speaker segments for readability
@@ -764,23 +765,128 @@ async function _loadTranscript(sessionId, audioSessionId, el) {
         last.text += ' ' + seg.text; last.end = seg.end;
       } else { blocks.push({...seg}); }
     }
+    const rawSpeakers = [...new Set(t.segments.map(s => s.speaker))];
     const speakers = [...new Set(blocks.map(b => b.speaker))];
     const palette = [cssVar('--accent'), cssVar('--success'), cssVar('--warning'), cssVar('--danger'), '#c4b5fd', '#f9a8d4'];
-    const color = s => palette[speakers.indexOf(s) % palette.length];
+    const color = s => palette[rawSpeakers.indexOf(s) >= 0 ? rawSpeakers.indexOf(s) % palette.length : speakers.indexOf(s) % palette.length];
     const fmt = s => { const m=Math.floor(s/60); return m+':'+String(Math.floor(s%60)).padStart(2,'0'); };
-    const html = blocks.map(b =>
-      `<div style="margin-bottom:8px">
-         <span style="color:${color(b.speaker)};font-weight:600;font-size:.75rem">${b.speaker}</span>
+    const displayName = (raw) => {
+      const entry = speakerMap[raw];
+      if (entry && entry.name) {
+        if (entry.type === 'auto' && entry.confidence != null) return entry.name + ' (' + Math.round(entry.confidence * 100) + '%)';
+        return entry.name;
+      }
+      return raw;
+    };
+    const escH = s => s.replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    const uid = 'hist-tseg-' + sessionId;
+    const html = blocks.map((b, i) =>
+      `<div class="hist-transcript-seg" data-idx="${i}" style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;transition:background .15s" onclick="playHistorySegment(${audioSessionId},${b.start},${b.end},'${uid}',${i})">
+         <span class="hist-transcript-speaker" data-speaker="${escH(b.speaker)}" style="color:${color(b.speaker)};font-weight:600;font-size:.75rem;cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" onclick="event.stopPropagation();openHistorySpeakerPicker('${escH(b.speaker)}',${audioSessionId})" title="Click to assign crew">${escH(displayName(b.speaker))}</span>
          <span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">[${fmt(b.start)}]</span>
          <div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">${b.text.trim().replace(/</g,'&lt;')}</div>
        </div>`
     ).join('');
-    el.innerHTML = '<div style="max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + html + '</div>';
+    el.innerHTML = '<div id="' + uid + '" style="max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + html + '</div>';
   } else {
     // legacy: plain text fallback
     const text = t.text ? t.text.replace(/</g,'&lt;') : '(empty)';
     el.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:200px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>';
   }
+}
+
+// History page: segment playback via a shared audio element
+let _histAudio = null;
+let _histAudioTimer = null;
+
+function playHistorySegment(audioSessionId, start, end, containerId, idx) {
+  if (!_histAudio || _histAudio.dataset.sid !== String(audioSessionId)) {
+    if (_histAudio) { _histAudio.pause(); _histAudio.remove(); }
+    _histAudio = document.createElement('audio');
+    _histAudio.src = '/api/audio/' + audioSessionId + '/stream';
+    _histAudio.preload = 'auto';
+    _histAudio.dataset.sid = String(audioSessionId);
+  }
+  if (_histAudioTimer) {
+    _histAudio.removeEventListener('timeupdate', _histAudioTimer);
+    _histAudioTimer = null;
+  }
+  _histAudio.currentTime = start;
+  _histAudio.play();
+  // Highlight active segment
+  const container = document.getElementById(containerId);
+  if (container) {
+    container.querySelectorAll('.hist-transcript-seg').forEach((el, i) => {
+      el.style.background = i === idx ? 'var(--bg-hover, rgba(255,255,255,0.08))' : '';
+    });
+  }
+  _histAudioTimer = function() {
+    if (_histAudio.currentTime >= end) {
+      _histAudio.pause();
+      _histAudio.removeEventListener('timeupdate', _histAudioTimer);
+      _histAudioTimer = null;
+      if (container) {
+        container.querySelectorAll('.hist-transcript-seg').forEach(el => { el.style.background = ''; });
+      }
+    }
+  };
+  _histAudio.addEventListener('timeupdate', _histAudioTimer);
+}
+
+async function openHistorySpeakerPicker(speakerLabel, audioSessionId) {
+  let users;
+  try {
+    const r = await fetch('/api/crew/users');
+    if (!r.ok) return;
+    users = await r.json();
+  } catch { return; }
+
+  const old = document.getElementById('speaker-picker');
+  if (old) old.remove();
+  const oldBd = document.getElementById('speaker-picker-backdrop');
+  if (oldBd) oldBd.remove();
+
+  const picker = document.createElement('div');
+  picker.id = 'speaker-picker';
+  picker.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--bg-primary);border:1px solid var(--border);border-radius:8px;padding:16px;z-index:1000;box-shadow:0 4px 20px rgba(0,0,0,0.3);min-width:200px;max-height:300px;overflow-y:auto';
+
+  const escH = s => s.replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  let html = '<div style="font-weight:600;margin-bottom:8px;font-size:.85rem">Assign ' + escH(speakerLabel) + ' to:</div>';
+  if (!users || !users.length) {
+    html += '<div style="color:var(--text-secondary);font-size:.8rem">No crew members found</div>';
+  } else {
+    for (const u of users) {
+      html += '<div style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" onmouseout="this.style.background=\'\'" onclick="assignHistorySpeaker(\'' + escH(speakerLabel) + '\',' + u.id + ',' + audioSessionId + ')">' + escH(u.name || u.email) + '</div>';
+    }
+  }
+  html += '<div style="text-align:right;margin-top:8px"><button class="btn-export" style="font-size:.75rem" onclick="document.getElementById(\'speaker-picker\').remove();document.getElementById(\'speaker-picker-backdrop\').remove()">Cancel</button></div>';
+  picker.innerHTML = html;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'speaker-picker-backdrop';
+  backdrop.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.4);z-index:999';
+  backdrop.onclick = () => { picker.remove(); backdrop.remove(); };
+  document.body.appendChild(backdrop);
+  document.body.appendChild(picker);
+}
+
+async function assignHistorySpeaker(speakerLabel, userId, audioSessionId) {
+  const r = await fetch('/api/audio/' + audioSessionId + '/transcript/assign-speaker', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({speaker_label: speakerLabel, user_id: userId})
+  });
+  const picker = document.getElementById('speaker-picker');
+  const backdrop = document.getElementById('speaker-picker-backdrop');
+  if (picker) picker.remove();
+  if (backdrop) backdrop.remove();
+
+  if (!r.ok) { alert('Failed to assign speaker'); return; }
+  const data = await r.json();
+  // Update all matching speaker labels
+  document.querySelectorAll('.hist-transcript-speaker[data-speaker="' + speakerLabel + '"]').forEach(el => {
+    el.textContent = data.name;
+  });
 }
 
 async function startTranscript(sessionId, audioSessionId) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -961,7 +961,8 @@ async function loadTranscript() {
     _renderDiarizedTranscript(body, t);
   } else {
     const text = t.text ? esc(t.text) : '(empty)';
-    body.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>';
+    body.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>'
+      + '<div style="margin-top:8px"><button class="btn-export" style="font-size:.75rem" onclick="retranscribe()" title="Re-run transcription with speaker diarization">&#8635; Retranscribe with diarization</button></div>';
   }
 }
 
@@ -1108,6 +1109,13 @@ async function assignSpeaker(speakerLabel, userId) {
 async function startTranscript() {
   const r = await fetch('/api/audio/' + _session.audio_session_id + '/transcribe', {method: 'POST'});
   if (!r.ok) { alert('Failed to start transcription'); return; }
+  loadTranscript();
+}
+
+async function retranscribe() {
+  if (!confirm('Re-run transcription with diarization? The existing transcript will be replaced.')) return;
+  const r = await fetch('/api/audio/' + _session.audio_session_id + '/retranscribe', {method: 'POST'});
+  if (!r.ok) { alert('Failed to start retranscription'); return; }
   loadTranscript();
 }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -268,37 +268,38 @@ function _createPlayer(videoId) {
     _videoSync.player.loadVideoById(videoId);
     return;
   }
-  _videoSync.player = new YT.Player('yt-player', {
-    height: '100%',
-    width: '100%',
-    videoId: videoId,
-    playerVars: {
-      modestbranding: 1,
-      rel: 0,
-      enablejsapi: 1,
-      origin: location.origin,
-    },
+  // Create an iframe MANUALLY with the right `allow` attribute BEFORE loading
+  // the YouTube embed.  Setting `allow` after the iframe loads is too late —
+  // the security context is already established and 360 panning, gyroscope,
+  // and VR controls won't work for spherical videos.
+  const container = document.getElementById('yt-player');
+  if (!container) return;
+  const iframe = document.createElement('iframe');
+  iframe.id = 'yt-player-iframe';
+  iframe.width = '100%';
+  iframe.height = '100%';
+  iframe.frameBorder = '0';
+  iframe.setAttribute(
+    'allow',
+    'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen; xr-spatial-tracking'
+  );
+  iframe.setAttribute('allowfullscreen', '');
+  const params = new URLSearchParams({
+    enablejsapi: '1',
+    modestbranding: '1',
+    rel: '0',
+    origin: location.origin,
+  });
+  iframe.src = 'https://www.youtube.com/embed/' + videoId + '?' + params.toString();
+  container.innerHTML = '';
+  container.appendChild(iframe);
+
+  // Attach the YT.Player API to the existing iframe (not a div).
+  _videoSync.player = new YT.Player('yt-player-iframe', {
     events: {
-      onReady: _onPlayerReady,
       onStateChange: _onPlayerStateChange,
     },
   });
-}
-
-function _onPlayerReady(event) {
-  // Enable 360-video panning + VR controls by adding the right iframe permissions.
-  // YouTube's IFrame API doesn't set these by default, so click-and-drag pan and
-  // gyroscope tilt don't work for spherical (360) videos without this fix.
-  try {
-    const iframe = event.target.getIframe();
-    if (iframe) {
-      iframe.setAttribute(
-        'allow',
-        'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen; xr-spatial-tracking'
-      );
-      iframe.setAttribute('allowfullscreen', '');
-    }
-  } catch (e) { /* non-fatal */ }
 }
 
 function switchVideo(idx) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1085,7 +1085,7 @@ async function openSpeakerPicker(speakerLabel) {
   try {
     const r = await fetch('/api/crew/users');
     if (!r.ok) return;
-    users = await r.json();
+    users = (await r.json()).users || [];
   } catch { return; }
 
   // Remove any existing picker

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -276,18 +276,21 @@ function _createPlayer(videoId) {
   if (!container) return;
   const iframe = document.createElement('iframe');
   iframe.id = 'yt-player-iframe';
-  iframe.width = '100%';
-  iframe.height = '100%';
-  iframe.frameBorder = '0';
+  iframe.style.width = '100%';
+  iframe.style.height = '100%';
+  iframe.style.border = '0';
   iframe.setAttribute(
     'allow',
     'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen; xr-spatial-tracking'
   );
   iframe.setAttribute('allowfullscreen', '');
+  iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+  // Match YouTube's official embed code as closely as possible.
+  // Notably: no modestbranding (deprecated and can interfere with player chrome
+  // that hosts 360 controls), no rel param, just enablejsapi for sync.
   const params = new URLSearchParams({
     enablejsapi: '1',
-    modestbranding: '1',
-    rel: '0',
+    playsinline: '1',
     origin: location.origin,
   });
   iframe.src = 'https://www.youtube.com/embed/' + videoId + '?' + params.toString();

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -15,6 +15,9 @@ let _maneuverMarkers = []; // Leaflet markers for maneuvers
 let _transcriptId = null; // transcript ID for tuning extraction
 let _tuningSegmentAudio = null; // shared <audio> for segment playback
 let _tuningSegmentTimer = null; // timeupdate stop timer
+let _transcriptAudio = null; // shared <audio> for transcript segment playback
+let _transcriptBlocks = []; // merged transcript blocks for highlight tracking
+let _speakerMap = {}; // speaker_map from API (crew assignments)
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -953,31 +956,153 @@ async function loadTranscript() {
     _transcriptId = t.id;
     loadTuningExtractions();
   }
+  _speakerMap = t.speaker_map || {};
   if (t.segments && t.segments.length > 0) {
-    const blocks = [];
-    for (const seg of t.segments) {
-      const last = blocks[blocks.length - 1];
-      if (last && last.speaker === seg.speaker) {
-        last.text += ' ' + seg.text; last.end = seg.end;
-      } else { blocks.push({...seg}); }
-    }
-    const speakers = [...new Set(blocks.map(b => b.speaker))];
-    const palette = [cssVar('--accent'), cssVar('--success'), cssVar('--warning'), cssVar('--danger'), '#c4b5fd', '#f9a8d4'];
-    const color = s => palette[speakers.indexOf(s) % palette.length];
-    const fmt = s => { const m = Math.floor(s / 60); return m + ':' + String(Math.floor(s % 60)).padStart(2, '0'); };
-    body.innerHTML = '<div style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
-      + blocks.map(b =>
-        '<div style="margin-bottom:8px">'
-        + '<span style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem">' + esc(b.speaker) + '</span>'
-        + '<span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">[' + fmt(b.start) + ']</span>'
-        + '<div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">' + esc(b.text.trim()) + '</div>'
-        + '</div>'
-      ).join('')
-      + '</div>';
+    _renderDiarizedTranscript(body, t);
   } else {
     const text = t.text ? esc(t.text) : '(empty)';
     body.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>';
   }
+}
+
+function _renderDiarizedTranscript(body, t) {
+  const blocks = [];
+  for (const seg of t.segments) {
+    const last = blocks[blocks.length - 1];
+    if (last && last.speaker === seg.speaker) {
+      last.text += ' ' + seg.text; last.end = seg.end;
+    } else { blocks.push({...seg}); }
+  }
+  _transcriptBlocks = blocks;
+  const rawSpeakers = [...new Set(t.segments.map(s => s.speaker))];
+  const speakers = [...new Set(blocks.map(b => b.speaker))];
+  const palette = [cssVar('--accent'), cssVar('--success'), cssVar('--warning'), cssVar('--danger'), '#c4b5fd', '#f9a8d4'];
+  const color = s => palette[rawSpeakers.indexOf(s) >= 0 ? rawSpeakers.indexOf(s) % palette.length : speakers.indexOf(s) % palette.length];
+  const fmt = s => { const m = Math.floor(s / 60); return m + ':' + String(Math.floor(s % 60)).padStart(2, '0'); };
+
+  // Display name for a speaker (crew name from speaker_map, or raw label)
+  const displayName = (rawLabel) => {
+    const entry = _speakerMap[rawLabel];
+    if (entry && entry.name) {
+      if (entry.type === 'auto' && entry.confidence != null) {
+        return entry.name + ' (' + Math.round(entry.confidence * 100) + '%)';
+      }
+      return entry.name;
+    }
+    return rawLabel;
+  };
+
+  body.innerHTML = '<div id="transcript-segments" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
+    + blocks.map((b, i) =>
+      '<div class="transcript-seg" data-idx="' + i + '" style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;transition:background .15s" onclick="playTranscriptSegment(' + i + ')">'
+      + '<span class="transcript-speaker" data-speaker="' + esc(b.speaker) + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" onclick="event.stopPropagation();openSpeakerPicker(\'' + esc(b.speaker) + '\')" title="Click to assign crew">' + esc(displayName(b.speaker)) + '</span>'
+      + '<span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">[' + fmt(b.start) + ']</span>'
+      + '<div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">' + esc(b.text.trim()) + '</div>'
+      + '</div>'
+    ).join('')
+    + '</div>';
+
+  // Set up audio tracking for active segment highlighting
+  _setupTranscriptAudioTracking();
+}
+
+function _setupTranscriptAudioTracking() {
+  // Find the main audio element on the page
+  const audioEl = document.querySelector('#audio-body audio');
+  if (!audioEl) return;
+  _transcriptAudio = audioEl;
+  audioEl.addEventListener('timeupdate', _highlightActiveSegment);
+}
+
+function _highlightActiveSegment() {
+  if (!_transcriptAudio || !_transcriptBlocks.length) return;
+  const t = _transcriptAudio.currentTime;
+  const segs = document.querySelectorAll('.transcript-seg');
+  for (let i = 0; i < _transcriptBlocks.length; i++) {
+    const b = _transcriptBlocks[i];
+    const el = segs[i];
+    if (!el) continue;
+    if (t >= b.start && t <= b.end) {
+      el.style.background = 'var(--bg-hover, rgba(255,255,255,0.08))';
+      // Scroll into view if needed
+      const container = document.getElementById('transcript-segments');
+      if (container && (el.offsetTop < container.scrollTop || el.offsetTop + el.offsetHeight > container.scrollTop + container.clientHeight)) {
+        el.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+      }
+    } else {
+      el.style.background = '';
+    }
+  }
+}
+
+function playTranscriptSegment(idx) {
+  const b = _transcriptBlocks[idx];
+  if (!b) return;
+  const audioEl = document.querySelector('#audio-body audio');
+  if (!audioEl) return;
+  _transcriptAudio = audioEl;
+  audioEl.currentTime = b.start;
+  audioEl.play();
+}
+
+async function openSpeakerPicker(speakerLabel) {
+  // Fetch crew list for the picker
+  let users;
+  try {
+    const r = await fetch('/api/crew/users');
+    if (!r.ok) return;
+    users = await r.json();
+  } catch { return; }
+
+  // Remove any existing picker
+  const old = document.getElementById('speaker-picker');
+  if (old) old.remove();
+
+  // Build a simple dropdown picker
+  const picker = document.createElement('div');
+  picker.id = 'speaker-picker';
+  picker.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--bg-primary);border:1px solid var(--border);border-radius:8px;padding:16px;z-index:1000;box-shadow:0 4px 20px rgba(0,0,0,0.3);min-width:200px;max-height:300px;overflow-y:auto';
+
+  let html = '<div style="font-weight:600;margin-bottom:8px;font-size:.85rem">Assign ' + esc(speakerLabel) + ' to:</div>';
+  if (!users || !users.length) {
+    html += '<div style="color:var(--text-secondary);font-size:.8rem">No crew members found</div>';
+  } else {
+    for (const u of users) {
+      html += '<div class="speaker-pick-option" style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" onmouseout="this.style.background=\'\'" onclick="assignSpeaker(\'' + esc(speakerLabel) + '\',' + u.id + ')">' + esc(u.name || u.email) + '</div>';
+    }
+  }
+  html += '<div style="text-align:right;margin-top:8px"><button class="btn-export" style="font-size:.75rem" onclick="document.getElementById(\'speaker-picker\').remove()">Cancel</button></div>';
+  picker.innerHTML = html;
+
+  // Backdrop
+  const backdrop = document.createElement('div');
+  backdrop.id = 'speaker-picker-backdrop';
+  backdrop.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.4);z-index:999';
+  backdrop.onclick = () => { picker.remove(); backdrop.remove(); };
+  document.body.appendChild(backdrop);
+  document.body.appendChild(picker);
+}
+
+async function assignSpeaker(speakerLabel, userId) {
+  const r = await fetch('/api/audio/' + _session.audio_session_id + '/transcript/assign-speaker', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({speaker_label: speakerLabel, user_id: userId})
+  });
+  // Clean up picker
+  const picker = document.getElementById('speaker-picker');
+  const backdrop = document.getElementById('speaker-picker-backdrop');
+  if (picker) picker.remove();
+  if (backdrop) backdrop.remove();
+
+  if (!r.ok) { alert('Failed to assign speaker'); return; }
+  const data = await r.json();
+  // Update speaker_map locally and re-render labels
+  _speakerMap[speakerLabel] = {type: 'crew', user_id: data.user_id, name: data.name};
+  // Update all speaker labels in the transcript
+  document.querySelectorAll('.transcript-speaker[data-speaker="' + speakerLabel + '"]').forEach(el => {
+    el.textContent = data.name;
+  });
 }
 
 async function startTranscript() {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -266,43 +266,52 @@ function onYouTubeIframeAPIReady() {
 function _createPlayer(videoId) {
   if (_videoSync.player) {
     _videoSync.player.loadVideoById(videoId);
+    _updateWatchOnYoutubeLink(videoId);
     return;
   }
-  // Create an iframe MANUALLY with the right `allow` attribute BEFORE loading
-  // the YouTube embed.  Setting `allow` after the iframe loads is too late —
-  // the security context is already established and 360 panning, gyroscope,
-  // and VR controls won't work for spherical videos.
-  const container = document.getElementById('yt-player');
-  if (!container) return;
-  const iframe = document.createElement('iframe');
-  iframe.id = 'yt-player-iframe';
-  iframe.style.width = '100%';
-  iframe.style.height = '100%';
-  iframe.style.border = '0';
-  iframe.setAttribute(
-    'allow',
-    'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen; xr-spatial-tracking'
-  );
-  iframe.setAttribute('allowfullscreen', '');
-  iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
-  // Match YouTube's official embed code as closely as possible.
-  // Notably: no modestbranding (deprecated and can interfere with player chrome
-  // that hosts 360 controls), no rel param, just enablejsapi for sync.
-  const params = new URLSearchParams({
-    enablejsapi: '1',
-    playsinline: '1',
-    origin: location.origin,
-  });
-  iframe.src = 'https://www.youtube.com/embed/' + videoId + '?' + params.toString();
-  container.innerHTML = '';
-  container.appendChild(iframe);
-
-  // Attach the YT.Player API to the existing iframe (not a div).
-  _videoSync.player = new YT.Player('yt-player-iframe', {
+  // Use the standard YT.Player div-based instantiation. The manual iframe
+  // approach broke YouTube's embedder identity verification (Error 153).
+  // 360 video panning is NOT supported in YouTube iframe embeds for
+  // third-party domains regardless of `allow` attributes — it only works on
+  // youtube.com itself and in the YouTube app. We expose a "Watch on YouTube"
+  // link below the player as the workaround for spherical videos.
+  _videoSync.player = new YT.Player('yt-player', {
+    height: '100%',
+    width: '100%',
+    videoId: videoId,
+    playerVars: {
+      modestbranding: 1,
+      rel: 0,
+      enablejsapi: 1,
+      origin: location.origin,
+    },
     events: {
       onStateChange: _onPlayerStateChange,
     },
   });
+  _updateWatchOnYoutubeLink(videoId);
+}
+
+function _updateWatchOnYoutubeLink(videoId) {
+  // Render a "Watch on YouTube" link below the player so 360 / spherical
+  // videos can be opened in YouTube's native viewer for panning controls.
+  let linkBar = document.getElementById('yt-watch-on-youtube');
+  if (!linkBar) {
+    linkBar = document.createElement('div');
+    linkBar.id = 'yt-watch-on-youtube';
+    linkBar.style.cssText = 'margin-top:6px;text-align:right;font-size:.75rem';
+    const container = document.getElementById('video-container');
+    if (container) container.appendChild(linkBar);
+  }
+  // Try to seek to current sync position
+  let t = 0;
+  try {
+    if (_videoSync && _videoSync.player && _videoSync.player.getCurrentTime) {
+      t = Math.floor(_videoSync.player.getCurrentTime() || 0);
+    }
+  } catch (e) { /* ignore */ }
+  const url = 'https://www.youtube.com/watch?v=' + encodeURIComponent(videoId) + (t > 0 ? '&t=' + t + 's' : '');
+  linkBar.innerHTML = '<a href="' + url + '" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none" title="Open in YouTube for 360° panning controls">Watch on YouTube &#8599;</a>';
 }
 
 function switchVideo(idx) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -279,9 +279,26 @@ function _createPlayer(videoId) {
       origin: location.origin,
     },
     events: {
+      onReady: _onPlayerReady,
       onStateChange: _onPlayerStateChange,
     },
   });
+}
+
+function _onPlayerReady(event) {
+  // Enable 360-video panning + VR controls by adding the right iframe permissions.
+  // YouTube's IFrame API doesn't set these by default, so click-and-drag pan and
+  // gyroscope tilt don't work for spherical (360) videos without this fix.
+  try {
+    const iframe = event.target.getIframe();
+    if (iframe) {
+      iframe.setAttribute(
+        'allow',
+        'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen; xr-spatial-tracking'
+      );
+      iframe.setAttribute('allowfullscreen', '');
+    }
+  } catch (e) { /* non-fatal */ }
 }
 
 function switchVideo(idx) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -957,7 +957,10 @@ async function loadTranscript() {
     loadTuningExtractions();
   }
   _speakerMap = t.speaker_map || {};
-  if (t.segments && t.segments.length > 0) {
+  // Check if segments have speaker labels (diarized) vs plain whisper segments
+  const hasDiarizedSegments = t.segments && t.segments.length > 0
+    && t.segments.some(s => s.speaker);
+  if (hasDiarizedSegments) {
     _renderDiarizedTranscript(body, t);
   } else {
     const text = t.text ? esc(t.text) : '(empty)';

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -4245,6 +4245,15 @@ class Storage:
         )
         await db.commit()
 
+    async def delete_transcript(self, audio_session_id: int) -> bool:
+        """Delete the transcript for an audio session. Returns True if found and deleted."""
+        db = self._conn()
+        cur = await db.execute(
+            "DELETE FROM transcripts WHERE audio_session_id = ?", (audio_session_id,)
+        )
+        await db.commit()
+        return (cur.rowcount or 0) > 0
+
     async def get_transcript(self, audio_session_id: int) -> dict[str, Any] | None:
         """Return the transcript row for *audio_session_id*, or None if not found."""
         cur = await self._read_conn().execute(

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -4246,8 +4246,17 @@ class Storage:
         await db.commit()
 
     async def delete_transcript(self, audio_session_id: int) -> bool:
-        """Delete the transcript for an audio session. Returns True if found and deleted."""
+        """Delete the transcript (and linked extraction_runs) for an audio session.
+
+        Returns True if found and deleted.
+        """
         db = self._conn()
+        # Delete extraction_runs first (no ON DELETE CASCADE on FK)
+        await db.execute(
+            "DELETE FROM extraction_runs WHERE transcript_id IN"
+            " (SELECT id FROM transcripts WHERE audio_session_id = ?)",
+            (audio_session_id,),
+        )
         cur = await db.execute(
             "DELETE FROM transcripts WHERE audio_session_id = ?", (audio_session_id,)
         )

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -1274,6 +1274,22 @@ _MIGRATIONS: dict[int, str] = {
             sort_order  INTEGER NOT NULL DEFAULT 0
         );
     """,
+    57: """
+        -- Diarized transcript crew association + voice profiles (#443)
+        ALTER TABLE transcripts ADD COLUMN speaker_map TEXT;
+
+        CREATE TABLE IF NOT EXISTS crew_voice_profiles (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            embedding     BLOB    NOT NULL,
+            segment_count INTEGER NOT NULL DEFAULT 0,
+            session_count INTEGER NOT NULL DEFAULT 0,
+            created_at    TEXT    NOT NULL,
+            updated_at    TEXT    NOT NULL,
+            UNIQUE(user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_crew_voice_profiles_user ON crew_voice_profiles(user_id);
+    """,
 }
 
 
@@ -4233,7 +4249,7 @@ class Storage:
         """Return the transcript row for *audio_session_id*, or None if not found."""
         cur = await self._read_conn().execute(
             "SELECT id, audio_session_id, status, text, error_msg, model,"
-            " created_utc, updated_utc, segments_json"
+            " created_utc, updated_utc, segments_json, speaker_anon_map, speaker_map"
             " FROM transcripts WHERE audio_session_id = ?",
             (audio_session_id,),
         )
@@ -5397,21 +5413,30 @@ class Storage:
         return True
 
     async def get_transcript_with_anon(self, audio_session_id: int) -> dict[str, Any] | None:
-        """Get transcript with speaker anonymization map applied to segments."""
+        """Get transcript with speaker_map and anonymization applied to segments.
+
+        Priority: anonymization (speaker_anon_map) > crew assignment (speaker_map).
+        """
         t = await self.get_transcript(audio_session_id)
         if t is None:
             return None
         anon_map: dict[str, str] = json.loads(t.get("speaker_anon_map") or "{}")
-        if anon_map and t.get("segments_json"):
+        crew_map: dict[str, Any] = json.loads(t.get("speaker_map") or "{}")
+        if (anon_map or crew_map) and t.get("segments_json"):
             segments = json.loads(t["segments_json"])
             for seg in segments:
                 speaker = seg.get("speaker", "")
                 if speaker in anon_map:
+                    # Anonymization takes priority
                     seg["speaker"] = anon_map[speaker]
                     seg["text"] = "[REDACTED]"
+                elif speaker in crew_map:
+                    entry = crew_map[speaker]
+                    if isinstance(entry, dict):
+                        seg["speaker"] = entry.get("name", speaker)
             t["segments_json"] = json.dumps(segments)
-            # Also redact the plain text
-            if t.get("text"):
+            # Also redact the plain text for anonymized speakers
+            if t.get("text") and anon_map:
                 lines = t["text"].split("\n")
                 redacted_lines = []
                 for line in lines:
@@ -5489,6 +5514,133 @@ class Storage:
         await db.commit()
         logger.info("User {} anonymized to {!r}", user_id, replacement)
         return count
+
+    # ------------------------------------------------------------------
+    # Speaker crew assignment (#443)
+    # ------------------------------------------------------------------
+
+    async def assign_speaker_crew(
+        self, transcript_id: int, speaker_label: str, user_id: int, name: str
+    ) -> bool:
+        """Assign a speaker label to a crew member. Returns True if transcript was found."""
+        db = self._conn()
+        cur = await db.execute("SELECT speaker_map FROM transcripts WHERE id = ?", (transcript_id,))
+        row = await cur.fetchone()
+        if row is None:
+            return False
+        existing: dict[str, Any] = json.loads(row["speaker_map"] or "{}")
+        existing[speaker_label] = {"type": "crew", "user_id": user_id, "name": name}
+        await db.execute(
+            "UPDATE transcripts SET speaker_map = ? WHERE id = ?",
+            (json.dumps(existing), transcript_id),
+        )
+        await db.commit()
+        logger.info(
+            "Speaker {} assigned to user {} ({}) in transcript {}",
+            speaker_label,
+            user_id,
+            name,
+            transcript_id,
+        )
+        return True
+
+    async def get_speaker_map(self, transcript_id: int) -> dict[str, Any]:
+        """Return the speaker_map for a transcript (empty dict if none)."""
+        cur = await self._read_conn().execute(
+            "SELECT speaker_map FROM transcripts WHERE id = ?", (transcript_id,)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return {}
+        result: dict[str, Any] = json.loads(row["speaker_map"] or "{}")  # type: ignore[index]
+        return result
+
+    # ------------------------------------------------------------------
+    # Voice profiles (#443)
+    # ------------------------------------------------------------------
+
+    async def upsert_voice_profile(
+        self,
+        user_id: int,
+        embedding: bytes,
+        segment_count: int,
+        session_count: int,
+    ) -> int:
+        """Insert or update a voice profile. Returns the row id."""
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        now = _datetime.now(_UTC).isoformat()
+        db = self._conn()
+        cur = await db.execute(
+            "INSERT INTO crew_voice_profiles"
+            " (user_id, embedding, segment_count, session_count, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(user_id)"
+            " DO UPDATE SET embedding = excluded.embedding,"
+            " segment_count = excluded.segment_count,"
+            " session_count = excluded.session_count,"
+            " updated_at = excluded.updated_at",
+            (user_id, embedding, segment_count, session_count, now, now),
+        )
+        await db.commit()
+        return cur.lastrowid or 0
+
+    async def get_voice_profile(self, user_id: int) -> dict[str, Any] | None:
+        """Return the voice profile for a user, or None."""
+        cur = await self._read_conn().execute(
+            "SELECT id, user_id, embedding, segment_count, session_count,"
+            " created_at, updated_at"
+            " FROM crew_voice_profiles WHERE user_id = ?",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+    async def delete_voice_profile(self, user_id: int) -> bool:
+        """Delete a voice profile. Returns True if found and deleted."""
+        db = self._conn()
+        cur = await db.execute("DELETE FROM crew_voice_profiles WHERE user_id = ?", (user_id,))
+        await db.commit()
+        return (cur.rowcount or 0) > 0
+
+    async def revoke_voice_profile_consent(self, user_id: int) -> None:
+        """Revoke voice_profile consent and hard-delete all related data.
+
+        Deletes: voice profile, all 'auto' speaker_map entries referencing this user.
+        Preserves: manual 'crew' speaker_map entries (crew metadata, not biometric).
+        """
+        db = self._conn()
+        # 1. Delete the voice profile
+        await db.execute("DELETE FROM crew_voice_profiles WHERE user_id = ?", (user_id,))
+        # 2. Remove 'auto' entries from speaker_map in all transcripts
+        cur = await db.execute(
+            "SELECT id, speaker_map FROM transcripts WHERE speaker_map IS NOT NULL"
+        )
+        rows = await cur.fetchall()
+        for row in rows:
+            smap: dict[str, Any] = json.loads(row["speaker_map"] or "{}")
+            changed = False
+            to_remove = []
+            for label, entry in smap.items():
+                if (
+                    isinstance(entry, dict)
+                    and entry.get("type") == "auto"
+                    and entry.get("user_id") == user_id
+                ):
+                    to_remove.append(label)
+                    changed = True
+            for label in to_remove:
+                del smap[label]
+            if changed:
+                await db.execute(
+                    "UPDATE transcripts SET speaker_map = ? WHERE id = ?",
+                    (json.dumps(smap), row["id"]),
+                )
+        # 3. Revoke the consent
+        await self.set_crew_consent(user_id, "voice_profile", False)
+        await db.commit()
+        logger.info("Voice profile consent revoked for user {}, data deleted", user_id)
 
     # ------------------------------------------------------------------
     # Deployment log (#125)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -131,7 +131,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 56
+_CURRENT_VERSION: int = 57
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -5570,7 +5570,7 @@ class Storage:
         row = await cur.fetchone()
         if row is None:
             return {}
-        result: dict[str, Any] = json.loads(row["speaker_map"] or "{}")  # type: ignore[index]
+        result: dict[str, Any] = json.loads(row["speaker_map"] or "{}")
         return result
 
     # ------------------------------------------------------------------

--- a/src/helmlog/templates/history.html
+++ b/src/helmlog/templates/history.html
@@ -42,5 +42,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/history.js?v=6"></script>
+<script src="/static/history.js?v=7"></script>
 {% endblock %}

--- a/src/helmlog/templates/history.html
+++ b/src/helmlog/templates/history.html
@@ -42,5 +42,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/history.js?v=7"></script>
+<script src="/static/history.js?v=8"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=3"></script>
+<script src="/static/session.js?v=4"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=5"></script>
+<script src="/static/session.js?v=6"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=4"></script>
+<script src="/static/session.js?v=5"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=2"></script>
+<script src="/static/session.js?v=3"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -81,6 +81,11 @@
   <div id="track-hint" style="font-size:.72rem;color:var(--text-secondary);margin-top:4px"></div>
 </div>
 
+<div id="video-container" class="card" style="display:none">
+  <div id="video-switcher" style="display:flex;gap:6px;margin-bottom:8px"></div>
+  <div id="yt-player" style="aspect-ratio:16/9;border-radius:8px;overflow:hidden"></div>
+</div>
+
 <div id="wind-field-card" class="card" style="display:none">
   <div class="section-title" onclick="toggleSection('wind-field')">Wind Field <span id="wind-field-toggle">&#9660;</span></div>
   <div class="section-body" id="wind-field-body">
@@ -111,11 +116,6 @@
     </div>
     <div id="polar-summary" style="font-size:.78rem;color:var(--text-secondary);margin-top:8px;text-align:center"></div>
   </div>
-</div>
-
-<div id="video-container" class="card" style="display:none">
-  <div id="video-switcher" style="display:flex;gap:6px;margin-bottom:8px"></div>
-  <div id="yt-player" style="aspect-ratio:16/9;border-radius:8px;overflow:hidden"></div>
 </div>
 
 <div class="card" id="videos-card" style="display:none">
@@ -165,6 +165,11 @@
   <div class="section-body" id="discussion-body" style="margin-top:6px"></div>
 </div>
 
+<div id="audio-card" class="card" style="display:none">
+  <div class="section-title">Audio</div>
+  <div id="audio-body"></div>
+</div>
+
 <div class="card" id="transcript-card" style="display:none">
   <div class="section-title" onclick="toggleSection('transcript')">Transcript <span id="transcript-toggle">&#9660;</span></div>
   <div class="section-body" id="transcript-body"></div>
@@ -205,11 +210,6 @@
 <div class="card" id="exports-card" style="display:none">
   <div class="section-title">Exports</div>
   <div class="session-exports" id="exports-body"></div>
-</div>
-
-<div id="audio-card" class="card" style="display:none">
-  <div class="section-title">Audio</div>
-  <div id="audio-body"></div>
 </div>
 
 <div id="danger-zone" class="card" style="display:none;border-color:var(--danger)">

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js"></script>
+<script src="/static/session.js?v=2"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -223,5 +223,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=6"></script>
+<script src="/static/session.js?v=7"></script>
 {% endblock %}

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 # Remote transcription offload
 # ---------------------------------------------------------------------------
 
-_REMOTE_TIMEOUT_S = 600  # 10 minutes — long recordings on slow networks
+_REMOTE_TIMEOUT_S = 3600  # 1 hour — diarization on CPU is slow for long debriefs
 
 
 async def _try_remote_transcribe(
@@ -284,7 +284,10 @@ def _run_diarizer(file_path: str) -> list[tuple[float, float, str]]:
     pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", token=token)
     if pipeline is None:
         raise RuntimeError("pyannote Pipeline.from_pretrained returned None — check HF_TOKEN")
-    pipeline.to(torch.device("cpu"))
+    # Use Apple Silicon GPU when available — ~5x faster than CPU for pyannote
+    device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
+    logger.debug("pyannote device: {}", device)
+    pipeline.to(device)
 
     # Load audio via soundfile → numpy, then convert to torch tensor.
     # soundfile returns (samples,) for mono or (samples, channels) for multi-channel;

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -147,6 +147,9 @@ async def transcribe_session(
                 audio_session_id,
                 len(text),
             )
+            # Voice learning: auto-match speakers against stored profiles
+            if diarize and segments:
+                await _try_auto_match(storage, transcript_id, file_path, segments)
             await _run_trigger_scan(storage, audio_session_id, row, segments)
             return
 
@@ -165,6 +168,8 @@ async def transcribe_session(
             )
             assert segments_json_str is not None  # _run_with_diarization always returns str
             segments = json.loads(segments_json_str)
+            # Voice learning: auto-match speakers against stored profiles
+            await _try_auto_match(storage, transcript_id, file_path, segments)
         else:
             raw_segs = await asyncio.to_thread(
                 _run_whisper_segments, file_path=file_path, model_size=model_size
@@ -332,3 +337,321 @@ def _run_with_diarization(*, file_path: str, model_size: str) -> tuple[str, str]
     segments = _merge(whisper_segs, diar_segs)
     plain = "\n".join(f"{seg['speaker']}: {str(seg['text']).strip()}" for seg in segments)
     return plain, json.dumps(segments)
+
+
+# ---------------------------------------------------------------------------
+# Voice learning: embedding extraction + auto-matching (#443)
+# ---------------------------------------------------------------------------
+
+# Minimum thresholds before building a voice profile
+_MIN_SEGMENTS_FOR_PROFILE = 30
+_MIN_SESSIONS_FOR_PROFILE = 2
+
+# Confidence thresholds for auto-matching
+_AUTO_MATCH_HIGH = 0.7  # auto-assign
+_AUTO_MATCH_LOW = 0.4  # suggest (marginal)
+
+
+async def _try_auto_match(
+    storage: Storage,
+    transcript_id: int,
+    file_path: str,
+    segments: list[dict[str, object]],
+) -> None:
+    """Best-effort auto-matching of speakers against stored voice profiles."""
+    try:
+        # Build diar_segs from merged segments for embedding extraction
+        diar_segs = [
+            (float(str(seg["start"])), float(str(seg["end"])), str(seg.get("speaker", "")))
+            for seg in segments
+            if seg.get("speaker")
+        ]
+        if not diar_segs:
+            return
+        speaker_embs = await asyncio.to_thread(_extract_speaker_embeddings, file_path, diar_segs)
+        if speaker_embs:
+            await auto_match_speakers(storage, transcript_id, speaker_embs)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Auto-match failed (non-critical): {}", exc)
+
+
+def _extract_speaker_embeddings(
+    file_path: str,
+    diar_segs: list[tuple[float, float, str]],
+) -> dict[str, bytes]:
+    """Extract per-speaker embedding vectors from diarization segments.
+
+    Uses the pyannote embedding model to compute a centroid embedding for each
+    speaker by averaging embeddings across their segments.
+
+    Returns a dict mapping normalised speaker labels (SPEAKER_00, etc.) to
+    serialised float32 embedding bytes.
+    """
+    try:
+        import numpy as np
+        import soundfile as sf
+        import torch
+        from pyannote.audio import Model
+    except ImportError:
+        logger.debug("pyannote/torch not available for embedding extraction")
+        return {}
+
+    token = os.environ.get("HF_TOKEN") or None
+    try:
+        loaded = Model.from_pretrained("pyannote/wespeaker-voxceleb-resnet34-LM", token=token)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load embedding model: {}", exc)
+        return {}
+    if loaded is None:
+        logger.debug("Embedding model returned None")
+        return {}
+
+    from pyannote.audio import Inference
+
+    inference = Inference(loaded, window="whole")
+
+    data, sample_rate = sf.read(file_path, dtype="float32")
+    if data.ndim == 1:
+        data = data.reshape(-1, 1)
+
+    # Normalise speaker labels same as _merge
+    unique: list[str] = []
+    for _, _, label in diar_segs:
+        if label not in unique:
+            unique.append(label)
+    label_map = {lbl: f"SPEAKER_{i:02d}" for i, lbl in enumerate(unique)}
+
+    # Group segments by speaker
+    speaker_segs: dict[str, list[tuple[float, float]]] = {}
+    for s, e, lbl in diar_segs:
+        norm = label_map[lbl]
+        speaker_segs.setdefault(norm, []).append((s, e))
+
+    embeddings: dict[str, bytes] = {}
+    for speaker, segs in speaker_segs.items():
+        seg_embeddings = []
+        for start, end in segs:
+            start_frame = int(start * sample_rate)
+            end_frame = min(int(end * sample_rate), len(data))
+            if end_frame - start_frame < sample_rate * 0.5:
+                continue  # skip very short segments
+            chunk = data[start_frame:end_frame]
+            if chunk.ndim > 1:
+                waveform = torch.from_numpy(chunk).T
+            else:
+                waveform = torch.from_numpy(chunk).unsqueeze(0)
+            try:
+                emb = inference({"waveform": waveform, "sample_rate": sample_rate})
+                seg_embeddings.append(emb)
+            except Exception:  # noqa: BLE001
+                continue
+        if seg_embeddings:
+            centroid = np.mean(seg_embeddings, axis=0).astype(np.float32)
+            embeddings[speaker] = centroid.tobytes()
+
+    return embeddings
+
+
+def _cosine_similarity(a: bytes, b: bytes) -> float:
+    """Compute cosine similarity between two float32 embedding byte vectors."""
+    import numpy as np
+
+    va = np.frombuffer(a, dtype=np.float32)
+    vb = np.frombuffer(b, dtype=np.float32)
+    if len(va) != len(vb) or len(va) == 0:
+        return 0.0
+    dot = float(np.dot(va, vb))
+    norm = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    return dot / norm if norm > 0 else 0.0
+
+
+async def auto_match_speakers(
+    storage: Storage,
+    transcript_id: int,
+    speaker_embeddings: dict[str, bytes],
+) -> dict[str, dict[str, object]]:
+    """Match diarized speakers against stored voice profiles.
+
+    Returns a dict of speaker_label → {type, user_id, name, confidence} for
+    speakers that exceed the marginal confidence threshold.
+    """
+    if not speaker_embeddings:
+        return {}
+
+    # Load all voice profiles with consent
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT vp.user_id, vp.embedding, u.name"
+        " FROM crew_voice_profiles vp"
+        " JOIN users u ON u.id = vp.user_id"
+        " JOIN crew_consents cc ON cc.user_id = vp.user_id"
+        "   AND cc.consent_type = 'voice_profile' AND cc.granted = 1"
+    )
+    profiles = await cur.fetchall()
+    if not profiles:
+        return {}
+
+    matches: dict[str, dict[str, object]] = {}
+    used_users: set[int] = set()
+
+    # For each speaker, find best matching profile
+    scored: list[tuple[str, int, str, float]] = []
+    for speaker, emb in speaker_embeddings.items():
+        for profile in profiles:
+            sim = _cosine_similarity(emb, profile["embedding"])
+            scored.append((speaker, profile["user_id"], profile["name"], sim))
+
+    # Sort by confidence descending, assign greedily (no double-assignment)
+    scored.sort(key=lambda x: x[3], reverse=True)
+    for speaker, uid, name, conf in scored:
+        if speaker in matches or uid in used_users:
+            continue
+        if conf < _AUTO_MATCH_LOW:
+            continue
+        matches[speaker] = {
+            "type": "auto",
+            "user_id": uid,
+            "name": name,
+            "confidence": round(conf, 2),
+        }
+        used_users.add(uid)
+
+    # Write auto-matches to the transcript's speaker_map
+    if matches:
+        existing = await storage.get_speaker_map(transcript_id)
+        for label, entry in matches.items():
+            if label not in existing:  # don't overwrite manual assignments
+                existing[label] = entry
+        await db.execute(
+            "UPDATE transcripts SET speaker_map = ? WHERE id = ?",
+            (json.dumps(existing), transcript_id),
+        )
+        await db.commit()
+        logger.info(
+            "Auto-matched {} speakers in transcript {}: {}",
+            len(matches),
+            transcript_id,
+            {k: f"{v['name']} ({v['confidence']})" for k, v in matches.items()},
+        )
+
+    return matches
+
+
+async def maybe_build_voice_profile(
+    storage: Storage,
+    user_id: int,
+) -> bool:
+    """Check if enough manual assignments exist to build/update a voice profile.
+
+    Requires ≥ _MIN_SEGMENTS_FOR_PROFILE segments across ≥ _MIN_SESSIONS_FOR_PROFILE sessions.
+    Returns True if a profile was built or updated.
+    """
+    # Check consent
+    consents = await storage.get_crew_consents(user_id)
+    has_consent = any(c["consent_type"] == "voice_profile" and c["granted"] for c in consents)
+    if not has_consent:
+        return False
+
+    # Count manual crew assignments across transcripts
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT t.id, t.speaker_map, a.file_path, t.segments_json"
+        " FROM transcripts t"
+        " JOIN audio_sessions a ON a.id = t.audio_session_id"
+        " WHERE t.speaker_map IS NOT NULL AND t.segments_json IS NOT NULL"
+    )
+    rows = await cur.fetchall()
+
+    total_segments = 0
+    sessions_with_assignment = 0
+
+    for row in rows:
+        smap = json.loads(row["speaker_map"] or "{}")
+        user_labels = [
+            label
+            for label, entry in smap.items()
+            if isinstance(entry, dict)
+            and entry.get("type") == "crew"
+            and entry.get("user_id") == user_id
+        ]
+        if not user_labels:
+            continue
+        sessions_with_assignment += 1
+        segments = json.loads(row["segments_json"] or "[]")
+        for seg in segments:
+            if seg.get("speaker") in user_labels:
+                total_segments += 1
+
+    if (
+        total_segments < _MIN_SEGMENTS_FOR_PROFILE
+        or sessions_with_assignment < _MIN_SESSIONS_FOR_PROFILE
+    ):
+        logger.debug(
+            "Voice profile for user {}: {}/{} segments, {}/{} sessions — not enough yet",
+            user_id,
+            total_segments,
+            _MIN_SEGMENTS_FOR_PROFILE,
+            sessions_with_assignment,
+            _MIN_SESSIONS_FOR_PROFILE,
+        )
+        return False
+
+    # Compute aggregate embedding from all assigned segments
+    if not _pyannote_available():
+        logger.debug("pyannote not available — cannot build voice profile")
+        return False
+
+    logger.info(
+        "Building voice profile for user {}: {} segments across {} sessions",
+        user_id,
+        total_segments,
+        sessions_with_assignment,
+    )
+
+    try:
+        import numpy as np
+    except ImportError:
+        return False
+
+    all_embeddings: list[bytes] = []
+    for row in rows:
+        smap = json.loads(row["speaker_map"] or "{}")
+        user_labels = [
+            label
+            for label, entry in smap.items()
+            if isinstance(entry, dict)
+            and entry.get("type") == "crew"
+            and entry.get("user_id") == user_id
+        ]
+        if not user_labels:
+            continue
+        file_path = row["file_path"]
+        # Extract embeddings for the assigned speaker labels
+        segments = json.loads(row["segments_json"] or "[]")
+        diar_segs = [
+            (seg["start"], seg["end"], seg["speaker"])
+            for seg in segments
+            if seg.get("speaker") in user_labels
+        ]
+        if not diar_segs:
+            continue
+        try:
+            embs = await asyncio.to_thread(_extract_speaker_embeddings, file_path, diar_segs)
+            all_embeddings.extend(embs.values())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Embedding extraction failed for {}: {}", file_path, exc)
+
+    if not all_embeddings:
+        return False
+
+    # Compute centroid
+    vecs = [np.frombuffer(e, dtype=np.float32) for e in all_embeddings]
+    centroid = np.mean(vecs, axis=0).astype(np.float32)
+    await storage.upsert_voice_profile(
+        user_id,
+        centroid.tobytes(),
+        segment_count=total_segments,
+        session_count=sessions_with_assignment,
+    )
+    logger.info("Voice profile built for user {}", user_id)
+    return True

--- a/tests/test_diarize_crew.py
+++ b/tests/test_diarize_crew.py
@@ -1,0 +1,616 @@
+"""Tests for diarized transcript crew association and voice profiles (#443).
+
+Covers:
+- Schema migration 57: speaker_map column + crew_voice_profiles table
+- Storage: assign_speaker_crew, get_speaker_map, voice profile CRUD
+- API: assign-speaker endpoint, voice profile consent + hard delete
+- Transcript display: speaker_map applied in get_transcript_with_anon
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+
+_START_UTC = datetime(2026, 2, 26, 14, 0, 0, tzinfo=UTC)
+_END_UTC = datetime(2026, 2, 26, 14, 30, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_audio_session(storage: Storage, tmp_path: Path) -> int:
+    from helmlog.audio import AudioSession
+
+    wav_file = tmp_path / "test.wav"
+    wav_file.write_bytes(b"RIFF")
+    session = AudioSession(
+        file_path=str(wav_file),
+        device_name="Test",
+        start_utc=_START_UTC,
+        end_utc=_END_UTC,
+        sample_rate=48000,
+        channels=1,
+    )
+    return await storage.write_audio_session(session)
+
+
+async def _create_transcript_with_segments(storage: Storage, audio_session_id: int) -> int:
+    """Create a completed transcript with diarized segments."""
+    tid = await storage.create_transcript_job(audio_session_id, "base")
+    segments = [
+        {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_00", "text": "Ready about."},
+        {"start": 2.1, "end": 4.0, "speaker": "SPEAKER_01", "text": "Ready."},
+        {"start": 4.1, "end": 6.0, "speaker": "SPEAKER_00", "text": "Helm's a-lee!"},
+    ]
+    await storage.update_transcript(
+        tid,
+        status="done",
+        text="SPEAKER_00: Ready about.\nSPEAKER_01: Ready.\nSPEAKER_00: Helm's a-lee!",
+        segments_json=json.dumps(segments),
+    )
+    return tid
+
+
+async def _create_user(storage: Storage, email: str, name: str, role: str = "crew") -> int:
+    """Create a user and return their id."""
+    db = storage._conn()
+    now = datetime.now(UTC).isoformat()
+    cur = await db.execute(
+        "INSERT INTO users (email, name, role, created_at) VALUES (?, ?, ?, ?)",
+        (email, name, role, now),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return cur.lastrowid
+
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_57_adds_speaker_map_column(storage: Storage) -> None:
+    """Migration 57 adds speaker_map TEXT column to transcripts."""
+    db = storage._conn()
+    cur = await db.execute("PRAGMA table_info(transcripts)")
+    cols = {row["name"] for row in await cur.fetchall()}
+    assert "speaker_map" in cols
+
+
+@pytest.mark.asyncio
+async def test_migration_57_creates_crew_voice_profiles(storage: Storage) -> None:
+    """Migration 57 creates crew_voice_profiles table."""
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='crew_voice_profiles'"
+    )
+    row = await cur.fetchone()
+    assert row is not None
+
+
+# ---------------------------------------------------------------------------
+# Storage: assign_speaker_crew
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assign_speaker_crew(storage: Storage, tmp_path: Path) -> None:
+    """assign_speaker_crew stores a crew mapping in speaker_map."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    user_id = await _create_user(storage, "dave@boat.com", "Dave")
+
+    ok = await storage.assign_speaker_crew(tid, "SPEAKER_00", user_id, "Dave")
+    assert ok is True
+
+    speaker_map = await storage.get_speaker_map(tid)
+    assert speaker_map["SPEAKER_00"] == {
+        "type": "crew",
+        "user_id": user_id,
+        "name": "Dave",
+    }
+
+
+@pytest.mark.asyncio
+async def test_assign_speaker_crew_not_found(storage: Storage) -> None:
+    """assign_speaker_crew returns False for nonexistent transcript."""
+    ok = await storage.assign_speaker_crew(999, "SPEAKER_00", 1, "Dave")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_assign_speaker_crew_preserves_existing(storage: Storage, tmp_path: Path) -> None:
+    """Assigning a second speaker preserves the first."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid1 = await _create_user(storage, "dave@boat.com", "Dave")
+    uid2 = await _create_user(storage, "mike@boat.com", "Mike")
+
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid1, "Dave")
+    await storage.assign_speaker_crew(tid, "SPEAKER_01", uid2, "Mike")
+
+    speaker_map = await storage.get_speaker_map(tid)
+    assert "SPEAKER_00" in speaker_map
+    assert "SPEAKER_01" in speaker_map
+    assert speaker_map["SPEAKER_00"]["name"] == "Dave"
+    assert speaker_map["SPEAKER_01"]["name"] == "Mike"
+
+
+@pytest.mark.asyncio
+async def test_assign_speaker_crew_overwrite(storage: Storage, tmp_path: Path) -> None:
+    """Reassigning a speaker overwrites the previous mapping."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid1 = await _create_user(storage, "dave@boat.com", "Dave")
+    uid2 = await _create_user(storage, "mike@boat.com", "Mike")
+
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid1, "Dave")
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid2, "Mike")
+
+    speaker_map = await storage.get_speaker_map(tid)
+    assert speaker_map["SPEAKER_00"]["name"] == "Mike"
+
+
+# ---------------------------------------------------------------------------
+# Storage: speaker_map interop with anonymization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_speaker_map_coexists_with_anon(storage: Storage, tmp_path: Path) -> None:
+    """speaker_map crew entries and speaker_anon_map redactions coexist."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+
+    # Assign speaker 0 to crew
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid, "Dave")
+    # Anonymize speaker 1
+    await storage.anonymize_speaker(tid, "SPEAKER_01")
+
+    t = await storage.get_transcript_with_anon(audio_id)
+    assert t is not None
+    segs = json.loads(t["segments_json"])
+    # SPEAKER_00 should show as Dave (crew mapping)
+    assert segs[0]["speaker"] == "Dave"
+    # SPEAKER_01 should be redacted (anonymization takes priority)
+    assert segs[1]["speaker"] == "REDACTED"
+    assert segs[1]["text"] == "[REDACTED]"
+    # SPEAKER_00 in third segment should also show as Dave
+    assert segs[2]["speaker"] == "Dave"
+
+
+@pytest.mark.asyncio
+async def test_get_transcript_with_anon_applies_speaker_map(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """get_transcript_with_anon replaces speaker labels with crew names from speaker_map."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid, "Dave")
+
+    t = await storage.get_transcript_with_anon(audio_id)
+    assert t is not None
+    segs = json.loads(t["segments_json"])
+    assert segs[0]["speaker"] == "Dave"
+    assert segs[2]["speaker"] == "Dave"
+    # Unmapped speaker stays as-is
+    assert segs[1]["speaker"] == "SPEAKER_01"
+
+
+# ---------------------------------------------------------------------------
+# Storage: voice profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_voice_profile(storage: Storage) -> None:
+    """Upserting a voice profile stores embedding + counts."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    # Grant voice_profile consent
+    await storage.set_crew_consent(uid, "voice_profile", True)
+
+    embedding = b"\x00" * 128  # fake embedding
+    await storage.upsert_voice_profile(uid, embedding, segment_count=30, session_count=2)
+
+    profile = await storage.get_voice_profile(uid)
+    assert profile is not None
+    assert profile["embedding"] == embedding
+    assert profile["segment_count"] == 30
+    assert profile["session_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_voice_profile_updates(storage: Storage) -> None:
+    """Upserting again updates the existing profile."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+
+    await storage.upsert_voice_profile(uid, b"\x01" * 128, segment_count=30, session_count=2)
+    await storage.upsert_voice_profile(uid, b"\x02" * 128, segment_count=60, session_count=4)
+
+    profile = await storage.get_voice_profile(uid)
+    assert profile is not None
+    assert profile["embedding"] == b"\x02" * 128
+    assert profile["segment_count"] == 60
+
+
+@pytest.mark.asyncio
+async def test_delete_voice_profile(storage: Storage) -> None:
+    """delete_voice_profile removes the profile."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    await storage.upsert_voice_profile(uid, b"\x01" * 128, segment_count=30, session_count=2)
+
+    deleted = await storage.delete_voice_profile(uid)
+    assert deleted is True
+
+    profile = await storage.get_voice_profile(uid)
+    assert profile is None
+
+
+@pytest.mark.asyncio
+async def test_delete_voice_profile_not_found(storage: Storage) -> None:
+    """delete_voice_profile returns False if no profile exists."""
+    deleted = await storage.delete_voice_profile(999)
+    assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_consent_revoke_deletes_voice_profile(storage: Storage) -> None:
+    """Revoking voice_profile consent hard-deletes the voice profile."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    await storage.upsert_voice_profile(uid, b"\x01" * 128, segment_count=30, session_count=2)
+
+    # Revoke consent — should cascade delete
+    await storage.revoke_voice_profile_consent(uid)
+
+    profile = await storage.get_voice_profile(uid)
+    assert profile is None
+    # Consent should be revoked
+    consents = await storage.get_crew_consents(uid)
+    vp = [c for c in consents if c["consent_type"] == "voice_profile"]
+    assert len(vp) == 1
+    assert vp[0]["granted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_revoke_voice_consent_clears_auto_speaker_map_entries(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Revoking consent removes 'auto' speaker_map entries but keeps 'crew' ones."""
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+
+    # Simulate both a manual crew assignment and an auto-match
+    db = storage._conn()
+    speaker_map = {
+        "SPEAKER_00": {"type": "crew", "user_id": uid, "name": "Dave"},
+        "SPEAKER_01": {"type": "auto", "user_id": uid, "name": "Dave", "confidence": 0.87},
+    }
+    await db.execute(
+        "UPDATE transcripts SET speaker_map = ? WHERE id = ?",
+        (json.dumps(speaker_map), tid),
+    )
+    await db.commit()
+
+    await storage.revoke_voice_profile_consent(uid)
+
+    smap = await storage.get_speaker_map(tid)
+    # Manual crew assignment preserved
+    assert smap["SPEAKER_00"]["type"] == "crew"
+    # Auto entry removed
+    assert "SPEAKER_01" not in smap
+
+
+# ---------------------------------------------------------------------------
+# API: assign-speaker endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_assign_speaker(storage: Storage, tmp_path: Path) -> None:
+    """POST assign-speaker updates the speaker_map and returns it."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{audio_id}/transcript/assign-speaker",
+            json={"speaker_label": "SPEAKER_00", "user_id": uid},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["speaker_label"] == "SPEAKER_00"
+    assert data["user_id"] == uid
+    assert data["name"] == "Dave"
+
+
+@pytest.mark.asyncio
+async def test_api_assign_speaker_missing_label(storage: Storage, tmp_path: Path) -> None:
+    """POST assign-speaker with missing speaker_label returns 422."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    await _create_transcript_with_segments(storage, audio_id)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{audio_id}/transcript/assign-speaker",
+            json={"user_id": 1},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_api_assign_speaker_no_transcript(storage: Storage, tmp_path: Path) -> None:
+    """POST assign-speaker returns 404 when no transcript exists."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{audio_id}/transcript/assign-speaker",
+            json={"speaker_label": "SPEAKER_00", "user_id": 1},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_api_transcript_includes_speaker_map(storage: Storage, tmp_path: Path) -> None:
+    """GET transcript includes speaker_map (without internal details) for UI rendering."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid, "Dave")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/audio/{audio_id}/transcript")
+    assert resp.status_code == 200
+    data = resp.json()
+    # speaker_map should be exposed for UI
+    assert "speaker_map" in data
+    assert data["speaker_map"]["SPEAKER_00"]["name"] == "Dave"
+
+
+# ---------------------------------------------------------------------------
+# API: voice profile endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_delete_voice_profile(storage: Storage, tmp_path: Path) -> None:
+    """DELETE voice profile removes it."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    await storage.upsert_voice_profile(uid, b"\x01" * 128, segment_count=30, session_count=2)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.delete(f"/api/crew/{uid}/voice-profile")
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# Voice learning: cosine similarity + auto-match
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_similarity_identical() -> None:
+    """Identical embeddings have similarity 1.0."""
+    import struct
+
+    from helmlog.transcribe import _cosine_similarity
+
+    emb = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    assert abs(_cosine_similarity(emb, emb) - 1.0) < 1e-6
+
+
+def test_cosine_similarity_orthogonal() -> None:
+    """Orthogonal embeddings have similarity 0.0."""
+    import struct
+
+    from helmlog.transcribe import _cosine_similarity
+
+    a = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    b = struct.pack("<4f", 0.0, 1.0, 0.0, 0.0)
+    assert abs(_cosine_similarity(a, b)) < 1e-6
+
+
+def test_cosine_similarity_opposite() -> None:
+    """Opposite embeddings have similarity -1.0."""
+    import struct
+
+    from helmlog.transcribe import _cosine_similarity
+
+    a = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    b = struct.pack("<4f", -1.0, 0.0, 0.0, 0.0)
+    assert abs(_cosine_similarity(a, b) + 1.0) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_auto_match_speakers_with_profiles(storage: Storage, tmp_path: Path) -> None:
+    """Auto-match assigns speakers when profiles exist with high similarity."""
+    import struct
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+
+    # Grant consent and store a voice profile
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    emb = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    await storage.upsert_voice_profile(uid, emb, segment_count=30, session_count=2)
+
+    # Auto-match with identical embedding for SPEAKER_00
+    from helmlog.transcribe import auto_match_speakers
+
+    speaker_embs = {"SPEAKER_00": emb}
+    matches = await auto_match_speakers(storage, tid, speaker_embs)
+
+    assert "SPEAKER_00" in matches
+    assert matches["SPEAKER_00"]["user_id"] == uid
+    assert matches["SPEAKER_00"]["name"] == "Dave"
+    assert matches["SPEAKER_00"]["confidence"] >= 0.7
+
+
+@pytest.mark.asyncio
+async def test_auto_match_no_profiles(storage: Storage, tmp_path: Path) -> None:
+    """Auto-match returns empty when no voice profiles exist."""
+    import struct
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+
+    from helmlog.transcribe import auto_match_speakers
+
+    emb = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    matches = await auto_match_speakers(storage, tid, {"SPEAKER_00": emb})
+    assert matches == {}
+
+
+@pytest.mark.asyncio
+async def test_auto_match_low_confidence_excluded(storage: Storage, tmp_path: Path) -> None:
+    """Auto-match excludes speakers below the low confidence threshold."""
+    import struct
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    # Profile embedding orthogonal to speaker embedding → ~0.0 similarity
+    profile_emb = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    speaker_emb = struct.pack("<4f", 0.0, 1.0, 0.0, 0.0)
+    await storage.upsert_voice_profile(uid, profile_emb, segment_count=30, session_count=2)
+
+    from helmlog.transcribe import auto_match_speakers
+
+    matches = await auto_match_speakers(storage, tid, {"SPEAKER_00": speaker_emb})
+    assert "SPEAKER_00" not in matches
+
+
+@pytest.mark.asyncio
+async def test_auto_match_does_not_overwrite_manual(storage: Storage, tmp_path: Path) -> None:
+    """Auto-match does not overwrite existing manual crew assignments."""
+    import struct
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    tid = await _create_transcript_with_segments(storage, audio_id)
+    uid1 = await _create_user(storage, "dave@boat.com", "Dave")
+    uid2 = await _create_user(storage, "mike@boat.com", "Mike")
+
+    # Manual crew assignment for SPEAKER_00
+    await storage.assign_speaker_crew(tid, "SPEAKER_00", uid1, "Dave")
+
+    # Voice profile for Mike matches SPEAKER_00
+    await storage.set_crew_consent(uid2, "voice_profile", True)
+    emb = struct.pack("<4f", 1.0, 0.0, 0.0, 0.0)
+    await storage.upsert_voice_profile(uid2, emb, segment_count=30, session_count=2)
+
+    from helmlog.transcribe import auto_match_speakers
+
+    await auto_match_speakers(storage, tid, {"SPEAKER_00": emb})
+    # Auto-match should not have written over the manual assignment
+    smap = await storage.get_speaker_map(tid)
+    assert smap["SPEAKER_00"]["type"] == "crew"
+    assert smap["SPEAKER_00"]["name"] == "Dave"
+
+
+@pytest.mark.asyncio
+async def test_maybe_build_profile_insufficient_data(storage: Storage) -> None:
+    """maybe_build_voice_profile returns False when data is insufficient."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+
+    from helmlog.transcribe import maybe_build_voice_profile
+
+    result = await maybe_build_voice_profile(storage, uid)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_build_profile_no_consent(storage: Storage, tmp_path: Path) -> None:
+    """maybe_build_voice_profile returns False without voice_profile consent."""
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    # No consent granted
+
+    from helmlog.transcribe import maybe_build_voice_profile
+
+    result = await maybe_build_voice_profile(storage, uid)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_api_revoke_voice_consent(storage: Storage, tmp_path: Path) -> None:
+    """Revoking voice_profile consent via API deletes profile too."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    uid = await _create_user(storage, "dave@boat.com", "Dave")
+    await storage.set_crew_consent(uid, "voice_profile", True)
+    await storage.upsert_voice_profile(uid, b"\x01" * 128, segment_count=30, session_count=2)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.put(
+            f"/api/crew/{uid}/consents",
+            json={"consent_type": "voice_profile", "granted": False},
+        )
+    assert resp.status_code == 200
+
+    # Profile should be gone
+    profile = await storage.get_voice_profile(uid)
+    assert profile is None

--- a/tests/test_diarize_crew.py
+++ b/tests/test_diarize_crew.py
@@ -417,6 +417,60 @@ async def test_api_transcript_includes_speaker_map(storage: Storage, tmp_path: P
 
 
 # ---------------------------------------------------------------------------
+# API: retranscribe endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_retranscribe(storage: Storage, tmp_path: Path) -> None:
+    """POST retranscribe deletes existing transcript and creates a new job."""
+    from unittest.mock import AsyncMock, patch
+
+    import httpx
+
+    from helmlog.web import create_app
+
+    audio_id = await _create_audio_session(storage, tmp_path)
+    await _create_transcript_with_segments(storage, audio_id)
+
+    # Verify transcript exists
+    t = await storage.get_transcript(audio_id)
+    assert t is not None
+    assert t["status"] == "done"
+
+    app = create_app(storage)
+    with patch("helmlog.web.asyncio.create_task") as mock_create_task:
+        mock_create_task.return_value = AsyncMock()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/audio/{audio_id}/retranscribe")
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["status"] == "accepted"
+
+    # Old transcript should be replaced with a new pending one
+    t2 = await storage.get_transcript(audio_id)
+    assert t2 is not None
+    assert t2["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_api_retranscribe_no_session(storage: Storage, tmp_path: Path) -> None:
+    """POST retranscribe returns 404 for nonexistent audio session."""
+    import httpx
+
+    from helmlog.web import create_app
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/audio/999/retranscribe")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # API: voice profile endpoints
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -614,9 +614,7 @@ class TestTokenResolution:
             token = await reader._resolve_token()
         assert token == "jwt-custom"
 
-    async def test_password_file_default_is_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_password_file_default_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without SK_PASSWORD_FILE env var, password_file defaults to None."""
         monkeypatch.delenv("SK_PASSWORD_FILE", raising=False)
         cfg = SKReaderConfig()


### PR DESCRIPTION
## Summary
- **Segment playback**: click a transcript segment to jump audio to that position; active segment highlighting during playback. Works on both `/session/{id}` and `/history`
- **Crew association**: click a speaker label (e.g. SPEAKER_00) to assign it to a crew member via a picker modal. Assignment persists to a new `speaker_map` JSON column on transcripts and survives page reload
- **Voice learning**: after manual crew assignments accumulate (≥30 segments across ≥2 sessions with voice_profile consent), builds speaker embeddings using pyannote and auto-matches on new transcriptions with confidence levels
- **Privacy**: `voice_profile` consent type enforces biometric PII requirements — revoking consent hard-deletes all embeddings and auto-match entries while preserving manual crew assignments

### Schema
- Migration 57: `speaker_map TEXT` column on `transcripts`, `crew_voice_profiles` table with `ON DELETE CASCADE` FK to users

### Files changed
- `storage.py`: migration 57, `assign_speaker_crew`, `get_speaker_map`, voice profile CRUD, `revoke_voice_profile_consent`, updated `get_transcript` and `get_transcript_with_anon` to apply speaker_map
- `transcribe.py`: `_extract_speaker_embeddings`, `auto_match_speakers`, `maybe_build_voice_profile`, `_cosine_similarity`, auto-match wired into transcription pipeline
- `routes/audio.py`: `POST assign-speaker` endpoint, speaker_map in transcript GET response, voice profile build trigger
- `routes/crew.py`: `DELETE voice-profile` endpoint, `voice_profile` consent type with hard-delete
- `session.js`: segment playback, active highlighting, crew picker modal
- `history.js`: segment playback, crew picker (same UX as session page)

Closes #443

## Test plan
- [x] 29 new tests in `test_diarize_crew.py` covering:
  - Schema migration (speaker_map column, crew_voice_profiles table)
  - Storage: assign/overwrite/preserve speaker-crew mappings
  - speaker_map + speaker_anon_map interop (anonymization takes priority)
  - Voice profile CRUD, consent revocation hard-delete
  - Auto-match with cosine similarity (high/low/no confidence)
  - Auto-match preserves manual crew assignments
  - API endpoints (assign-speaker, voice-profile delete, consent revocation)
  - Transcript GET includes speaker_map for UI
- [x] All existing tests pass (199 in test_web.py + test_diarize_crew.py)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format`)
- [ ] Visual check: segment playback and crew picker on `/session/{id}` and `/history`

🤖 Generated with [Claude Code](https://claude.ai/code)