### PR TITLE
Fix Watch-on-YouTube link: follow current video + playhead

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -346,7 +346,7 @@ function onYouTubeIframeAPIReady() {
 function _createPlayer(videoId) {
   if (_videoSync.player) {
     _videoSync.player.loadVideoById(videoId);
-    _updateWatchOnYoutubeLink(videoId);
+    _ensureWatchOnYoutubeLink();
     return;
   }
   // Use the standard YT.Player div-based instantiation. The manual iframe
@@ -370,29 +370,35 @@ function _createPlayer(videoId) {
       onStateChange: _onPlayerStateChange,
     },
   });
-  _updateWatchOnYoutubeLink(videoId);
+  _ensureWatchOnYoutubeLink();
 }
 
-function _updateWatchOnYoutubeLink(videoId) {
-  // Render a "Watch on YouTube" link below the player so 360 / spherical
-  // videos can be opened in YouTube's native viewer for panning controls.
-  let linkBar = document.getElementById('yt-watch-on-youtube');
-  if (!linkBar) {
-    linkBar = document.createElement('div');
-    linkBar.id = 'yt-watch-on-youtube';
-    linkBar.style.cssText = 'margin-top:6px;text-align:right;font-size:.75rem';
-    const container = document.getElementById('video-container');
-    if (container) container.appendChild(linkBar);
-  }
-  // Try to seek to current sync position
+// Render the "Watch on YouTube" link once. The URL is computed live in the
+// click handler so it always reflects the currently selected video and its
+// current playhead — the old implementation baked a stale videoId + t=0 into
+// the href at player-create time and never refreshed on switchVideo().
+function _ensureWatchOnYoutubeLink() {
+  if (document.getElementById('yt-watch-on-youtube')) return;
+  const linkBar = document.createElement('div');
+  linkBar.id = 'yt-watch-on-youtube';
+  linkBar.style.cssText = 'margin-top:6px;text-align:right;font-size:.75rem';
+  const container = document.getElementById('video-container');
+  if (container) container.appendChild(linkBar);
+  linkBar.innerHTML = '<a href="#" rel="noopener" style="color:var(--accent);text-decoration:none" title="Open in YouTube for 360° panning controls" onclick="return _openWatchOnYoutube(event)">Watch on YouTube &#8599;</a>';
+}
+
+function _openWatchOnYoutube(ev) {
+  if (ev && ev.preventDefault) ev.preventDefault();
+  if (!_videoSync || !_videoSync.videoId) return false;
   let t = 0;
   try {
-    if (_videoSync && _videoSync.player && _videoSync.player.getCurrentTime) {
+    if (_videoSync.player && _videoSync.player.getCurrentTime) {
       t = Math.floor(_videoSync.player.getCurrentTime() || 0);
     }
   } catch (e) { /* ignore */ }
-  const url = 'https://www.youtube.com/watch?v=' + encodeURIComponent(videoId) + (t > 0 ? '&t=' + t + 's' : '');
-  linkBar.innerHTML = '<a href="' + url + '" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none" title="Open in YouTube for 360° panning controls">Watch on YouTube &#8599;</a>';
+  const url = 'https://www.youtube.com/watch?v=' + encodeURIComponent(_videoSync.videoId) + (t > 0 ? '&t=' + t + 's' : '');
+  window.open(url, '_blank', 'noopener');
+  return false;
 }
 
 function _onVideoReady() {

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <meta name="helmlog-version" content="{{ git_sha }}"/>
 <title>{% block title %}HelmLog{% endblock %}</title>
-<link rel="stylesheet" href="/static/base.css"/>
+<link rel="stylesheet" href="/static/base.css?v={{ git_sha }}"/>
 {% if theme_css %}<style>{{ theme_css }}</style>{% endif %}
 {% block extra_css %}{% endblock %}
 </head>
@@ -40,7 +40,7 @@
 <footer>{{ git_info }}<span class="footer-sep"> · </span><a href="#" onclick="window.open(buildIssueUrl('bug'),'_blank');return false">Report a bug</a><span class="footer-sep"> · </span><a href="#" onclick="window.open(buildIssueUrl('feature'),'_blank');return false">Request a feature</a></footer>
 </div>
 {% endblock %}
-<script src="/static/shared.js"></script>
+<script src="/static/shared.js?v={{ git_sha }}"></script>
 <script>initNav();(async()=>{try{const r=await fetch('/api/notifications/count');if(r.ok){const d=await r.json();const b=document.getElementById('notif-badge');if(d.unread>0){b.textContent=d.unread;b.style.display='inline';}}}catch(e){}})();</script>
 {% block scripts %}{% endblock %}
 </body>

--- a/src/helmlog/templates/history.html
+++ b/src/helmlog/templates/history.html
@@ -42,5 +42,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/history.js?v=8"></script>
+<script src="/static/history.js?v={{ git_sha }}"></script>
 {% endblock %}

--- a/src/helmlog/templates/home.html
+++ b/src/helmlog/templates/home.html
@@ -261,5 +261,5 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/home.js"></script>
+<script src="/static/home.js?v={{ git_sha }}"></script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -240,7 +240,7 @@
 
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="/static/session.js?v=7"></script>
+<script src="/static/session.js?v={{ git_sha }}"></script>
 <script>
 async function renameSession() {
   const sessionId = document.getElementById('app-config').dataset.sessionId;


### PR DESCRIPTION
## Summary

Two related bugs in the session-page player:

1. **Stale video ID after switching cameras.** `switchVideo()` called `loadVideoById()` on the YT player but never refreshed the "Watch on YouTube" link, so clicking any of the switcher buttons left the link pointing at the *first* video.
2. **Stale timestamp.** The link's `&t=` was baked in at `_createPlayer` time when `getCurrentTime()` returns 0, so even if you scrubbed or let it play, clicking the link always dropped you at 0s.

## Fix

Replace `_updateWatchOnYoutubeLink(videoId)` (which rendered the anchor with a pre-built href) with:

- `_ensureWatchOnYoutubeLink()` — renders the anchor element *once*, with `href="#"` and an onclick handler.
- `_openWatchOnYoutube(ev)` — the click handler. Reads `_videoSync.videoId` and `_videoSync.player.getCurrentTime()` *live*, builds the URL with the current videoId + floored seconds, `window.open()`s it in a new tab with `noopener`.

Every click gets a fresh URL. `switchVideo()` doesn't need to know about the link at all anymore — it just updates `_videoSync.videoId` (which it already does) and the next click picks it up.

## Test plan
- [ ] Open a session with 2+ linked videos in the player
- [ ] Click "Watch on YouTube" immediately after the player loads → opens the first video at t=0 (matches playhead)
- [ ] Scrub to 1:30, click → opens first video at `&t=90s`
- [ ] Click a different switcher button, scrub to 0:45, click → opens *second* video at `&t=45s`
- [ ] Pause, click → opens current video at current paused time

Reported in-session from CleanShot 2026-04-10 at 15:25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)