### PR TITLE
Video switcher buttons show the unique part of each title

### DIFF
--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -568,10 +568,12 @@ async function toggleHistoryPlayer(sessionId) {
 
   // Build switcher + player + video list
   let html = '';
-  if (videos.filter(v => v.video_id).length > 1) {
+  const playable = videos.filter(v => v.video_id);
+  if (playable.length > 1) {
+    const btnLabels = videoButtonLabels(playable);
     html += '<div style="display:flex;gap:6px;margin-bottom:6px">';
-    html += videos.filter(v => v.video_id).map((v, i) => {
-      const label = (v.label || v.title || 'Video ' + (i + 1)).replace(/&/g,'&amp;').replace(/</g,'&lt;');
+    html += playable.map((v, i) => {
+      const label = btnLabels[i].replace(/&/g,'&amp;').replace(/</g,'&lt;');
       const cls = v.video_id === vid.video_id ? 'filter-btn active' : 'filter-btn';
       return '<button class="' + cls + '" onclick="switchHistVideo(' + sessionId + ',\'' + v.video_id + '\',this)">' + label + '</button>';
     }).join('');

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -324,10 +324,10 @@ async function loadVideoPlayer() {
   // Render video switcher if multiple videos
   if (videos.length > 1) {
     const switcher = document.getElementById('video-switcher');
+    const btnLabels = videoButtonLabels(videos);
     switcher.innerHTML = videos.map((v, i) => {
-      const label = v.label || v.title || ('Video ' + (i + 1));
       const cls = i === _videoSync.activeIdx ? 'filter-btn active' : 'filter-btn';
-      return '<button class="' + cls + '" onclick="switchVideo(' + i + ')">' + esc(label) + '</button>';
+      return '<button class="' + cls + '" onclick="switchVideo(' + i + ')">' + esc(btnLabels[i]) + '</button>';
     }).join('');
   }
 

--- a/src/helmlog/static/shared.js
+++ b/src/helmlog/static/shared.js
@@ -147,6 +147,64 @@ function parseVideoPosition(str) {
 }
 
 // ---------------------------------------------------------------------------
+// Video selector button labels
+// ---------------------------------------------------------------------------
+
+// Given a list of video objects (each with .title, .label, .video_id), return
+// a parallel list of short strings to use as switcher-button labels. The
+// algorithm strips time-of-day tokens from each title, then collapses
+// everything that's common across all titles (longest common prefix +
+// longest common suffix) so only the part that actually varies is left.
+//
+// When that leaves nothing unique (e.g. grandfathered videos that only differ
+// by upload time), fall back to the stripped time tokens themselves. Final
+// fallback is "Video 1/2/3" so a degenerate set never renders empty buttons.
+//
+// Pure function — no DOM access. Called by session.js and history.js.
+function videoButtonLabels(videos) {
+  // HH:MM or HH:MM:SS, optionally followed by a 2–5 char uppercase TZ abbr.
+  const TIME_RE = /\b\d{1,2}:\d{2}(?::\d{2})?(?:\s*[A-Z]{2,5})?\b/g;
+
+  const sources = videos.map((v, i) => v.title || v.label || ('Video ' + (i + 1)));
+  const stripped = sources.map(s => s.replace(TIME_RE, '').replace(/\s+/g, ' ').trim());
+  const times = sources.map(s => {
+    const m = s.match(TIME_RE);
+    return m ? m.join(' ') : '';
+  });
+
+  function lcp(strs) {
+    if (!strs.length) return '';
+    let p = strs[0];
+    for (let i = 1; i < strs.length; i++) {
+      while (p && !strs[i].startsWith(p)) p = p.substring(0, p.length - 1);
+      if (!p) return '';
+    }
+    return p;
+  }
+  function lcsuf(strs) {
+    if (!strs.length) return '';
+    let s = strs[0];
+    for (let i = 1; i < strs.length; i++) {
+      while (s && !strs[i].endsWith(s)) s = s.substring(1);
+      if (!s) return '';
+    }
+    return s;
+  }
+
+  const prefix = lcp(stripped);
+  const afterPrefix = stripped.map(s => s.substring(prefix.length));
+  const suffix = lcsuf(afterPrefix);
+  const unique = afterPrefix.map(s => s.substring(0, s.length - suffix.length).trim());
+
+  const collapsed = unique.every(l => !l) || new Set(unique).size === 1;
+  if (collapsed) {
+    if (new Set(times).size > 1 && times.every(t => t)) return times;
+    return videos.map((_, i) => 'Video ' + (i + 1));
+  }
+  return unique.map((l, i) => l || ('Video ' + (i + 1)));
+}
+
+// ---------------------------------------------------------------------------
 // Grafana URL helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New `videoButtonLabels(videos)` helper in `shared.js`: strips time-of-day tokens (`HH:MM[:SS][ TZ]`) from each video title, collapses the longest common prefix + suffix across the set, and returns just the varying portion as the button label.
- Fallback when that's degenerate: use the stripped time tokens as labels. Last resort: `Video 1/2/3`.
- Wired into `session.js` (session detail page player switcher) and `history.js` (history-page embedded player switcher).
- VIDEOS panel (hyperlinked titles) isn't changed — the existing `v.title || v.youtube_url` already hyperlinks the title when it's present. The reason the current five videos show raw URLs there is that their `title` column is empty on the Pi. That's fixed separately in `feature/video-title-session-name-camera-letters` (next PR).

## Why this is a thing
Previous code did `v.label || v.title || 'Video N'`, so every button for the current 5-video session read "360 cam 360 cam 360 cam". The new algorithm gives you `a / b / c` for the incoming new-title-scheme videos and `17:42 PDT / 17:55 PDT / 18:09 PDT` for the grandfathered set once their titles are populated.

## Test cases (verified against the pure function in node)
| Input titles | Output labels |
|---|---|
| `...— 360 cam a/b/c` × 3 | `["a","b","c"]` |
| `2026-04-08 17:42/17:55/18:09 PDT — CYC spring Race 3` × 3 | `["17:42 PDT","17:55 PDT","18:09 PDT"]` |
| `— bow` / `— stern` | `["bow","stern"]` |
| `— bow a` / `— bow b` / `— stern a` | `["bow a","bow b","stern a"]` |
| Two with empty titles and label `"360 cam"` | `["Video 1","Video 2"]` (degenerate fallback) |

## Test plan
- [x] Pure-function unit tests via `node -e` (see table above)
- [ ] Manual: load `/session/21/…` with 4 linked videos, confirm switcher renders 4 buttons with unique labels (will show `Video 1-4` until backend PR populates titles)
- [ ] Manual: same check from `/history` page embedded player
- [ ] No mypy/ruff impact — pure JS change

Depends on follow-up PR `feature/video-title-session-name-camera-letters` to populate video titles on the Pi; until then this PR's visible effect on the grandfathered 5 videos is "Video 1-4" labels instead of "360 cam 360 cam 360 cam 360 cam".

🤖 Generated with [Claude Code](https://claude.com/claude-code)