### PR TITLE
feat: multi-camera Insta360 pipeline (#445)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ htmlcov/
 .DS_Store
 **/.DS_Store
 .env.claude-dev
+docker/libMediaSDK-dev*.deb

--- a/docker/stitch-360.sh
+++ b/docker/stitch-360.sh
@@ -18,6 +18,10 @@ set -euo pipefail
 
 OUTPUT=""
 INPUTS=()
+FLOWSTATE="1"
+DIRECTION_LOCK="1"
+BITRATE=""
+RESOLUTION=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -25,11 +29,41 @@ while [ $# -gt 0 ]; do
       OUTPUT="$2"
       shift 2
       ;;
+    --flowstate)
+      FLOWSTATE="1"
+      shift
+      ;;
+    --no-flowstate)
+      FLOWSTATE="0"
+      shift
+      ;;
+    --direction-lock)
+      DIRECTION_LOCK="1"
+      shift
+      ;;
+    --no-direction-lock)
+      DIRECTION_LOCK="0"
+      shift
+      ;;
+    --bitrate)
+      BITRATE="$2"
+      shift 2
+      ;;
+    --resolution)
+      RESOLUTION="$2"
+      shift 2
+      ;;
     --help|-h)
-      echo "Usage: stitch-360 --output /output/FILE.mp4 /input/*.insv [...]"
+      echo "Usage: stitch-360 [opts] --output /output/FILE.mp4 /input/*.insv [...]"
       echo ""
       echo "Stitches Insta360 X4 .insv files into equirectangular 360° MP4."
       echo "Auto-detects stitcher: MediaSDKTest (best) or ffmpeg (fallback)."
+      echo ""
+      echo "Options:"
+      echo "  --flowstate / --no-flowstate           FlowState stabilization (default: on)"
+      echo "  --direction-lock / --no-direction-lock FlowState direction lock (default: on)"
+      echo "  --bitrate <N>                          Output bitrate (e.g. 100M)"
+      echo "  --resolution <WxH>                     Output resolution (e.g. 3840x1920)"
       exit 0
       ;;
     *)
@@ -78,13 +112,25 @@ case "$STITCHER" in
     # MediaSDKTest takes a single input file; for multi-segment recordings
     # we use the first segment (MediaSDK reads subsequent segments automatically
     # when they're in the same directory with sequential naming).
-    echo "==> Stitching with MediaSDK..."
-    MediaSDKTest \
-      -inputs "${INPUTS[0]}" \
-      -output "$TEMP_OUTPUT" \
-      -enable_flowstate \
-      -enable_directionlock \
+    echo "==> Stitching with MediaSDK (flowstate=$FLOWSTATE direction-lock=$DIRECTION_LOCK)..."
+    MEDIASDK_ARGS=(
+      -inputs "${INPUTS[0]}"
+      -output "$TEMP_OUTPUT"
       -enable_denoise
+    )
+    if [ "$FLOWSTATE" = "1" ]; then
+      MEDIASDK_ARGS+=(-enable_flowstate)
+    fi
+    if [ "$DIRECTION_LOCK" = "1" ]; then
+      MEDIASDK_ARGS+=(-enable_directionlock)
+    fi
+    if [ -n "$BITRATE" ]; then
+      MEDIASDK_ARGS+=(-bitrate "$BITRATE")
+    fi
+    if [ -n "$RESOLUTION" ]; then
+      MEDIASDK_ARGS+=(-output_size "$RESOLUTION")
+    fi
+    MediaSDKTest "${MEDIASDK_ARGS[@]}"
     ;;
   ffmpeg)
     # Fallback: .insv contains dual-fisheye (two video streams). Stream-copy

--- a/docs/ideation-log.md
+++ b/docs/ideation-log.md
@@ -2208,3 +2208,63 @@ disables Signal K, audio, and CAN readers.
   infrastructure needed. Litestream is interesting for continuous streaming
   but adds complexity. The read-only mode is important to prevent the
   replica from trying to record data or connect to instruments.
+
+---
+
+## IDX-035: BLE shutter-remote emulation as fallback for X4 OSC mode control
+
+- **Date captured:** 2026-04-10
+- **Origin:** Insta360 horizon-leveling investigation that landed
+  `is_dual_fisheye()` and `promote_to_insv_extension()` in
+  `src/helmlog/insta360.py`
+- **Status:** `raw`
+- **Related:** `src/helmlog/cameras.py`, `src/helmlog/insta360.py`,
+  `scripts/import-matched.sh`
+
+**Description:**
+Insurance plan in case Insta360 ever changes the X4 OSC behaviour we
+currently rely on. Today the X4 (firmware `DLC4_1.9.21.6_build5`) records
+correct dual-fisheye 360° content via OSC `camera.startCapture` but
+mislabels the file `.mp4`; we work around it by probing the stream count
+with ffprobe (`is_dual_fisheye`) and renaming on disk during import
+(`promote_to_insv_extension`). If a future firmware actually starts
+recording flat single-lens video over OSC, no amount of `setOptions` can
+fix it (we exhaustively probed every documented and undocumented option,
+and `videoStitchingSupport` is hard-coded to `["none"]`). At that point
+we'd need to drive the camera through a transport that inherits the
+touchscreen mode the way the physical shutter button does — i.e. emulate
+a Bluetooth shutter remote from the Pi.
+
+**Reference implementation details (verified by Patrick Chwalek's
+ESP32 work and the btittelbach ESPHome config — see Notes for sources):**
+
+- Pi advertises BLE local name `Insta360 GPS Remote` (the camera's
+  "Add Remote" pairing screen filters on this name)
+- Service UUID: `0000ce80-0000-1000-8000-00805f9b34fb`
+- Write characteristic (commands): `0000ce81-...`
+- Notify characteristic (status): `0000ce82-...`
+- Shutter toggle (one press = start, next press = stop, inherits
+  whatever mode the touchscreen is in):
+  `fc ef fe 86 00 03 01 02 00`
+- Mode button: `fc ef fe 86 00 03 01 01 00`
+- Power short / long: `... 00 03 01 00 00` / `... 00 03`
+- No pairing/bonding crypto required after first "Add Remote" handshake;
+  the camera whitelists the Pi's BLE MAC and reconnects automatically
+
+Implementation would live in a new `src/helmlog/cameras_ble.py` sibling
+module, called from the same `start_camera`/`stop_camera` entry points
+in `cameras.py` selected by a `CAMERA_TRANSPORT=osc|ble` env var. Pi
+side: `bleak` for GATT writes, BlueZ `btmgmt`/`bless` for advertising
+the local name. Estimate: 1–2 days of work to a first cut.
+
+**Notes:**
+- *2026-04-10:* Captured during the same investigation that found the
+  `.mp4` mislabelling. The actual fix turned out to be much smaller (the
+  OSC recordings were always correct content with a wrong extension), so
+  this BLE plan is intentionally being parked rather than built. Holding
+  it here so we don't have to re-discover the protocol from scratch if
+  Insta360 ever forces our hand. Sources:
+  [pchwalek/insta360_ble_esp32](https://github.com/pchwalek/insta360_ble_esp32),
+  [Patrick Chwalek — BLE Control of Insta360 Cameras](https://medium.com/@patrickchwalek/ble-control-of-insta360-cameras-7bf6894648a4),
+  [btittelbach ESPHome X4 config](https://github.com/btittelbach/esphome_config_examples/blob/main/insta360_ble_remote_waveshare_touch169_esp32s3.yaml),
+  [Hackaday: X3 BLE remote with ESP32](https://hackaday.io/project/188975-insta360-x3-ble-remote-control-with-esp32).

--- a/docs/video-pipeline.md
+++ b/docs/video-pipeline.md
@@ -106,7 +106,109 @@ This will:
 - Check YouTube credentials
 - Install the launchd agent to watch for SD card mounts
 
-## Usage
+## Lifecycle (issue #445, Apple Silicon path)
+
+The Insta360 MediaSDK Linux/amd64 image runs unusably slow under Docker
+Rosetta emulation on Apple Silicon (~500× slower than realtime in
+testing). On a Mac, **Insta360 Studio is the only viable stitcher** —
+it's a universal Apple-Silicon binary that ships with the same MediaSDK
+under the hood. Studio doesn't expose a CLI, so the lifecycle is split
+into a fully-automated import + upload + archive flow with one manual
+GUI step in the middle:
+
+```
+SD card                ~/Insta360 Imports/        Insta360 Studio
+   │                          │                          │
+   │  ./scripts/import-       │  open files,             │
+   │   matched.sh             │  click Export →          │
+   │  (only files that ───►   │  Start Export       ───► ~/Insta360 Exports/<cam>/
+   │   match a Pi session)    │                          │
+   │                          │                          │
+   │                          │   ./scripts/watch-       │
+   │                          │   exports.sh             │
+   │                          │   (fswatch)         ◄────┘
+   │                          │       │
+   │                          │       ▼
+   │                          │   ./scripts/upload-stitched.sh
+   │                          │       │
+   │                          │       ├─ verify_channel(corvo105)
+   │                          │       ├─ upload to YouTube (resumable, retry)
+   │                          │       ├─ link to race on Pi (parent_race walked)
+   │                          │       ├─ ledger entry written
+   │                          │       └─ macOS notification
+   │                          │
+   │                          ▼
+   │              /Volumes/Insta360 Backups/helmlog/
+   │              (source segments + stitched export
+   │               moved here once linked)
+   │
+   ▼
+(SD card untouched — never deleted automatically)
+```
+
+The user-visible work is **drag files into Studio → click Export → walk
+away.** Everything before and after that is automatic.
+
+### Step 1 — Import session-matching files from the SD card
+
+```bash
+PI_SESSION_COOKIE=<your cookie> ./scripts/import-matched.sh
+```
+
+Walks every `VID_*.{mp4,insv}` on the card, probes its actual duration
+with `ffprobe`, fetches the HelmLog session list from the Pi, and copies
+**only the recordings that overlap a real session** into
+`~/Insta360 Imports/`. Random non-session footage on the same card
+(drone shots, kid videos, dock loading) is ignored. Idempotent — re-runs
+skip files already in the import dir.
+
+### Step 2 — Stitch in Insta360 Studio (manual)
+
+Open the imports folder in Studio (drag-drop or File → Open), select
+your preferred export preset (saved from the previous run), and click
+**Start Export**. Export to `~/Insta360 Exports/<camera_label>/`.
+Studio remembers the last-used settings, so this is two clicks per file
+once you've configured it once.
+
+### Step 3 — Auto-upload + link + archive
+
+Run the watcher in the background (or install the launchd agent below)
+and forget about it:
+
+```bash
+PI_SESSION_COOKIE=<cookie> ./scripts/watch-exports.sh
+```
+
+The watcher fires `upload-stitched.sh` on every new MP4 in
+`~/Insta360 Exports/`. Each upload:
+
+1. Reads the timestamp from the filename
+2. Fetches Pi sessions and walks `parent_race_id` to find the right race
+3. Uploads to YouTube with the title `YYYY-MM-DD HH:MMZ — Event Race N — <camera> cam`
+4. Links the YouTube URL to the race on the Pi with label `360 cam — <camera>`
+5. Writes a ledger entry so the same file can't double-upload
+6. Moves the stitched export **and** the matching source segments from
+   `~/Insta360 Imports/` to `/Volumes/Insta360 Backups/helmlog/`
+7. Pops a macOS notification with the YouTube URL
+
+The ledger lives at `~/.config/helmlog/video-ledger.json` and is keyed
+by camera label + filename + size — re-importing the same SD card later
+won't re-upload anything.
+
+### Auto-start on login (launchd)
+
+```bash
+# Edit the plist to set your PI_SESSION_COOKIE first:
+$EDITOR launchd/com.helmlog.video-watch.plist
+
+cp launchd/com.helmlog.video-watch.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.helmlog.video-watch.plist
+mkdir -p ~/Library/Logs/helmlog
+```
+
+The watcher then runs at every login and respawns on crash.
+
+## Usage (legacy SD-card-driven flow)
 
 ### Automatic (recommended)
 

--- a/docs/video-pipeline.md
+++ b/docs/video-pipeline.md
@@ -102,7 +102,7 @@ cd ~/src/helmlog  # or wherever your clone is
 
 This will:
 - Verify Docker, exiftool, and uv are available
-- Create `~/Videos/helmlog/` for output files
+- Create `~/Insta360 Exports/` for output files
 - Check YouTube credentials
 - Install the launchd agent to watch for SD card mounts
 
@@ -129,15 +129,64 @@ All via environment variables (or set in `~/.zshrc`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VIDEO_OUTPUT_DIR` | `~/Videos/helmlog` | Where stitched MP4s are saved |
+| `VIDEO_OUTPUT_DIR` | `~/Insta360 Exports` | Base dir; per-camera videos land in `<dir>/<camera_label>/` |
 | `VIDEO_RESOLUTION` | `3840x1920` | Output resolution (4K) |
+| `VIDEO_BITRATE` | *(stitcher default)* | Output bitrate (e.g. `100M`) |
+| `VIDEO_FLOWSTATE` | `true` | FlowState motion stabilization |
+| `VIDEO_DIRECTION_LOCK` | `true` | FlowState direction lock |
 | `DOCKER_IMAGE` | `insta360-cli-utils` | Docker image for stitching |
 | `PI_API_URL` | `http://corvopi:3002` | HelmLog API on the Pi |
 | `VIDEO_PRIVACY` | `unlisted` | YouTube privacy (private/unlisted/public) |
 | `TIMEZONE` | `America/Los_Angeles` | Camera's local timezone |
+| `YOUTUBE_ACCOUNT` | `corvo105` | YouTube channel handle. Picks `~/.config/helmlog/youtube/<account>.json` |
 | `YOUTUBE_CLIENT_SECRETS` | `~/.helmlog-youtube-client-secrets.json` | OAuth2 client secrets |
-| `YOUTUBE_TOKEN_FILE` | `~/.helmlog-youtube-token.json` | Cached OAuth2 token |
+| `YOUTUBE_TOKEN_FILE` | *(account-derived)* | Override OAuth2 token cache |
 | `PI_SESSION_COOKIE` | *(none)* | Session cookie for auto-linking videos (see below) |
+
+### Multi-camera support (issue #445)
+
+When more than one Insta360 volume is mounted (one SD card per physical
+camera, e.g. `bow` + `stern`), `process-videos.sh` fans out and runs one
+pipeline per volume in parallel. Each camera is identified by macOS
+volume UUID and mapped to a user-assigned label in
+`~/.config/helmlog/cameras.toml`:
+
+```toml
+[cameras]
+"ABCD-1234" = "bow"
+"EFGH-5678" = "stern"
+```
+
+On first sight of an unknown card the pipeline writes a placeholder
+(`camera-<uuid8>`) — rename it in the config file to set the label
+shown in YouTube titles (`… — bow cam`) and on the Pi link
+(`360 cam — bow`). Output paths use the label as a sub-directory:
+
+```
+~/Insta360 Exports/
+├── bow/
+│   └── 20260810_140000.mp4
+└── stern/
+    └── 20260810_140000.mp4
+```
+
+The default base directory changed from `~/Videos/helmlog` (issue #445).
+The old directory is left untouched on upgrade.
+
+### YouTube channel verification
+
+When `YOUTUBE_ACCOUNT` is set, the pipeline calls `channels.list(mine=true)`
+after loading the cached token and aborts the run if the authenticated
+channel title or handle doesn't match. This catches the "uploaded to my
+personal account by mistake" case before any bytes leave the Mac.
+Network failures during verification are downgraded to a warning so a
+flaky connection doesn't block uploads.
+
+### Future work (deferred from #445)
+
+- Admin UI in HelmLog to edit `video_settings` + camera labels (currently file-only on the Mac)
+- Pi-side `video_settings` table as the source of truth, with the Mac caching the latest values
+- OSC HTTP API path for pulling files over Wi-Fi without mounting the SD card
 
 ## How Videos Get Linked to Sessions
 

--- a/launchd/com.helmlog.video-watch.plist
+++ b/launchd/com.helmlog.video-watch.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.helmlog.video-watch — folder watcher for Insta360 stitched exports.
+
+  Install:
+    cp launchd/com.helmlog.video-watch.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.helmlog.video-watch.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.helmlog.video-watch.plist
+    rm ~/Library/LaunchAgents/com.helmlog.video-watch.plist
+
+  Logs (rotated by helmlog/scripts; truncate or delete as needed):
+    ~/Library/Logs/helmlog/video-watch.log
+    ~/Library/Logs/helmlog/video-watch.err
+
+  Notes:
+    - PI_SESSION_COOKIE must be edited below for the linker to work; without
+      it, uploads still happen but won't appear on the session page.
+    - The agent runs at user login (RunAtLoad) and KeepAlive=true means
+      launchd will respawn it if it dies.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.helmlog.video-watch</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/dweatbrook/src/helmlog/scripts/watch-exports.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/dweatbrook/src/helmlog</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>PI_API_URL</key>
+        <string>http://corvopi-live:3002</string>
+        <key>YOUTUBE_ACCOUNT</key>
+        <string>corvo105</string>
+        <key>TIMEZONE</key>
+        <string>America/Los_Angeles</string>
+        <key>VIDEO_PRIVACY</key>
+        <string>unlisted</string>
+        <!-- Edit this with your active Pi session cookie. Without it the
+             upload still works but the link step is skipped. -->
+        <key>PI_SESSION_COOKIE</key>
+        <string></string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/dweatbrook/Library/Logs/helmlog/video-watch.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/dweatbrook/Library/Logs/helmlog/video-watch.err</string>
+</dict>
+</plist>

--- a/scripts/import-matched.sh
+++ b/scripts/import-matched.sh
@@ -80,6 +80,7 @@ from helmlog.insta360 import (
     discover_recordings,
     match_sessions,
     probe_duration_s,
+    promote_to_insv_extension,
     recording_start_utc,
 )
 from helmlog.pipeline import fetch_sessions_from_pi
@@ -144,15 +145,30 @@ async def main() -> int:
         # Copy every segment of this recording. Multi-segment recordings
         # (Studio joins them on export) need all parts present in the import
         # dir before Studio can stitch them together.
+        #
+        # After each copy, promote dual-fisheye .mp4 → .insv on disk so
+        # Insta360 Studio recognises the X4 OSC-recorded files as 360°
+        # (see promote_to_insv_extension docstring for the full story).
         for seg in rec.segments:
             dest = import_dir / seg.name
+            # Already-present check must consider the .insv twin too,
+            # otherwise re-runs would re-copy every promoted file.
+            promoted_dest = dest.with_suffix(".insv")
             if dest.exists() and dest.stat().st_size == seg.stat().st_size:
+                skipped_existing += 1
+                continue
+            if (
+                dest.suffix.lower() == ".mp4"
+                and promoted_dest.exists()
+                and promoted_dest.stat().st_size == seg.stat().st_size
+            ):
                 skipped_existing += 1
                 continue
             tmp = dest.with_suffix(dest.suffix + ".part")
             print(f"    copying {seg.name} ({seg.stat().st_size / 1_073_741_824:.2f} GB)")
             shutil.copy2(seg, tmp)
             tmp.replace(dest)
+            promote_to_insv_extension(dest)
             copied += 1
 
         # Also copy the LRV preview if it exists — Studio uses it for fast

--- a/scripts/import-matched.sh
+++ b/scripts/import-matched.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# import-matched.sh — Copy session-matching Insta360 recordings off the SD
+# card into a clean staging directory for processing.
+#
+# Walks every VID_*.mp4 / .insv on the card, parses the timestamp from the
+# filename, probes the actual video duration with ffprobe, then asks the
+# HelmLog Pi which races/practices/debriefs that recording overlaps. Only
+# files that overlap a real session get copied — random non-session footage
+# (drone shots, dock loading, kid videos) is ignored so the import dir
+# stays clean and small.
+#
+# Usage:
+#   ./scripts/import-matched.sh                    # auto-detect SD card
+#   ./scripts/import-matched.sh /Volumes/Sailing360
+#
+# Environment overrides:
+#   HELMLOG_IMPORT_DIR    where to copy matches  (default: ~/Insta360 Imports)
+#   PI_API_URL            HelmLog API            (default: http://corvopi-live:3002)
+#   PI_SESSION_COOKIE     Pi auth cookie         (REQUIRED — fetch fails open
+#                          but then nothing matches and nothing is copied)
+#   TIMEZONE              camera local TZ        (default: America/Los_Angeles)
+#
+# Idempotent: re-running skips files that are already in the import dir.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMPORT_DIR="${HELMLOG_IMPORT_DIR:-$HOME/Insta360 Imports}"
+PI_API="${PI_API_URL:-http://corvopi-live:3002}"
+COOKIE="${PI_SESSION_COOKIE:-}"
+TZ_NAME="${TIMEZONE:-America/Los_Angeles}"
+
+log() { echo "[$(date -u +%H:%M:%SZ)] $*"; }
+
+# ── Locate the SD card ───────────────────────────────────────────────────
+find_mount() {
+  if [ -n "${1:-}" ] && [ -d "$1/DCIM/Camera01" ]; then
+    echo "$1"
+    return 0
+  fi
+  for vol in /Volumes/*; do
+    if [ -d "$vol/DCIM/Camera01" ]; then
+      echo "$vol"
+      return 0
+    fi
+  done
+  return 1
+}
+
+SD_MOUNT=$(find_mount "${1:-}") || {
+  log "No Insta360 SD card mounted — nothing to import."
+  exit 0
+}
+log "SD card: $SD_MOUNT"
+log "Import dir: $IMPORT_DIR"
+log "Pi API: $PI_API"
+mkdir -p "$IMPORT_DIR"
+
+if [ -z "$COOKIE" ]; then
+  log "WARN: PI_SESSION_COOKIE not set — session fetch will return zero, nothing will be copied."
+fi
+
+# ── Match + copy via Python (reuses pipeline modules) ─────────────────────
+cd "$PROJECT_DIR"
+
+PI_API_URL="$PI_API" PI_SESSION_COOKIE="$COOKIE" TIMEZONE="$TZ_NAME" \
+HELMLOG_SD_MOUNT="$SD_MOUNT" HELMLOG_IMPORT_DIR="$IMPORT_DIR" \
+uv run --no-sync python << 'PY'
+import asyncio
+import os
+import shutil
+from datetime import timedelta
+from pathlib import Path
+
+from loguru import logger
+
+from helmlog.insta360 import (
+    discover_recordings,
+    match_sessions,
+    probe_duration_s,
+    recording_start_utc,
+)
+from helmlog.pipeline import fetch_sessions_from_pi
+
+
+async def main() -> int:
+    sd = Path(os.environ["HELMLOG_SD_MOUNT"])
+    import_dir = Path(os.environ["HELMLOG_IMPORT_DIR"])
+    pi_url = os.environ["PI_API_URL"]
+    cookie = os.environ.get("PI_SESSION_COOKIE", "")
+    tz = os.environ.get("TIMEZONE", "America/Los_Angeles")
+
+    sessions = await fetch_sessions_from_pi(pi_url, session_cookie=cookie)
+    print(f"fetched {len(sessions)} session(s) from Pi")
+    if not sessions:
+        print("nothing to match against — exiting")
+        return 0
+
+    recordings = discover_recordings(sd)
+    print(f"discovered {len(recordings)} recording(s) on SD card")
+
+    copied = 0
+    skipped_existing = 0
+    skipped_unmatched = 0
+
+    for rec in recordings:
+        start = recording_start_utc(rec, tz)
+
+        # Probe the actual duration so the matching window is real, not the
+        # old start+2h heuristic. Falls back to 2h on probe failure (won't
+        # under-match).
+        first = rec.segments[0] if rec.segments else None
+        duration = probe_duration_s(first) if first is not None else None
+        if duration is None:
+            duration = 7200.0
+        end = start + timedelta(seconds=duration)
+
+        matched = match_sessions(start, end, sessions)
+        if matched is None:
+            skipped_unmatched += 1
+            continue
+
+        # Walk debrief → parent race the same way the upload pipeline does, so
+        # the import decision and the link decision agree on which session
+        # this recording belongs to.
+        parent_id = matched.get("parent_race_id")
+        target = matched
+        if parent_id is not None:
+            for s in sessions:
+                if s.get("id") == parent_id and (
+                    s.get("type") == "race" or s.get("session_type") == "race"
+                ):
+                    target = s
+                    break
+
+        name = target.get("name", target.get("id"))
+        print(
+            f"  [{rec.timestamp_str}] {len(rec.segments)} seg, "
+            f"{rec.total_size_bytes / 1_073_741_824:.2f} GB → {name}"
+        )
+
+        # Copy every segment of this recording. Multi-segment recordings
+        # (Studio joins them on export) need all parts present in the import
+        # dir before Studio can stitch them together.
+        for seg in rec.segments:
+            dest = import_dir / seg.name
+            if dest.exists() and dest.stat().st_size == seg.stat().st_size:
+                skipped_existing += 1
+                continue
+            tmp = dest.with_suffix(dest.suffix + ".part")
+            print(f"    copying {seg.name} ({seg.stat().st_size / 1_073_741_824:.2f} GB)")
+            shutil.copy2(seg, tmp)
+            tmp.replace(dest)
+            copied += 1
+
+        # Also copy the LRV preview if it exists — Studio uses it for fast
+        # scrubbing and it's tiny relative to the main file.
+        for seg in rec.segments:
+            lrv = seg.with_name(seg.name.replace("VID_", "LRV_").replace("_00_", "_01_"))
+            if lrv.exists():
+                lrv_dest = import_dir / lrv.name
+                if not lrv_dest.exists():
+                    shutil.copy2(lrv, lrv_dest)
+
+    print()
+    print(
+        f"summary: {copied} segment(s) copied, "
+        f"{skipped_existing} already-present, "
+        f"{skipped_unmatched} unmatched recording(s) skipped"
+    )
+    return 0
+
+
+import sys
+
+sys.exit(asyncio.run(main()))
+PY

--- a/scripts/process-videos.sh
+++ b/scripts/process-videos.sh
@@ -13,15 +13,24 @@
 # or run manually after inserting the SD card.
 #
 # Environment overrides:
-#   VIDEO_OUTPUT_DIR          where stitched MP4s go  (default: ~/Videos/helmlog)
-#   VIDEO_RESOLUTION          output resolution       (default: 3840x1920)
+#   VIDEO_OUTPUT_DIR          base dir for stitched MP4s (default: ~/Insta360 Exports)
+#                              Each camera's videos go in <VIDEO_OUTPUT_DIR>/<camera_label>/
+#   VIDEO_RESOLUTION          output resolution        (default: 3840x1920)
+#   VIDEO_BITRATE             output bitrate           (e.g. 100M; default: stitcher default)
+#   VIDEO_FLOWSTATE           FlowState stabilization  (default: true)
+#   VIDEO_DIRECTION_LOCK      FlowState direction lock (default: true)
 #   DOCKER_IMAGE              stitcher image           (default: insta360-cli-utils)
-#   PI_API_URL                HelmLog API          (default: http://corvopi:3002)
+#   PI_API_URL                HelmLog API              (default: http://corvopi:3002)
 #   VIDEO_PRIVACY             YouTube privacy          (default: unlisted)
 #   TIMEZONE                  camera local timezone    (default: America/Los_Angeles)
+#   YOUTUBE_ACCOUNT           YouTube channel handle   (default: corvo105)
+#                              Selects ~/.config/helmlog/youtube/<account>.json
 #   YOUTUBE_CLIENT_SECRETS    OAuth2 client secrets    (default: ~/.helmlog-youtube-client-secrets.json)
-#   YOUTUBE_TOKEN_FILE        OAuth2 token cache       (default: ~/.helmlog-youtube-token.json)
 #   PI_SESSION_COOKIE         session cookie for Pi API (enables auto-linking videos to sessions)
+#
+# Multi-camera: when invoked without arguments the script processes EVERY
+# mounted Insta360 volume in parallel. Pass an explicit mount path to
+# process just one.
 
 set -euo pipefail
 
@@ -30,12 +39,16 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
-OUTPUT_DIR="${VIDEO_OUTPUT_DIR:-$HOME/Videos/helmlog}"
+OUTPUT_BASE="${VIDEO_OUTPUT_DIR:-$HOME/Insta360 Exports}"
 RESOLUTION="${VIDEO_RESOLUTION:-3840x1920}"
+BITRATE="${VIDEO_BITRATE:-}"
+FLOWSTATE="${VIDEO_FLOWSTATE:-true}"
+DIRECTION_LOCK="${VIDEO_DIRECTION_LOCK:-true}"
 IMAGE="${DOCKER_IMAGE:-insta360-cli-utils}"
 PI_API="${PI_API_URL:-http://corvopi:3002}"
-PRIVACY="${VIDEO_PRIVACY:-private}"
+PRIVACY="${VIDEO_PRIVACY:-unlisted}"
 TZ_NAME="${TIMEZONE:-America/Los_Angeles}"
+YT_ACCOUNT="${YOUTUBE_ACCOUNT:-corvo105}"
 
 log() { echo "[$(date -u +%H:%M:%SZ)] $*"; }
 warn() { echo "[$(date -u +%H:%M:%SZ)] WARNING: $*" >&2; }
@@ -43,31 +56,67 @@ die() { echo "[$(date -u +%H:%M:%SZ)] ERROR: $*" >&2; exit 1; }
 
 # ── 1. Locate the Insta360 SD card ──────────────────────────────────────────
 
-find_insta360_mount() {
+find_insta360_mounts() {
   # Explicit argument takes priority
   if [ -n "${1:-}" ] && [ -d "$1/DCIM/Camera01" ]; then
     echo "$1"
     return 0
   fi
-  # Auto-detect: look for Insta360 volume in /Volumes
+  local found=0
   for vol in /Volumes/*; do
     if [ -d "$vol/DCIM/Camera01" ]; then
-      # Verify it has Insta360 video files (.insv or .mp4 with VID_ prefix)
       if ls "$vol"/DCIM/Camera01/VID_*.insv &>/dev/null || ls "$vol"/DCIM/Camera01/VID_*.mp4 &>/dev/null; then
         echo "$vol"
-        return 0
+        found=1
       fi
     fi
   done
-  return 1
+  [ "$found" = "1" ]
 }
 
-SD_MOUNT=$(find_insta360_mount "${1:-}") || {
+MOUNTS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && MOUNTS+=("$line")
+done < <(find_insta360_mounts "${1:-}" || true)
+
+if [ ${#MOUNTS[@]} -eq 0 ]; then
   log "No Insta360 SD card detected — nothing to do."
   exit 0
+fi
+
+log "Insta360 volume(s) found: ${MOUNTS[*]}"
+
+# Resolve a camera label per mount via volume UUID lookup
+resolve_camera_label_for() {
+  local mount="$1"
+  cd "$PROJECT_DIR" && uv run --no-sync python -c "
+from pathlib import Path
+from helmlog.insta360 import resolve_camera_label
+label, _known = resolve_camera_label(Path('$mount'))
+print(label)
+" 2>/dev/null || echo "$(basename "$mount")"
 }
 
-log "Insta360 SD card found at: $SD_MOUNT"
+# When multiple volumes are mounted, recurse one process per volume so each
+# camera processes in parallel without sharing temp dirs.
+if [ ${#MOUNTS[@]} -gt 1 ] && [ -z "${HELMLOG_PIPELINE_CHILD:-}" ]; then
+  log "Fanning out ${#MOUNTS[@]} pipeline runs (one per camera)..."
+  pids=()
+  for m in "${MOUNTS[@]}"; do
+    HELMLOG_PIPELINE_CHILD=1 "$0" "$m" &
+    pids+=($!)
+  done
+  for pid in "${pids[@]}"; do
+    wait "$pid" || warn "child pipeline pid $pid exited non-zero"
+  done
+  exit 0
+fi
+
+SD_MOUNT="${MOUNTS[0]}"
+CAMERA_LABEL="$(resolve_camera_label_for "$SD_MOUNT")"
+OUTPUT_DIR="$OUTPUT_BASE/$CAMERA_LABEL"
+log "Processing $SD_MOUNT as camera label: $CAMERA_LABEL"
+log "Output dir: $OUTPUT_DIR"
 
 # ── 2. Confirmation dialog (only when triggered by launchd) ─────────────────
 
@@ -152,10 +201,25 @@ for r in json.load(sys.stdin):
       INPUT_ARGS="$INPUT_ARGS /input/$BASENAME"
     done
 
+    STITCH_FLAGS=()
+    if [ "$FLOWSTATE" = "true" ]; then
+      STITCH_FLAGS+=(--flowstate)
+    else
+      STITCH_FLAGS+=(--no-flowstate)
+    fi
+    if [ "$DIRECTION_LOCK" = "true" ]; then
+      STITCH_FLAGS+=(--direction-lock)
+    else
+      STITCH_FLAGS+=(--no-direction-lock)
+    fi
+    [ -n "$BITRATE" ] && STITCH_FLAGS+=(--bitrate "$BITRATE")
+    [ -n "$RESOLUTION" ] && STITCH_FLAGS+=(--resolution "$RESOLUTION")
+
     docker run --rm \
       -v "$CAMERA_DIR:/input:ro" \
       -v "$OUTPUT_DIR:/output" \
       "$IMAGE" \
+      "${STITCH_FLAGS[@]}" \
       --output "/output/${TS}.mp4" $INPUT_ARGS \
     || {
       warn "[$TS] Stitching failed — skipping this recording"
@@ -201,6 +265,11 @@ fi
 
 log "Uploading to YouTube and linking to sessions..."
 
+export HELMLOG_CAMERA_LABEL="$CAMERA_LABEL"
+export YOUTUBE_ACCOUNT="$YT_ACCOUNT"
+export VIDEO_PRIVACY="$PRIVACY"
+export PI_API_URL="$PI_API"
+
 cd "$PROJECT_DIR"
 uv run python -c "
 import asyncio
@@ -219,6 +288,8 @@ async def main():
         pi_session_cookie=os.environ.get('PI_SESSION_COOKIE', ''),
         privacy=os.environ.get('VIDEO_PRIVACY', 'unlisted'),
         timezone=os.environ.get('TIMEZONE', 'America/Los_Angeles'),
+        camera_label=os.environ.get('HELMLOG_CAMERA_LABEL', ''),
+        youtube_account=os.environ.get('YOUTUBE_ACCOUNT', ''),
     )
 
     # Fetch sessions from the Pi for matching

--- a/scripts/upload-stitched.sh
+++ b/scripts/upload-stitched.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# upload-stitched.sh — Upload one already-stitched Insta360 export to YouTube
+# and link it to the matching HelmLog session.
+#
+# Usage:
+#   ./scripts/upload-stitched.sh /path/to/VID_YYYYMMDD_HHMMSS_00_NNN.mp4
+#
+# Designed to be called by a folder watcher (see scripts/watch-exports.sh) but
+# safe to run by hand. Single-file in, single result out — no batching here.
+#
+# Skips files that:
+#   - aren't named in the X4 VID_*.mp4 / .insv pattern
+#   - are still being written (size still growing)
+#   - are already in the upload ledger
+#
+# Environment overrides (same names as process-videos.sh):
+#   PI_API_URL              default http://corvopi-live:3002
+#   PI_SESSION_COOKIE       required for linking (no link if empty)
+#   YOUTUBE_ACCOUNT         default corvo105
+#   HELMLOG_CAMERA_LABEL    default derived from parent dir name
+#   TIMEZONE                default America/Los_Angeles
+#   VIDEO_PRIVACY           default unlisted
+#   HELMLOG_IMPORT_DIR      default ~/Insta360 Imports
+#   HELMLOG_BACKUP_DIR      default /Volumes/Insta360 Backups/helmlog
+#                           After upload+link succeeds, the stitched export
+#                           and any matching source segments in the import
+#                           dir are moved here. Set to "" to disable moves.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FILE="${1:-}"
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+  echo "Usage: $0 /path/to/VID_*.mp4" >&2
+  exit 1
+fi
+
+# Sanity-check the filename pattern; the timestamp comes from the name.
+BASE=$(basename "$FILE")
+if ! [[ "$BASE" =~ ^(PRO_)?VID_([0-9]{8}_[0-9]{6}) ]]; then
+  echo "Skipping (not an Insta360 VID file): $BASE" >&2
+  exit 0
+fi
+TS="${BASH_REMATCH[2]}"
+
+# Wait for the file to stop growing — Studio writes incrementally and we
+# don't want to upload a half-rendered file.
+prev_size=-1
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  cur=$(stat -f%z "$FILE" 2>/dev/null || echo 0)
+  if [ "$cur" -gt 0 ] && [ "$cur" -eq "$prev_size" ]; then
+    break
+  fi
+  prev_size=$cur
+  sleep 3
+done
+
+# Default the camera label from the parent directory if not set explicitly,
+# so files dropped into ~/Insta360 Exports/stern/ get tagged "stern".
+if [ -z "${HELMLOG_CAMERA_LABEL:-}" ]; then
+  parent=$(basename "$(dirname "$FILE")")
+  if [ "$parent" != "Insta360 Exports" ] && [ "$parent" != "." ]; then
+    export HELMLOG_CAMERA_LABEL="$parent"
+  fi
+fi
+
+export PI_API_URL="${PI_API_URL:-http://corvopi-live:3002}"
+export PI_SESSION_COOKIE="${PI_SESSION_COOKIE:-}"
+export YOUTUBE_ACCOUNT="${YOUTUBE_ACCOUNT:-corvo105}"
+export TIMEZONE="${TIMEZONE:-America/Los_Angeles}"
+export VIDEO_PRIVACY="${VIDEO_PRIVACY:-unlisted}"
+export HELMLOG_IMPORT_DIR="${HELMLOG_IMPORT_DIR:-$HOME/Insta360 Imports}"
+export HELMLOG_BACKUP_DIR="${HELMLOG_BACKUP_DIR:-/Volumes/Insta360 Backups/helmlog}"
+
+cd "$PROJECT_DIR"
+
+uv run --no-sync python - "$FILE" "$TS" << 'PY'
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from helmlog.insta360 import InstaRecording
+from helmlog.pipeline import PipelineConfig, fetch_sessions_from_pi, process_recording
+from helmlog.video_ledger import LedgerEntry, LedgerKey, VideoLedger
+
+
+async def main() -> int:
+    src = Path(sys.argv[1])
+    ts = sys.argv[2]
+
+    cfg = PipelineConfig(
+        pi_api_url=os.environ["PI_API_URL"],
+        pi_session_cookie=os.environ.get("PI_SESSION_COOKIE", ""),
+        privacy=os.environ.get("VIDEO_PRIVACY", "unlisted"),
+        timezone=os.environ.get("TIMEZONE", "America/Los_Angeles"),
+        camera_label=os.environ.get("HELMLOG_CAMERA_LABEL", ""),
+        youtube_account=os.environ.get("YOUTUBE_ACCOUNT", ""),
+    )
+
+    # Skip if we've already uploaded this exact file (size + name).
+    ledger = VideoLedger()
+    key = LedgerKey(
+        volume_uuid=cfg.camera_label or "unknown",
+        source_filename=src.name,
+        size_bytes=src.stat().st_size,
+    )
+    if ledger.has(key):
+        prev = ledger.get(key)
+        print(f"already uploaded: {prev.youtube_url if prev else 'unknown'} — skipping")
+        return 0
+
+    sessions = await fetch_sessions_from_pi(
+        cfg.pi_api_url, session_cookie=cfg.pi_session_cookie
+    )
+    print(f"fetched {len(sessions)} session(s) from Pi")
+
+    rec = InstaRecording(
+        timestamp_str=ts,
+        segments=[src],
+        total_size_bytes=src.stat().st_size,
+        needs_stitching=False,
+    )
+    result = await process_recording(
+        rec=rec, video_path=src, sessions=sessions, config=cfg
+    )
+
+    print(
+        f"uploaded={result.uploaded} video_id={result.video_id} "
+        f"session_id={result.session_id} linked={result.linked} "
+        f"error={result.error}"
+    )
+
+    if result.uploaded and result.video_id and result.youtube_url:
+        ledger.record(
+            LedgerEntry(
+                volume_uuid=cfg.camera_label or "unknown",
+                source_filename=src.name,
+                size_bytes=src.stat().st_size,
+                video_id=result.video_id,
+                youtube_url=result.youtube_url,
+                camera_label=cfg.camera_label,
+                session_id=result.session_id,
+                linked=result.linked,
+            )
+        )
+
+        # Move the stitched export and any matching source segments from the
+        # import dir to the long-term backup volume. Only run when linking
+        # succeeded too — keeps unlinked uploads in place for manual
+        # troubleshooting.
+        if result.linked:
+            backup_dir = Path(os.environ.get("HELMLOG_BACKUP_DIR", "")).expanduser()
+            import_dir = Path(
+                os.environ.get("HELMLOG_IMPORT_DIR", "~/Insta360 Imports")
+            ).expanduser()
+            if backup_dir and str(backup_dir):
+                _move_to_backup(src, ts, backup_dir, import_dir)
+
+        # macOS notification — fire-and-forget, no error if osascript missing
+        try:
+            import subprocess
+
+            subprocess.run(
+                [
+                    "osascript",
+                    "-e",
+                    f'display notification "{result.youtube_url}" '
+                    f'with title "HelmLog video uploaded" '
+                    f'subtitle "{src.name}"',
+                ],
+                check=False,
+                timeout=5,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return 0
+
+    return 1
+
+
+def _move_to_backup(
+    stitched: Path, timestamp: str, backup_dir: Path, import_dir: Path
+) -> None:
+    """Move the uploaded stitched MP4 + matching source segments to backups.
+
+    Source segments are identified by the recording timestamp, e.g. all files
+    in ``import_dir`` whose name matches ``VID_<timestamp>_00_*`` (and the
+    ``LRV_..._01_*`` previews) get archived together.
+
+    Cross-volume moves on macOS use ``shutil.move`` which copy-then-deletes,
+    so this can take a few minutes for a 13 GB file. The function logs each
+    move and continues on individual failures rather than aborting the run —
+    a partial backup is better than none.
+    """
+    import shutil
+
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"backup: cannot create {backup_dir}: {exc}")
+        return
+
+    moved: list[Path] = []
+
+    # 1. The stitched MP4 we just uploaded.
+    if stitched.exists():
+        try:
+            dest = backup_dir / stitched.name
+            print(f"backup: moving stitched export → {dest}")
+            shutil.move(str(stitched), str(dest))
+            moved.append(dest)
+        except OSError as exc:
+            print(f"backup: failed to move {stitched.name}: {exc}")
+
+    # 2. All source segments in the import dir for this timestamp.
+    if import_dir.is_dir():
+        for src_file in sorted(import_dir.iterdir()):
+            name = src_file.name
+            # Match VID_<ts>_00_* (main lens) and LRV_<ts>_01_* (preview)
+            if not (
+                name.startswith(f"VID_{timestamp}_00_")
+                or name.startswith(f"LRV_{timestamp}_01_")
+            ):
+                continue
+            try:
+                dest = backup_dir / name
+                print(f"backup: moving source → {dest}")
+                shutil.move(str(src_file), str(dest))
+                moved.append(dest)
+            except OSError as exc:
+                print(f"backup: failed to move {name}: {exc}")
+
+    if moved:
+        print(f"backup: archived {len(moved)} file(s) to {backup_dir}")
+    else:
+        print(f"backup: nothing to move from {import_dir}")
+
+
+sys.exit(asyncio.run(main()))
+PY

--- a/scripts/watch-exports.sh
+++ b/scripts/watch-exports.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# watch-exports.sh — Watch ~/Insta360 Exports/ for newly stitched MP4s and
+# auto-upload + link each one to its matching HelmLog session.
+#
+# Designed to run as a background launchd agent (see
+# launchd/com.helmlog.video-watch.plist) but safe to run by hand for testing.
+#
+# Usage:
+#   ./scripts/watch-exports.sh                # watch default dir
+#   ./scripts/watch-exports.sh /custom/path   # watch a different dir
+#
+# Companion to upload-stitched.sh — this script just spots new files and
+# delegates the actual upload to upload-stitched.sh per file.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCH_DIR="${1:-$HOME/Insta360 Exports}"
+UPLOAD_SCRIPT="$SCRIPT_DIR/upload-stitched.sh"
+
+if ! command -v fswatch >/dev/null 2>&1; then
+  echo "ERROR: fswatch is required (brew install fswatch)" >&2
+  exit 1
+fi
+
+if [ ! -d "$WATCH_DIR" ]; then
+  echo "ERROR: watch dir does not exist: $WATCH_DIR" >&2
+  exit 1
+fi
+
+if [ ! -x "$UPLOAD_SCRIPT" ]; then
+  echo "ERROR: upload script not executable: $UPLOAD_SCRIPT" >&2
+  exit 1
+fi
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+log "Watching: $WATCH_DIR"
+log "Upload script: $UPLOAD_SCRIPT"
+
+# fswatch flags:
+#   -0          NUL-separated output (handles spaces in paths)
+#   -r          recurse so per-camera subdirs are covered
+#   -e          exclude regex (skip everything by default …)
+#   -i          … then include only VID_*.mp4 / .insv
+#   --event     only fire on Created / MovedTo (file appearance)
+#   --latency   small debounce
+fswatch \
+  -0 \
+  -r \
+  --latency 1 \
+  --event=Created \
+  --event=Updated \
+  --event=MovedTo \
+  -e ".*" \
+  -i 'VID_[0-9]{8}_[0-9]{6}_[0-9]{2}_[0-9]+.*\.(mp4|insv)$' \
+  "$WATCH_DIR" |
+  while IFS= read -r -d '' f; do
+    log "event: $f"
+    # Run uploads sequentially — one big upload at a time keeps quota,
+    # bandwidth, and YouTube rate-limits sane.
+    "$UPLOAD_SCRIPT" "$f" || log "upload failed for $f"
+  done

--- a/src/helmlog/insta360.py
+++ b/src/helmlog/insta360.py
@@ -19,16 +19,17 @@ stitcher automatically pairs front+back.
 
 from __future__ import annotations
 
+import plistlib
 import re
+import subprocess
+import tomllib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from loguru import logger
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Filename parsing
@@ -171,6 +172,123 @@ def recording_start_utc(rec: InstaRecording, tz_name: str) -> datetime:
     naive = datetime.strptime(rec.timestamp_str, "%Y%m%d_%H%M%S")
     local_dt = naive.replace(tzinfo=tz)
     return local_dt.astimezone(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Camera identity (volume UUID → user-assigned label)
+# ---------------------------------------------------------------------------
+
+
+def default_camera_labels_path() -> Path:
+    """Return the on-disk camera-label config path on the Mac."""
+    return Path.home() / ".config" / "helmlog" / "cameras.toml"
+
+
+def volume_uuid_for(mount_path: Path) -> str | None:
+    """Return the macOS volume UUID for a mounted volume.
+
+    Uses ``diskutil info -plist <mount>``. Returns ``None`` on any
+    failure (non-macOS, unmounted, etc.) so callers can fall back to
+    the volume basename.
+    """
+    try:
+        result = subprocess.run(
+            ["diskutil", "info", "-plist", str(mount_path)],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.debug("diskutil lookup failed for {}: {}", mount_path, exc)
+        return None
+    try:
+        info = plistlib.loads(result.stdout)
+    except plistlib.InvalidFileException as exc:
+        logger.debug("Could not parse diskutil plist for {}: {}", mount_path, exc)
+        return None
+    uuid = info.get("VolumeUUID") or info.get("DiskUUID")
+    return str(uuid) if uuid else None
+
+
+def _placeholder_label(volume_uuid: str) -> str:
+    """Build a placeholder camera label from a volume UUID."""
+    short = volume_uuid.replace("-", "").lower()[:8]
+    return f"camera-{short}"
+
+
+def load_camera_labels(path: Path | None = None) -> dict[str, str]:
+    """Load the volume-UUID → camera-label map from the Mac config file.
+
+    Returns an empty dict if the file is missing or unparseable.
+    """
+    cfg = path or default_camera_labels_path()
+    if not cfg.exists():
+        return {}
+    try:
+        data = tomllib.loads(cfg.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Could not read camera labels {}: {}", cfg, exc)
+        return {}
+    cameras = data.get("cameras", {})
+    if not isinstance(cameras, dict):
+        return {}
+    return {str(k).lower(): str(v) for k, v in cameras.items() if v}
+
+
+def save_camera_label(volume_uuid: str, label: str, path: Path | None = None) -> None:
+    """Persist a label for a volume UUID, creating the file if needed."""
+    cfg = path or default_camera_labels_path()
+    existing = load_camera_labels(cfg)
+    existing[volume_uuid.lower()] = label
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["[cameras]"]
+    for uuid, lbl in sorted(existing.items()):
+        lines.append(f'"{uuid}" = "{lbl}"')
+    cfg.write_text("\n".join(lines) + "\n")
+
+
+def resolve_camera_label(
+    mount_path: Path,
+    *,
+    labels_path: Path | None = None,
+) -> tuple[str, bool]:
+    """Resolve the camera label to use for a mounted volume.
+
+    Strategy:
+      1. Look up the volume UUID via ``diskutil``.
+      2. If a stored label exists for that UUID, use it (``known=True``).
+      3. Otherwise persist a placeholder ``camera-<uuid8>`` and return
+         it as ``known=False`` so the caller can notify the user to
+         rename the camera in the config.
+      4. If the UUID lookup fails, fall back to the volume basename.
+
+    Returns:
+        ``(label, is_user_assigned)``.
+    """
+    uuid = volume_uuid_for(mount_path)
+    if uuid is None:
+        fallback = mount_path.name or "camera"
+        logger.warning(
+            "No volume UUID for {} — using basename {!r} as camera label",
+            mount_path,
+            fallback,
+        )
+        return fallback, False
+
+    labels = load_camera_labels(labels_path)
+    stored = labels.get(uuid.lower())
+    if stored:
+        return stored, True
+
+    placeholder = _placeholder_label(uuid)
+    save_camera_label(uuid, placeholder, labels_path)
+    logger.warning(
+        "Unknown camera (volume UUID {}); using placeholder label {!r}. Edit {} to rename.",
+        uuid,
+        placeholder,
+        labels_path or default_camera_labels_path(),
+    )
+    return placeholder, False
 
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/insta360.py
+++ b/src/helmlog/insta360.py
@@ -93,12 +93,100 @@ class InstaRecording:
 # ---------------------------------------------------------------------------
 
 
+def probe_duration_s(path: Path) -> float | None:
+    """Return the video duration in seconds, or ``None`` on probe failure.
+
+    Used by the import step to compute an accurate ``end_utc`` for session
+    matching — far more reliable than the old ``start_utc + 2 hours``
+    heuristic, which would over-match recordings to sessions hours away.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "csv=p=0",
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.debug("ffprobe duration failed for {}: {}", path, exc)
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def is_dual_fisheye(path: Path) -> bool:
+    """Return True if a video file is X4 dual-fisheye 360°.
+
+    Probes the container with ``ffprobe`` and considers a file to be
+    dual-fisheye when it contains **two** video streams of identical,
+    square dimensions (the X4 5.7K mode is 2880×2880 × 2; 8K mode is
+    3840×3840 × 2). Falls back to ``False`` on any probe failure so the
+    pipeline degrades to a direct upload rather than blowing up.
+
+    The X4 writes 360° captures as either ``.insv`` or ``.mp4``
+    depending on firmware/mode — the file extension is not a reliable
+    signal, so we look at the streams instead.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v",
+                "-show_entries",
+                "stream=width,height",
+                "-of",
+                "csv=p=0",
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.debug("ffprobe failed for {}: {}", path, exc)
+        return False
+    streams = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if len(streams) != 2:
+        return False
+    if streams[0] != streams[1]:
+        return False
+    try:
+        w, h = (int(x) for x in streams[0].split(","))
+    except ValueError:
+        return False
+    return w == h and w >= 1920
+
+
 def discover_recordings(mount_path: Path) -> list[InstaRecording]:
     """Scan an Insta360 SD card for video files and group into recordings.
 
     Looks in ``<mount_path>/DCIM/Camera01/`` for VID_*.insv and VID_*.mp4,
     groups by recording timestamp, and returns them sorted chronologically.
     Only ``_00_`` (back/main lens) segments are included.
+
+    Each recording is probed with :func:`is_dual_fisheye` to decide
+    whether it needs stitching — the X4 can write 360° captures as
+    either ``.insv`` or ``.mp4``, so the file extension alone isn't a
+    reliable signal.
 
     Args:
         mount_path: Root of the mounted SD card (e.g. ``/Volumes/Insta360 X4``).
@@ -111,23 +199,21 @@ def discover_recordings(mount_path: Path) -> list[InstaRecording]:
         logger.debug("No DCIM/Camera01 found at {}", mount_path)
         return []
 
-    # Collect main-lens segments grouped by timestamp + extension
+    # Collect main-lens segments grouped by timestamp
     groups: dict[str, list[tuple[int, Path]]] = {}
-    extensions: dict[str, str] = {}  # timestamp → extension
     for f in camera_dir.iterdir():
         info = parse_insv_filename(f.name)
         if info is None or info.lens != "00":
             continue
         groups.setdefault(info.timestamp_str, []).append((info.segment, f))
-        extensions[info.timestamp_str] = info.extension
 
     recordings: list[InstaRecording] = []
     for ts, segs in sorted(groups.items()):
         segs.sort(key=lambda t: t[0])  # sort by segment number
         paths = [p for _, p in segs]
         total = sum(p.stat().st_size for p in paths)
-        ext = extensions[ts]
-        needs_stitch = ext == "insv"
+        # Probe the first segment — all segments of one recording share format
+        needs_stitch = is_dual_fisheye(paths[0])
         recordings.append(
             InstaRecording(
                 timestamp_str=ts,

--- a/src/helmlog/insta360.py
+++ b/src/helmlog/insta360.py
@@ -15,6 +15,24 @@ File naming convention (Insta360 X4):
 
 Only ``_00_`` files are included in recording segments; for .insv the
 stitcher automatically pairs front+back.
+
+X4 OSC startCapture quirk
+-------------------------
+When the X4 is started via the OSC HTTP API (``camera.startCapture``)
+rather than the physical shutter button, the camera writes a *correct*
+dual-fisheye 360° recording — two HEVC video streams + audio + IMU
+trailer — but **labels the file with a ``.mp4`` extension** instead of
+``.insv``. Insta360 Studio (and the GoPro VR plugin, Pano2VR, etc.)
+gate 360° processing on the extension and silently treat ``.mp4`` as
+flat single-lens video, discarding the second video stream and the
+gyroscope metadata needed for horizon-leveling.
+
+:func:`is_dual_fisheye` detects this content-vs-extension mismatch by
+probing the stream count + dimensions with ffprobe.
+:func:`promote_to_insv_extension` renames the file in place when copied
+into the import staging dir so Studio sees it as the 360° recording it
+really is. Genuine single-lens ``.mp4`` files (one video stream) are
+left untouched.
 """
 
 from __future__ import annotations
@@ -174,6 +192,46 @@ def is_dual_fisheye(path: Path) -> bool:
     except ValueError:
         return False
     return w == h and w >= 1920
+
+
+def promote_to_insv_extension(path: Path) -> Path:
+    """Rename a dual-fisheye ``.mp4`` to ``.insv`` on disk and return the new path.
+
+    Insta360 Studio (and Pano2VR, the GoPro VR plugin, Premiere's spatial
+    metadata reader, etc.) gate 360° processing on the ``.insv`` file
+    extension and silently treat ``.mp4`` as flat single-lens video —
+    throwing away the second video stream and the IMU/gyro metadata
+    needed for horizon-leveling.
+
+    The X4 OSC ``camera.startCapture`` writes correct dual-fisheye
+    content but mislabels the file ``.mp4``; this helper detects that
+    case via :func:`is_dual_fisheye` and renames the file in place so
+    Studio (and any downstream tool that reads from ``HELMLOG_IMPORT_DIR``)
+    sees it as the 360° recording it actually is.
+
+    No-op for files that are not ``.mp4``, files that fail the
+    dual-fisheye probe, and the case where the ``.insv`` twin already
+    exists. Idempotent. Returns the (possibly new) path.
+    """
+    if path.suffix.lower() != ".mp4":
+        return path
+    if not is_dual_fisheye(path):
+        return path
+    target = path.with_suffix(".insv")
+    if target.exists():
+        logger.warning(
+            "Refusing to promote {} → {}: target already exists",
+            path.name,
+            target.name,
+        )
+        return path
+    path.rename(target)
+    logger.info(
+        "Promoted X4 OSC recording {} → {} (dual-fisheye 360°, .mp4 → .insv)",
+        path.name,
+        target.name,
+    )
+    return target
 
 
 def discover_recordings(mount_path: Path) -> list[InstaRecording]:

--- a/src/helmlog/pipeline.py
+++ b/src/helmlog/pipeline.py
@@ -26,12 +26,28 @@ from helmlog.youtube import build_description, build_title, upload_video
 
 @dataclass(frozen=True)
 class PipelineConfig:
-    """Runtime configuration for the video pipeline."""
+    """Runtime configuration for the video pipeline.
+
+    Attributes:
+        pi_api_url: HelmLog Pi base URL.
+        pi_session_cookie: Auth cookie for Pi API calls (enables linking).
+        privacy: YouTube privacy status for uploads.
+        timezone: Camera local timezone for filename → UTC conversion.
+        camera_label: Per-camera identifier (e.g. ``"bow"``, ``"stern"``).
+            Used for output subdirectory, YouTube title suffix, and the
+            link label posted to the Pi. Empty string disables the
+            per-camera suffix (single-camera mode).
+        youtube_account: YouTube channel handle to upload to. Drives
+            which OAuth token file is loaded — see
+            :func:`helmlog.youtube.upload_video`.
+    """
 
     pi_api_url: str = "http://corvopi:3002"
     pi_session_cookie: str = ""
     privacy: str = "unlisted"
     timezone: str = "America/Los_Angeles"
+    camera_label: str = ""
+    youtube_account: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +101,20 @@ async def fetch_sessions_from_pi(
         return []
 
 
+def build_link_label(camera_label: str = "") -> str:
+    """Build the per-video label posted to the Pi when linking.
+
+    Examples:
+        >>> build_link_label("")
+        '360 cam'
+        >>> build_link_label("bow")
+        '360 cam — bow'
+    """
+    if camera_label:
+        return f"360 cam — {camera_label}"
+    return "360 cam"
+
+
 async def _link_video_on_pi(
     *,
     pi_api_url: str,
@@ -92,6 +122,7 @@ async def _link_video_on_pi(
     youtube_url: str,
     sync_utc: str,
     session_cookie: str,
+    label: str = "360 cam",
 ) -> httpx.Response:
     """POST to the Pi API to link a YouTube video to a session.
 
@@ -102,7 +133,7 @@ async def _link_video_on_pi(
             f"{pi_api_url}/api/sessions/{session_id}/videos",
             json={
                 "youtube_url": youtube_url,
-                "label": "360 cam",
+                "label": label,
                 "sync_utc": sync_utc,
                 "sync_offset_s": 0.0,
             },
@@ -146,6 +177,7 @@ async def process_recording(
     result.session_id = session_id
 
     # Build metadata
+    title_suffix = f" — {config.camera_label} cam" if config.camera_label else ""
     if session:
         title = build_title(
             event=session.get("event"),
@@ -153,6 +185,7 @@ async def process_recording(
             race_num=session.get("race_num"),
             date=start_utc.strftime("%Y-%m-%d"),
         )
+        title = f"{title}{title_suffix}"
         base = f"{config.pi_api_url}/history"
         session_slug = session.get("slug")
         if session_id and session_slug:
@@ -176,6 +209,7 @@ async def process_recording(
             race_num=None,
             date=start_utc.strftime("%Y-%m-%d"),
         )
+        title = f"{title}{title_suffix}"
         desc = build_description(
             session_url=f"{config.pi_api_url}/history",
             start_utc=start_utc.isoformat(),
@@ -190,6 +224,7 @@ async def process_recording(
             title=title,
             description=desc,
             privacy=config.privacy,
+            youtube_account=config.youtube_account or None,
         )
         result.uploaded = True
         result.video_id = upload_result.video_id
@@ -209,6 +244,7 @@ async def process_recording(
                 youtube_url=upload_result.youtube_url,
                 sync_utc=start_utc.isoformat(),
                 session_cookie=config.pi_session_cookie,
+                label=build_link_label(config.camera_label),
             )
             if link_resp.status_code == 201:
                 result.linked = True

--- a/src/helmlog/pipeline.py
+++ b/src/helmlog/pipeline.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
 from loguru import logger
@@ -202,15 +203,19 @@ async def process_recording(
     session_id: int | None = session.get("id") if session else None
     result.session_id = session_id
 
-    # Build metadata
+    # Build metadata. Date + time in the title use the configured local
+    # timezone (typically the boat's local time) so sailors reading the
+    # YouTube channel see the date/time they actually sailed — and so titles
+    # sort chronologically when the session spans midnight UTC.
     title_suffix = f" — {config.camera_label} cam" if config.camera_label else ""
     # The /api/sessions endpoint returns the session-type field as ``type``,
     # not ``session_type`` — fall through to keep older callers working.
     sess_type = (
         session.get("type") or session.get("session_type") or "sailing" if session else "sailing"
     )
-    title_date = start_utc.strftime("%Y-%m-%d")
-    title_time = start_utc.strftime("%H:%MZ")
+    local_start = start_utc.astimezone(ZoneInfo(config.timezone))
+    title_date = local_start.strftime("%Y-%m-%d")
+    title_time = local_start.strftime("%H:%M %Z")
     if session:
         title = build_title(
             event=session.get("event"),

--- a/src/helmlog/pipeline.py
+++ b/src/helmlog/pipeline.py
@@ -172,18 +172,52 @@ async def process_recording(
     end_utc = start_utc + timedelta(hours=2)
 
     # Match to a session
-    session = match_sessions(start_utc, end_utc, sessions)
+    matched = match_sessions(start_utc, end_utc, sessions)
+    # The /api/sessions list mixes races, debriefs, and practice sessions, but
+    # the link endpoint only accepts race IDs. When the matcher picks a child
+    # session (e.g. a debrief), follow ``parent_race_id`` to the parent race
+    # and use *its* metadata for both linking and title-building so the
+    # YouTube title says "Race 4", not "Debrief 4".
+    session = matched
+    if matched is not None:
+        parent_race_id = matched.get("parent_race_id")
+        if parent_race_id is not None:
+            parent = next(
+                (
+                    s
+                    for s in sessions
+                    if s.get("id") == parent_race_id
+                    and (s.get("type") == "race" or s.get("session_type") == "race")
+                ),
+                None,
+            )
+            if parent is not None:
+                session = parent
+                logger.info(
+                    "[{}] Walked from {} → parent race {} for link + title",
+                    rec.timestamp_str,
+                    matched.get("name", matched.get("id")),
+                    parent.get("name", parent.get("id")),
+                )
     session_id: int | None = session.get("id") if session else None
     result.session_id = session_id
 
     # Build metadata
     title_suffix = f" — {config.camera_label} cam" if config.camera_label else ""
+    # The /api/sessions endpoint returns the session-type field as ``type``,
+    # not ``session_type`` — fall through to keep older callers working.
+    sess_type = (
+        session.get("type") or session.get("session_type") or "sailing" if session else "sailing"
+    )
+    title_date = start_utc.strftime("%Y-%m-%d")
+    title_time = start_utc.strftime("%H:%MZ")
     if session:
         title = build_title(
             event=session.get("event"),
-            session_type=session.get("session_type", "sailing"),
+            session_type=sess_type,
             race_num=session.get("race_num"),
-            date=start_utc.strftime("%Y-%m-%d"),
+            date=title_date,
+            time=title_time,
         )
         title = f"{title}{title_suffix}"
         base = f"{config.pi_api_url}/history"
@@ -207,7 +241,8 @@ async def process_recording(
             event=None,
             session_type="sailing",
             race_num=None,
-            date=start_utc.strftime("%Y-%m-%d"),
+            date=title_date,
+            time=title_time,
         )
         title = f"{title}{title_suffix}"
         desc = build_description(

--- a/src/helmlog/video_ledger.py
+++ b/src/helmlog/video_ledger.py
@@ -1,0 +1,114 @@
+"""Persistent record of which Insta360 recordings have already been uploaded.
+
+The ledger is a small JSON file keyed by ``(volume_uuid, source_filename,
+size_bytes)`` so the pipeline can skip recordings that have already made
+it to YouTube even if the SD card is re-inserted, the camera is plugged
+in twice, or a previous run was interrupted after upload but before
+linking.
+
+The file lives at ``~/.config/helmlog/video-ledger.json`` by default.
+A single ledger is shared across all cameras — entries are
+camera-distinguished by ``volume_uuid``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def default_ledger_path() -> Path:
+    """Return the default ledger location."""
+    return Path.home() / ".config" / "helmlog" / "video-ledger.json"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LedgerKey:
+    """Identifies a recording uniquely across re-mounts and renames."""
+
+    volume_uuid: str
+    source_filename: str
+    size_bytes: int
+
+    def as_str(self) -> str:
+        return f"{self.volume_uuid}|{self.source_filename}|{self.size_bytes}"
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """One row in the ledger."""
+
+    volume_uuid: str
+    source_filename: str
+    size_bytes: int
+    video_id: str
+    youtube_url: str
+    camera_label: str = ""
+    session_id: int | None = None
+    linked: bool = False
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+class VideoLedger:
+    """Tiny JSON-backed ledger of uploaded recordings."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or default_ledger_path()
+        self._entries: dict[str, LedgerEntry] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Could not read video ledger {}: {}", self.path, exc)
+            return
+        for row in raw.get("entries", []):
+            try:
+                entry = LedgerEntry(**row)
+            except TypeError as exc:
+                logger.warning("Skipping malformed ledger row: {}", exc)
+                continue
+            self._entries[
+                LedgerKey(entry.volume_uuid, entry.source_filename, entry.size_bytes).as_str()
+            ] = entry
+
+    def has(self, key: LedgerKey) -> bool:
+        return key.as_str() in self._entries
+
+    def get(self, key: LedgerKey) -> LedgerEntry | None:
+        return self._entries.get(key.as_str())
+
+    def record(self, entry: LedgerEntry) -> None:
+        """Add or update an entry and atomically rewrite the file."""
+        key = LedgerKey(entry.volume_uuid, entry.source_filename, entry.size_bytes)
+        self._entries[key.as_str()] = entry
+        self._flush()
+
+    def _flush(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"entries": [asdict(e) for e in self._entries.values()]}
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.replace(self.path)
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/src/helmlog/youtube.py
+++ b/src/helmlog/youtube.py
@@ -154,21 +154,29 @@ def build_title(
     session_type: str,
     race_num: int | None,
     date: str,
+    time: str | None = None,
 ) -> str:
     """Build a YouTube video title from session metadata.
 
+    Titles lead with date (and optional time) so they sort correctly in
+    chronological order under any alphabetic listing — that's how we
+    keep race videos lined up on the YouTube channel page.
+
     Examples:
-        >>> build_title(event="Ballard Cup", session_type="race", race_num=2, date="2026-08-10")
-        'Ballard Cup Race 2 — 2026-08-10'
-        >>> build_title(event=None, session_type="practice", race_num=None, date="2026-08-10")
-        'Practice — 2026-08-10'
+        >>> build_title(event="Ballard Cup", session_type="race", race_num=2,
+        ...             date="2026-08-10", time="14:05")
+        '2026-08-10 14:05 — Ballard Cup Race 2'
+        >>> build_title(event=None, session_type="practice", race_num=None,
+        ...             date="2026-08-10")
+        '2026-08-10 — Practice'
     """
     label = session_type.capitalize()
     if race_num is not None:
         label = f"{label} {race_num}"
     if event:
         label = f"{event} {label}"
-    return f"{label} — {date}"
+    prefix = f"{date} {time}" if time else date
+    return f"{prefix} — {label}"
 
 
 def build_description(
@@ -285,18 +293,47 @@ async def upload_video(
 
     logger.info("Uploading {} to YouTube as {!r} ({})", file_path.name, title, privacy)
 
-    # Run the upload in a thread to avoid blocking the event loop
+    # Run the upload in a thread to avoid blocking the event loop. Each
+    # ``next_chunk`` call can fail transiently on flaky connections (timeouts,
+    # connection resets, 5xx). Retry the call (not the whole upload) with
+    # exponential backoff so the resumable upload picks up where it left off
+    # instead of starting over from byte zero.
     def _do_upload() -> str:
+        import socket
+        import time
+
         request = service.videos().insert(  # type: ignore[attr-defined]
             part="snippet,status",
             body=body,
             media_body=media,
         )
         response: Any = None
+        retryable: tuple[type[BaseException], ...] = (
+            TimeoutError,
+            ConnectionError,
+            socket.timeout,
+        )
+        max_attempts = 6
         while response is None:
-            status, response = request.next_chunk()
-            if status:
-                logger.debug("Upload progress: {:.0%}", status.progress())
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    status, response = request.next_chunk()
+                except retryable as exc:
+                    if attempt == max_attempts:
+                        raise
+                    delay = 2**attempt
+                    logger.warning(
+                        "Upload chunk failed ({}); retry {}/{} in {}s",
+                        exc,
+                        attempt,
+                        max_attempts - 1,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                if status:
+                    logger.debug("Upload progress: {:.0%}", status.progress())
+                break
         return str(response["id"])
 
     video_id: str = await asyncio.to_thread(_do_upload)

--- a/src/helmlog/youtube.py
+++ b/src/helmlog/youtube.py
@@ -23,7 +23,21 @@ from googleapiclient.discovery import build as _build_service  # type: ignore[im
 from googleapiclient.http import MediaFileUpload  # type: ignore[import-untyped]
 from loguru import logger
 
-_SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+_SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.readonly",
+]
+
+
+def account_token_path(account: str) -> Path:
+    """Return the OAuth token cache path for a YouTube account.
+
+    Tokens live under ``~/.config/helmlog/youtube/<account>.json`` so
+    multiple channels can be used without clobbering each other.
+    """
+    base = Path.home() / ".config" / "helmlog" / "youtube"
+    return base / f"{account}.json"
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -82,6 +96,51 @@ def load_credentials(client_secrets: Path, token_file: Path) -> Credentials:
 def build_service(creds: Credentials) -> object:
     """Build the YouTube API service object."""
     return _build_service("youtube", "v3", credentials=creds)
+
+
+class ChannelMismatchError(RuntimeError):
+    """Raised when the authenticated channel does not match the expected account."""
+
+
+def verify_channel(service: object, expected_account: str) -> str:
+    """Confirm the loaded credentials authenticate to the expected channel.
+
+    Calls ``channels.list(mine=true)`` and compares the returned channel
+    title and custom URL/handle against ``expected_account``. Match is
+    case-insensitive and tolerates a leading ``@`` on the handle.
+
+    Args:
+        service: The YouTube API service from :func:`build_service`.
+        expected_account: Channel handle or title (e.g. ``"corvo105"``).
+
+    Returns:
+        The actual channel title returned by the API.
+
+    Raises:
+        ChannelMismatchError: If neither title nor handle matches.
+    """
+    expected = expected_account.lstrip("@").lower()
+    response = (
+        service.channels()  # type: ignore[attr-defined]
+        .list(part="snippet", mine=True)
+        .execute()
+    )
+    items = response.get("items") or []
+    if not items:
+        raise ChannelMismatchError(
+            f"YouTube credentials returned no channel; expected {expected_account!r}"
+        )
+    snippet = items[0].get("snippet", {})
+    title = str(snippet.get("title", ""))
+    custom_url = str(snippet.get("customUrl", "")).lstrip("@")
+    candidates = {title.lower(), custom_url.lower()}
+    if expected not in candidates:
+        raise ChannelMismatchError(
+            f"YouTube credentials authenticate {title!r}/{custom_url!r}, "
+            f"expected {expected_account!r}. Re-run OAuth for this account."
+        )
+    logger.info("YouTube channel verified: {} ({})", title, custom_url or "no handle")
+    return title
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +212,7 @@ async def upload_video(
     tags: list[str] | None = None,
     client_secrets: Path | None = None,
     token_file: Path | None = None,
+    youtube_account: str | None = None,
 ) -> UploadResult:
     """Upload a video to YouTube via the Data API v3.
 
@@ -178,15 +238,36 @@ async def upload_video(
             str(Path.home() / ".helmlog-youtube-client-secrets.json"),
         )
     )
-    token = token_file or Path(
-        os.environ.get(
-            "YOUTUBE_TOKEN_FILE",
-            str(Path.home() / ".helmlog-youtube-token.json"),
+    if token_file is not None:
+        token = token_file
+    elif youtube_account:
+        token = account_token_path(youtube_account)
+        token.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        token = Path(
+            os.environ.get(
+                "YOUTUBE_TOKEN_FILE",
+                str(Path.home() / ".helmlog-youtube-token.json"),
+            )
         )
-    )
 
     creds = load_credentials(secrets, token)
     service = build_service(creds)
+
+    # Verify we're talking to the expected channel before uploading. Network
+    # errors are downgraded to a warning so transient failures don't block
+    # uploads (the cached token is still trusted in that case).
+    if youtube_account:
+        try:
+            verify_channel(service, youtube_account)
+        except ChannelMismatchError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Could not verify YouTube channel for {!r}: {} — proceeding",
+                youtube_account,
+                exc,
+            )
 
     body: dict[str, object] = {
         "snippet": {

--- a/tests/test_insta360.py
+++ b/tests/test_insta360.py
@@ -15,6 +15,7 @@ from helmlog.insta360 import (
     discover_recordings,
     match_sessions,
     parse_insv_filename,
+    promote_to_insv_extension,
     recording_start_utc,
 )
 
@@ -189,6 +190,87 @@ class TestDiscoverRecordings:
             recs = discover_recordings(tmp_path)
         assert len(recs) == 1
         assert recs[0].needs_stitching is True
+
+
+# ---------------------------------------------------------------------------
+# .mp4 → .insv promotion (Insta360 Studio recognises 360° by extension only,
+# but the X4 OSC startCapture writes dual-fisheye content as .mp4 — we
+# rename during import-matched.sh copy so Studio sees the imports correctly.)
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteToInsvExtension:
+    def test_dual_fisheye_mp4_renamed_to_insv(self, tmp_path: Path) -> None:
+        """A dual-fisheye .mp4 must be renamed to .insv on disk."""
+        from unittest.mock import patch
+
+        src = tmp_path / "VID_20260810_140530_00_000.mp4"
+        src.write_bytes(b"\x00" * 4096)
+
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=True):
+            result = promote_to_insv_extension(src)
+
+        assert result.name == "VID_20260810_140530_00_000.insv"
+        assert result.exists()
+        assert not src.exists()
+
+    def test_single_lens_mp4_left_alone(self, tmp_path: Path) -> None:
+        """A genuine single-lens .mp4 must NOT be renamed."""
+        from unittest.mock import patch
+
+        src = tmp_path / "VID_20260810_140530_00_000.mp4"
+        src.write_bytes(b"\x00" * 4096)
+
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=False):
+            result = promote_to_insv_extension(src)
+
+        assert result == src
+        assert src.exists()
+        assert not src.with_suffix(".insv").exists()
+
+    def test_insv_not_probed(self, tmp_path: Path) -> None:
+        """A .insv file is trusted by extension; ffprobe is not invoked."""
+        from unittest.mock import patch
+
+        src = tmp_path / "VID_20260810_140530_00_000.insv"
+        src.write_bytes(b"\x00" * 4096)
+
+        with patch(
+            "helmlog.insta360.is_dual_fisheye", side_effect=AssertionError("should not be called")
+        ):
+            result = promote_to_insv_extension(src)
+
+        assert result == src
+        assert src.exists()
+
+    def test_idempotent_when_target_already_exists(self, tmp_path: Path) -> None:
+        """If the .insv twin already exists, leave the .mp4 alone (no clobber)."""
+        from unittest.mock import patch
+
+        src = tmp_path / "VID_20260810_140530_00_000.mp4"
+        src.write_bytes(b"\x00" * 4096)
+        (tmp_path / "VID_20260810_140530_00_000.insv").write_bytes(b"\xff" * 4096)
+
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=True):
+            result = promote_to_insv_extension(src)
+
+        # Source still exists, target was not overwritten
+        assert result == src
+        assert src.exists()
+        assert (tmp_path / "VID_20260810_140530_00_000.insv").read_bytes() == b"\xff" * 4096
+
+    def test_uppercase_mp4_extension_handled(self, tmp_path: Path) -> None:
+        """Defensive: handle .MP4 (some camera firmware variants) too."""
+        from unittest.mock import patch
+
+        src = tmp_path / "VID_20260810_140530_00_000.MP4"
+        src.write_bytes(b"\x00" * 4096)
+
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=True):
+            result = promote_to_insv_extension(src)
+
+        assert result.name == "VID_20260810_140530_00_000.insv"
+        assert result.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_insta360.py
+++ b/tests/test_insta360.py
@@ -150,40 +150,45 @@ class TestDiscoverRecordings:
         assert len(recs[0].segments) == 1
         assert "_00_" in recs[0].segments[0].name
 
-    def test_insv_needs_stitching(self, tmp_path: Path) -> None:
-        """.insv recordings should have needs_stitching=True."""
+    def test_dual_fisheye_needs_stitching(self, tmp_path: Path) -> None:
+        """A recording probed as dual-fisheye should have needs_stitching=True."""
+        from unittest.mock import patch
+
         cam = tmp_path / "DCIM" / "Camera01"
         cam.mkdir(parents=True)
         (cam / "VID_20260810_140530_00_000.insv").write_bytes(b"\x00" * 100)
 
-        recs = discover_recordings(tmp_path)
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=True):
+            recs = discover_recordings(tmp_path)
         assert len(recs) == 1
         assert recs[0].needs_stitching is True
 
-    def test_mp4_no_stitching(self, tmp_path: Path) -> None:
-        """.mp4 recordings should have needs_stitching=False."""
+    def test_single_lens_no_stitching(self, tmp_path: Path) -> None:
+        """A recording probed as single-stream should have needs_stitching=False."""
+        from unittest.mock import patch
+
         cam = tmp_path / "DCIM" / "Camera01"
         cam.mkdir(parents=True)
         (cam / "VID_20260810_140530_00_001.mp4").write_bytes(b"\x00" * 200)
 
-        recs = discover_recordings(tmp_path)
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=False):
+            recs = discover_recordings(tmp_path)
         assert len(recs) == 1
         assert recs[0].needs_stitching is False
-        assert recs[0].segments[0].name == "VID_20260810_140530_00_001.mp4"
 
-    def test_mixed_insv_and_mp4(self, tmp_path: Path) -> None:
-        """SD card with both 360° and single-lens recordings."""
+    def test_mp4_can_be_dual_fisheye_too(self, tmp_path: Path) -> None:
+        """The X4 can write 360° captures as .mp4 — extension is not the signal."""
+        from unittest.mock import patch
+
         cam = tmp_path / "DCIM" / "Camera01"
         cam.mkdir(parents=True)
-        (cam / "VID_20260810_140530_00_000.insv").write_bytes(b"\x00" * 100)
-        (cam / "VID_20260810_153000_00_001.mp4").write_bytes(b"\x00" * 200)
+        # An .mp4 that ffprobe says is dual-fisheye must still get stitched.
+        (cam / "VID_20260810_140530_00_000.mp4").write_bytes(b"\x00" * 100)
 
-        recs = discover_recordings(tmp_path)
-        assert len(recs) == 2
-        assert recs[0].timestamp_str == "20260810_140530"
+        with patch("helmlog.insta360.is_dual_fisheye", return_value=True):
+            recs = discover_recordings(tmp_path)
+        assert len(recs) == 1
         assert recs[0].needs_stitching is True
-        assert recs[1].timestamp_str == "20260810_153000"
-        assert recs[1].needs_stitching is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_video_multicamera.py
+++ b/tests/test_video_multicamera.py
@@ -1,0 +1,266 @@
+"""Tests for multi-camera video pipeline pieces (issue #445).
+
+Covers the additions that extend the existing pipeline:
+
+* per-camera link label & title suffix
+* account-scoped YouTube token paths
+* YouTube channel verification
+* camera label resolution + persistence
+* the JSON-backed video upload ledger
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from helmlog.insta360 import (
+    InstaRecording,
+    _placeholder_label,
+    load_camera_labels,
+    resolve_camera_label,
+    save_camera_label,
+)
+from helmlog.pipeline import PipelineConfig, build_link_label, process_recording
+from helmlog.video_ledger import LedgerEntry, LedgerKey, VideoLedger
+from helmlog.youtube import (
+    ChannelMismatchError,
+    UploadResult,
+    account_token_path,
+    verify_channel,
+)
+
+# ---------------------------------------------------------------------------
+# Link label
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLinkLabel:
+    def test_default_label(self) -> None:
+        assert build_link_label("") == "360 cam"
+
+    def test_per_camera_label(self) -> None:
+        assert build_link_label("bow") == "360 cam — bow"
+        assert build_link_label("stern") == "360 cam — stern"
+
+
+# ---------------------------------------------------------------------------
+# process_recording — camera label propagation
+# ---------------------------------------------------------------------------
+
+
+def _sessions() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": 10,
+            "name": "Race 1",
+            "start_utc": "2026-08-10T14:00:00+00:00",
+            "end_utc": "2026-08-10T15:00:00+00:00",
+            "event": "Ballard Cup",
+            "race_num": 1,
+            "session_type": "race",
+        },
+    ]
+
+
+def _upload_result() -> UploadResult:
+    return UploadResult(
+        video_id="abc",
+        youtube_url="https://youtu.be/abc",
+        title="Ballard Cup Race 1 — 2026-08-10 — bow cam",
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_label_in_title_and_link() -> None:
+    rec = InstaRecording(timestamp_str="20260810_070500", segments=[], total_size_bytes=0)
+    cfg = PipelineConfig(
+        pi_api_url="http://corvopi:3002",
+        pi_session_cookie="cookie",
+        timezone="America/Los_Angeles",
+        camera_label="bow",
+        youtube_account="corvo105",
+    )
+
+    mock_upload = AsyncMock(return_value=_upload_result())
+    mock_link = AsyncMock(return_value=httpx.Response(201))
+
+    with (
+        patch("helmlog.pipeline.upload_video", mock_upload),
+        patch("helmlog.pipeline._link_video_on_pi", mock_link),
+    ):
+        result = await process_recording(
+            rec=rec, video_path="/tmp/test.mp4", sessions=_sessions(), config=cfg
+        )
+
+    assert result.linked is True
+    assert mock_upload.call_args.kwargs["title"].endswith("— bow cam")
+    assert mock_upload.call_args.kwargs["youtube_account"] == "corvo105"
+    assert mock_link.call_args.kwargs["label"] == "360 cam — bow"
+
+
+@pytest.mark.asyncio
+async def test_no_camera_label_keeps_legacy_label() -> None:
+    rec = InstaRecording(timestamp_str="20260810_070500", segments=[], total_size_bytes=0)
+    cfg = PipelineConfig(pi_session_cookie="cookie")
+
+    mock_upload = AsyncMock(return_value=_upload_result())
+    mock_link = AsyncMock(return_value=httpx.Response(201))
+
+    with (
+        patch("helmlog.pipeline.upload_video", mock_upload),
+        patch("helmlog.pipeline._link_video_on_pi", mock_link),
+    ):
+        await process_recording(
+            rec=rec, video_path="/tmp/test.mp4", sessions=_sessions(), config=cfg
+        )
+
+    assert "cam" not in mock_upload.call_args.kwargs["title"].split("—")[-1].lower() or (
+        mock_upload.call_args.kwargs["title"].endswith("2026-08-10")
+    )
+    assert mock_link.call_args.kwargs["label"] == "360 cam"
+
+
+# ---------------------------------------------------------------------------
+# YouTube account-scoped tokens & channel verification
+# ---------------------------------------------------------------------------
+
+
+class TestAccountTokenPath:
+    def test_path_under_config_dir(self) -> None:
+        p = account_token_path("corvo105")
+        assert p.name == "corvo105.json"
+        assert "helmlog" in p.parts
+        assert "youtube" in p.parts
+
+
+class TestVerifyChannel:
+    def _service(self, items: list[dict[str, Any]]) -> MagicMock:
+        svc = MagicMock()
+        svc.channels.return_value.list.return_value.execute.return_value = {"items": items}
+        return svc
+
+    def test_match_by_title(self) -> None:
+        svc = self._service([{"snippet": {"title": "corvo105", "customUrl": "@corvo105"}}])
+        assert verify_channel(svc, "corvo105") == "corvo105"
+
+    def test_match_by_handle_with_at_sign(self) -> None:
+        svc = self._service([{"snippet": {"title": "Corvo Sailing", "customUrl": "@corvo105"}}])
+        assert verify_channel(svc, "@corvo105") == "Corvo Sailing"
+
+    def test_mismatch_raises(self) -> None:
+        svc = self._service([{"snippet": {"title": "Other", "customUrl": "@other"}}])
+        with pytest.raises(ChannelMismatchError):
+            verify_channel(svc, "corvo105")
+
+    def test_no_items_raises(self) -> None:
+        svc = self._service([])
+        with pytest.raises(ChannelMismatchError):
+            verify_channel(svc, "corvo105")
+
+
+# ---------------------------------------------------------------------------
+# Camera label resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCameraLabels:
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "cameras.toml"
+        save_camera_label("ABCD-1234", "bow", cfg)
+        save_camera_label("EFGH-5678", "stern", cfg)
+        labels = load_camera_labels(cfg)
+        assert labels == {"abcd-1234": "bow", "efgh-5678": "stern"}
+
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_camera_labels(tmp_path / "nope.toml") == {}
+
+    def test_resolve_known_camera(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "cameras.toml"
+        save_camera_label("AAAA-BBBB", "bow", cfg)
+
+        with patch("helmlog.insta360.volume_uuid_for", return_value="AAAA-BBBB"):
+            label, known = resolve_camera_label(Path("/Volumes/X4"), labels_path=cfg)
+
+        assert label == "bow"
+        assert known is True
+
+    def test_resolve_unknown_creates_placeholder(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "cameras.toml"
+
+        with patch(
+            "helmlog.insta360.volume_uuid_for", return_value="11112222-3333-4444-5555-666677778888"
+        ):
+            label, known = resolve_camera_label(Path("/Volumes/X4"), labels_path=cfg)
+
+        assert known is False
+        assert label.startswith("camera-")
+        # placeholder must have been persisted so subsequent runs see it
+        labels = load_camera_labels(cfg)
+        assert any(v.startswith("camera-") for v in labels.values())
+
+    def test_resolve_uuid_lookup_failure_falls_back_to_basename(self, tmp_path: Path) -> None:
+        with patch("helmlog.insta360.volume_uuid_for", return_value=None):
+            label, known = resolve_camera_label(
+                Path("/Volumes/Insta360-A"), labels_path=tmp_path / "c.toml"
+            )
+        assert label == "Insta360-A"
+        assert known is False
+
+    def test_placeholder_label_format(self) -> None:
+        assert _placeholder_label("ABCD-1234-EF56-7890") == "camera-abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# Video ledger
+# ---------------------------------------------------------------------------
+
+
+class TestVideoLedger:
+    def test_record_and_lookup(self, tmp_path: Path) -> None:
+        ledger = VideoLedger(tmp_path / "ledger.json")
+        key = LedgerKey("UUID-1", "VID_20260810_140000_00_000.insv", 1234)
+        assert not ledger.has(key)
+
+        ledger.record(
+            LedgerEntry(
+                volume_uuid="UUID-1",
+                source_filename="VID_20260810_140000_00_000.insv",
+                size_bytes=1234,
+                video_id="abc",
+                youtube_url="https://youtu.be/abc",
+                camera_label="bow",
+                session_id=10,
+                linked=True,
+            )
+        )
+        assert ledger.has(key)
+        entry = ledger.get(key)
+        assert entry is not None
+        assert entry.video_id == "abc"
+
+    def test_persistence_across_instances(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.json"
+        a = VideoLedger(path)
+        a.record(
+            LedgerEntry(
+                volume_uuid="UUID-1",
+                source_filename="VID.insv",
+                size_bytes=99,
+                video_id="vid",
+                youtube_url="https://y.t/vid",
+            )
+        )
+        b = VideoLedger(path)
+        assert b.has(LedgerKey("UUID-1", "VID.insv", 99))
+        assert len(b) == 1
+
+    def test_corrupt_file_does_not_raise(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.json"
+        path.write_text("not json {")
+        ledger = VideoLedger(path)
+        assert len(ledger) == 0

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -27,25 +27,42 @@ from helmlog.youtube import (
 class TestBuildTitle:
     def test_race_with_event(self) -> None:
         title = build_title(event="Ballard Cup", session_type="race", race_num=2, date="2026-08-10")
-        assert title == "Ballard Cup Race 2 — 2026-08-10"
+        assert title == "2026-08-10 — Ballard Cup Race 2"
+
+    def test_race_with_time(self) -> None:
+        title = build_title(
+            event="Ballard Cup",
+            session_type="race",
+            race_num=2,
+            date="2026-08-10",
+            time="14:05Z",
+        )
+        assert title == "2026-08-10 14:05Z — Ballard Cup Race 2"
 
     def test_race_without_event(self) -> None:
         title = build_title(event=None, session_type="race", race_num=1, date="2026-08-10")
-        assert title == "Race 1 — 2026-08-10"
+        assert title == "2026-08-10 — Race 1"
 
     def test_practice(self) -> None:
         title = build_title(event=None, session_type="practice", race_num=None, date="2026-08-10")
-        assert title == "Practice — 2026-08-10"
+        assert title == "2026-08-10 — Practice"
 
     def test_practice_with_event(self) -> None:
         title = build_title(
             event="Ballard Cup", session_type="practice", race_num=None, date="2026-08-10"
         )
-        assert title == "Ballard Cup Practice — 2026-08-10"
+        assert title == "2026-08-10 — Ballard Cup Practice"
 
     def test_unknown_session_type(self) -> None:
         title = build_title(event=None, session_type="other", race_num=None, date="2026-08-10")
-        assert title == "Other — 2026-08-10"
+        assert title == "2026-08-10 — Other"
+
+    def test_titles_sort_chronologically(self) -> None:
+        """Date-leading titles must sort to chronological order alphabetically."""
+        a = build_title(event=None, session_type="race", race_num=1, date="2026-08-10")
+        b = build_title(event=None, session_type="race", race_num=2, date="2026-08-11")
+        c = build_title(event=None, session_type="race", race_num=3, date="2026-08-09")
+        assert sorted([a, b, c]) == [c, a, b]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 of #445 — extends the existing video pipeline (path 1 from the spec, mass-storage mount) with the Python+shell pieces needed for multi-camera fleets, persisted encoding settings, channel verification, and an upload ledger. Admin UI and the Pi-side `video_settings` table are deferred to a follow-up so this PR stays shippable.

- **Per-camera labels** — `resolve_camera_label()` looks up macOS volume UUID via `diskutil`, maps to user-assigned labels in `~/.config/helmlog/cameras.toml`, auto-creates a placeholder for unknown cards. Labels propagate to YouTube titles (`… — bow cam`), Pi link labels (`360 cam — bow`), and output sub-directories (`~/Insta360 Exports/<label>/`).
- **Multi-camera fan-out** — `process-videos.sh` runs one parallel pipeline per mounted Insta360 volume so two SD cards from a fleet process concurrently without sharing temp dirs.
- **YouTube account verification** — `verify_channel()` calls `channels.list(mine=true)` after loading the cached token and aborts on a wrong-channel match. Tokens move to `~/.config/helmlog/youtube/<account>.json`. Default `YOUTUBE_ACCOUNT=corvo105`.
- **FlowState plumbing** — `docker/stitch-360.sh` now accepts `--flowstate` / `--no-flowstate`, `--direction-lock` / `--no-direction-lock`, `--bitrate`, `--resolution`. Defaults match current behavior. `process-videos.sh` passes them through.
- **Upload ledger** — new `video_ledger.py` module: JSON-backed, keyed by `(volume_uuid, source_filename, size_bytes)` so re-mounting a card doesn't re-upload.
- **Output dir change** — default base dir is now `~/Insta360 Exports/` (was `~/Videos/helmlog`). Old dir untouched on upgrade.

### Risk tier

**Standard** — touches `pipeline.py`, `insta360.py`, `youtube.py`, `process-videos.sh`, `stitch-360.sh`, plus a new module and tests. No Critical/High files.

### Deferred to follow-up

The spec calls for a Pi-side `video_settings` table, an admin UI, and a Pi-as-source-of-truth flow. Those need a sqlite migration + new admin route + template — kept out of this PR to keep the diff focused on the runnable Mac-side pipeline. The settings currently live in the env vars + the new `cameras.toml` file. Documented in `docs/video-pipeline.md` under "Future work".

OSC over Wi-Fi (path 3) is also deferred — flagged as future work in the docs.

## Test plan

- [x] `uv run pytest tests/test_video_multicamera.py -v` — 17 new tests (link label, camera-label propagation through `process_recording`, account-scoped token paths, channel verify match/mismatch/no-items, camera-label resolve/save/load, ledger persistence/corruption)
- [x] `uv run pytest --no-cov` — 1579 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check` — clean (one preexisting unrelated formatting issue in `scripts/transcribe_worker.py`)
- [x] `uv run mypy src/helmlog/{insta360,pipeline,youtube,video_ledger}.py` — clean
- [x] `bash -n scripts/process-videos.sh && bash -n docker/stitch-360.sh` — syntax clean
- [ ] Manual smoke: plug in real X4 SD card, confirm pipeline runs end-to-end with default `corvo105` account
- [ ] Manual smoke: simulate two volumes mounted at once and confirm fan-out

Closes #445

Generated with [Claude Code](https://claude.ai/code)