### PR TITLE
Session rename + human-readable URL slugs (#449)

### DIFF
--- a/src/helmlog/pipeline.py
+++ b/src/helmlog/pipeline.py
@@ -155,10 +155,10 @@ async def process_recording(
         )
         base = f"{config.pi_api_url}/history"
         session_slug = session.get("slug")
-        if session_slug:
-            session_url = f"{config.pi_api_url}/session/{session_slug}"
+        if session_id and session_slug:
+            session_url = f"{config.pi_api_url}/session/{session_id}/{session_slug}"
         elif session_id:
-            session_url = f"{base}#{session_id}"
+            session_url = f"{config.pi_api_url}/session/{session_id}"
         else:
             session_url = base
         s_end = session.get("end_utc", "")

--- a/src/helmlog/pipeline.py
+++ b/src/helmlog/pipeline.py
@@ -154,7 +154,13 @@ async def process_recording(
             date=start_utc.strftime("%Y-%m-%d"),
         )
         base = f"{config.pi_api_url}/history"
-        session_url = f"{base}#{session_id}" if session_id else base
+        session_slug = session.get("slug")
+        if session_slug:
+            session_url = f"{config.pi_api_url}/session/{session_slug}"
+        elif session_id:
+            session_url = f"{base}#{session_id}"
+        else:
+            session_url = base
         s_end = session.get("end_utc", "")
         desc = build_description(
             session_url=session_url,

--- a/src/helmlog/races.py
+++ b/src/helmlog/races.py
@@ -7,6 +7,7 @@ storage.py. This module is importable without hardware or a running server.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -33,6 +34,8 @@ class Race:
     start_utc: datetime
     end_utc: datetime | None
     session_type: str = "race"  # "race" | "practice"
+    slug: str = ""  # human-readable URL slug (#449); backfilled from name
+    renamed_at: datetime | None = None  # UTC ts of most recent rename (#449)
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +86,28 @@ def default_event_for_date(d: date, rules: dict[int, str] | None = None) -> str 
     if not rules:
         return None
     return rules.get(d.weekday())
+
+
+_SLUG_RUN_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(text: str, *, max_length: int = 80) -> str:
+    """Slugify ``text`` for use in a URL path segment.
+
+    Lowercases, replaces every run of non-``[a-z0-9]`` with a single ``-``,
+    strips leading/trailing ``-``, and caps total length at ``max_length``.
+    When truncation splits a word, the slug is trimmed back to the last ``-``
+    boundary so partial words aren't left dangling. Returns ``""`` for empty
+    input — callers are responsible for a fallback (typically ``race-{id}``).
+    """
+    s = _SLUG_RUN_RE.sub("-", text.lower()).strip("-")
+    if len(s) <= max_length:
+        return s
+    window = s[:max_length]
+    boundary = window.rfind("-")
+    if boundary > 0:
+        return window[:boundary].rstrip("-")
+    return window.rstrip("-")
 
 
 def build_race_name(event: str, d: date, race_num: int, session_type: str = "race") -> str:

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -54,55 +54,31 @@ async def history_page(request: Request) -> Response:
     )
 
 
-@router.get("/session/{session_ref}", response_class=HTMLResponse, include_in_schema=False)
-async def session_detail_page(request: Request, session_ref: str) -> Response:
-    """Session detail page — accepts either the integer id or a slug (#449).
+def _canonical_session_url(race_id: int, slug: str | None) -> str:
+    """Build the canonical ``/session/{id}/{slug}`` URL (#449).
 
-    * ``/session/{id}`` → 301 to ``/session/{current_slug}``.
-    * ``/session/{slug}`` with a live slug → render the page.
-    * ``/session/{slug}`` matching a retired slug (within 30 days) → 301
-      to the current slug.
-    * Anything else → 404.
+    The integer id is the stable identity — it stays in the URL even when
+    the session is renamed, so bookmarks survive any slug change. The slug
+    is purely cosmetic for readability. When a row has no slug yet (pre-v58
+    data), the URL collapses to ``/session/{id}``.
     """
+    return f"/session/{race_id}/{slug}" if slug else f"/session/{race_id}"
+
+
+async def _render_session_page(
+    request: Request,
+    race: Any,  # helmlog.races.Race  # noqa: ANN401
+) -> Response:
+    """Render the session detail template for a resolved race (#449)."""
     from datetime import UTC, datetime, timedelta
 
     storage = get_storage(request)
-
-    # Integer id → look up current slug and 301. Rows pre-dating v58 may have
-    # no slug yet (e.g. raw test inserts); fall through and render inline in
-    # that case rather than redirect in a loop.
-    race = None
-    if session_ref.isdigit():
-        race_id = int(session_ref)
-        race = await storage.get_race(race_id)
-        if race is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        if race.slug:
-            return RedirectResponse(url=f"/session/{race.slug}", status_code=301)
-
-    # Slug path — current slug renders, retired slug redirects, else 404.
-    if race is None:
-        race = await storage.get_race_by_slug(session_ref)
-    if race is None:
-        retired = await storage.lookup_retired_slug(session_ref)
-        if retired is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        race_id, retired_at = retired
-        if datetime.now(UTC) - retired_at > timedelta(days=RACE_SLUG_RETENTION_DAYS):
-            raise HTTPException(status_code=404, detail="Session not found")
-        current = await storage.get_race(race_id)
-        if current is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        return RedirectResponse(url=f"/session/{current.slug}", status_code=301)
-
     user: dict[str, Any] | None = getattr(request.state, "user", None)
     user_role = user.get("role", "viewer") if user else "viewer"
     renamed_banner = None
     if race.renamed_at is not None:
         age = datetime.now(UTC) - race.renamed_at
         if age <= timedelta(days=RACE_SLUG_RETENTION_DAYS):
-            # Find the most recently retired slug for this race to show as
-            # "renamed from". Pick the newest entry by retired_at.
             db = storage._read_conn()  # noqa: SLF001
             hist_cur = await db.execute(
                 "SELECT slug FROM race_slug_history WHERE race_id = ?"
@@ -121,12 +97,82 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
             session_id=race.id,
             session_name=race.name,
             session_slug=race.slug,
+            session_url=_canonical_session_url(race.id, race.slug),
             renamed_from=renamed_banner,
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             user_role=user_role,
         ),
     )
+
+
+@router.get(
+    "/session/{session_id:int}/{slug}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def session_detail_page_canonical(request: Request, session_id: int, slug: str) -> Response:
+    """Canonical session URL carrying both the stable id and the slug (#449).
+
+    * If the id exists and the slug matches the current slug → render.
+    * If the id exists but the slug is stale (renamed) → 301 to the new
+      canonical URL so old bookmarks keep working indefinitely.
+    * If the id doesn't exist → 404.
+    """
+    storage = get_storage(request)
+    race = await storage.get_race(session_id)
+    if race is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if race.slug and slug != race.slug:
+        return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
+    return await _render_session_page(request, race)
+
+
+@router.get(
+    "/session/{session_ref}",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def session_detail_page(request: Request, session_ref: str) -> Response:
+    """Single-segment session URL — 301s to the canonical ``/session/{id}/{slug}``.
+
+    Accepts an integer id or a slug (current or retired within 30 days):
+
+    * ``/session/{id}`` → 301 to ``/session/{id}/{slug}``. If the row has
+      no slug yet (pre-v58 data) we render inline instead of redirecting.
+    * ``/session/{slug}`` (current) → 301 to ``/session/{id}/{slug}``.
+    * ``/session/{slug}`` (retired, within retention window) → 301 to the
+      current canonical URL.
+    * Unknown id / slug → 404.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    storage = get_storage(request)
+
+    if session_ref.isdigit():
+        race_id = int(session_ref)
+        race = await storage.get_race(race_id)
+        if race is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        if race.slug:
+            return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
+        # Row predates v58 and has no slug — render inline under /session/{id}.
+        return await _render_session_page(request, race)
+
+    race = await storage.get_race_by_slug(session_ref)
+    if race is not None:
+        return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
+
+    retired = await storage.lookup_retired_slug(session_ref)
+    if retired is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    race_id, retired_at = retired
+    if datetime.now(UTC) - retired_at > timedelta(days=RACE_SLUG_RETENTION_DAYS):
+        raise HTTPException(status_code=404, detail="Session not found")
+    current = await storage.get_race(race_id)
+    if current is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return RedirectResponse(url=_canonical_session_url(current.id, current.slug), status_code=301)
 
 
 @router.get("/sails", response_class=HTMLResponse, include_in_schema=False)

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -128,6 +128,28 @@ async def session_detail_page_canonical(request: Request, session_id: int, slug:
     return await _render_session_page(request, race)
 
 
+async def _render_debrief_page(request: Request, debrief: dict[str, Any]) -> Response:
+    """Render the session template for a debrief (audio_sessions row) (#449)."""
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "session.html",
+        tpl_ctx(
+            request,
+            "/history",
+            session_id=debrief["id"],
+            session_name=debrief["name"],
+            session_slug="",
+            session_url=f"/session/{debrief['id']}",
+            renamed_from=None,
+            grafana_port=request.app.state.race_config.grafana_port,
+            grafana_uid=request.app.state.race_config.grafana_uid,
+            user_role=user_role,
+        ),
+    )
+
+
 @router.get(
     "/session/{session_ref}",
     response_class=HTMLResponse,
@@ -136,11 +158,15 @@ async def session_detail_page_canonical(request: Request, session_id: int, slug:
 async def session_detail_page(request: Request, session_ref: str) -> Response:
     """Single-segment session URL — 301s to the canonical ``/session/{id}/{slug}``.
 
-    Accepts an integer id or a slug (current or retired within 30 days):
+    Accepts an integer id (race or debrief) or a slug:
 
-    * ``/session/{id}`` → 301 to ``/session/{id}/{slug}``. If the row has
-      no slug yet (pre-v58 data) we render inline instead of redirecting.
-    * ``/session/{slug}`` (current) → 301 to ``/session/{id}/{slug}``.
+    * ``/session/{race_id}`` → 301 to ``/session/{id}/{slug}``. A race row
+      with no slug (pre-v58 data whose backfill didn't complete) has one
+      lazily allocated on first access.
+    * ``/session/{audio_id}`` where that id matches a debrief row in
+      ``audio_sessions`` → render inline (debriefs have no slug; the id is
+      the stable key from the history list).
+    * ``/session/{slug}`` (current) → 301 to the canonical URL.
     * ``/session/{slug}`` (retired, within retention window) → 301 to the
       current canonical URL.
     * Unknown id / slug → 404.
@@ -150,14 +176,20 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
     storage = get_storage(request)
 
     if session_ref.isdigit():
-        race_id = int(session_ref)
-        race = await storage.get_race(race_id)
-        if race is None:
-            raise HTTPException(status_code=404, detail="Session not found")
-        if race.slug:
-            return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
-        # Row predates v58 and has no slug — render inline under /session/{id}.
-        return await _render_session_page(request, race)
+        numeric_id = int(session_ref)
+        race = await storage.get_race(numeric_id)
+        if race is not None:
+            slug = race.slug or await storage.ensure_race_slug(race.id) or ""
+            if slug:
+                return RedirectResponse(url=_canonical_session_url(race.id, slug), status_code=301)
+            # Last-resort fallback — render inline rather than redirect-loop.
+            return await _render_session_page(request, race)
+        # Not a race — try the debrief (audio_sessions) id space so history
+        # links to debrief sessions keep resolving.
+        debrief = await storage.get_debrief_session(numeric_id)
+        if debrief is not None:
+            return await _render_debrief_page(request, debrief)
+        raise HTTPException(status_code=404, detail="Session not found")
 
     race = await storage.get_race_by_slug(session_ref)
     if race is not None:

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -8,10 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse, Response
 
 from helmlog.auth import require_auth
 from helmlog.routes._helpers import audit, get_storage, templates, tpl_ctx
+from helmlog.storage import RACE_SLUG_RETENTION_DAYS
 
 router = APIRouter()
 
@@ -53,22 +54,74 @@ async def history_page(request: Request) -> Response:
     )
 
 
-@router.get("/session/{session_id}", response_class=HTMLResponse, include_in_schema=False)
-async def session_detail_page(request: Request, session_id: int) -> Response:
+@router.get("/session/{session_ref}", response_class=HTMLResponse, include_in_schema=False)
+async def session_detail_page(request: Request, session_ref: str) -> Response:
+    """Session detail page — accepts either the integer id or a slug (#449).
+
+    * ``/session/{id}`` → 301 to ``/session/{current_slug}``.
+    * ``/session/{slug}`` with a live slug → render the page.
+    * ``/session/{slug}`` matching a retired slug (within 30 days) → 301
+      to the current slug.
+    * Anything else → 404.
+    """
+    from datetime import UTC, datetime, timedelta
+
     storage = get_storage(request)
-    cur = await storage._conn().execute("SELECT name FROM races WHERE id = ?", (session_id,))
-    row = await cur.fetchone()
-    session_name = row["name"] if row else f"Session {session_id}"
+
+    # Integer id → look up current slug and 301. Rows pre-dating v58 may have
+    # no slug yet (e.g. raw test inserts); fall through and render inline in
+    # that case rather than redirect in a loop.
+    race = None
+    if session_ref.isdigit():
+        race_id = int(session_ref)
+        race = await storage.get_race(race_id)
+        if race is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        if race.slug:
+            return RedirectResponse(url=f"/session/{race.slug}", status_code=301)
+
+    # Slug path — current slug renders, retired slug redirects, else 404.
+    if race is None:
+        race = await storage.get_race_by_slug(session_ref)
+    if race is None:
+        retired = await storage.lookup_retired_slug(session_ref)
+        if retired is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        race_id, retired_at = retired
+        if datetime.now(UTC) - retired_at > timedelta(days=RACE_SLUG_RETENTION_DAYS):
+            raise HTTPException(status_code=404, detail="Session not found")
+        current = await storage.get_race(race_id)
+        if current is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return RedirectResponse(url=f"/session/{current.slug}", status_code=301)
+
     user: dict[str, Any] | None = getattr(request.state, "user", None)
     user_role = user.get("role", "viewer") if user else "viewer"
+    renamed_banner = None
+    if race.renamed_at is not None:
+        age = datetime.now(UTC) - race.renamed_at
+        if age <= timedelta(days=RACE_SLUG_RETENTION_DAYS):
+            # Find the most recently retired slug for this race to show as
+            # "renamed from". Pick the newest entry by retired_at.
+            db = storage._read_conn()  # noqa: SLF001
+            hist_cur = await db.execute(
+                "SELECT slug FROM race_slug_history WHERE race_id = ?"
+                " ORDER BY retired_at DESC LIMIT 1",
+                (race.id,),
+            )
+            hist_row = await hist_cur.fetchone()
+            if hist_row is not None:
+                renamed_banner = hist_row["slug"]
     return templates.TemplateResponse(
         request,
         "session.html",
         tpl_ctx(
             request,
             "/history",
-            session_id=session_id,
-            session_name=session_name,
+            session_id=race.id,
+            session_name=race.name,
+            session_slug=race.slug,
+            renamed_from=renamed_banner,
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             user_role=user_role,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -876,6 +876,10 @@ async def api_rename_session(
             "slug": updated.slug,
             "renamed_at": updated.renamed_at.isoformat() if updated.renamed_at else None,
             "retired_slug": retired_slug,
-            "url": f"/session/{updated.slug}",
+            "url": (
+                f"/session/{updated.id}/{updated.slug}"
+                if updated.slug
+                else f"/session/{updated.id}"
+            ),
         }
     )

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -817,3 +817,65 @@ async def api_delete_session(
             await asyncio.to_thread(p.unlink)
             logger.info("Deleted file: {}", p)
     await audit(request, "session.delete", detail=row["name"], user=_user)
+
+
+@router.patch("/api/sessions/{session_id}")
+async def api_rename_session(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Rename a race session and regenerate its slug (#449).
+
+    Body: ``{"name": str?, "event": str?, "race_num": int?}`` — at least one
+    field is required. When *name* is omitted but *event* or *race_num*
+    changes, the name is regenerated from the standard ``build_race_name``
+    template. Admin only.
+    """
+    storage = get_storage(request)
+    body = await request.json()
+    raw_name = body.get("name")
+    raw_event = body.get("event")
+    raw_race_num = body.get("race_num")
+    if raw_name is None and raw_event is None and raw_race_num is None:
+        raise HTTPException(status_code=422, detail="name, event, or race_num required")
+
+    new_name = str(raw_name) if raw_name is not None else None
+    new_event = str(raw_event).strip() if raw_event is not None else None
+    if new_event == "":
+        raise HTTPException(status_code=422, detail="event must not be blank")
+    try:
+        new_race_num = int(raw_race_num) if raw_race_num is not None else None
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail="race_num must be an integer") from exc
+
+    try:
+        updated, retired_slug = await storage.rename_race(
+            session_id,
+            new_name=new_name,
+            new_event=new_event,
+            new_race_num=new_race_num,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except ValueError as exc:
+        if str(exc) == "name_taken":
+            raise HTTPException(status_code=409, detail={"error": "name_taken"}) from exc
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    changed = retired_slug is not None or updated.renamed_at is not None
+    if changed:
+        detail = f"{session_id}: {retired_slug!r} → {updated.slug!r} ({updated.name!r})"
+        await audit(request, "race.rename", detail=detail, user=_user)
+    return JSONResponse(
+        {
+            "id": updated.id,
+            "name": updated.name,
+            "event": updated.event,
+            "race_num": updated.race_num,
+            "slug": updated.slug,
+            "renamed_at": updated.renamed_at.isoformat() if updated.renamed_at else None,
+            "retired_slug": retired_slug,
+            "url": f"/session/{updated.slug}",
+        }
+    )

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -131,7 +131,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 57
+_CURRENT_VERSION: int = 58
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1290,7 +1290,26 @@ _MIGRATIONS: dict[int, str] = {
         );
         CREATE INDEX IF NOT EXISTS idx_crew_voice_profiles_user ON crew_voice_profiles(user_id);
     """,
+    58: """
+        -- Session rename + human-readable URL slugs (#449).
+        -- slug is NULL until the post-DDL backfill in _migrate_v58_slugs runs.
+        ALTER TABLE races ADD COLUMN slug TEXT;
+        ALTER TABLE races ADD COLUMN renamed_at TEXT;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_races_slug ON races(slug);
+
+        CREATE TABLE IF NOT EXISTS race_slug_history (
+            slug       TEXT PRIMARY KEY,
+            race_id    INTEGER NOT NULL REFERENCES races(id) ON DELETE CASCADE,
+            retired_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_race_slug_history_race ON race_slug_history(race_id);
+    """,
 }
+
+# Retention window for retired slugs (#449). Requests for a retired slug 301
+# to the current slug while the retirement is within this window; beyond it
+# they 404.
+RACE_SLUG_RETENTION_DAYS: int = 30
 
 
 def _split_migration_sql(sql: str) -> list[str]:
@@ -1550,6 +1569,10 @@ class Storage:
         # Post-DDL data migration for v56 (seed categories)
         if current < 56:
             await self._migrate_v56_categories()
+
+        # Post-DDL data migration for v58 (backfill race slugs)
+        if current < 58:
+            await self._migrate_v58_slugs()
 
         logger.debug("Schema is at version {}", _CURRENT_VERSION)
 
@@ -1864,6 +1887,39 @@ class Storage:
             )
         await db.commit()
         logger.info("v56 data migration: seeded {} categories", len(CATEGORY_ORDER))
+
+    async def _migrate_v58_slugs(self) -> None:
+        """Data migration for v58: backfill ``races.slug`` from ``name`` (#449).
+
+        Slug is the slugified ``name``; when two rows collide, the row with the
+        lowest ``id`` keeps the bare slug and higher-id rows get ``-2``, ``-3``
+        suffixes. Empty slugs (e.g. a name that's all punctuation) fall back to
+        ``race-{id}``.
+        """
+        from helmlog.races import slugify
+
+        db = self._conn()
+        cur = await db.execute("SELECT id, name FROM races WHERE slug IS NULL ORDER BY id ASC")
+        rows = await cur.fetchall()
+        if not rows:
+            return
+
+        # Seed the used-set with any slugs already present on rows we're not
+        # touching (defensive — a prior partial backfill).
+        used_cur = await db.execute("SELECT slug FROM races WHERE slug IS NOT NULL")
+        used: set[str] = {r["slug"] for r in await used_cur.fetchall()}
+
+        for row in rows:
+            base = slugify(row["name"]) or f"race-{row['id']}"
+            slug = base
+            n = 2
+            while slug in used:
+                slug = f"{base}-{n}"
+                n += 1
+            used.add(slug)
+            await db.execute("UPDATE races SET slug = ? WHERE id = ?", (slug, row["id"]))
+        await db.commit()
+        logger.info("v58 data migration: backfilled slugs for {} races", len(rows))
 
     # ------------------------------------------------------------------
     # Write (batched)
@@ -2330,6 +2386,44 @@ class Storage:
     # Races
     # ------------------------------------------------------------------
 
+    async def _allocate_slug(
+        self,
+        base: str,
+        *,
+        exclude_race_id: int | None = None,
+    ) -> str:
+        """Return an unused slug derived from *base*.
+
+        Collides against both live ``races.slug`` and non-expired
+        ``race_slug_history`` entries (same race_id is treated as free so
+        this race's own retired slugs can be reused). When the base itself
+        is free we return it unchanged; otherwise we append ``-2``, ``-3``, …
+
+        If *exclude_race_id* matches a row currently holding ``base``, that
+        row is ignored so a no-op slug check on the same race doesn't force
+        an unnecessary suffix.
+        """
+        db = self._conn()
+        n = 1
+        while True:
+            candidate = base if n == 1 else f"{base}-{n}"
+            live_cur = await db.execute(
+                "SELECT id FROM races WHERE slug = ? AND (? IS NULL OR id != ?)",
+                (candidate, exclude_race_id, exclude_race_id),
+            )
+            if await live_cur.fetchone() is not None:
+                n += 1
+                continue
+            hist_cur = await db.execute(
+                "SELECT race_id FROM race_slug_history WHERE slug = ?"
+                " AND (? IS NULL OR race_id != ?)",
+                (candidate, exclude_race_id, exclude_race_id),
+            )
+            if await hist_cur.fetchone() is not None:
+                n += 1
+                continue
+            return candidate
+
     async def start_race(
         self,
         event: str,
@@ -2341,6 +2435,7 @@ class Storage:
     ) -> Race:
         """Auto-close any open race for the day, insert a new race row, and return it."""
         from helmlog.races import Race as _Race
+        from helmlog.races import slugify
 
         db = self._conn()
 
@@ -2356,13 +2451,19 @@ class Storage:
                 (start_utc.isoformat(), open_row["id"]),
             )
 
+        # Insert with NULL slug first; we compute and assign the final slug
+        # after the insert so the empty-name fallback can use the row id.
         cur = await db.execute(
-            "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
-            " VALUES (?, ?, ?, ?, ?, NULL, ?)",
+            "INSERT INTO races"
+            " (name, event, race_num, date, start_utc, end_utc, session_type, slug)"
+            " VALUES (?, ?, ?, ?, ?, NULL, ?, NULL)",
             (name, event, race_num, date_str, start_utc.isoformat(), session_type),
         )
-        await db.commit()
         assert cur.lastrowid is not None
+        base = slugify(name) or f"race-{cur.lastrowid}"
+        slug = await self._allocate_slug(base, exclude_race_id=cur.lastrowid)
+        await db.execute("UPDATE races SET slug = ? WHERE id = ?", (slug, cur.lastrowid))
+        await db.commit()
         logger.info("Race started: {} (id={}) type={}", name, cur.lastrowid, session_type)
         self._session_active = True
         return _Race(
@@ -2374,6 +2475,7 @@ class Storage:
             start_utc=start_utc,
             end_utc=None,
             session_type=session_type,
+            slug=slug,
         )
 
     async def end_race(self, race_id: int, end_utc: datetime) -> None:
@@ -2386,6 +2488,131 @@ class Storage:
         await db.commit()
         self._session_active = False
         logger.info("Race {} ended at {}", race_id, end_utc.isoformat())
+
+    async def rename_race(
+        self,
+        race_id: int,
+        *,
+        new_name: str | None = None,
+        new_event: str | None = None,
+        new_race_num: int | None = None,
+    ) -> tuple[Race, str | None]:
+        """Rename a race and regenerate its slug (#449).
+
+        At least one of *new_name*, *new_event*, *new_race_num* must be set.
+        When *new_name* is ``None`` but event/race_num change, the name is
+        regenerated via ``build_race_name``. Returns ``(updated_race,
+        retired_slug_or_None)`` — the retired slug is ``None`` when the
+        rename was a no-op or didn't change the slug.
+
+        Raises:
+            LookupError: if the race id doesn't exist.
+            ValueError: with message ``"name_taken"`` if the resulting name
+                collides with another race's ``name``.
+        """
+        from datetime import UTC as _UTC
+        from datetime import date as _date
+        from datetime import datetime as _datetime
+
+        from helmlog.races import build_race_name, slugify
+
+        current = await self.get_race(race_id)
+        if current is None:
+            raise LookupError(f"race {race_id} not found")
+
+        target_event = new_event if new_event is not None else current.event
+        target_race_num = new_race_num if new_race_num is not None else current.race_num
+        if new_name is not None:
+            target_name = new_name.strip()
+            if not target_name:
+                raise ValueError("name_blank")
+        elif new_event is not None or new_race_num is not None:
+            d = _date.fromisoformat(current.date)
+            target_name = build_race_name(target_event, d, target_race_num, current.session_type)
+        else:
+            target_name = current.name
+
+        no_op = (
+            target_name == current.name
+            and target_event == current.event
+            and target_race_num == current.race_num
+        )
+        if no_op:
+            return current, None
+
+        db = self._conn()
+
+        # Name collision on another race?
+        collide_cur = await db.execute(
+            "SELECT id FROM races WHERE name = ? AND id != ?",
+            (target_name, race_id),
+        )
+        if await collide_cur.fetchone() is not None:
+            raise ValueError("name_taken")
+
+        base = slugify(target_name) or f"race-{race_id}"
+        new_slug = await self._allocate_slug(base, exclude_race_id=race_id)
+        old_slug = current.slug
+        now = _datetime.now(_UTC).isoformat()
+
+        slug_changed = new_slug != old_slug
+
+        await db.execute(
+            "UPDATE races"
+            " SET name = ?, event = ?, race_num = ?, slug = ?, renamed_at = ?"
+            " WHERE id = ?",
+            (target_name, target_event, target_race_num, new_slug, now, race_id),
+        )
+
+        retired: str | None = None
+        if slug_changed and old_slug:
+            # If the new slug matches a retired entry this race previously
+            # owned (rename-churn back to a prior name), clean up that entry.
+            await db.execute(
+                "DELETE FROM race_slug_history WHERE race_id = ? AND slug = ?",
+                (race_id, new_slug),
+            )
+            await db.execute(
+                "INSERT OR REPLACE INTO race_slug_history (slug, race_id, retired_at)"
+                " VALUES (?, ?, ?)",
+                (old_slug, race_id, now),
+            )
+            retired = old_slug
+
+        await db.commit()
+        logger.info(
+            "Race {} renamed: {!r} → {!r} (slug {!r} → {!r})",
+            race_id,
+            current.name,
+            target_name,
+            old_slug,
+            new_slug,
+        )
+        updated = await self.get_race(race_id)
+        assert updated is not None
+        return updated, retired
+
+    async def purge_expired_slug_history(self, retention_days: int) -> int:
+        """Delete ``race_slug_history`` rows older than *retention_days* (#449).
+
+        Returns the number of rows deleted. Callers typically invoke this
+        from a periodic maintenance task; the slug resolution logic also
+        treats rows older than the retention window as 404 at read time so
+        purging is a housekeeping optimisation rather than a correctness
+        requirement.
+        """
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+        from datetime import timedelta as _timedelta
+
+        cutoff = (_datetime.now(_UTC) - _timedelta(days=retention_days)).isoformat()
+        db = self._conn()
+        cur = await db.execute(
+            "DELETE FROM race_slug_history WHERE retired_at < ?",
+            (cutoff,),
+        )
+        await db.commit()
+        return cur.rowcount or 0
 
     # -- Scheduled starts (#345) ------------------------------------------
 
@@ -2472,14 +2699,16 @@ class Storage:
         from datetime import UTC as _UTC
         from datetime import datetime as _datetime
 
+        from helmlog.races import slugify
+
         db = self._conn()
         now = _datetime.now(_UTC).isoformat()
         cur = await db.execute(
             "INSERT INTO races"
             " (name, event, race_num, date, start_utc, end_utc,"
             "  session_type, source, source_id, imported_at,"
-            "  peer_fingerprint, peer_co_op_id)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "  peer_fingerprint, peer_co_op_id, slug)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
             (
                 name,
                 event,
@@ -2495,9 +2724,12 @@ class Storage:
                 peer_co_op_id,
             ),
         )
-        await db.commit()
         race_id = cur.lastrowid
         assert race_id is not None
+        base = slugify(name) or f"race-{race_id}"
+        slug = await self._allocate_slug(base, exclude_race_id=race_id)
+        await db.execute("UPDATE races SET slug = ? WHERE id = ?", (slug, race_id))
+        await db.commit()
         logger.info("Imported race {} (source={}, source_id={})", race_id, source, source_id)
         return race_id
 
@@ -2593,21 +2825,12 @@ class Storage:
         await db.commit()
         return len(pos_rows)
 
-    async def get_race(self, race_id: int) -> Race | None:
-        """Return the race with the given id, or None if not found."""
+    @staticmethod
+    def _row_to_race(row: Any) -> Race:  # noqa: ANN401
         from datetime import datetime as _datetime
 
         from helmlog.races import Race as _Race
 
-        db = self._read_conn()
-        cur = await db.execute(
-            "SELECT id, name, event, race_num, date, start_utc, end_utc, session_type"
-            " FROM races WHERE id = ?",
-            (race_id,),
-        )
-        row = await cur.fetchone()
-        if row is None:
-            return None
         return _Race(
             id=row["id"],
             name=row["name"],
@@ -2617,88 +2840,82 @@ class Storage:
             start_utc=_datetime.fromisoformat(row["start_utc"]),
             end_utc=_datetime.fromisoformat(row["end_utc"]) if row["end_utc"] else None,
             session_type=row["session_type"],
+            slug=row["slug"] or "",
+            renamed_at=(_datetime.fromisoformat(row["renamed_at"]) if row["renamed_at"] else None),
         )
 
-    async def get_current_race(self) -> Race | None:
-        """Return the most recent race with no end_utc, or None."""
-        from datetime import datetime as _datetime
+    _RACE_COLS = (
+        "id, name, event, race_num, date, start_utc, end_utc, session_type, slug, renamed_at"
+    )
 
-        from helmlog.races import Race as _Race
-
+    async def get_race(self, race_id: int) -> Race | None:
+        """Return the race with the given id, or None if not found."""
         db = self._read_conn()
         cur = await db.execute(
-            "SELECT id, name, event, race_num, date, start_utc, end_utc, session_type"
-            " FROM races WHERE end_utc IS NULL ORDER BY start_utc DESC LIMIT 1"
+            f"SELECT {self._RACE_COLS} FROM races WHERE id = ?",
+            (race_id,),
         )
         row = await cur.fetchone()
         if row is None:
             return None
-        return _Race(
-            id=row["id"],
-            name=row["name"],
-            event=row["event"],
-            race_num=row["race_num"],
-            date=row["date"],
-            start_utc=_datetime.fromisoformat(row["start_utc"]),
-            end_utc=None,
-            session_type=row["session_type"],
+        return self._row_to_race(row)
+
+    async def get_race_by_slug(self, slug: str) -> Race | None:
+        """Return the race whose *current* slug matches, or None (#449)."""
+        db = self._read_conn()
+        cur = await db.execute(
+            f"SELECT {self._RACE_COLS} FROM races WHERE slug = ?",
+            (slug,),
         )
+        row = await cur.fetchone()
+        return self._row_to_race(row) if row else None
+
+    async def lookup_retired_slug(self, slug: str) -> tuple[int, datetime] | None:
+        """Return ``(race_id, retired_at)`` for a retired slug, or None (#449)."""
+        from datetime import datetime as _datetime
+
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT race_id, retired_at FROM race_slug_history WHERE slug = ?",
+            (slug,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return int(row["race_id"]), _datetime.fromisoformat(row["retired_at"])
+
+    async def get_current_race(self) -> Race | None:
+        """Return the most recent race with no end_utc, or None."""
+        db = self._read_conn()
+        cur = await db.execute(
+            f"SELECT {self._RACE_COLS}"
+            " FROM races WHERE end_utc IS NULL ORDER BY start_utc DESC LIMIT 1"
+        )
+        row = await cur.fetchone()
+        return self._row_to_race(row) if row else None
 
     async def list_races_for_date(self, date_str: str) -> list[Race]:
         """Return all races for a UTC date string, ordered by start_utc ASC."""
-        from datetime import datetime as _datetime
-
-        from helmlog.races import Race as _Race
-
         db = self._read_conn()
         cur = await db.execute(
-            "SELECT id, name, event, race_num, date, start_utc, end_utc, session_type"
-            " FROM races WHERE date = ? ORDER BY start_utc ASC",
+            f"SELECT {self._RACE_COLS} FROM races WHERE date = ? ORDER BY start_utc ASC",
             (date_str,),
         )
         rows = await cur.fetchall()
-        return [
-            _Race(
-                id=row["id"],
-                name=row["name"],
-                event=row["event"],
-                race_num=row["race_num"],
-                date=row["date"],
-                start_utc=_datetime.fromisoformat(row["start_utc"]),
-                end_utc=_datetime.fromisoformat(row["end_utc"]) if row["end_utc"] else None,
-                session_type=row["session_type"],
-            )
-            for row in rows
-        ]
+        return [self._row_to_race(row) for row in rows]
 
     async def list_races_in_range(self, start_utc: datetime, end_utc: datetime) -> list[Race]:
         """Return all races whose time window overlaps ``[start_utc, end_utc]``."""
-        from datetime import datetime as _datetime
-
-        from helmlog.races import Race as _Race
-
         db = self._read_conn()
         cur = await db.execute(
-            "SELECT id, name, event, race_num, date, start_utc, end_utc, session_type"
+            f"SELECT {self._RACE_COLS}"
             " FROM races"
             " WHERE start_utc < ? AND (end_utc IS NULL OR end_utc > ?)"
             " ORDER BY start_utc ASC",
             (end_utc.isoformat(), start_utc.isoformat()),
         )
         rows = await cur.fetchall()
-        return [
-            _Race(
-                id=row["id"],
-                name=row["name"],
-                event=row["event"],
-                race_num=row["race_num"],
-                date=row["date"],
-                start_utc=_datetime.fromisoformat(row["start_utc"]),
-                end_utc=_datetime.fromisoformat(row["end_utc"]) if row["end_utc"] else None,
-                session_type=row["session_type"],
-            )
-            for row in rows
-        ]
+        return [self._row_to_race(row) for row in rows]
 
     async def count_sessions_for_date(self, date_str: str, session_type: str) -> int:
         """Return the count of sessions of the given type for a UTC date string."""
@@ -2757,6 +2974,7 @@ class Storage:
             where = "WHERE " + " AND ".join(race_where)
             parts.append(
                 f"SELECT r.id AS id, r.session_type AS type, r.name AS name,"
+                f" r.slug AS slug,"
                 f" r.event AS event, r.race_num AS race_num, r.date AS date,"
                 f" r.start_utc AS start_utc, r.end_utc AS end_utc,"
                 f" CASE WHEN a.id IS NOT NULL THEN 1 ELSE 0 END AS has_audio,"
@@ -2806,6 +3024,7 @@ class Storage:
             parts.append(
                 f"SELECT a.id AS id, 'debrief' AS type,"
                 f" COALESCE(a.name, a.file_path) AS name,"
+                f" NULL AS slug,"
                 f" COALESCE(r.event, '') AS event,"
                 f" r.race_num AS race_num,"
                 f" COALESCE(r.date, substr(a.start_utc, 1, 10)) AS date,"

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -1900,7 +1900,7 @@ class Storage:
 
         db = self._conn()
         cur = await db.execute("SELECT id, name FROM races WHERE slug IS NULL ORDER BY id ASC")
-        rows = await cur.fetchall()
+        rows = list(await cur.fetchall())
         if not rows:
             return
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -1570,9 +1570,11 @@ class Storage:
         if current < 56:
             await self._migrate_v56_categories()
 
-        # Post-DDL data migration for v58 (backfill race slugs)
-        if current < 58:
-            await self._migrate_v58_slugs()
+        # Post-DDL data migration for v58 (backfill race slugs). Always
+        # called — the method is idempotent (no-op when every row has a
+        # slug) so a previously-failed partial backfill gets repaired on
+        # the next boot instead of leaving rows with NULL slugs forever.
+        await self._migrate_v58_slugs()
 
         logger.debug("Schema is at version {}", _CURRENT_VERSION)
 
@@ -2869,6 +2871,46 @@ class Storage:
         )
         row = await cur.fetchone()
         return self._row_to_race(row) if row else None
+
+    async def ensure_race_slug(self, race_id: int) -> str | None:
+        """Allocate and persist a slug for *race_id* if it doesn't have one yet (#449).
+
+        Returns the slug (newly assigned or already present), or ``None`` if
+        the race doesn't exist. Used as a lazy repair for rows that missed
+        the v58 backfill — e.g. a race row whose backfill transaction
+        crashed on a prior boot.
+        """
+        from helmlog.races import slugify
+
+        db = self._conn()
+        cur = await db.execute("SELECT id, name, slug FROM races WHERE id = ?", (race_id,))
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        if row["slug"]:
+            return str(row["slug"])
+        base = slugify(row["name"]) or f"race-{race_id}"
+        slug = await self._allocate_slug(base, exclude_race_id=race_id)
+        await db.execute("UPDATE races SET slug = ? WHERE id = ?", (slug, race_id))
+        await db.commit()
+        logger.info("Lazy slug allocation for race {}: {}", race_id, slug)
+        return slug
+
+    async def get_debrief_session(self, audio_session_id: int) -> dict[str, Any] | None:
+        """Return a minimal debrief session record by audio_sessions id (#449).
+
+        Debriefs live in ``audio_sessions`` with ``session_type='debrief'`` and
+        have no slug. The session detail page renders them under
+        ``/session/{audio_id}`` so links from the history list keep working.
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT id, COALESCE(name, file_path) AS name, session_type, start_utc"
+            " FROM audio_sessions WHERE id = ? AND session_type = 'debrief'",
+            (audio_session_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
 
     async def lookup_retired_slug(self, slug: str) -> tuple[int, datetime] | None:
         """Return ``(race_id, retired_at)`` for a retired slug, or None (#449)."""

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -61,6 +61,7 @@
 {% block content %}
 <div id="app-config"
   data-session-id="{{ session_id }}"
+  data-session-slug="{{ session_slug or '' }}"
   data-grafana-port="{{ grafana_port }}"
   data-grafana-uid="{{ grafana_uid }}"
   data-user-role="{{ user_role }}"
@@ -68,10 +69,26 @@
 
 <a href="/history" class="back-link">&larr; History</a>
 
+{% if renamed_from %}
+<div class="card" style="background:var(--bg-secondary);border:1px dashed var(--accent-strong);font-size:.78rem;color:var(--text-secondary);margin-bottom:8px">
+  Renamed from <code>{{ renamed_from }}</code> — old bookmarks will continue to redirect here for 30 days.
+</div>
+{% endif %}
+
 <div class="card">
-  <div id="session-header">
-    <div class="session-name" id="session-name"></div>
-    <div class="session-meta" id="session-meta"></div>
+  <div id="session-header" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+    <div style="flex:1;min-width:0">
+      <div class="session-name" id="session-name">{{ session_name }}</div>
+      <div class="session-meta" id="session-meta"></div>
+    </div>
+    {% if user_role == "admin" %}
+    <button id="rename-session-btn"
+            type="button"
+            onclick="renameSession()"
+            style="background:none;border:1px solid var(--border);color:var(--text-secondary);border-radius:4px;padding:4px 10px;font-size:.75rem;cursor:pointer">
+      Rename
+    </button>
+    {% endif %}
   </div>
 </div>
 
@@ -224,4 +241,33 @@
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/session.js?v=7"></script>
+<script>
+async function renameSession() {
+  const sessionId = document.getElementById('app-config').dataset.sessionId;
+  const current = document.getElementById('session-name').textContent.trim();
+  const next = window.prompt('New session name:', current);
+  if (next === null) return;
+  const trimmed = next.trim();
+  if (!trimmed || trimmed === current) return;
+  try {
+    const resp = await fetch(`/api/sessions/${sessionId}`, {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({name: trimmed}),
+    });
+    if (resp.status === 409) {
+      window.alert('That name is already used by another session.');
+      return;
+    }
+    if (!resp.ok) {
+      window.alert(`Rename failed: ${resp.status}`);
+      return;
+    }
+    const body = await resp.json();
+    window.location.href = body.url;
+  } catch (err) {
+    window.alert(`Rename failed: ${err}`);
+  }
+}
+</script>
 {% endblock %}

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from helmlog.races import RaceConfig, build_grafana_url, build_race_name, default_event_for_date
+from helmlog.races import (
+    RaceConfig,
+    build_grafana_url,
+    build_race_name,
+    default_event_for_date,
+    slugify,
+)
 
 if TYPE_CHECKING:
     from helmlog.storage import Storage
@@ -79,6 +85,56 @@ def test_build_race_name_practice() -> None:
 def test_build_race_name_synthesized() -> None:
     name = build_race_name("BallardCup", date(2025, 8, 10), 2, "synthesized")
     assert name == "20250810-BallardCup-S2"
+
+
+# ---------------------------------------------------------------------------
+# slugify tests (#449)
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_basic() -> None:
+    assert slugify("20250810-BallardCup-2") == "20250810-ballardcup-2"
+
+
+def test_slugify_spaces_and_punctuation() -> None:
+    assert slugify("CYC Spring — Race 4") == "cyc-spring-race-4"
+
+
+def test_slugify_collapses_runs() -> None:
+    assert slugify("Hello   ---   World!!!") == "hello-world"
+
+
+def test_slugify_strips_edges() -> None:
+    assert slugify("--foo--bar--") == "foo-bar"
+
+
+def test_slugify_unicode_stripped() -> None:
+    # Non-ASCII characters are replaced with '-' and collapsed.
+    assert slugify("Ballard Cüp #1 — ¡finish!") == "ballard-c-p-1-finish"
+
+
+def test_slugify_empty_input_returns_empty() -> None:
+    assert slugify("") == ""
+    assert slugify("!!!") == ""
+
+
+def test_slugify_max_length_truncates_on_dash_boundary() -> None:
+    text = "one-two-three-four-five-six-seven-eight-nine-ten-eleven-twelve-thirteen-fourteen"
+    out = slugify(text, max_length=30)
+    assert len(out) <= 30
+    assert not out.endswith("-")
+    # Should cut at a dash, not mid-word
+    assert out == "one-two-three-four-five-six"
+
+
+def test_slugify_max_length_no_dash_in_window() -> None:
+    # If the first max_length chars contain no dash, hard-truncate.
+    out = slugify("abcdefghijklmnopqrstuvwxyz", max_length=10)
+    assert out == "abcdefghij"
+
+
+def test_slugify_already_lowercase_noop() -> None:
+    assert slugify("already-a-slug") == "already-a-slug"
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +229,145 @@ async def test_list_races_for_date_ordered(storage: Storage) -> None:
     assert races[0].race_num == 1
     assert races[1].race_num == 2
     assert races[0].start_utc < races[1].start_utc
+
+
+# ---------------------------------------------------------------------------
+# Slug + rename storage tests (#449)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_race_assigns_slug(storage: Storage) -> None:
+    race = await storage.start_race("CYC Spring", _START1, _DATE, 4, "20250810-CYC Spring-4")
+    assert race.slug == "20250810-cyc-spring-4"
+
+
+@pytest.mark.asyncio
+async def test_start_race_slug_collision_appends_suffix(storage: Storage) -> None:
+    # Two races with names that slugify to the same thing → second gets -2.
+    r1 = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-ballardcup-1")
+    r2 = await storage.start_race("BallardCup", _START2, _DATE, 1, "20250810-BallardCup-1")
+    assert r1.slug == "20250810-ballardcup-1"
+    assert r2.slug == "20250810-ballardcup-1-2"
+
+
+@pytest.mark.asyncio
+async def test_get_race_by_slug_returns_current(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "20250810-CYC-1")
+    found = await storage.get_race_by_slug(race.slug)
+    assert found is not None
+    assert found.id == race.id
+
+
+@pytest.mark.asyncio
+async def test_get_race_by_slug_miss(storage: Storage) -> None:
+    assert await storage.get_race_by_slug("nope") is None
+
+
+@pytest.mark.asyncio
+async def test_rename_race_updates_name_and_slug(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 4, "20260408-CYC-4")
+    updated, retired = await storage.rename_race(
+        race.id, new_name="Ballard Cup #1 — finish line confusion"
+    )
+    assert updated.name == "Ballard Cup #1 — finish line confusion"
+    assert updated.slug == "ballard-cup-1-finish-line-confusion"
+    assert retired == "20260408-cyc-4"
+    assert updated.renamed_at is not None
+
+    # Retired slug is recorded in history.
+    hit = await storage.lookup_retired_slug("20260408-cyc-4")
+    assert hit is not None
+    assert hit[0] == race.id
+
+
+@pytest.mark.asyncio
+async def test_rename_race_noop_when_same_values(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "20250810-CYC-1")
+    updated, retired = await storage.rename_race(race.id, new_name="20250810-CYC-1")
+    assert retired is None
+    assert updated.renamed_at is None  # no-op leaves renamed_at untouched
+
+
+@pytest.mark.asyncio
+async def test_rename_race_name_collision_raises(storage: Storage) -> None:
+    await storage.start_race("CYC", _START1, _DATE, 1, "20250810-CYC-1")
+    r2 = await storage.start_race("CYC", _START2, _DATE, 2, "20250810-CYC-2")
+    with pytest.raises(ValueError, match="name_taken"):
+        await storage.rename_race(r2.id, new_name="20250810-CYC-1")
+
+
+@pytest.mark.asyncio
+async def test_rename_race_blank_name_raises(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "20250810-CYC-1")
+    with pytest.raises(ValueError, match="name_blank"):
+        await storage.rename_race(race.id, new_name="   ")
+
+
+@pytest.mark.asyncio
+async def test_rename_race_changing_event_regenerates_name(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "20250810-CYC-1")
+    updated, _retired = await storage.rename_race(race.id, new_event="BallardCup", new_race_num=3)
+    assert updated.name == "20250810-BallardCup-3"
+    assert updated.event == "BallardCup"
+    assert updated.race_num == 3
+    assert updated.slug == "20250810-ballardcup-3"
+
+
+@pytest.mark.asyncio
+async def test_rename_race_slug_collision_with_other_race(storage: Storage) -> None:
+    # r1's slug is "cool-race". When r2 is renamed to produce the same slug,
+    # r2 should end up with "cool-race-2".
+    r1 = await storage.start_race("E", _START1, _DATE, 1, "Cool Race")
+    r2 = await storage.start_race("E", _START2, _DATE, 2, "20260408-E-2")
+    assert r1.slug == "cool-race"
+    updated, _ = await storage.rename_race(r2.id, new_name="Cool  Race!")
+    assert updated.name == "Cool  Race!"
+    assert updated.slug == "cool-race-2"
+
+
+@pytest.mark.asyncio
+async def test_rename_race_back_to_prior_name_reuses_slug(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "Alpha")
+    await storage.rename_race(race.id, new_name="Beta")
+    # "alpha" is now in history. Renaming back should reclaim the bare slug
+    # and remove the history row (not append -2).
+    updated, retired_from_beta = await storage.rename_race(race.id, new_name="Alpha")
+    assert updated.slug == "alpha"
+    assert retired_from_beta == "beta"
+    assert await storage.lookup_retired_slug("alpha") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_retired_slug_after_rename(storage: Storage) -> None:
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "Original")
+    await storage.rename_race(race.id, new_name="Renamed")
+    hit = await storage.lookup_retired_slug("original")
+    assert hit is not None
+    rid, ts = hit
+    assert rid == race.id
+    assert ts.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_slug_history(storage: Storage) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    race = await storage.start_race("CYC", _START1, _DATE, 1, "Original")
+    await storage.rename_race(race.id, new_name="Renamed")
+
+    # Nothing to purge immediately.
+    assert await storage.purge_expired_slug_history(30) == 0
+
+    # Backdate the history row to 40 days ago and purge with 30-day retention.
+    old_ts = (datetime.now(UTC) - timedelta(days=40)).isoformat()
+    await storage._conn().execute(  # noqa: SLF001
+        "UPDATE race_slug_history SET retired_at = ? WHERE slug = ?",
+        (old_ts, "original"),
+    )
+    await storage._conn().commit()  # noqa: SLF001
+    assert await storage.purge_expired_slug_history(30) == 1
+    assert await storage.lookup_retired_slug("original") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -102,7 +102,7 @@ async def test_rename_admin_success(storage: Storage, admin_client: httpx.AsyncC
     assert body["name"] == "Ballard Cup #1 — finish line confusion"
     assert body["slug"] == "ballard-cup-1-finish-line-confusion"
     assert body["retired_slug"] == "20260408-cyc-4"
-    assert body["url"] == "/session/ballard-cup-1-finish-line-confusion"
+    assert body["url"] == f"/session/{race_id}/ballard-cup-1-finish-line-confusion"
 
     # Audit row written
     audit_rows = await storage.list_audit_log(limit=5)
@@ -177,19 +177,54 @@ async def test_rename_event_and_race_num_regenerates_name(
 
 
 @pytest.mark.asyncio
-async def test_int_id_redirects_to_slug(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+async def test_int_id_redirects_to_canonical(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     resp = await admin_client.get(f"/session/{race_id}")
     assert resp.status_code == 301
-    assert resp.headers["location"] == "/session/20260408-cyc-1"
+    assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1"
 
 
 @pytest.mark.asyncio
-async def test_current_slug_renders_page(storage: Storage, admin_client: httpx.AsyncClient) -> None:
-    await _seed_race(storage, name="20260408-CYC-1")
+async def test_slug_only_redirects_to_canonical(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
     resp = await admin_client.get("/session/20260408-cyc-1")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1"
+
+
+@pytest.mark.asyncio
+async def test_canonical_url_renders_page(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.get(f"/session/{race_id}/20260408-cyc-1")
     assert resp.status_code == 200
     assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_canonical_url_stale_slug_redirects(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """Old bookmarks with a renamed slug still resolve via the stable id (#449)."""
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    await storage.rename_race(race_id, new_name="New Name")
+    # Canonical id/old-slug should 301 to canonical id/new-slug.
+    resp = await admin_client.get(f"/session/{race_id}/20260408-cyc-1")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"/session/{race_id}/new-name"
+
+
+@pytest.mark.asyncio
+async def test_canonical_url_wrong_id_404(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    resp = await admin_client.get("/session/99999/anything")
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -200,7 +235,7 @@ async def test_retired_slug_redirects_within_window(
     await storage.rename_race(race_id, new_name="New Name")
     resp = await admin_client.get("/session/20260408-cyc-1")
     assert resp.status_code == 301
-    assert resp.headers["location"] == "/session/new-name"
+    assert resp.headers["location"] == f"/session/{race_id}/new-name"
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -267,6 +267,106 @@ async def test_unknown_int_id_404(storage: Storage, admin_client: httpx.AsyncCli
 
 
 # ---------------------------------------------------------------------------
+# Debrief fallback + lazy slug allocation (#449 follow-up)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_debrief_session_renders_under_int_url(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """Debrief (audio_sessions) ids fall through from /session/{id} and render."""
+    db = storage._conn()  # noqa: SLF001
+    cur = await db.execute(
+        "INSERT INTO audio_sessions"
+        " (file_path, device_name, start_utc, end_utc, sample_rate, channels,"
+        "  session_type, name)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "/tmp/debrief.wav",
+            "Mic",
+            _START.isoformat(),
+            (_START + timedelta(minutes=30)).isoformat(),
+            48000,
+            1,
+            "debrief",
+            "Post-race debrief",
+        ),
+    )
+    await db.commit()
+    audio_id = cur.lastrowid
+    assert audio_id is not None
+
+    resp = await admin_client.get(f"/session/{audio_id}")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_race_without_slug_is_lazily_assigned(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """A race row with NULL slug (e.g. failed backfill) gets one on access."""
+    db = storage._conn()  # noqa: SLF001
+    cur = await db.execute(
+        "INSERT INTO races"
+        " (name, event, race_num, date, start_utc, end_utc, session_type, slug)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+        (
+            "20260408-Practice-1",
+            "Practice",
+            1,
+            "2026-04-08",
+            _START.isoformat(),
+            (_START + timedelta(hours=1)).isoformat(),
+            "practice",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+
+    resp = await admin_client.get(f"/session/{race_id}")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"/session/{race_id}/20260408-practice-1"
+
+    # Subsequent calls should keep redirecting (slug now persisted).
+    race = await storage.get_race(race_id)
+    assert race is not None
+    assert race.slug == "20260408-practice-1"
+
+
+@pytest.mark.asyncio
+async def test_v58_backfill_is_idempotent(storage: Storage) -> None:
+    """Re-running ``_migrate_v58_slugs`` after a partial failure completes it."""
+    db = storage._conn()  # noqa: SLF001
+    await db.execute(
+        "INSERT INTO races"
+        " (name, event, race_num, date, start_utc, end_utc, session_type, slug)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+        (
+            "Partial backfill row",
+            "E",
+            1,
+            "2026-04-08",
+            _START.isoformat(),
+            None,
+            "race",
+        ),
+    )
+    await db.commit()
+
+    await storage._migrate_v58_slugs()  # noqa: SLF001
+    cur = await db.execute("SELECT slug FROM races WHERE name = 'Partial backfill row'")
+    row = await cur.fetchone()
+    assert row is not None
+    assert row["slug"] == "partial-backfill-row"
+
+    # Running again is a no-op and does not raise.
+    await storage._migrate_v58_slugs()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
 # Video pipeline — rename must not break race_videos links
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -1,0 +1,258 @@
+"""Tests for session rename + human-readable URL slugs (#449).
+
+Covers the decision table from the structured spec: rename API auth matrix,
+slug collision handling, id→slug redirect, retired-slug redirect + expiry,
+and 404 fall-through.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from helmlog.auth import generate_token, session_expires_at
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from helmlog.storage import Storage
+
+
+_START = datetime(2026, 4, 8, 19, 0, 0, tzinfo=UTC)
+
+
+async def _create_user(storage: Storage, role: str) -> str:
+    email = f"{role}@rename-test.com"
+    user_id = await storage.create_user(email, f"Test {role}", role)
+    session_id = generate_token()
+    await storage.create_session(session_id, user_id, session_expires_at())
+    return session_id
+
+
+@pytest_asyncio.fixture
+async def admin_client(storage: Storage) -> AsyncIterator[httpx.AsyncClient]:
+    """Admin-authed HTTP client."""
+    session_id = await _create_user(storage, "admin")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+            follow_redirects=False,
+        ) as client:
+            yield client
+
+
+@pytest_asyncio.fixture
+async def viewer_client(storage: Storage) -> AsyncIterator[httpx.AsyncClient]:
+    """Read-only viewer client — rename must 403."""
+    session_id = await _create_user(storage, "viewer")
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"session": session_id},
+            follow_redirects=False,
+        ) as client:
+            yield client
+
+
+@pytest_asyncio.fixture
+async def anon_client(storage: Storage) -> AsyncIterator[httpx.AsyncClient]:
+    """Unauthenticated client — rename must 401."""
+    with patch.dict(os.environ, {"AUTH_DISABLED": "false"}):
+        app = create_app(storage)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=False,
+        ) as client:
+            yield client
+
+
+async def _seed_race(storage: Storage, *, name: str, race_num: int = 1) -> int:
+    race = await storage.start_race("CYC Spring", _START, "2026-04-08", race_num, name)
+    await storage.end_race(race.id, _START + timedelta(hours=1))
+    return race.id
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/sessions/{id} — auth matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_admin_success(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-4")
+    resp = await admin_client.patch(
+        f"/api/sessions/{race_id}",
+        json={"name": "Ballard Cup #1 — finish line confusion"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Ballard Cup #1 — finish line confusion"
+    assert body["slug"] == "ballard-cup-1-finish-line-confusion"
+    assert body["retired_slug"] == "20260408-cyc-4"
+    assert body["url"] == "/session/ballard-cup-1-finish-line-confusion"
+
+    # Audit row written
+    audit_rows = await storage.list_audit_log(limit=5)
+    actions = [row["action"] for row in audit_rows]
+    assert "race.rename" in actions
+
+
+@pytest.mark.asyncio
+async def test_rename_viewer_forbidden(storage: Storage, viewer_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-4")
+    resp = await viewer_client.patch(f"/api/sessions/{race_id}", json={"name": "New Name"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_rename_unauthenticated_401(storage: Storage, anon_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-4")
+    resp = await anon_client.patch(f"/api/sessions/{race_id}", json={"name": "New Name"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_rename_name_collision_409(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    await _seed_race(storage, name="20260408-CYC-1", race_num=1)
+    race2_id = await _seed_race(
+        storage,
+        name="20260408-CYC-2",
+        race_num=2,
+    )
+    resp = await admin_client.patch(
+        f"/api/sessions/{race2_id}",
+        json={"name": "20260408-CYC-1"},
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["detail"] == {"error": "name_taken"}
+
+
+@pytest.mark.asyncio
+async def test_rename_nonexistent_race_404(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    resp = await admin_client.patch("/api/sessions/99999", json={"name": "X"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rename_empty_body_422(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.patch(f"/api/sessions/{race_id}", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_event_and_race_num_regenerates_name(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.patch(
+        f"/api/sessions/{race_id}",
+        json={"event": "BallardCup", "race_num": 3},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "20260408-BallardCup-3"
+    assert body["slug"] == "20260408-ballardcup-3"
+
+
+# ---------------------------------------------------------------------------
+# Slug routing — /session/{slug} and /session/{id} redirects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_int_id_redirects_to_slug(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.get(f"/session/{race_id}")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == "/session/20260408-cyc-1"
+
+
+@pytest.mark.asyncio
+async def test_current_slug_renders_page(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.get("/session/20260408-cyc-1")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_retired_slug_redirects_within_window(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    await storage.rename_race(race_id, new_name="New Name")
+    resp = await admin_client.get("/session/20260408-cyc-1")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == "/session/new-name"
+
+
+@pytest.mark.asyncio
+async def test_retired_slug_expired_404(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    await storage.rename_race(race_id, new_name="New Name")
+    # Backdate the history row past the 30-day retention window.
+    old_ts = (datetime.now(UTC) - timedelta(days=40)).isoformat()
+    db = storage._conn()  # noqa: SLF001
+    await db.execute(
+        "UPDATE race_slug_history SET retired_at = ? WHERE slug = ?",
+        (old_ts, "20260408-cyc-1"),
+    )
+    await db.commit()
+    resp = await admin_client.get("/session/20260408-cyc-1")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_unknown_slug_404(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    resp = await admin_client.get("/session/never-existed")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_unknown_int_id_404(storage: Storage, admin_client: httpx.AsyncClient) -> None:
+    resp = await admin_client.get("/session/99999")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Video pipeline — rename must not break race_videos links
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_does_not_touch_race_videos(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    await storage.add_race_video(
+        race_id=race_id,
+        youtube_url="https://youtu.be/abc",
+        video_id="abc",
+        title="stern cam",
+        label="stern",
+        sync_utc=_START,
+        sync_offset_s=0.0,
+    )
+    resp = await admin_client.patch(f"/api/sessions/{race_id}", json={"name": "Totally New"})
+    assert resp.status_code == 200
+
+    videos = await storage.list_race_videos(race_id)
+    assert len(videos) == 1
+    assert videos[0]["youtube_url"] == "https://youtu.be/abc"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -100,6 +100,34 @@ class TestMigration:
         assert row is not None
         assert row[0] == "boat_settings"
 
+    async def test_migration_v58_backfills_slugs_with_collisions(self, storage: Storage) -> None:
+        """v58 backfill slugifies names and resolves collisions by id order (#449)."""
+        db = storage._conn()
+
+        # Insert three rows with colliding slug bases, then wipe the slug to
+        # simulate pre-migration state, then re-run the v58 backfill.
+        await db.execute(
+            "INSERT INTO races"
+            " (name, event, race_num, date, start_utc, end_utc, session_type, slug)"
+            " VALUES"
+            " ('Ballard Cup', 'BC', 1, '2025-08-10', '2025-08-10T12:00:00+00:00',"
+            "  NULL, 'race', NULL),"
+            " ('ballard-cup', 'BC', 2, '2025-08-10', '2025-08-10T13:00:00+00:00',"
+            "  NULL, 'race', NULL),"
+            " ('BALLARD CUP!!', 'BC', 3, '2025-08-10', '2025-08-10T14:00:00+00:00',"
+            "  NULL, 'race', NULL)"
+        )
+        await db.commit()
+
+        await storage._migrate_v58_slugs()  # noqa: SLF001
+
+        cur = await db.execute("SELECT id, slug FROM races ORDER BY id ASC")
+        slugs = [row["slug"] for row in await cur.fetchall()]
+        # First race keeps the bare slug, later ones get suffixed.
+        assert slugs[0] == "ballard-cup"
+        assert slugs[1] == "ballard-cup-2"
+        assert slugs[2] == "ballard-cup-3"
+
     async def test_migration_v39_adds_point_of_sail(self, storage: Storage) -> None:
         """Migration v39 adds point_of_sail column and auto-populates existing sails."""
         db = storage._conn()


### PR DESCRIPTION
## Summary

- Admin-only `PATCH /api/sessions/{id}` renames a race session: accepts any combination of `name`, `event`, `race_num`; regenerates the slug; writes the retired slug to a new `race_slug_history` table; audit-logs the change.
- Adds `races.slug TEXT UNIQUE` (+ `renamed_at`) in schema v58 with a post-DDL backfill that slugifies existing names and resolves collisions by id order.
- `/session/{id}` now 301-redirects to `/session/{slug}`; retired slugs 301 for 30 days and 404 afterwards; unknown paths 404.
- Session detail page shows a "Renamed from …" banner for 30 days after the most recent rename and gives admins a Rename button that hits the new API.
- Video pipeline already reads fresh metadata at upload time; `session_url` in the YouTube description now prefers `/session/{slug}` when available, so a pre-upload rename flows through to both the title and the link.

Per the spec comment on #449:
- Retention window: 30 days with retired-slug redirects.
- Write permission: admin only.
- Rename may change event/race_num (endpoint accepts them; name is auto-regenerated if not explicitly supplied).
- `race_videos` rows are untouched — the pipeline reads race metadata at upload time so a rename before processing uses the new name.

Closes #449

## Test plan

- [x] `uv run pytest tests/test_races.py tests/test_storage.py::TestMigration tests/test_session_rename.py` — 42 + 6 + 14 = 62 new/touched tests pass
- [x] `uv run pytest` — full suite: 1599 passed, 2 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — no new errors in touched files (pre-existing errors in `storage.py`, `routes/network.py`, `routes/aruco.py` unchanged)
- [ ] Manual smoke on Pi: rename a real session, verify the old URL redirects and the YouTube title picks up the new name on next process

🤖 Generated with [Claude Code](https://claude.com/claude-code)