### PR TITLE
Auto-run import-matched on SD card mount

### DIFF
--- a/launchd/com.helmlog.sd-import.plist
+++ b/launchd/com.helmlog.sd-import.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.helmlog.sd-import — triggers import-matched.sh when an Insta360 SD
+  card (or any volume) is mounted.
+
+  Copy the cookie-filled version into ~/Library/LaunchAgents/ and load with
+  launchctl. Pairs with com.helmlog.video-watch.plist: this one copies the
+  session-matching recordings off the card into ~/Insta360 Imports/, then
+  the user manually opens Insta360 Studio to export to ~/Insta360 Exports/,
+  and video-watch picks up the exports and uploads them.
+
+  PI_SESSION_COOKIE must be filled in before loading — without it the
+  session-fetch returns empty and nothing is copied.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.helmlog.sd-import</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/dweatbrook/src/helmlog/scripts/import-matched.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/dweatbrook/src/helmlog</string>
+
+    <key>WatchPaths</key>
+    <array>
+        <string>/Volumes</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/dweatbrook</string>
+        <key>PATH</key>
+        <string>/Users/dweatbrook/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>PI_API_URL</key>
+        <string>http://corvopi-live:3002</string>
+        <key>TIMEZONE</key>
+        <string>America/Los_Angeles</string>
+        <!-- Filled in by the installer at ~/Library/LaunchAgents/ time. -->
+        <key>PI_SESSION_COOKIE</key>
+        <string></string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/dweatbrook/Library/Logs/helmlog/sd-import.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/dweatbrook/Library/Logs/helmlog/sd-import.err</string>
+</dict>
+</plist>

--- a/scripts/watch-exports.sh
+++ b/scripts/watch-exports.sh
@@ -41,6 +41,10 @@ log "Upload script: $UPLOAD_SCRIPT"
 # fswatch flags:
 #   -0          NUL-separated output (handles spaces in paths)
 #   -r          recurse so per-camera subdirs are covered
+#   -E          extended regex — {n}, [0-9], etc. in the include pattern
+#               only work under extended syntax; without -E the include
+#               filter silently never matches and -e ".*" swallows every
+#               event, which is exactly what happens if you forget -E.
 #   -e          exclude regex (skip everything by default …)
 #   -i          … then include only VID_*.mp4 / .insv
 #   --event     only fire on Created / MovedTo (file appearance)
@@ -48,6 +52,7 @@ log "Upload script: $UPLOAD_SCRIPT"
 fswatch \
   -0 \
   -r \
+  -E \
   --latency 1 \
   --event=Created \
   --event=Updated \


### PR DESCRIPTION
## Summary
- Adds `launchd/com.helmlog.sd-import.plist`, a WatchPaths agent on `/Volumes` that fires `scripts/import-matched.sh` whenever a volume is mounted.
- Closes the last manual step in the Insta360 automation loop: plug in the X4, the card is scanned, session-matching recordings are copied into `~/Insta360 Imports/` for Insta360 Studio, and Studio exports flow through `com.helmlog.video-watch` to YouTube + session link.
- Companion to `com.helmlog.video-watch.plist` added in #448 — together the two agents form the full hands-off pipeline.

`PI_SESSION_COOKIE` must be filled in when copying the plist to `~/Library/LaunchAgents/`; the repo copy ships empty.

## Test plan
- [x] Agent loads via `launchctl load ~/Library/LaunchAgents/com.helmlog.sd-import.plist`
- [x] `com.helmlog.video-watch` fswatch loop running in parallel (pid verified, log shows watching)
- [ ] Plug in X4 SD card, confirm `~/Library/Logs/helmlog/sd-import.log` shows discovery + copy of matching recordings
- [ ] Open `~/Insta360 Imports/` in Studio, export one, confirm auto-upload via video-watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)