### PR TITLE
feat: maneuver analysis — entry/exit metrics, distance loss, ranking, video deep-links

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -437,10 +437,13 @@ async def enrich_session_maneuvers(
     twa: list[tuple[datetime, float]] = []
     tws: list[tuple[datetime, float]] = []
     for r in winds_raw:
+        ref_raw = r.get("reference")
+        if ref_raw is None:
+            continue
         try:
-            ref = int(r.get("reference", -1) or -1)
+            ref = int(ref_raw)
         except (TypeError, ValueError):
-            ref = -1
+            continue
         # 0 = boat-referenced TWA, 4 = north-referenced TWD. Both are "true wind".
         if ref not in (0, 4):
             continue

--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -305,6 +305,75 @@ def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 _ENRICH_PAD_S = 60  # seconds of instrument data to load beyond the session window
+_TRACK_PRE_S = 20  # seconds of track before maneuver_ts
+_TRACK_POST_S = 30  # seconds of track after exit_ts (or maneuver_ts if exit unknown)
+
+
+def extract_local_track(
+    *,
+    maneuver_ts: datetime,
+    exit_ts: datetime | None,
+    entry_bearing_deg: float | None,
+    positions: list[tuple[datetime, float, float]],
+    bsp: list[tuple[datetime, float]],
+    pre_s: int = _TRACK_PRE_S,
+    post_s: int = _TRACK_POST_S,
+) -> list[dict[str, float]]:
+    """Return the boat track around the maneuver in a local entry-aligned frame.
+
+    Points are translated so the maneuver-start position is at the origin,
+    then rotated so the entry bearing points along +y (North up = entry
+    direction). ``t`` is seconds relative to ``maneuver_ts``. If
+    ``entry_bearing`` is None the track is returned in an east/north frame
+    (still centered on entry). BSP is looked up by nearest-second for an
+    optional colour channel in the UI.
+    """
+    if not positions:
+        return []
+    end_anchor = exit_ts or maneuver_ts
+    win_start = maneuver_ts - timedelta(seconds=pre_s)
+    win_end = end_anchor + timedelta(seconds=post_s)
+    window = [(ts, lat, lon) for ts, lat, lon in positions if win_start <= ts <= win_end]
+    if len(window) < 2:
+        return []
+
+    entry_pos = _position_at(positions, maneuver_ts)
+    if entry_pos is None:
+        return []
+    lat0, lon0 = entry_pos
+
+    if entry_bearing_deg is not None:
+        br_rad = math.radians(entry_bearing_deg)
+        cos_b = math.cos(br_rad)
+        sin_b = math.sin(br_rad)
+    else:
+        cos_b, sin_b = 1.0, 0.0
+
+    bsp_by_sec: dict[str, float] = {}
+    for ts_b, bv in bsp:
+        bsp_by_sec.setdefault(ts_b.isoformat()[:19], bv)
+
+    out: list[dict[str, float]] = []
+    for ts, lat, lon in window:
+        # East (x) / North (y) in metres from entry position.
+        ex, ny = _ll_to_xy(lat0, lon0, lat, lon)
+        # Rotate so entry bearing → +y. Bearing is measured clockwise from
+        # north, so the rotation from (E, N) into (cross, forward) is:
+        #   forward = N*cos(b) + E*sin(b)
+        #   cross   = E*cos(b) − N*sin(b)
+        forward = ny * cos_b + ex * sin_b
+        cross = ex * cos_b - ny * sin_b
+        t_rel = (ts - maneuver_ts).total_seconds()
+        bv = bsp_by_sec.get(ts.isoformat()[:19])
+        pt: dict[str, float] = {
+            "t": round(t_rel, 1),
+            "x": round(cross, 2),
+            "y": round(forward, 2),
+        }
+        if bv is not None:
+            pt["bsp"] = round(bv, 2)
+        out.append(pt)
+    return out
 
 
 def _parse_iso(s: str) -> datetime:
@@ -360,6 +429,11 @@ async def enrich_session_maneuvers(
     if not bsp and cogsog_raw:
         bsp = [(_ts_of(r), float(r["sog_kts"])) for r in cogsog_raw]
 
+    # Build a heading lookup so we can convert north-referenced TWD to TWA.
+    hdg_by_sec: dict[str, float] = {}
+    for ts_h, hv in hdg:
+        hdg_by_sec.setdefault(ts_h.isoformat()[:19], hv)
+
     twa: list[tuple[datetime, float]] = []
     tws: list[tuple[datetime, float]] = []
     for r in winds_raw:
@@ -367,11 +441,20 @@ async def enrich_session_maneuvers(
             ref = int(r.get("reference", -1) or -1)
         except (TypeError, ValueError):
             ref = -1
-        if ref != 0:  # only boat-referenced TWA for simplicity
+        # 0 = boat-referenced TWA, 4 = north-referenced TWD. Both are "true wind".
+        if ref not in (0, 4):
             continue
         ts = _ts_of(r)
-        twa.append((ts, float(r["wind_angle_deg"])))
         tws.append((ts, float(r["wind_speed_kts"])))
+        if ref == 0:
+            raw = abs(float(r["wind_angle_deg"])) % 360.0
+            twa.append((ts, raw if raw <= 180.0 else 360.0 - raw))
+        else:
+            twd = float(r["wind_angle_deg"]) % 360.0
+            hv = hdg_by_sec.get(ts.isoformat()[:19])
+            if hv is not None:
+                raw = (twd - hv + 360.0) % 360.0
+                twa.append((ts, raw if raw <= 180.0 else 360.0 - raw))
 
     positions: list[tuple[datetime, float, float]] = [
         (_ts_of(r), float(r["latitude_deg"]), float(r["longitude_deg"])) for r in positions_raw
@@ -438,6 +521,15 @@ async def enrich_session_maneuvers(
         pos = _position_at(positions, m_ts)
         d["lat"] = pos[0] if pos else None
         d["lon"] = pos[1] if pos else None
+
+        # Local entry-aligned track for per-maneuver diagrams and overlay.
+        d["track"] = extract_local_track(
+            maneuver_ts=m_ts,
+            exit_ts=exit_ts,
+            entry_bearing_deg=metrics.entry_hdg,
+            positions=positions,
+            bsp=bsp,
+        )
 
         # Per-maneuver YouTube deep-link offset.
         if video_sync and video_sync_utc is not None:

--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -74,6 +74,22 @@ def _mean_in_range(
     return statistics.fmean(vals)
 
 
+def _circular_mean_deg(
+    series: list[tuple[datetime, float]], start: datetime, end: datetime
+) -> float | None:
+    """Mean of angular values in [start, end) in degrees, handling 0/360 wrap."""
+    if not series:
+        return None
+    vals = [v for ts, v in series if start <= ts < end]
+    if not vals:
+        return None
+    sx = sum(math.sin(math.radians(v)) for v in vals)
+    sy = sum(math.cos(math.radians(v)) for v in vals)
+    if sx == 0 and sy == 0:
+        return None
+    return (math.degrees(math.atan2(sx, sy)) + 360.0) % 360.0
+
+
 def _signed_heading_delta(h1: float, h2: float) -> float:
     """Shortest-arc signed delta from h1 to h2 in (−180, 180]."""
     diff = (h2 - h1 + 360.0) % 360.0
@@ -436,6 +452,10 @@ async def enrich_session_maneuvers(
 
     twa: list[tuple[datetime, float]] = []
     tws: list[tuple[datetime, float]] = []
+    # North-referenced true wind direction (TWD) per second. Used to
+    # rotate per-maneuver tracks into a wind-up frame and to compute the
+    # "climb the ladder" upwind-progress reference line.
+    twd: list[tuple[datetime, float]] = []
     for r in winds_raw:
         ref_raw = r.get("reference")
         if ref_raw is None:
@@ -450,13 +470,19 @@ async def enrich_session_maneuvers(
         ts = _ts_of(r)
         tws.append((ts, float(r["wind_speed_kts"])))
         if ref == 0:
-            raw = abs(float(r["wind_angle_deg"])) % 360.0
-            twa.append((ts, raw if raw <= 180.0 else 360.0 - raw))
-        else:
-            twd = float(r["wind_angle_deg"]) % 360.0
+            signed_twa = float(r["wind_angle_deg"])
+            folded = abs(signed_twa) % 360.0
+            twa.append((ts, folded if folded <= 180.0 else 360.0 - folded))
+            # TWD = heading + signed TWA (wind_angle_deg is positive-starboard).
             hv = hdg_by_sec.get(ts.isoformat()[:19])
             if hv is not None:
-                raw = (twd - hv + 360.0) % 360.0
+                twd.append((ts, (hv + signed_twa + 360.0) % 360.0))
+        else:
+            twd_val = float(r["wind_angle_deg"]) % 360.0
+            twd.append((ts, twd_val))
+            hv = hdg_by_sec.get(ts.isoformat()[:19])
+            if hv is not None:
+                raw = (twd_val - hv + 360.0) % 360.0
                 twa.append((ts, raw if raw <= 180.0 else 360.0 - raw))
 
     positions: list[tuple[datetime, float, float]] = [
@@ -467,6 +493,7 @@ async def enrich_session_maneuvers(
     bsp.sort(key=lambda p: p[0])
     twa.sort(key=lambda p: p[0])
     tws.sort(key=lambda p: p[0])
+    twd.sort(key=lambda p: p[0])
     positions.sort(key=lambda p: p[0])
 
     # Video sync for deep-links. Pick the first race video.
@@ -525,14 +552,43 @@ async def enrich_session_maneuvers(
         d["lat"] = pos[0] if pos else None
         d["lon"] = pos[1] if pos else None
 
-        # Local entry-aligned track for per-maneuver diagrams and overlay.
+        # Mean TWD around the maneuver (circular mean). The window spans
+        # the whole pre/post diagnostic range so we get a stable wind axis
+        # for rotating the overlay track into a wind-up frame.
+        twd_window_start = m_ts - timedelta(seconds=_TRACK_PRE_S)
+        twd_window_end = (exit_ts or m_ts) + timedelta(seconds=_TRACK_POST_S)
+        mean_twd = _circular_mean_deg(twd, twd_window_start, twd_window_end)
+        d["twd_deg"] = round(mean_twd, 1) if mean_twd is not None else None
+
+        # Local track rotated so TWD → +y (upwind up). Falls back to
+        # entry heading when TWD is unavailable.
+        rot_bearing = mean_twd if mean_twd is not None else metrics.entry_hdg
         d["track"] = extract_local_track(
             maneuver_ts=m_ts,
             exit_ts=exit_ts,
-            entry_bearing_deg=metrics.entry_hdg,
+            entry_bearing_deg=rot_bearing,
             positions=positions,
             bsp=bsp,
         )
+
+        # "Climb the ladder" reference: distance the boat would have made
+        # directly upwind if it had held VMG at entry SOG for the entire
+        # maneuver duration, signed positive for upwind tacks and negative
+        # for downwind gybes. With the wind-up rotation this becomes a
+        # simple vertical line the UI can draw from (0,0) to (0,ghost).
+        ghost: float | None = None
+        if (
+            metrics.duration_sec
+            and metrics.duration_sec > 0
+            and metrics.entry_sog is not None
+            and metrics.entry_twa is not None
+        ):
+            travelled_m = metrics.entry_sog * 0.514444 * metrics.duration_sec
+            twa_rad = math.radians(metrics.entry_twa)
+            ghost_mag = travelled_m * math.cos(twa_rad)
+            # Upwind (TWA < 90) → positive (toward +y == wind); downwind → negative.
+            ghost = ghost_mag if metrics.entry_twa < 90.0 else -ghost_mag
+        d["ghost_m"] = round(ghost, 2) if ghost is not None else None
 
         # Per-maneuver YouTube deep-link offset.
         if video_sync and video_sync_utc is not None:

--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -1,0 +1,459 @@
+"""Per-maneuver metric enrichment and ranking.
+
+Given a detected maneuver (from ``maneuver_detector``) and slices of the
+instrument timeseries around it, compute the entry/exit state, turn
+geometry, and distance lost relative to an idealized instant-turn reference.
+
+Distance loss model: forward progress along the entry COG vector. The
+idealized "instant turn" boat continues at the entry SOG along the entry
+heading for the full maneuver duration; the actual forward progress is the
+projection of (exit_pos − entry_pos) onto that unit vector. Positive
+``distance_loss_m`` means the boat gave up ground relative to that
+reference — the simplest useful proxy for tacking loss, iterable later.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+# Windows (seconds) used to sample steady-state entry / exit conditions.
+# _SKIP skips the transition right at the maneuver boundary.
+_ENTRY_WINDOW_S = 15
+_EXIT_WINDOW_S = 15
+_SKIP_S = 3
+
+_KTS_TO_MS = 0.514444
+_EARTH_R_M = 6371000.0
+
+
+@dataclass(frozen=True)
+class ManeuverMetrics:
+    """Enriched metrics for a single maneuver."""
+
+    entry_ts: datetime
+    exit_ts: datetime | None
+    duration_sec: float | None
+    entry_bsp: float | None
+    exit_bsp: float | None
+    entry_hdg: float | None
+    exit_hdg: float | None
+    entry_twa: float | None
+    exit_twa: float | None
+    entry_tws: float | None
+    exit_tws: float | None
+    entry_sog: float | None
+    min_bsp: float | None
+    turn_angle_deg: float | None
+    turn_rate_deg_s: float | None
+    distance_loss_m: float | None
+    time_to_recover_s: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["entry_ts"] = self.entry_ts.isoformat() if self.entry_ts else None
+        d["exit_ts"] = self.exit_ts.isoformat() if self.exit_ts else None
+        return d
+
+
+def _mean_in_range(
+    series: list[tuple[datetime, float]], start: datetime, end: datetime
+) -> float | None:
+    if not series:
+        return None
+    vals = [v for ts, v in series if start <= ts < end]
+    if not vals:
+        return None
+    return statistics.fmean(vals)
+
+
+def _signed_heading_delta(h1: float, h2: float) -> float:
+    """Shortest-arc signed delta from h1 to h2 in (−180, 180]."""
+    diff = (h2 - h1 + 360.0) % 360.0
+    return diff if diff <= 180.0 else diff - 360.0
+
+
+def _ll_to_xy(lat0: float, lon0: float, lat: float, lon: float) -> tuple[float, float]:
+    """Equirectangular projection around (lat0, lon0) in metres."""
+    lat0_rad = math.radians(lat0)
+    x = _EARTH_R_M * math.radians(lon - lon0) * math.cos(lat0_rad)
+    y = _EARTH_R_M * math.radians(lat - lat0)
+    return x, y
+
+
+def _position_at(
+    positions: list[tuple[datetime, float, float]], target: datetime
+) -> tuple[float, float] | None:
+    """Return the position nearest to ``target`` (by absolute time delta)."""
+    if not positions:
+        return None
+    best: tuple[float, float, float] | None = None  # (delta, lat, lon)
+    for ts, lat, lon in positions:
+        delta = abs((ts - target).total_seconds())
+        if best is None or delta < best[0]:
+            best = (delta, lat, lon)
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
+def _average_cog_between(
+    positions: list[tuple[datetime, float, float]],
+    start: datetime,
+    end: datetime,
+) -> float | None:
+    """Bearing (degrees true) of the vector from the first to last sample in range."""
+    pts = [(ts, lat, lon) for ts, lat, lon in positions if start <= ts <= end]
+    if len(pts) < 2:
+        return None
+    _, lat0, lon0 = pts[0]
+    _, lat1, lon1 = pts[-1]
+    x, y = _ll_to_xy(lat0, lon0, lat1, lon1)
+    if x == 0 and y == 0:
+        return None
+    bearing_rad = math.atan2(x, y)
+    return (math.degrees(bearing_rad) + 360.0) % 360.0
+
+
+def _entry_sog(
+    positions: list[tuple[datetime, float, float]],
+    start: datetime,
+    end: datetime,
+) -> float | None:
+    """SOG (knots) estimated from the distance travelled between start and end positions."""
+    pts = [(ts, lat, lon) for ts, lat, lon in positions if start <= ts <= end]
+    if len(pts) < 2:
+        return None
+    ts0, lat0, lon0 = pts[0]
+    ts1, lat1, lon1 = pts[-1]
+    x, y = _ll_to_xy(lat0, lon0, lat1, lon1)
+    dist = math.hypot(x, y)
+    dt = (ts1 - ts0).total_seconds()
+    if dt <= 0:
+        return None
+    return (dist / dt) / _KTS_TO_MS
+
+
+def enrich_maneuver(
+    *,
+    maneuver_ts: datetime,
+    exit_ts: datetime | None,
+    hdg: list[tuple[datetime, float]],
+    bsp: list[tuple[datetime, float]],
+    twa: list[tuple[datetime, float]],
+    tws: list[tuple[datetime, float]],
+    positions: list[tuple[datetime, float, float]],
+) -> ManeuverMetrics:
+    """Compute entry/exit metrics, turn geometry, and distance loss.
+
+    Inputs are sorted ``(datetime, value)`` pairs covering at least the
+    entry pre-window through exit post-window. Positions are
+    ``(datetime, lat_deg, lon_deg)``. Any missing series yields ``None`` for
+    the fields it drives — the function never raises on missing data.
+    """
+    entry_end = maneuver_ts - timedelta(seconds=_SKIP_S)
+    entry_start = entry_end - timedelta(seconds=_ENTRY_WINDOW_S)
+
+    fallback_exit = exit_ts or (maneuver_ts + timedelta(seconds=_EXIT_WINDOW_S))
+    exit_start = fallback_exit + timedelta(seconds=_SKIP_S)
+    exit_end = exit_start + timedelta(seconds=_EXIT_WINDOW_S)
+
+    duration = (exit_ts - maneuver_ts).total_seconds() if exit_ts else None
+
+    entry_bsp = _mean_in_range(bsp, entry_start, entry_end)
+    exit_bsp = _mean_in_range(bsp, exit_start, exit_end)
+    entry_hdg = _mean_in_range(hdg, entry_start, entry_end)
+    exit_hdg = _mean_in_range(hdg, exit_start, exit_end)
+    entry_twa_raw = _mean_in_range(twa, entry_start, entry_end)
+    exit_twa_raw = _mean_in_range(twa, exit_start, exit_end)
+    entry_tws = _mean_in_range(tws, entry_start, entry_end)
+    exit_tws = _mean_in_range(tws, exit_start, exit_end)
+
+    # Fold TWA to [0, 180] for readability.
+    def _fold(v: float | None) -> float | None:
+        if v is None:
+            return None
+        a = abs(v) % 360.0
+        return a if a <= 180.0 else 360.0 - a
+
+    entry_twa = _fold(entry_twa_raw)
+    exit_twa = _fold(exit_twa_raw)
+
+    # min_bsp during the maneuver window.
+    min_bsp: float | None = None
+    if bsp:
+        window_vals = [v for ts, v in bsp if maneuver_ts <= ts <= fallback_exit]
+        if window_vals:
+            min_bsp = min(window_vals)
+
+    # Turn geometry. Fall back to COG from positions if HDG unavailable.
+    entry_bearing = entry_hdg
+    exit_bearing = exit_hdg
+    if entry_bearing is None:
+        entry_bearing = _average_cog_between(positions, entry_start, entry_end)
+    if exit_bearing is None:
+        exit_bearing = _average_cog_between(positions, exit_start, exit_end)
+
+    turn_angle: float | None = None
+    turn_rate: float | None = None
+    if entry_bearing is not None and exit_bearing is not None:
+        turn_angle = _signed_heading_delta(entry_bearing, exit_bearing)
+        if duration and duration > 0:
+            turn_rate = abs(turn_angle) / duration
+
+    # Distance loss along the entry COG vector.
+    distance_loss: float | None = None
+    entry_sog = _entry_sog(positions, entry_start, entry_end)
+    entry_pos = _position_at(positions, maneuver_ts)
+    exit_pos = _position_at(positions, fallback_exit)
+    if (
+        entry_sog is not None
+        and entry_pos is not None
+        and exit_pos is not None
+        and duration is not None
+        and duration > 0
+    ):
+        # Use the positional entry bearing for the loss projection — that's
+        # the direction the boat was actually moving, independent of any
+        # compass offset.
+        ref_bearing = _average_cog_between(positions, entry_start, entry_end)
+        if ref_bearing is not None:
+            ideal_distance_m = entry_sog * _KTS_TO_MS * duration
+            lat0, lon0 = entry_pos
+            ex_x, ex_y = _ll_to_xy(lat0, lon0, exit_pos[0], exit_pos[1])
+            # Unit vector along entry bearing (x=east, y=north).
+            br_rad = math.radians(ref_bearing)
+            ux, uy = math.sin(br_rad), math.cos(br_rad)
+            actual_forward_m = ex_x * ux + ex_y * uy
+            distance_loss = ideal_distance_m - actual_forward_m
+
+    time_to_recover = duration  # entry→resettle == maneuver duration
+
+    return ManeuverMetrics(
+        entry_ts=maneuver_ts,
+        exit_ts=exit_ts,
+        duration_sec=duration,
+        entry_bsp=round(entry_bsp, 3) if entry_bsp is not None else None,
+        exit_bsp=round(exit_bsp, 3) if exit_bsp is not None else None,
+        entry_hdg=round(entry_hdg, 1) if entry_hdg is not None else None,
+        exit_hdg=round(exit_hdg, 1) if exit_hdg is not None else None,
+        entry_twa=round(entry_twa, 1) if entry_twa is not None else None,
+        exit_twa=round(exit_twa, 1) if exit_twa is not None else None,
+        entry_tws=round(entry_tws, 2) if entry_tws is not None else None,
+        exit_tws=round(exit_tws, 2) if exit_tws is not None else None,
+        entry_sog=round(entry_sog, 2) if entry_sog is not None else None,
+        min_bsp=round(min_bsp, 3) if min_bsp is not None else None,
+        turn_angle_deg=round(turn_angle, 1) if turn_angle is not None else None,
+        turn_rate_deg_s=round(turn_rate, 2) if turn_rate is not None else None,
+        distance_loss_m=round(distance_loss, 2) if distance_loss is not None else None,
+        time_to_recover_s=round(time_to_recover, 1) if time_to_recover is not None else None,
+    )
+
+
+def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Attach a ``rank`` label (``good`` / ``avg`` / ``bad``) in-place.
+
+    Ranking is by ``distance_loss_m`` when available, else ``loss_kts``.
+    Top quartile (lowest loss) → ``good``; bottom quartile → ``bad``;
+    middle half → ``avg``. Entries with no loss data get ``rank=None``.
+    """
+    if not items:
+        return items
+
+    def _key(m: dict[str, Any]) -> float | None:
+        v = m.get("distance_loss_m")
+        if v is not None:
+            return float(v)
+        v = m.get("loss_kts")
+        return float(v) if v is not None else None
+
+    ranked = [m for m in items if _key(m) is not None]
+    unranked = [m for m in items if _key(m) is None]
+    if not ranked:
+        for m in items:
+            m["rank"] = None
+        return items
+
+    sorted_items = sorted(ranked, key=lambda m: _key(m) or 0.0)
+    n = len(sorted_items)
+    q1 = max(1, n // 4)
+    q3 = max(q1, n - n // 4)
+    good = {id(m) for m in sorted_items[:q1]}
+    bad = {id(m) for m in sorted_items[q3:]}
+    for m in ranked:
+        if id(m) in good:
+            m["rank"] = "good"
+        elif id(m) in bad:
+            m["rank"] = "bad"
+        else:
+            m["rank"] = "avg"
+    for m in unranked:
+        m["rank"] = None
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Storage integration
+# ---------------------------------------------------------------------------
+
+
+_ENRICH_PAD_S = 60  # seconds of instrument data to load beyond the session window
+
+
+def _parse_iso(s: str) -> datetime:
+    return datetime.fromisoformat(str(s).replace(" ", "T")).replace(tzinfo=UTC)
+
+
+async def enrich_session_maneuvers(
+    storage: Storage, session_id: int
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Load stored maneuvers for a session and attach analysis metrics + rank.
+
+    Returns ``(maneuvers, video_sync)`` where ``video_sync`` is the first
+    race video's ``{video_id, sync_utc, sync_offset_s, duration_s}`` or
+    ``None`` if no video is linked. Maneuvers are returned as JSON-ready
+    dicts with all metric fields rounded, plus ``lat``/``lon`` and — when
+    a video is available — ``youtube_url``.
+    """
+    rows = await storage.get_session_maneuvers(session_id)
+    if not rows:
+        return [], None
+
+    db = storage._conn()
+    race_cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    race_row = await race_cur.fetchone()
+    if race_row is None:
+        return [], None
+
+    start = _parse_iso(race_row["start_utc"])
+    end = _parse_iso(race_row["end_utc"]) if race_row["end_utc"] else start + timedelta(hours=24)
+    start_pad = start - timedelta(seconds=_ENRICH_PAD_S)
+    end_pad = end + timedelta(seconds=_ENRICH_PAD_S)
+
+    # Load all instrument series once, scoped to session where possible.
+    async def _load(table: str) -> list[dict[str, Any]]:
+        data = await storage.query_range(table, start_pad, end_pad, race_id=session_id)
+        if not data:
+            data = await storage.query_range(table, start_pad, end_pad)
+        return data
+
+    headings_raw = await _load("headings")
+    speeds_raw = await _load("speeds")
+    winds_raw = await _load("winds")
+    positions_raw = await _load("positions")
+    cogsog_raw = await _load("cogsog")
+
+    def _ts_of(row: dict[str, Any]) -> datetime:
+        return _parse_iso(str(row["ts"]))
+
+    hdg: list[tuple[datetime, float]] = [(_ts_of(r), float(r["heading_deg"])) for r in headings_raw]
+    if not hdg and cogsog_raw:
+        hdg = [(_ts_of(r), float(r["cog_deg"])) for r in cogsog_raw]
+    bsp: list[tuple[datetime, float]] = [(_ts_of(r), float(r["speed_kts"])) for r in speeds_raw]
+    if not bsp and cogsog_raw:
+        bsp = [(_ts_of(r), float(r["sog_kts"])) for r in cogsog_raw]
+
+    twa: list[tuple[datetime, float]] = []
+    tws: list[tuple[datetime, float]] = []
+    for r in winds_raw:
+        try:
+            ref = int(r.get("reference", -1) or -1)
+        except (TypeError, ValueError):
+            ref = -1
+        if ref != 0:  # only boat-referenced TWA for simplicity
+            continue
+        ts = _ts_of(r)
+        twa.append((ts, float(r["wind_angle_deg"])))
+        tws.append((ts, float(r["wind_speed_kts"])))
+
+    positions: list[tuple[datetime, float, float]] = [
+        (_ts_of(r), float(r["latitude_deg"]), float(r["longitude_deg"])) for r in positions_raw
+    ]
+
+    hdg.sort(key=lambda p: p[0])
+    bsp.sort(key=lambda p: p[0])
+    twa.sort(key=lambda p: p[0])
+    tws.sort(key=lambda p: p[0])
+    positions.sort(key=lambda p: p[0])
+
+    # Video sync for deep-links. Pick the first race video.
+    video_cur = await db.execute(
+        "SELECT video_id, sync_utc, sync_offset_s, duration_s, youtube_url"
+        " FROM race_videos WHERE race_id = ? ORDER BY id LIMIT 1",
+        (session_id,),
+    )
+    video_row = await video_cur.fetchone()
+    video_sync: dict[str, Any] | None = None
+    if video_row is not None:
+        video_sync = {
+            "video_id": video_row["video_id"],
+            "sync_utc": str(video_row["sync_utc"]),
+            "sync_offset_s": float(video_row["sync_offset_s"] or 0.0),
+            "duration_s": float(video_row["duration_s"] or 0.0),
+            "youtube_url": video_row["youtube_url"],
+        }
+        video_sync_utc = _parse_iso(str(video_row["sync_utc"]))
+    else:
+        video_sync_utc = None
+
+    # Build enriched output.
+    enriched: list[dict[str, Any]] = []
+    for row in rows:
+        d = dict(row)
+        raw_details = d.get("details")
+        if isinstance(raw_details, str):
+            try:
+                d["details"] = json.loads(raw_details)
+            except json.JSONDecodeError:
+                d["details"] = {}
+
+        m_ts = _parse_iso(str(d["ts"]))
+        exit_ts = _parse_iso(str(d["end_ts"])) if d.get("end_ts") else None
+
+        metrics = enrich_maneuver(
+            maneuver_ts=m_ts,
+            exit_ts=exit_ts,
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        md = metrics.to_dict()
+        # Don't let entry_ts/exit_ts clobber the stored ts/end_ts fields.
+        md.pop("entry_ts", None)
+        md.pop("exit_ts", None)
+        # Storage's duration_sec is already present; metrics duration matches it.
+        md.pop("duration_sec", None)
+        d.update(md)
+
+        # Nearest position for the map marker.
+        pos = _position_at(positions, m_ts)
+        d["lat"] = pos[0] if pos else None
+        d["lon"] = pos[1] if pos else None
+
+        # Per-maneuver YouTube deep-link offset.
+        if video_sync and video_sync_utc is not None:
+            offset_s = video_sync["sync_offset_s"] + (m_ts - video_sync_utc).total_seconds()
+            if 0 <= offset_s <= (video_sync["duration_s"] or offset_s + 1):
+                d["video_offset_s"] = round(offset_s, 1)
+                vid = video_sync["video_id"]
+                d["youtube_url"] = f"https://www.youtube.com/watch?v={vid}&t={int(offset_s)}s"
+            else:
+                d["video_offset_s"] = None
+                d["youtube_url"] = None
+        else:
+            d["video_offset_s"] = None
+            d["youtube_url"] = None
+
+        enriched.append(d)
+
+    rank_maneuvers(enriched)
+    return enriched, video_sync

--- a/src/helmlog/routes/instruments.py
+++ b/src/helmlog/routes/instruments.py
@@ -23,6 +23,12 @@ async def api_state(
     ss = request.app.state.session_state
     from helmlog.races import Race as _Race
     from helmlog.races import configured_tz, default_event_for_date, local_today, local_weekday
+    from helmlog.storage import get_effective_setting
+
+    # Effective timezone: DB setting → env → "UTC". configured_tz() only
+    # reads env, so a settings.json / DB-configured timezone was invisible
+    # to the frontend. Resolve via the full settings chain here.
+    tz_name = await get_effective_setting(storage, "TIMEZONE", str(configured_tz()))
 
     now = datetime.now(UTC)
     today = local_today()
@@ -105,7 +111,7 @@ async def api_state(
         {
             "date": date_str,
             "weekday": weekday,
-            "timezone": str(configured_tz()),
+            "timezone": tz_name,
             "event": event,
             "event_is_default": event_is_default,
             "current_race": current_dict,

--- a/src/helmlog/routes/instruments.py
+++ b/src/helmlog/routes/instruments.py
@@ -22,13 +22,17 @@ async def api_state(
     storage = get_storage(request)
     ss = request.app.state.session_state
     from helmlog.races import Race as _Race
-    from helmlog.races import configured_tz, default_event_for_date, local_today, local_weekday
+    from helmlog.races import default_event_for_date, local_today, local_weekday
+    from helmlog.routes._helpers import SETTINGS_BY_KEY
     from helmlog.storage import get_effective_setting
 
-    # Effective timezone: DB setting → env → "UTC". configured_tz() only
-    # reads env, so a settings.json / DB-configured timezone was invisible
-    # to the frontend. Resolve via the full settings chain here.
-    tz_name = await get_effective_setting(storage, "TIMEZONE", str(configured_tz()))
+    # Effective timezone: DB setting → env → SettingDef.default. The old
+    # code used configured_tz() which only reads the env var and silently
+    # falls back to "UTC", so DB-configured and UI-default timezones never
+    # reached the frontend on boats that hadn't set the env var.
+    tz_def = SETTINGS_BY_KEY.get("TIMEZONE")
+    tz_default = tz_def.default if tz_def else "UTC"
+    tz_name = await get_effective_setting(storage, "TIMEZONE", tz_default)
 
     now = datetime.now(UTC)
     today = local_today()

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from loguru import logger
 
 from helmlog.auth import require_auth, require_developer
@@ -620,66 +620,75 @@ async def api_session_maneuvers(
     session_id: int,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
-    """Return detected maneuvers for a session, with nearest GPS position."""
+    """Return detected maneuvers for a session with full per-maneuver metrics.
+
+    Each entry carries entry/exit state (BSP, TWA, TWS, HDG), min BSP during
+    the maneuver, turn angle and rate, distance-loss against an entry-vector
+    reference, nearest GPS position, a quartile rank (good/avg/bad), and a
+    ``youtube_url`` deep-link to the linked session video at the maneuver
+    timestamp when a video is linked.
+    """
     storage = get_storage(request)
-    import json as _json
+    from helmlog.analysis.maneuvers import enrich_session_maneuvers
 
-    rows = await storage.get_session_maneuvers(session_id)
-
-    # Enrich with nearest position so the front end can place map markers.
-    # Find the closest position by checking both before and after the
-    # maneuver timestamp and picking the one with the smallest time gap.
-    # Scope queries to the session's time range so positions from other
-    # sessions are never returned.
-    db = storage._conn()
-    race_cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
-    race_row = await race_cur.fetchone()
-    session_start = str(race_row["start_utc"])[:19] if race_row else None
-    session_end = str(race_row["end_utc"])[:19] if race_row else None
-
-    enriched = []
-    for row in rows:
-        d = dict(row)
-        ts_str = str(d["ts"])[:19]
-        # Position just before or at the maneuver time (within session)
-        before_cur = await db.execute(
-            "SELECT latitude_deg, longitude_deg, ts FROM positions"
-            " WHERE ts <= ? AND ts >= ? AND race_id = ?"
-            " ORDER BY ts DESC LIMIT 1",
-            (ts_str, session_start, session_id),
-        )
-        before = await before_cur.fetchone()
-        # Position just after the maneuver time (within session)
-        after_cur = await db.execute(
-            "SELECT latitude_deg, longitude_deg, ts FROM positions"
-            " WHERE ts > ? AND ts <= ? AND race_id = ?"
-            " ORDER BY ts LIMIT 1",
-            (ts_str, session_end, session_id),
-        )
-        after = await after_cur.fetchone()
-
-        # Pick the closer one by time delta
-        pos = None
-        if before and after:
-            from datetime import datetime as _dt
-
-            t_man = _dt.fromisoformat(ts_str)
-            t_before = _dt.fromisoformat(str(before["ts"])[:19])
-            t_after = _dt.fromisoformat(str(after["ts"])[:19])
-            pos = before if (t_man - t_before) <= (t_after - t_man) else after
-        else:
-            pos = before or after
-
-        d["lat"] = float(pos["latitude_deg"]) if pos else None
-        d["lon"] = float(pos["longitude_deg"]) if pos else None
-        if d.get("details") and isinstance(d["details"], str):
-            try:
-                d["details"] = _json.loads(d["details"])
-            except Exception:
-                d["details"] = {}
-        enriched.append(d)
-
+    enriched, _video_sync = await enrich_session_maneuvers(storage, session_id)
     return JSONResponse(enriched)
+
+
+_MANEUVER_CSV_COLUMNS = [
+    "ts",
+    "type",
+    "rank",
+    "duration_sec",
+    "entry_hdg",
+    "exit_hdg",
+    "turn_angle_deg",
+    "turn_rate_deg_s",
+    "entry_bsp",
+    "exit_bsp",
+    "min_bsp",
+    "loss_kts",
+    "distance_loss_m",
+    "entry_twa",
+    "exit_twa",
+    "entry_tws",
+    "exit_tws",
+    "time_to_recover_s",
+    "lat",
+    "lon",
+    "youtube_url",
+]
+
+
+@router.get("/api/sessions/{session_id}/maneuvers.csv")
+async def api_session_maneuvers_csv(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> Response:
+    """CSV export of the enriched maneuver list for a session."""
+    from helmlog.analysis.maneuvers import enrich_session_maneuvers
+
+    storage = get_storage(request)
+    enriched, _ = await enrich_session_maneuvers(storage, session_id)
+
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_MANEUVER_CSV_COLUMNS, extrasaction="ignore")
+    writer.writeheader()
+    for m in enriched:
+        writer.writerow(
+            {k: m.get(k, "") if m.get(k) is not None else "" for k in _MANEUVER_CSV_COLUMNS}
+        )
+
+    filename = f"session_{session_id}_maneuvers.csv"
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.post("/api/sessions/{session_id}/detect-maneuvers", status_code=202)

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1999,6 +1999,7 @@ const _MANEUVER_COLORS = { tack: cssVar('--accent-strong'), gybe: cssVar('--warn
 const _RANK_COLORS = { good: cssVar('--success'), bad: cssVar('--error'), avg: cssVar('--text-secondary') };
 let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distance_loss_m | loss_kts | turn_angle_deg
 let _maneuverFilter = 'all';  // all | tack | gybe | rounding | good | bad
+let _maneuverOverlay = false; // toggle for all-tacks-overlaid diagram
 
 async function loadManeuvers() {
   const r = await fetch('/api/sessions/' + SESSION_ID + '/maneuvers');
@@ -2038,6 +2039,98 @@ function setManeuverFilter(f) {
   renderManeuverCard();
 }
 
+function toggleManeuverOverlay() {
+  _maneuverOverlay = !_maneuverOverlay;
+  renderManeuverCard();
+}
+
+// ---------- Tack diagram rendering (SVG) ----------
+
+function _trackBounds(tracks) {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  tracks.forEach(tr => tr.forEach(p => {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }));
+  if (!isFinite(minX)) return null;
+  // Square-ish bounds with a bit of padding.
+  const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
+  const half = Math.max(10, Math.max(maxX - minX, maxY - minY) / 2 + 5);
+  return { minX: cx - half, maxX: cx + half, minY: cy - half, maxY: cy + half };
+}
+
+function _renderTrackSvg(tracks, opts) {
+  // tracks: array of { points, color, label, highlight? }
+  opts = opts || {};
+  const w = opts.width || 260;
+  const h = opts.height || 200;
+  const pad = 12;
+  const pointSets = tracks.map(t => t.points).filter(p => p && p.length);
+  if (!pointSets.length) return '';
+  const b = _trackBounds(pointSets);
+  if (!b) return '';
+  const sx = x => pad + (x - b.minX) / (b.maxX - b.minX) * (w - 2 * pad);
+  // SVG y grows downward; our "forward" y should go up.
+  const sy = y => (h - pad) - (y - b.minY) / (b.maxY - b.minY) * (h - 2 * pad);
+
+  const scaleM = (b.maxX - b.minX);
+  const gridStep = scaleM > 200 ? 50 : scaleM > 80 ? 20 : 10;
+  const gridLines = [];
+  for (let gx = Math.ceil(b.minX / gridStep) * gridStep; gx <= b.maxX; gx += gridStep) {
+    gridLines.push('<line x1="' + sx(gx) + '" y1="' + pad + '" x2="' + sx(gx) + '" y2="' + (h - pad) + '" stroke="var(--border)" stroke-width="0.5"/>');
+  }
+  for (let gy = Math.ceil(b.minY / gridStep) * gridStep; gy <= b.maxY; gy += gridStep) {
+    gridLines.push('<line x1="' + pad + '" y1="' + sy(gy) + '" x2="' + (w - pad) + '" y2="' + sy(gy) + '" stroke="var(--border)" stroke-width="0.5"/>');
+  }
+
+  // Origin crosshair (entry point).
+  const originX = sx(0), originY = sy(0);
+  const crosshair = '<circle cx="' + originX + '" cy="' + originY + '" r="3" fill="var(--accent)"/>'
+    + '<line x1="' + originX + '" y1="' + (originY - 8) + '" x2="' + originX + '" y2="' + (originY + 8) + '" stroke="var(--accent)" stroke-width="0.6"/>'
+    + '<line x1="' + (originX - 8) + '" y1="' + originY + '" x2="' + (originX + 8) + '" y2="' + originY + '" stroke="var(--accent)" stroke-width="0.6"/>';
+
+  // Entry direction arrow (+y).
+  const arrowY1 = sy(0), arrowY2 = sy(Math.min(b.maxY, scaleM * 0.25));
+  const entryArrow = '<line x1="' + originX + '" y1="' + arrowY1 + '" x2="' + originX + '" y2="' + arrowY2 + '" stroke="var(--accent)" stroke-width="1" stroke-dasharray="2,2"/>';
+
+  const paths = tracks.map(t => {
+    if (!t.points || !t.points.length) return '';
+    const d = t.points.map((p, i) => (i === 0 ? 'M' : 'L') + sx(p.x).toFixed(1) + ' ' + sy(p.y).toFixed(1)).join(' ');
+    const width = t.highlight ? 2.5 : 1.2;
+    const opacity = t.highlight ? 1 : 0.55;
+    return '<path d="' + d + '" fill="none" stroke="' + t.color + '" stroke-width="' + width + '" opacity="' + opacity + '"/>';
+  }).join('');
+
+  const scaleLabel = '<text x="' + (w - pad) + '" y="' + (h - 2) + '" text-anchor="end" font-size="9" fill="var(--text-secondary)">grid ' + gridStep + ' m</text>';
+
+  return '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:3px">'
+    + gridLines.join('') + entryArrow + paths + crosshair + scaleLabel + '</svg>';
+}
+
+function _renderOverlaySvg() {
+  const items = _maneuverRows().filter(m => m.track && m.track.length);
+  if (!items.length) {
+    return '<div style="color:var(--text-secondary);font-size:.75rem">No track data for current filter.</div>';
+  }
+  const tracks = items.map(m => ({
+    points: m.track,
+    color: _RANK_COLORS[m.rank] || _MANEUVER_COLORS[m.type] || 'var(--text-secondary)',
+    label: m.type,
+    highlight: false,
+  }));
+  const svg = _renderTrackSvg(tracks, { width: 380, height: 300 });
+  const legend = '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">'
+    + items.length + ' maneuvers overlaid. Colours = rank '
+    + '<span style="color:' + _RANK_COLORS.good + '">●good</span> '
+    + '<span style="color:' + _RANK_COLORS.avg + '">●avg</span> '
+    + '<span style="color:' + _RANK_COLORS.bad + '">●bad</span>. '
+    + 'Entry at origin (+), entry direction ↑.'
+    + '</div>';
+  return svg + legend;
+}
+
 function _manHeader(label, key) {
   const arrow = _maneuverSort.key === key ? (_maneuverSort.dir > 0 ? ' ▲' : ' ▼') : '';
   return '<th style="cursor:pointer" onclick="setManeuverSort(\'' + key + '\')">' + label + arrow + '</th>';
@@ -2059,11 +2152,15 @@ function renderManeuverCard() {
   const good = _maneuvers.filter(m => m.rank === 'good').length;
   const bad = _maneuvers.filter(m => m.rank === 'bad').length;
 
+  const overlayBtnStyle = 'font-size:.7rem;padding:2px 8px;border:1px solid var(--border);background:'
+    + (_maneuverOverlay ? 'var(--accent)' : 'transparent') + ';color:'
+    + (_maneuverOverlay ? 'var(--bg-primary)' : 'var(--text-secondary)') + ';cursor:pointer;border-radius:3px';
   const summary = '<div style="color:var(--text-secondary);font-size:.75rem;margin-bottom:6px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">'
     + '<span>' + tacks + 'T · ' + gybes + 'G · ' + roundings + 'R</span>'
     + '<span style="color:' + _RANK_COLORS.good + '">' + good + ' good</span>'
     + '<span style="color:' + _RANK_COLORS.bad + '">' + bad + ' bad</span>'
     + '<span style="flex:1"></span>'
+    + '<button style="' + overlayBtnStyle + '" onclick="toggleManeuverOverlay()" title="Overlay all filtered tacks on one diagram">overlay</button>'
     + '<a href="/api/sessions/' + SESSION_ID + '/maneuvers.csv" download style="color:var(--accent);text-decoration:none">CSV &#8595;</a>'
     + '</div>';
 
@@ -2110,7 +2207,11 @@ function renderManeuverCard() {
       + '</tr>';
   }).join('');
 
-  body.innerHTML = summary + filterBar
+  const overlayBlock = _maneuverOverlay
+    ? '<div style="margin-bottom:8px">' + _renderOverlaySvg() + '</div>'
+    : '';
+
+  body.innerHTML = summary + filterBar + overlayBlock
     + '<table class="maneuver-table"><thead><tr>'
     + _manHeader('Type', 'type')
     + _manHeader('Time', 'ts')
@@ -2138,8 +2239,20 @@ function _renderManeuverDetail(m) {
     ['Time to recover', m.time_to_recover_s != null ? m.time_to_recover_s.toFixed(1) + ' s' : '—'],
     ['Distance loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
   ];
-  el.innerHTML = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
+  const metricsGrid = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
     + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')
+    + '</div>';
+  const diagram = (m.track && m.track.length)
+    ? _renderTrackSvg([{
+        points: m.track,
+        color: _RANK_COLORS[m.rank] || _MANEUVER_COLORS[m.type] || 'var(--accent)',
+        label: m.type,
+        highlight: true,
+      }])
+    : '';
+  el.innerHTML = '<div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">'
+    + '<div style="flex:1;min-width:260px">' + metricsGrid + '</div>'
+    + (diagram ? '<div>' + diagram + '</div>' : '')
     + '</div>';
 }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2106,17 +2106,17 @@ function _trackBounds(tracks) {
 }
 
 function _renderTrackSvg(tracks, opts) {
-  // tracks: array of { points, color, label, highlight? }
+  // tracks: array of { points, color, label, highlight?, maneuverIdx? }
   opts = opts || {};
   const w = opts.width || 260;
   const h = opts.height || 200;
   const pad = 12;
+  const interactive = !!opts.interactive;
   const pointSets = tracks.map(t => t.points).filter(p => p && p.length);
   if (!pointSets.length) return '';
   const b = _trackBounds(pointSets);
   if (!b) return '';
   const sx = x => pad + (x - b.minX) / (b.maxX - b.minX) * (w - 2 * pad);
-  // SVG y grows downward; our "forward" y should go up.
   const sy = y => (h - pad) - (y - b.minY) / (b.maxY - b.minY) * (h - 2 * pad);
 
   const scaleM = (b.maxX - b.minX);
@@ -2129,28 +2129,104 @@ function _renderTrackSvg(tracks, opts) {
     gridLines.push('<line x1="' + pad + '" y1="' + sy(gy) + '" x2="' + (w - pad) + '" y2="' + sy(gy) + '" stroke="var(--border)" stroke-width="0.5"/>');
   }
 
-  // Origin crosshair (entry point).
   const originX = sx(0), originY = sy(0);
   const crosshair = '<circle cx="' + originX + '" cy="' + originY + '" r="3" fill="var(--accent)"/>'
     + '<line x1="' + originX + '" y1="' + (originY - 8) + '" x2="' + originX + '" y2="' + (originY + 8) + '" stroke="var(--accent)" stroke-width="0.6"/>'
     + '<line x1="' + (originX - 8) + '" y1="' + originY + '" x2="' + (originX + 8) + '" y2="' + originY + '" stroke="var(--accent)" stroke-width="0.6"/>';
 
-  // Entry direction arrow (+y).
   const arrowY1 = sy(0), arrowY2 = sy(Math.min(b.maxY, scaleM * 0.25));
   const entryArrow = '<line x1="' + originX + '" y1="' + arrowY1 + '" x2="' + originX + '" y2="' + arrowY2 + '" stroke="var(--accent)" stroke-width="1" stroke-dasharray="2,2"/>';
 
   const paths = tracks.map(t => {
     if (!t.points || !t.points.length) return '';
     const d = t.points.map((p, i) => (i === 0 ? 'M' : 'L') + sx(p.x).toFixed(1) + ' ' + sy(p.y).toFixed(1)).join(' ');
-    const width = t.highlight ? 2.5 : 1.2;
-    const opacity = t.highlight ? 1 : 0.55;
-    return '<path d="' + d + '" fill="none" stroke="' + t.color + '" stroke-width="' + width + '" opacity="' + opacity + '"/>';
+    const width = t.highlight ? 2.5 : 1.4;
+    const opacity = t.highlight ? 1 : 0.7;
+    let attrs = 'fill="none" stroke="' + t.color + '" stroke-width="' + width + '" opacity="' + opacity + '" stroke-linecap="round"';
+    if (interactive && t.maneuverIdx != null) {
+      attrs += ' style="pointer-events:stroke;cursor:pointer"'
+        + ' onmousemove="showOverlayTip(event,' + t.maneuverIdx + ')"'
+        + ' onmouseleave="hideOverlayTip()"'
+        + ' onclick="highlightManeuver(' + t.maneuverIdx + ')"';
+    }
+    return '<path d="' + d + '" ' + attrs + '/>';
   }).join('');
+
+  // Invisible fat underlay to widen hover hit-target.
+  const hoverUnderlay = interactive ? tracks.map(t => {
+    if (!t.points || !t.points.length || t.maneuverIdx == null) return '';
+    const d = t.points.map((p, i) => (i === 0 ? 'M' : 'L') + sx(p.x).toFixed(1) + ' ' + sy(p.y).toFixed(1)).join(' ');
+    return '<path d="' + d + '" fill="none" stroke="rgba(0,0,0,0)" stroke-width="12"'
+      + ' style="pointer-events:stroke;cursor:pointer"'
+      + ' onmousemove="showOverlayTip(event,' + t.maneuverIdx + ')"'
+      + ' onmouseleave="hideOverlayTip()"'
+      + ' onclick="highlightManeuver(' + t.maneuverIdx + ')"/>';
+  }).join('') : '';
 
   const scaleLabel = '<text x="' + (w - pad) + '" y="' + (h - 2) + '" text-anchor="end" font-size="9" fill="var(--text-secondary)">grid ' + gridStep + ' m</text>';
 
   return '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:3px">'
-    + gridLines.join('') + entryArrow + paths + crosshair + scaleLabel + '</svg>';
+    + gridLines.join('') + entryArrow + hoverUnderlay + paths + crosshair + scaleLabel + '</svg>';
+}
+
+// Overlay tooltip for per-trace stats + YouTube link
+function _ensureOverlayTip() {
+  let tip = document.getElementById('overlay-tip');
+  if (!tip) {
+    tip = document.createElement('div');
+    tip.id = 'overlay-tip';
+    tip.style.cssText = 'position:fixed;z-index:9999;background:var(--bg-primary);'
+      + 'border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:.72rem;'
+      + 'box-shadow:0 4px 12px rgba(0,0,0,0.3);max-width:220px;display:none';
+    tip.onmouseleave = hideOverlayTip;
+    document.body.appendChild(tip);
+  }
+  return tip;
+}
+
+function showOverlayTip(ev, idx) {
+  const m = _maneuvers[idx];
+  if (!m) return;
+  const tip = _ensureOverlayTip();
+  const color = _MANEUVER_COLORS[m.type] || 'var(--text-secondary)';
+  const rankColor = m.rank ? _RANK_COLORS[m.rank] : 'var(--text-secondary)';
+  const twsVal = m.entry_tws != null ? m.entry_tws : (m.tws_bin != null ? m.tws_bin : null);
+  const twsStr = twsVal != null ? ((twsVal.toFixed ? twsVal.toFixed(1) : twsVal) + ' kt') : '—';
+  const rows = [
+    ['Elapsed', _fmtElapsed(m.ts)],
+    ['Time', fmtTime(m.ts)],
+    ['Duration', m.duration_sec != null ? m.duration_sec.toFixed(1) + ' s' : '—'],
+    ['Turn', m.turn_angle_deg != null ? Math.round(Math.abs(m.turn_angle_deg)) + '°' : '—'],
+    ['BSP in→out', (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '—') + '→' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '—')],
+    ['BSP loss', m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—'],
+    ['Dist loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
+    ['TWS', twsStr],
+  ];
+  const header = '<div style="margin-bottom:4px">'
+    + '<span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>'
+    + (m.rank ? ' <span style="color:' + rankColor + '">●' + esc(m.rank) + '</span>' : '')
+    + '</div>';
+  const grid = '<div style="display:grid;grid-template-columns:auto 1fr;gap:2px 8px">'
+    + rows.map(([k, v]) => '<span style="color:var(--text-secondary)">' + k + '</span><b>' + esc(v) + '</b>').join('')
+    + '</div>';
+  const yt = m.youtube_url
+    ? '<div style="margin-top:6px"><a href="' + esc(m.youtube_url) + '" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none">&#9654; Watch on YouTube &#8599;</a></div>'
+    : '';
+  tip.innerHTML = header + grid + yt;
+  tip.style.display = 'block';
+  const margin = 12;
+  let x = ev.clientX + margin;
+  let y = ev.clientY + margin;
+  const r = tip.getBoundingClientRect();
+  if (x + r.width > window.innerWidth) x = ev.clientX - r.width - margin;
+  if (y + r.height > window.innerHeight) y = ev.clientY - r.height - margin;
+  tip.style.left = Math.max(2, x) + 'px';
+  tip.style.top = Math.max(2, y) + 'px';
+}
+
+function hideOverlayTip() {
+  const tip = document.getElementById('overlay-tip');
+  if (tip) tip.style.display = 'none';
 }
 
 function _renderOverlaySvg() {
@@ -2165,14 +2241,15 @@ function _renderOverlaySvg() {
     color: _RANK_COLORS[m.rank] || _MANEUVER_COLORS[m.type] || 'var(--text-secondary)',
     label: m.type,
     highlight: false,
+    maneuverIdx: _maneuvers.indexOf(m),
   }));
-  const svg = _renderTrackSvg(tracks, { width: 380, height: 300 });
+  const svg = _renderTrackSvg(tracks, { width: 380, height: 300, interactive: true });
   const legend = '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">'
     + items.length + ' of ' + _maneuvers.length + ' overlaid. Colours = rank '
     + '<span style="color:' + _RANK_COLORS.good + '">●good</span> '
     + '<span style="color:' + _RANK_COLORS.avg + '">●avg</span> '
     + '<span style="color:' + _RANK_COLORS.bad + '">●bad</span>. '
-    + 'Entry at origin (+), entry direction ↑.'
+    + 'Entry at origin (+), entry direction ↑. Hover a trace for stats &amp; video.'
     + '</div>';
   return svg + legend;
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2157,35 +2157,46 @@ function _renderTrackSvg(tracks, opts) {
     return best;
   });
 
-  // "Climb the ladder" ghost references — dashed vertical segments from
-  // the origin to each track's idealized upwind-progress endpoint. Lets
-  // you see at a glance how far you *would* have made had the tack been
-  // a zero-loss instant turn. Also draws a marker on the actual track at
-  // the same moment in time and connects them to show the upwind gap.
+  // "Climb the ladder" ghost references. In the wind-up frame the ghost
+  // is a dashed vertical segment from the origin to (0, ghost_m) — that
+  // is where a zero-loss instant-turn boat would be sitting at t=duration.
+  //
+  // To show the upwind gap against the actual track we:
+  //   1. Mark the actual boat position at t=duration (filled circle).
+  //   2. Drop a horizontal ("perpendicular to the wind") dashed line
+  //      from that point onto the wind axis — this is the projection
+  //      of the actual position onto the ladder.
+  //   3. Draw a vertical gap segment from the projection up to the
+  //      ghost endpoint. Its length is the upwind loss vs the ghost.
+  //   4. Label only the vertical gap so the number matches the shape.
   const ghostLines = tracks.map((t, i) => {
     if (t.ghost == null || isNaN(t.ghost)) return '';
     const gy1 = sy(0), gy2 = sy(t.ghost);
     let out = '<line x1="' + originX + '" y1="' + gy1 + '" x2="' + originX + '" y2="' + gy2
       + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="3,3" opacity="0.7"/>'
-      + '<circle cx="' + originX + '" cy="' + gy2 + '" r="2.5" fill="' + t.color + '" opacity="0.7"/>';
+      + '<circle cx="' + originX + '" cy="' + gy2 + '" r="2.5" fill="none" stroke="' + t.color
+      + '" stroke-width="1.2" opacity="0.8"/>';
 
     const actual = actualAtDuration[i];
     if (actual) {
       const ax = sx(actual.x), ay = sy(actual.y);
+      const projY = ay;  // projection onto x=0 keeps the same y (wind component).
       // Marker on the actual track at t = duration.
       out += '<circle cx="' + ax + '" cy="' + ay + '" r="3" fill="' + t.color
         + '" stroke="var(--bg-secondary)" stroke-width="1"/>';
-      // Dashed connector from actual point to ghost endpoint.
-      out += '<line x1="' + ax + '" y1="' + ay + '" x2="' + originX + '" y2="' + gy2
-        + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="1,2" opacity="0.6"/>';
-      // Delta label — only in single-track / highlighted mode to avoid
+      // Horizontal ("perpendicular to wind") projection from actual onto wind axis.
+      out += '<line x1="' + ax + '" y1="' + ay + '" x2="' + originX + '" y2="' + projY
+        + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="1,2" opacity="0.55"/>';
+      // Vertical gap segment from projection up to ghost endpoint.
+      out += '<line x1="' + originX + '" y1="' + projY + '" x2="' + originX + '" y2="' + gy2
+        + '" stroke="' + t.color + '" stroke-width="2.5" opacity="0.9"/>';
+      // Gap label — only in single-track / highlighted mode to avoid
       // clutter in the overlay.
       if (t.highlight) {
         const deltaM = t.ghost - actual.y;
-        const midX = (ax + originX) / 2;
-        const midY = (ay + gy2) / 2;
+        const midY = (projY + gy2) / 2;
         const label = (deltaM >= 0 ? '−' : '+') + Math.abs(deltaM).toFixed(1) + ' m';
-        out += '<text x="' + (midX + 4) + '" y="' + (midY - 2) + '" font-size="10" fill="' + t.color
+        out += '<text x="' + (originX + 6) + '" y="' + (midY + 3) + '" font-size="10" fill="' + t.color
           + '" style="paint-order:stroke;stroke:var(--bg-secondary);stroke-width:3px;stroke-linejoin:round">'
           + label + '</text>';
       }
@@ -2292,6 +2303,7 @@ function showOverlayTip(ev, idx) {
     ['BSP dip', m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—'],
     ['Min BSP', m.min_bsp != null ? m.min_bsp.toFixed(1) + ' kt' : '—'],
     ['Dist loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
+    ['Ladder ideal', m.ghost_m != null ? m.ghost_m.toFixed(1) + ' m' : '—'],
     ['Ladder Δ', ghostDeltaStr],
     ['TWS', twsStr],
     ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
@@ -2506,7 +2518,18 @@ function _renderManeuverDetail(m) {
     ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
     ['Time to recover', m.time_to_recover_s != null ? m.time_to_recover_s.toFixed(1) + ' s' : '—'],
     ['Distance loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
-    ['Ghost upwind', m.ghost_m != null ? m.ghost_m.toFixed(1) + ' m' : '—'],
+    ['Ladder ideal', m.ghost_m != null ? m.ghost_m.toFixed(1) + ' m' : '—'],
+    ['Ladder Δ', (() => {
+      if (!m.track || !m.track.length || m.duration_sec == null || m.ghost_m == null) return '—';
+      let best = null, bestDt = Infinity;
+      for (const p of m.track) {
+        const dt = Math.abs(p.t - m.duration_sec);
+        if (dt < bestDt) { bestDt = dt; best = p; }
+      }
+      if (!best) return '—';
+      const d = m.ghost_m - best.y;
+      return (d >= 0 ? '−' : '+') + Math.abs(d).toFixed(1) + ' m';
+    })()],
   ];
   const metricsGrid = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
     + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2143,16 +2143,54 @@ function _renderTrackSvg(tracks, opts) {
   const windLabels = '<text x="' + (w / 2) + '" y="10" text-anchor="middle" font-size="9" fill="var(--text-secondary)">↑ upwind</text>'
     + '<text x="' + (w / 2) + '" y="' + (h - 12) + '" text-anchor="middle" font-size="9" fill="var(--text-secondary)">↓ downwind</text>';
 
+  // For each trace, find the actual boat position at the same moment as
+  // the ghost endpoint (t = duration_sec) — that's where the boat was
+  // when a zero-loss tack would have put it at (0, ghost_m).
+  const actualAtDuration = tracks.map(t => {
+    if (!t.points || !t.points.length || t.durationSec == null) return null;
+    let best = null;
+    let bestDt = Infinity;
+    for (const p of t.points) {
+      const dt = Math.abs(p.t - t.durationSec);
+      if (dt < bestDt) { bestDt = dt; best = p; }
+    }
+    return best;
+  });
+
   // "Climb the ladder" ghost references — dashed vertical segments from
   // the origin to each track's idealized upwind-progress endpoint. Lets
   // you see at a glance how far you *would* have made had the tack been
-  // a zero-loss instant turn.
-  const ghostLines = tracks.map(t => {
+  // a zero-loss instant turn. Also draws a marker on the actual track at
+  // the same moment in time and connects them to show the upwind gap.
+  const ghostLines = tracks.map((t, i) => {
     if (t.ghost == null || isNaN(t.ghost)) return '';
     const gy1 = sy(0), gy2 = sy(t.ghost);
-    return '<line x1="' + originX + '" y1="' + gy1 + '" x2="' + originX + '" y2="' + gy2
-      + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="3,3" opacity="0.6"/>'
-      + '<circle cx="' + originX + '" cy="' + gy2 + '" r="2" fill="' + t.color + '" opacity="0.6"/>';
+    let out = '<line x1="' + originX + '" y1="' + gy1 + '" x2="' + originX + '" y2="' + gy2
+      + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="3,3" opacity="0.7"/>'
+      + '<circle cx="' + originX + '" cy="' + gy2 + '" r="2.5" fill="' + t.color + '" opacity="0.7"/>';
+
+    const actual = actualAtDuration[i];
+    if (actual) {
+      const ax = sx(actual.x), ay = sy(actual.y);
+      // Marker on the actual track at t = duration.
+      out += '<circle cx="' + ax + '" cy="' + ay + '" r="3" fill="' + t.color
+        + '" stroke="var(--bg-secondary)" stroke-width="1"/>';
+      // Dashed connector from actual point to ghost endpoint.
+      out += '<line x1="' + ax + '" y1="' + ay + '" x2="' + originX + '" y2="' + gy2
+        + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="1,2" opacity="0.6"/>';
+      // Delta label — only in single-track / highlighted mode to avoid
+      // clutter in the overlay.
+      if (t.highlight) {
+        const deltaM = t.ghost - actual.y;
+        const midX = (ax + originX) / 2;
+        const midY = (ay + gy2) / 2;
+        const label = (deltaM >= 0 ? '−' : '+') + Math.abs(deltaM).toFixed(1) + ' m';
+        out += '<text x="' + (midX + 4) + '" y="' + (midY - 2) + '" font-size="10" fill="' + t.color
+          + '" style="paint-order:stroke;stroke:var(--bg-secondary);stroke-width:3px;stroke-linejoin:round">'
+          + label + '</text>';
+      }
+    }
+    return out;
   }).join('');
 
   const paths = tracks.map(t => {
@@ -2232,6 +2270,19 @@ function showOverlayTip(ev, idx) {
   const rankColor = m.rank ? _RANK_COLORS[m.rank] : 'var(--text-secondary)';
   const twsVal = m.entry_tws != null ? m.entry_tws : (m.tws_bin != null ? m.tws_bin : null);
   const twsStr = twsVal != null ? ((twsVal.toFixed ? twsVal.toFixed(1) : twsVal) + ' kt') : '—';
+  // Actual upwind progress at t = duration, from the track points.
+  let ghostDelta = null;
+  if (m.track && m.track.length && m.duration_sec != null && m.ghost_m != null) {
+    let best = null, bestDt = Infinity;
+    for (const p of m.track) {
+      const dt = Math.abs(p.t - m.duration_sec);
+      if (dt < bestDt) { bestDt = dt; best = p; }
+    }
+    if (best) ghostDelta = m.ghost_m - best.y;
+  }
+  const ghostDeltaStr = ghostDelta != null
+    ? (ghostDelta >= 0 ? '−' : '+') + Math.abs(ghostDelta).toFixed(1) + ' m vs ghost'
+    : '—';
   const rows = [
     ['Elapsed', _fmtElapsed(m.ts)],
     ['Time', fmtTime(m.ts)],
@@ -2241,6 +2292,7 @@ function showOverlayTip(ev, idx) {
     ['BSP dip', m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—'],
     ['Min BSP', m.min_bsp != null ? m.min_bsp.toFixed(1) + ' kt' : '—'],
     ['Dist loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
+    ['Ladder Δ', ghostDeltaStr],
     ['TWS', twsStr],
     ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
   ];
@@ -2310,6 +2362,7 @@ function _renderOverlaySvg() {
     highlight: false,
     maneuverIdx: _maneuvers.indexOf(m),
     ghost: m.ghost_m,
+    durationSec: m.duration_sec,
   }));
   const svg = _renderTrackSvg(tracks, { width: 420, height: 340, interactive: true });
   const legend = '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">'
@@ -2465,6 +2518,7 @@ function _renderManeuverDetail(m) {
         label: m.type,
         highlight: true,
         ghost: m.ghost_m,
+        durationSec: m.duration_sec,
       }], { width: 300, height: 240 })
     : '';
   el.innerHTML = '<div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">'

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2106,7 +2106,7 @@ function _trackBounds(tracks) {
 }
 
 function _renderTrackSvg(tracks, opts) {
-  // tracks: array of { points, color, label, highlight?, maneuverIdx? }
+  // tracks: array of { points, color, label, highlight?, maneuverIdx?, ghost? }
   opts = opts || {};
   const w = opts.width || 260;
   const h = opts.height || 200;
@@ -2114,7 +2114,12 @@ function _renderTrackSvg(tracks, opts) {
   const interactive = !!opts.interactive;
   const pointSets = tracks.map(t => t.points).filter(p => p && p.length);
   if (!pointSets.length) return '';
-  const b = _trackBounds(pointSets);
+  // Extend bounds so the ghost reference line (running along y) is visible
+  // even when it extends beyond the actual track.
+  const ghostYs = tracks.map(t => t.ghost).filter(v => v != null && !isNaN(v));
+  const extras = ghostYs.map(y => ({ x: 0, y }));
+  const allPoints = pointSets.concat([extras]);
+  const b = _trackBounds(allPoints);
   if (!b) return '';
   const sx = x => pad + (x - b.minX) / (b.maxX - b.minX) * (w - 2 * pad);
   const sy = y => (h - pad) - (y - b.minY) / (b.maxY - b.minY) * (h - 2 * pad);
@@ -2134,8 +2139,21 @@ function _renderTrackSvg(tracks, opts) {
     + '<line x1="' + originX + '" y1="' + (originY - 8) + '" x2="' + originX + '" y2="' + (originY + 8) + '" stroke="var(--accent)" stroke-width="0.6"/>'
     + '<line x1="' + (originX - 8) + '" y1="' + originY + '" x2="' + (originX + 8) + '" y2="' + originY + '" stroke="var(--accent)" stroke-width="0.6"/>';
 
-  const arrowY1 = sy(0), arrowY2 = sy(Math.min(b.maxY, scaleM * 0.25));
-  const entryArrow = '<line x1="' + originX + '" y1="' + arrowY1 + '" x2="' + originX + '" y2="' + arrowY2 + '" stroke="var(--accent)" stroke-width="1" stroke-dasharray="2,2"/>';
+  // Wind-up frame: +y = upwind. Label it so the orientation is unambiguous.
+  const windLabels = '<text x="' + (w / 2) + '" y="10" text-anchor="middle" font-size="9" fill="var(--text-secondary)">↑ upwind</text>'
+    + '<text x="' + (w / 2) + '" y="' + (h - 12) + '" text-anchor="middle" font-size="9" fill="var(--text-secondary)">↓ downwind</text>';
+
+  // "Climb the ladder" ghost references — dashed vertical segments from
+  // the origin to each track's idealized upwind-progress endpoint. Lets
+  // you see at a glance how far you *would* have made had the tack been
+  // a zero-loss instant turn.
+  const ghostLines = tracks.map(t => {
+    if (t.ghost == null || isNaN(t.ghost)) return '';
+    const gy1 = sy(0), gy2 = sy(t.ghost);
+    return '<line x1="' + originX + '" y1="' + gy1 + '" x2="' + originX + '" y2="' + gy2
+      + '" stroke="' + t.color + '" stroke-width="1" stroke-dasharray="3,3" opacity="0.6"/>'
+      + '<circle cx="' + originX + '" cy="' + gy2 + '" r="2" fill="' + t.color + '" opacity="0.6"/>';
+  }).join('');
 
   const paths = tracks.map(t => {
     if (!t.points || !t.points.length) return '';
@@ -2144,9 +2162,10 @@ function _renderTrackSvg(tracks, opts) {
     const opacity = t.highlight ? 1 : 0.7;
     let attrs = 'fill="none" stroke="' + t.color + '" stroke-width="' + width + '" opacity="' + opacity + '" stroke-linecap="round"';
     if (interactive && t.maneuverIdx != null) {
-      attrs += ' style="pointer-events:stroke;cursor:pointer"'
-        + ' onmousemove="showOverlayTip(event,' + t.maneuverIdx + ')"'
-        + ' onmouseleave="hideOverlayTip()"'
+      attrs += ' data-man-idx="' + t.maneuverIdx + '"'
+        + ' style="pointer-events:stroke;cursor:pointer"'
+        + ' onmouseenter="showOverlayTip(event,' + t.maneuverIdx + ')"'
+        + ' onmouseleave="scheduleOverlayTipHide()"'
         + ' onclick="highlightManeuver(' + t.maneuverIdx + ')"';
     }
     return '<path d="' + d + '" ' + attrs + '/>';
@@ -2156,20 +2175,25 @@ function _renderTrackSvg(tracks, opts) {
   const hoverUnderlay = interactive ? tracks.map(t => {
     if (!t.points || !t.points.length || t.maneuverIdx == null) return '';
     const d = t.points.map((p, i) => (i === 0 ? 'M' : 'L') + sx(p.x).toFixed(1) + ' ' + sy(p.y).toFixed(1)).join(' ');
-    return '<path d="' + d + '" fill="none" stroke="rgba(0,0,0,0)" stroke-width="12"'
+    return '<path d="' + d + '" fill="none" stroke="rgba(0,0,0,0)" stroke-width="14"'
       + ' style="pointer-events:stroke;cursor:pointer"'
-      + ' onmousemove="showOverlayTip(event,' + t.maneuverIdx + ')"'
-      + ' onmouseleave="hideOverlayTip()"'
+      + ' onmouseenter="showOverlayTip(event,' + t.maneuverIdx + ')"'
+      + ' onmouseleave="scheduleOverlayTipHide()"'
       + ' onclick="highlightManeuver(' + t.maneuverIdx + ')"/>';
   }).join('') : '';
 
   const scaleLabel = '<text x="' + (w - pad) + '" y="' + (h - 2) + '" text-anchor="end" font-size="9" fill="var(--text-secondary)">grid ' + gridStep + ' m</text>';
 
   return '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:3px">'
-    + gridLines.join('') + entryArrow + hoverUnderlay + paths + crosshair + scaleLabel + '</svg>';
+    + gridLines.join('') + ghostLines + hoverUnderlay + paths + crosshair + windLabels + scaleLabel + '</svg>';
 }
 
-// Overlay tooltip for per-trace stats + YouTube link
+// Overlay tooltip — anchored on mouseenter, stays reachable by the mouse.
+// Hiding is delayed so the cursor can traverse from the trace to the tip;
+// entering the tip itself cancels the hide, so links inside are clickable.
+let _overlayTipHideTimer = null;
+let _overlayTipIdx = null;
+
 function _ensureOverlayTip() {
   let tip = document.getElementById('overlay-tip');
   if (!tip) {
@@ -2177,16 +2201,32 @@ function _ensureOverlayTip() {
     tip.id = 'overlay-tip';
     tip.style.cssText = 'position:fixed;z-index:9999;background:var(--bg-primary);'
       + 'border:1px solid var(--border);border-radius:4px;padding:6px 8px;font-size:.72rem;'
-      + 'box-shadow:0 4px 12px rgba(0,0,0,0.3);max-width:220px;display:none';
-    tip.onmouseleave = hideOverlayTip;
+      + 'box-shadow:0 4px 12px rgba(0,0,0,0.3);max-width:240px;display:none';
+    tip.onmouseenter = cancelOverlayTipHide;
+    tip.onmouseleave = scheduleOverlayTipHide;
     document.body.appendChild(tip);
   }
   return tip;
 }
 
+function _highlightManeuverRow(idx, on) {
+  // Mirror the overlay hover on the table row so the two views stay linked.
+  document.querySelectorAll('.maneuver-table tr').forEach(r => r.classList.remove('hover-row'));
+  if (on && idx != null) {
+    const row = document.getElementById('mrow-' + idx);
+    if (row) {
+      row.classList.add('hover-row');
+      row.scrollIntoView({block: 'nearest'});
+    }
+  }
+}
+
 function showOverlayTip(ev, idx) {
+  cancelOverlayTipHide();
   const m = _maneuvers[idx];
   if (!m) return;
+  _overlayTipIdx = idx;
+  _highlightManeuverRow(idx, true);
   const tip = _ensureOverlayTip();
   const color = _MANEUVER_COLORS[m.type] || 'var(--text-secondary)';
   const rankColor = m.rank ? _RANK_COLORS[m.rank] : 'var(--text-secondary)';
@@ -2198,13 +2238,16 @@ function showOverlayTip(ev, idx) {
     ['Duration', m.duration_sec != null ? m.duration_sec.toFixed(1) + ' s' : '—'],
     ['Turn', m.turn_angle_deg != null ? Math.round(Math.abs(m.turn_angle_deg)) + '°' : '—'],
     ['BSP in→out', (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '—') + '→' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '—')],
-    ['BSP loss', m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—'],
+    ['BSP dip', m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—'],
+    ['Min BSP', m.min_bsp != null ? m.min_bsp.toFixed(1) + ' kt' : '—'],
     ['Dist loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
     ['TWS', twsStr],
+    ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
   ];
-  const header = '<div style="margin-bottom:4px">'
-    + '<span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>'
-    + (m.rank ? ' <span style="color:' + rankColor + '">●' + esc(m.rank) + '</span>' : '')
+  const header = '<div style="margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;gap:6px">'
+    + '<span><span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>'
+    + (m.rank ? ' <span style="color:' + rankColor + '">●' + esc(m.rank) + '</span>' : '') + '</span>'
+    + '<span style="color:var(--text-secondary);cursor:pointer;font-size:.8rem" onclick="hideOverlayTip()" title="Close">✕</span>'
     + '</div>';
   const grid = '<div style="display:grid;grid-template-columns:auto 1fr;gap:2px 8px">'
     + rows.map(([k, v]) => '<span style="color:var(--text-secondary)">' + k + '</span><b>' + esc(v) + '</b>').join('')
@@ -2214,19 +2257,43 @@ function showOverlayTip(ev, idx) {
     : '';
   tip.innerHTML = header + grid + yt;
   tip.style.display = 'block';
-  const margin = 12;
-  let x = ev.clientX + margin;
-  let y = ev.clientY + margin;
+
+  // Anchor the tooltip to the overlay SVG (top-right of the container) so
+  // it does not follow the cursor. This keeps the YouTube link reachable
+  // and prevents the "tooltip runs away" problem.
+  const svgContainer = document.querySelector('#maneuvers-body svg');
   const r = tip.getBoundingClientRect();
-  if (x + r.width > window.innerWidth) x = ev.clientX - r.width - margin;
-  if (y + r.height > window.innerHeight) y = ev.clientY - r.height - margin;
-  tip.style.left = Math.max(2, x) + 'px';
-  tip.style.top = Math.max(2, y) + 'px';
+  let x = ev.clientX + 14;
+  let y = ev.clientY + 14;
+  if (svgContainer) {
+    const box = svgContainer.getBoundingClientRect();
+    x = box.right + 8;
+    y = box.top;
+  }
+  if (x + r.width > window.innerWidth) x = Math.max(2, window.innerWidth - r.width - 4);
+  if (y + r.height > window.innerHeight) y = Math.max(2, window.innerHeight - r.height - 4);
+  tip.style.left = x + 'px';
+  tip.style.top = y + 'px';
+}
+
+function scheduleOverlayTipHide() {
+  cancelOverlayTipHide();
+  _overlayTipHideTimer = setTimeout(hideOverlayTip, 180);
+}
+
+function cancelOverlayTipHide() {
+  if (_overlayTipHideTimer) {
+    clearTimeout(_overlayTipHideTimer);
+    _overlayTipHideTimer = null;
+  }
 }
 
 function hideOverlayTip() {
+  cancelOverlayTipHide();
   const tip = document.getElementById('overlay-tip');
   if (tip) tip.style.display = 'none';
+  _highlightManeuverRow(_overlayTipIdx, false);
+  _overlayTipIdx = null;
 }
 
 function _renderOverlaySvg() {
@@ -2242,8 +2309,9 @@ function _renderOverlaySvg() {
     label: m.type,
     highlight: false,
     maneuverIdx: _maneuvers.indexOf(m),
+    ghost: m.ghost_m,
   }));
-  const svg = _renderTrackSvg(tracks, { width: 380, height: 300, interactive: true });
+  const svg = _renderTrackSvg(tracks, { width: 420, height: 340, interactive: true });
   const legend = '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">'
     + items.length + ' of ' + _maneuvers.length + ' overlaid. Colours = rank '
     + '<span style="color:' + _RANK_COLORS.good + '">●good</span> '
@@ -2314,7 +2382,7 @@ function renderManeuverCard() {
     const t = fmtTime(m.ts);
     const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '—';
     const turn = m.turn_angle_deg != null ? Math.round(Math.abs(m.turn_angle_deg)) + '°' : '—';
-    const bspLoss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—';
+    const bspDip = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—';
     const distLoss = m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—';
     const entry = (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '—') + '→' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '—');
     // Fall back to the detector's stored tws_bin (integer kt) when the
@@ -2332,7 +2400,7 @@ function renderManeuverCard() {
       + '<td>' + dur + '</td>'
       + '<td>' + turn + '</td>'
       + '<td>' + entry + '</td>'
-      + '<td>' + bspLoss + '</td>'
+      + '<td title="BSP dip from pre-maneuver baseline to minimum BSP during the turn. Not exit−entry.">' + bspDip + '</td>'
       + '<td>' + distLoss + '</td>'
       + '<td>' + esc(cond) + '</td>'
       + '<td>' + yt + '</td>'
@@ -2360,7 +2428,7 @@ function renderManeuverCard() {
     + _manHeader('Dur', 'duration_sec')
     + _manHeader('Turn', 'turn_angle_deg')
     + '<th>BSP in→out</th>'
-    + _manHeader('BSP loss', 'loss_kts')
+    + '<th title="BSP dip: baseline − min BSP during the turn. Not exit−entry." onclick="setManeuverSort(\'loss_kts\')" style="cursor:pointer">BSP dip' + (_maneuverSort.key === 'loss_kts' ? (_maneuverSort.dir > 0 ? ' ▲' : ' ▼') : '') + '</th>'
     + _manHeader('Dist loss', 'distance_loss_m')
     + '<th>TWS</th><th></th>'
     + '</tr></thead><tbody>' + rows + '</tbody></table>'
@@ -2371,15 +2439,21 @@ function _renderManeuverDetail(m) {
   const el = document.getElementById('maneuver-detail');
   if (!el) return;
   if (!m) { el.innerHTML = ''; return; }
+  const bspDipLabel = m.loss_kts != null && m.entry_bsp != null && m.min_bsp != null
+    ? m.loss_kts.toFixed(2) + ' kt (' + m.entry_bsp.toFixed(1) + '→' + m.min_bsp.toFixed(1) + ')'
+    : (m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—');
   const rows = [
     ['Entry HDG', m.entry_hdg != null ? m.entry_hdg.toFixed(0) + '°' : '—'],
     ['Exit HDG', m.exit_hdg != null ? m.exit_hdg.toFixed(0) + '°' : '—'],
     ['Turn rate', m.turn_rate_deg_s != null ? m.turn_rate_deg_s.toFixed(1) + '°/s' : '—'],
     ['Min BSP', m.min_bsp != null ? m.min_bsp.toFixed(1) + ' kt' : '—'],
+    ['BSP dip', bspDipLabel],
     ['Entry TWA', m.entry_twa != null ? m.entry_twa.toFixed(0) + '°' : '—'],
     ['Exit TWA', m.exit_twa != null ? m.exit_twa.toFixed(0) + '°' : '—'],
+    ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
     ['Time to recover', m.time_to_recover_s != null ? m.time_to_recover_s.toFixed(1) + ' s' : '—'],
     ['Distance loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
+    ['Ghost upwind', m.ghost_m != null ? m.ghost_m.toFixed(1) + ' m' : '—'],
   ];
   const metricsGrid = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
     + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')
@@ -2390,7 +2464,8 @@ function _renderManeuverDetail(m) {
         color: _RANK_COLORS[m.rank] || _MANEUVER_COLORS[m.type] || 'var(--accent)',
         label: m.type,
         highlight: true,
-      }])
+        ghost: m.ghost_m,
+      }], { width: 300, height: 240 })
     : '';
   el.innerHTML = '<div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">'
     + '<div style="flex:1;min-width:260px">' + metricsGrid + '</div>'

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2000,13 +2000,57 @@ const _RANK_COLORS = { good: cssVar('--success'), bad: cssVar('--error'), avg: c
 let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distance_loss_m | loss_kts | turn_angle_deg
 let _maneuverFilter = 'all';  // all | tack | gybe | rounding | good | bad
 let _maneuverOverlay = false; // toggle for all-tacks-overlaid diagram
+let _maneuverSelected = new Set(); // ids of maneuvers selected for overlay
+
+function _parseUtc(iso) {
+  if (!iso) return null;
+  const s = (iso.endsWith('Z') || iso.includes('+')) ? iso : iso + 'Z';
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function _fmtElapsed(iso) {
+  const t = _parseUtc(iso);
+  if (!t || !_session || !_session.start_utc) return '\u2014';
+  const start = _parseUtc(_session.start_utc);
+  if (!start) return '\u2014';
+  const secs = Math.max(0, Math.round((t.getTime() - start.getTime()) / 1000));
+  const mm = Math.floor(secs / 60);
+  const ss = secs % 60;
+  return '+' + String(mm).padStart(2, '0') + ':' + String(ss).padStart(2, '0');
+}
 
 async function loadManeuvers() {
   const r = await fetch('/api/sessions/' + SESSION_ID + '/maneuvers');
   if (!r.ok) return;
   _maneuvers = await r.json();
+  // Default: select all maneuvers for overlay when a new list arrives.
+  _maneuverSelected = new Set(_maneuvers.map((m, i) => m.id != null ? m.id : i));
   renderManeuverCard();
   if (_map && _maneuvers.length) _addManeuverMarkers();
+}
+
+function _manKey(m, idx) {
+  return m.id != null ? m.id : idx;
+}
+
+function toggleManeuverSelected(keyStr) {
+  // keyStr may be a number-as-string; normalise
+  const key = isNaN(Number(keyStr)) ? keyStr : Number(keyStr);
+  if (_maneuverSelected.has(key)) _maneuverSelected.delete(key);
+  else _maneuverSelected.add(key);
+  if (_maneuverOverlay) renderManeuverCard();
+}
+
+function setManeuverSelectAll(mode) {
+  if (mode === 'all') {
+    _maneuverSelected = new Set(_maneuvers.map((m, i) => _manKey(m, i)));
+  } else if (mode === 'none') {
+    _maneuverSelected = new Set();
+  } else if (mode === 'filtered') {
+    _maneuverSelected = new Set(_maneuverRows().map((m) => _manKey(m, _maneuvers.indexOf(m))));
+  }
+  renderManeuverCard();
 }
 
 function _maneuverRows() {
@@ -2110,9 +2154,11 @@ function _renderTrackSvg(tracks, opts) {
 }
 
 function _renderOverlaySvg() {
-  const items = _maneuverRows().filter(m => m.track && m.track.length);
+  const items = _maneuvers
+    .filter((m, i) => _maneuverSelected.has(_manKey(m, i)))
+    .filter(m => m.track && m.track.length);
   if (!items.length) {
-    return '<div style="color:var(--text-secondary);font-size:.75rem">No track data for current filter.</div>';
+    return '<div style="color:var(--text-secondary);font-size:.75rem">No maneuvers selected for overlay. Tick rows below to include them.</div>';
   }
   const tracks = items.map(m => ({
     points: m.track,
@@ -2122,7 +2168,7 @@ function _renderOverlaySvg() {
   }));
   const svg = _renderTrackSvg(tracks, { width: 380, height: 300 });
   const legend = '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">'
-    + items.length + ' maneuvers overlaid. Colours = rank '
+    + items.length + ' of ' + _maneuvers.length + ' overlaid. Colours = rank '
     + '<span style="color:' + _RANK_COLORS.good + '">●good</span> '
     + '<span style="color:' + _RANK_COLORS.avg + '">●avg</span> '
     + '<span style="color:' + _RANK_COLORS.bad + '">●bad</span>. '
@@ -2178,24 +2224,33 @@ function renderManeuverCard() {
   const items = _maneuverRows();
   let rows = items.map((m) => {
     const idx = _maneuvers.indexOf(m);
+    const key = _manKey(m, idx);
     const color = _MANEUVER_COLORS[m.type] || 'var(--text-secondary)';
     const rankColor = m.rank ? _RANK_COLORS[m.rank] : 'transparent';
     const rankDot = m.rank
       ? '<span title="' + m.rank + '" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + rankColor + ';margin-right:4px"></span>'
       : '';
     const typeBadge = rankDot + '<span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>';
+    const selected = _maneuverSelected.has(key);
+    const cbox = '<input type="checkbox" ' + (selected ? 'checked ' : '') + 'onclick="event.stopPropagation();toggleManeuverSelected(\'' + key + '\')" title="Include in overlay">';
+    const elapsed = _fmtElapsed(m.ts);
     const t = fmtTime(m.ts);
     const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '—';
     const turn = m.turn_angle_deg != null ? Math.round(Math.abs(m.turn_angle_deg)) + '°' : '—';
     const bspLoss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—';
     const distLoss = m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—';
     const entry = (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '—') + '→' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '—');
-    const cond = (m.entry_tws != null ? m.entry_tws.toFixed(0) + ' kt' : '—');
+    // Fall back to the detector's stored tws_bin (integer kt) when the
+    // averaged entry window didn't hit any wind samples.
+    const twsVal = m.entry_tws != null ? m.entry_tws : (m.tws_bin != null ? m.tws_bin : null);
+    const cond = twsVal != null ? (twsVal.toFixed ? twsVal.toFixed(0) : twsVal) + ' kt' : '—';
     const yt = m.youtube_url
       ? '<a href="' + esc(m.youtube_url) + '" target="_blank" rel="noopener" title="Watch on YouTube" style="color:var(--accent);text-decoration:none" onclick="event.stopPropagation()">&#9654;</a>'
       : '';
     return '<tr id="mrow-' + idx + '" style="cursor:pointer" onclick="highlightManeuver(' + idx + ')">'
+      + '<td>' + cbox + '</td>'
       + '<td>' + typeBadge + '</td>'
+      + '<td style="font-variant-numeric:tabular-nums">' + elapsed + '</td>'
       + '<td>' + t + '</td>'
       + '<td>' + dur + '</td>'
       + '<td>' + turn + '</td>'
@@ -2211,9 +2266,19 @@ function renderManeuverCard() {
     ? '<div style="margin-bottom:8px">' + _renderOverlaySvg() + '</div>'
     : '';
 
-  body.innerHTML = summary + filterBar + overlayBlock
+  const selCount = _maneuverSelected.size;
+  const selectBar = '<div style="font-size:.7rem;color:var(--text-secondary);margin:4px 0;display:flex;gap:6px;align-items:center">'
+    + '<span>Overlay: ' + selCount + ' selected</span>'
+    + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'all\')">all</button>'
+    + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'none\')">none</button>'
+    + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'filtered\')">match filter</button>'
+    + '</div>';
+
+  body.innerHTML = summary + filterBar + overlayBlock + selectBar
     + '<table class="maneuver-table"><thead><tr>'
+    + '<th title="Include in overlay"></th>'
     + _manHeader('Type', 'type')
+    + '<th>Elapsed</th>'
     + _manHeader('Time', 'ts')
     + _manHeader('Dur', 'duration_sec')
     + _manHeader('Turn', 'turn_angle_deg')

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1996,6 +1996,9 @@ function renderPolarHeatmap() {
 // ---------------------------------------------------------------------------
 
 const _MANEUVER_COLORS = { tack: cssVar('--accent-strong'), gybe: cssVar('--warning'), rounding: cssVar('--success') };
+const _RANK_COLORS = { good: cssVar('--success'), bad: cssVar('--error'), avg: cssVar('--text-secondary') };
+let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distance_loss_m | loss_kts | turn_angle_deg
+let _maneuverFilter = 'all';  // all | tack | gybe | rounding | good | bad
 
 async function loadManeuvers() {
   const r = await fetch('/api/sessions/' + SESSION_ID + '/maneuvers');
@@ -2003,6 +2006,41 @@ async function loadManeuvers() {
   _maneuvers = await r.json();
   renderManeuverCard();
   if (_map && _maneuvers.length) _addManeuverMarkers();
+}
+
+function _maneuverRows() {
+  const items = _maneuvers.filter(m => {
+    if (_maneuverFilter === 'all') return true;
+    if (_maneuverFilter === 'good' || _maneuverFilter === 'bad') return m.rank === _maneuverFilter;
+    return m.type === _maneuverFilter;
+  });
+  const key = _maneuverSort.key, dir = _maneuverSort.dir;
+  items.sort((a, b) => {
+    let av = a[key], bv = b[key];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (key === 'ts') { av = new Date(av).getTime(); bv = new Date(bv).getTime(); }
+    if (key === 'type') return dir * String(av).localeCompare(String(bv));
+    return dir * (av - bv);
+  });
+  return items;
+}
+
+function setManeuverSort(key) {
+  if (_maneuverSort.key === key) _maneuverSort.dir *= -1;
+  else { _maneuverSort.key = key; _maneuverSort.dir = key === 'ts' ? 1 : -1; }
+  renderManeuverCard();
+}
+
+function setManeuverFilter(f) {
+  _maneuverFilter = f;
+  renderManeuverCard();
+}
+
+function _manHeader(label, key) {
+  const arrow = _maneuverSort.key === key ? (_maneuverSort.dir > 0 ? ' ▲' : ' ▼') : '';
+  return '<th style="cursor:pointer" onclick="setManeuverSort(\'' + key + '\')">' + label + arrow + '</th>';
 }
 
 function renderManeuverCard() {
@@ -2018,32 +2056,91 @@ function renderManeuverCard() {
   const tacks = _maneuvers.filter(m => m.type === 'tack').length;
   const gybes = _maneuvers.filter(m => m.type === 'gybe').length;
   const roundings = _maneuvers.filter(m => m.type === 'rounding').length;
-  const summary = '<div style="color:var(--text-secondary);font-size:.75rem;margin-bottom:6px">'
-    + tacks + ' tack' + (tacks !== 1 ? 's' : '')
-    + ' &middot; ' + gybes + ' gybe' + (gybes !== 1 ? 's' : '')
-    + ' &middot; ' + roundings + ' rounding' + (roundings !== 1 ? 's' : '')
+  const good = _maneuvers.filter(m => m.rank === 'good').length;
+  const bad = _maneuvers.filter(m => m.rank === 'bad').length;
+
+  const summary = '<div style="color:var(--text-secondary);font-size:.75rem;margin-bottom:6px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">'
+    + '<span>' + tacks + 'T · ' + gybes + 'G · ' + roundings + 'R</span>'
+    + '<span style="color:' + _RANK_COLORS.good + '">' + good + ' good</span>'
+    + '<span style="color:' + _RANK_COLORS.bad + '">' + bad + ' bad</span>'
+    + '<span style="flex:1"></span>'
+    + '<a href="/api/sessions/' + SESSION_ID + '/maneuvers.csv" download style="color:var(--accent);text-decoration:none">CSV &#8595;</a>'
     + '</div>';
 
-  let rows = _maneuvers.map((m, idx) => {
+  const filters = ['all', 'tack', 'gybe', 'rounding', 'good', 'bad'];
+  const filterBar = '<div style="display:flex;gap:4px;margin-bottom:6px;flex-wrap:wrap">'
+    + filters.map(f => {
+        const active = _maneuverFilter === f;
+        const style = 'font-size:.7rem;padding:2px 8px;border:1px solid var(--border);background:'
+          + (active ? 'var(--accent)' : 'transparent') + ';color:'
+          + (active ? 'var(--bg-primary)' : 'var(--text-secondary)') + ';cursor:pointer;border-radius:3px';
+        return '<button style="' + style + '" onclick="setManeuverFilter(\'' + f + '\')">' + f + '</button>';
+      }).join('')
+    + '</div>';
+
+  const items = _maneuverRows();
+  let rows = items.map((m) => {
+    const idx = _maneuvers.indexOf(m);
     const color = _MANEUVER_COLORS[m.type] || 'var(--text-secondary)';
-    const typeBadge = '<span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>';
+    const rankColor = m.rank ? _RANK_COLORS[m.rank] : 'transparent';
+    const rankDot = m.rank
+      ? '<span title="' + m.rank + '" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + rankColor + ';margin-right:4px"></span>'
+      : '';
+    const typeBadge = rankDot + '<span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>';
     const t = fmtTime(m.ts);
-    const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + ' s' : '—';
-    const loss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—';
-    const cond = (m.twa_bin != null ? m.twa_bin + '° TWA' : '') + (m.tws_bin != null ? (m.twa_bin != null ? ', ' : '') + m.tws_bin + ' kt TWS' : '');
+    const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '—';
+    const turn = m.turn_angle_deg != null ? Math.round(Math.abs(m.turn_angle_deg)) + '°' : '—';
+    const bspLoss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—';
+    const distLoss = m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—';
+    const entry = (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '—') + '→' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '—');
+    const cond = (m.entry_tws != null ? m.entry_tws.toFixed(0) + ' kt' : '—');
+    const yt = m.youtube_url
+      ? '<a href="' + esc(m.youtube_url) + '" target="_blank" rel="noopener" title="Watch on YouTube" style="color:var(--accent);text-decoration:none" onclick="event.stopPropagation()">&#9654;</a>'
+      : '';
     return '<tr id="mrow-' + idx + '" style="cursor:pointer" onclick="highlightManeuver(' + idx + ')">'
       + '<td>' + typeBadge + '</td>'
       + '<td>' + t + '</td>'
       + '<td>' + dur + '</td>'
-      + '<td>' + loss + '</td>'
-      + '<td>' + esc(cond || '—') + '</td>'
+      + '<td>' + turn + '</td>'
+      + '<td>' + entry + '</td>'
+      + '<td>' + bspLoss + '</td>'
+      + '<td>' + distLoss + '</td>'
+      + '<td>' + esc(cond) + '</td>'
+      + '<td>' + yt + '</td>'
       + '</tr>';
   }).join('');
 
-  body.innerHTML = summary
+  body.innerHTML = summary + filterBar
     + '<table class="maneuver-table"><thead><tr>'
-    + '<th>Type</th><th>Time</th><th>Duration</th><th>BSP Loss</th><th>Conditions</th>'
-    + '</tr></thead><tbody>' + rows + '</tbody></table>';
+    + _manHeader('Type', 'type')
+    + _manHeader('Time', 'ts')
+    + _manHeader('Dur', 'duration_sec')
+    + _manHeader('Turn', 'turn_angle_deg')
+    + '<th>BSP in→out</th>'
+    + _manHeader('BSP loss', 'loss_kts')
+    + _manHeader('Dist loss', 'distance_loss_m')
+    + '<th>TWS</th><th></th>'
+    + '</tr></thead><tbody>' + rows + '</tbody></table>'
+    + '<div id="maneuver-detail" style="margin-top:8px"></div>';
+}
+
+function _renderManeuverDetail(m) {
+  const el = document.getElementById('maneuver-detail');
+  if (!el) return;
+  if (!m) { el.innerHTML = ''; return; }
+  const rows = [
+    ['Entry HDG', m.entry_hdg != null ? m.entry_hdg.toFixed(0) + '°' : '—'],
+    ['Exit HDG', m.exit_hdg != null ? m.exit_hdg.toFixed(0) + '°' : '—'],
+    ['Turn rate', m.turn_rate_deg_s != null ? m.turn_rate_deg_s.toFixed(1) + '°/s' : '—'],
+    ['Min BSP', m.min_bsp != null ? m.min_bsp.toFixed(1) + ' kt' : '—'],
+    ['Entry TWA', m.entry_twa != null ? m.entry_twa.toFixed(0) + '°' : '—'],
+    ['Exit TWA', m.exit_twa != null ? m.exit_twa.toFixed(0) + '°' : '—'],
+    ['Time to recover', m.time_to_recover_s != null ? m.time_to_recover_s.toFixed(1) + ' s' : '—'],
+    ['Distance loss', m.distance_loss_m != null ? m.distance_loss_m.toFixed(1) + ' m' : '—'],
+  ];
+  el.innerHTML = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
+    + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')
+    + '</div>';
 }
 
 function _addManeuverMarkers() {
@@ -2081,11 +2178,20 @@ function highlightManeuver(idx) {
     row.classList.add('active-row');
     row.scrollIntoView({block: 'nearest'});
   }
-  // Move map cursor to maneuver position
   const m = _maneuvers[idx];
+  _renderManeuverDetail(m);
+  // Move map cursor to maneuver position
   if (m && _trackData) {
     const ts = new Date(m.ts.endsWith('Z') || m.ts.includes('+') ? m.ts : m.ts + 'Z');
     setPosition(ts);
+  }
+  // Seek the embedded player to the maneuver moment if a video is loaded.
+  if (m && _videoSync && _videoSync.player) {
+    const ts = new Date(m.ts.endsWith('Z') || m.ts.includes('+') ? m.ts : m.ts + 'Z');
+    const offset = _utcToVideoOffset(ts);
+    if (offset != null && offset >= 0 && _videoSync.player.seekTo) {
+      try { _videoSync.player.seekTo(offset, true); } catch (e) { /* ignore */ }
+    }
   }
   // Open the marker popup if available
   if (_maneuverMarkers[idx]) _maneuverMarkers[idx].openPopup();

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -21,6 +21,7 @@
 .maneuver-table th{color:var(--text-secondary);font-weight:400;text-align:left;padding:3px 6px;border-bottom:1px solid var(--border)}
 .maneuver-table td{padding:3px 6px;border-bottom:1px solid var(--border);color:var(--text-primary)}
 .maneuver-table tr.active-row td{background:var(--bg-secondary);color:var(--text-primary)}
+.maneuver-table tr.hover-row td{background:var(--bg-secondary);outline:1px solid var(--accent)}
 .badge-tack{color:var(--accent)}
 .badge-gybe{color:var(--warning)}
 .badge-rounding{color:var(--success)}

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 
 from helmlog.analysis.maneuvers import (
     enrich_maneuver,
+    extract_local_track,
     rank_maneuvers,
 )
 
@@ -206,6 +207,63 @@ class TestEnrichManeuver:
         )
         # Should still compute entry_bsp from pre-window
         assert m.entry_bsp is not None and abs(m.entry_bsp - 5.0) < 0.01
+
+
+class TestExtractLocalTrack:
+    def test_entry_aligned_track_has_forward_axis_along_entry_bearing(self) -> None:
+        # Straight line heading 090° (due east) at 5 kt for 60s.
+        positions = _straight_positions(37.0, -122.0, 90.0, 5.0, 60)
+        bsp = _const(60, 5.0)
+        track = extract_local_track(
+            maneuver_ts=_BASE_TS + timedelta(seconds=20),
+            exit_ts=_BASE_TS + timedelta(seconds=30),
+            entry_bearing_deg=90.0,
+            positions=positions,
+            bsp=bsp,
+        )
+        assert len(track) > 0
+        # All points should have forward (y) progress and ~0 cross (x).
+        for p in track:
+            assert abs(p["x"]) < 1.0  # cross-track < 1 m
+        ys = [p["y"] for p in track]
+        assert max(ys) > 0  # forward progress exists
+        assert min(ys) < 0  # pre-window points have negative forward
+
+    def test_origin_at_maneuver_start(self) -> None:
+        positions = _straight_positions(37.0, -122.0, 0.0, 5.0, 60)
+        bsp = _const(60, 5.0)
+        track = extract_local_track(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=35),
+            entry_bearing_deg=0.0,
+            positions=positions,
+            bsp=bsp,
+        )
+        zero = [p for p in track if p["t"] == 0.0]
+        assert len(zero) == 1
+        assert abs(zero[0]["x"]) < 0.01 and abs(zero[0]["y"]) < 0.01
+
+    def test_empty_positions_returns_empty(self) -> None:
+        track = extract_local_track(
+            maneuver_ts=_BASE_TS,
+            exit_ts=None,
+            entry_bearing_deg=0.0,
+            positions=[],
+            bsp=[],
+        )
+        assert track == []
+
+    def test_bsp_attached_when_available(self) -> None:
+        positions = _straight_positions(37.0, -122.0, 0.0, 5.0, 60)
+        bsp = _const(60, 4.2)
+        track = extract_local_track(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=35),
+            entry_bearing_deg=0.0,
+            positions=positions,
+            bsp=bsp,
+        )
+        assert any("bsp" in p and abs(p["bsp"] - 4.2) < 0.01 for p in track)
 
 
 class TestRankManeuvers:

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -1,0 +1,244 @@
+"""Tests for analysis/maneuvers.py — per-maneuver entry/exit metrics and loss calc."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+from helmlog.analysis.maneuvers import (
+    enrich_maneuver,
+    rank_maneuvers,
+)
+
+_BASE_TS = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+
+
+def _series(values: list[float], offset_s: int = 0) -> list[tuple[datetime, float]]:
+    return [(_BASE_TS + timedelta(seconds=offset_s + i), v) for i, v in enumerate(values)]
+
+
+def _const(n: int, v: float, offset_s: int = 0) -> list[tuple[datetime, float]]:
+    return _series([v] * n, offset_s=offset_s)
+
+
+def _straight_positions(
+    lat0: float, lon0: float, cog_deg: float, sog_kts: float, n: int, offset_s: int = 0
+) -> list[tuple[datetime, float, float]]:
+    """Generate positions moving at a constant SOG/COG from (lat0, lon0)."""
+    out = []
+    R = 6371000.0
+    ms = sog_kts * 0.514444
+    cog_rad = math.radians(cog_deg)
+    for i in range(n):
+        d = ms * i  # metres travelled
+        dn = d * math.cos(cog_rad)
+        de = d * math.sin(cog_rad)
+        dlat = math.degrees(dn / R)
+        dlon = math.degrees(de / (R * math.cos(math.radians(lat0))))
+        out.append((_BASE_TS + timedelta(seconds=offset_s + i), lat0 + dlat, lon0 + dlon))
+    return out
+
+
+class TestEnrichManeuver:
+    def test_entry_exit_averages_from_steady_windows(self) -> None:
+        # 30s pre @ hdg=10, bsp=6.0, twa=40, tws=12
+        # 10s turn (ignored for entry/exit)
+        # 30s post @ hdg=280, bsp=5.5, twa=-40 → folded 40, tws=12
+        turn_hdg = _series([10 + i * 27 for i in range(10)], 30)
+        hdg = _const(30, 10.0) + turn_hdg + _const(30, 280.0, 40)
+        bsp = _const(30, 6.0) + _const(10, 3.0, 30) + _const(30, 5.5, 40)
+        twa = _const(30, 40.0) + _const(10, 0.0, 30) + _const(30, 40.0, 40)
+        tws = _const(70, 12.0)
+        positions = _straight_positions(37.0, -122.0, 10.0, 6.0, 70)
+
+        maneuver_ts = _BASE_TS + timedelta(seconds=30)
+        exit_ts = _BASE_TS + timedelta(seconds=40)
+
+        m = enrich_maneuver(
+            maneuver_ts=maneuver_ts,
+            exit_ts=exit_ts,
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+
+        assert m.entry_bsp is not None and abs(m.entry_bsp - 6.0) < 0.01
+        assert m.exit_bsp is not None and abs(m.exit_bsp - 5.5) < 0.01
+        assert m.entry_hdg is not None and abs(m.entry_hdg - 10.0) < 1.0
+        assert m.exit_hdg is not None and abs(m.exit_hdg - 280.0) < 1.0
+        assert m.entry_twa is not None and abs(m.entry_twa - 40.0) < 0.1
+        assert m.exit_twa is not None and abs(m.exit_twa - 40.0) < 0.1
+        assert m.entry_tws is not None and abs(m.entry_tws - 12.0) < 0.01
+
+    def test_min_bsp_captured_during_maneuver(self) -> None:
+        hdg = _const(30, 10.0) + _const(10, 10.0, 30) + _const(30, 280.0, 40)
+        bsp_during = [6.0, 5.0, 4.0, 3.0, 2.0, 1.5, 2.0, 3.0, 4.0, 5.0]
+        bsp = _const(30, 6.0) + _series(bsp_during, 30) + _const(30, 5.5, 40)
+        twa = _const(70, 40.0)
+        tws = _const(70, 12.0)
+        positions = _straight_positions(37.0, -122.0, 10.0, 6.0, 70)
+
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        assert m.min_bsp is not None and abs(m.min_bsp - 1.5) < 0.01
+
+    def test_turn_angle_approx_90_for_quarter_turn(self) -> None:
+        hdg = _const(30, 0.0) + _const(10, 45.0, 30) + _const(30, 90.0, 40)
+        bsp = _const(70, 5.0)
+        twa = _const(70, 40.0)
+        tws = _const(70, 12.0)
+        positions = _straight_positions(37.0, -122.0, 0.0, 5.0, 70)
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        assert m.turn_angle_deg is not None and 80.0 <= abs(m.turn_angle_deg) <= 100.0
+
+    def test_turn_rate_is_angle_over_duration(self) -> None:
+        hdg = _const(30, 0.0) + _const(10, 45.0, 30) + _const(30, 90.0, 40)
+        bsp = _const(70, 5.0)
+        twa = _const(70, 40.0)
+        tws = _const(70, 12.0)
+        positions = _straight_positions(37.0, -122.0, 0.0, 5.0, 70)
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        assert m.duration_sec is not None and m.duration_sec == 10.0
+        assert m.turn_rate_deg_s is not None and 7.0 <= m.turn_rate_deg_s <= 11.0
+
+    def test_distance_loss_zero_for_straight_line(self) -> None:
+        # No actual turn — boat keeps going straight; entry-vector projection
+        # should show ~0 loss against the idealized path.
+        hdg = _const(70, 0.0)
+        bsp = _const(70, 6.0)
+        twa = _const(70, 40.0)
+        tws = _const(70, 12.0)
+        positions = _straight_positions(37.0, -122.0, 0.0, 6.0, 70)
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        assert m.distance_loss_m is not None
+        assert abs(m.distance_loss_m) < 1.0
+
+    def test_distance_loss_positive_for_real_tack(self) -> None:
+        # Pre-window: bearing 0° at 6 kt for 30s
+        # During maneuver: 10s of near-zero progress (boat stalls in tack)
+        # Exit: bearing 270° at 5 kt for 30s (ends up well off the entry line)
+        pre = _straight_positions(37.0, -122.0, 0.0, 6.0, 30)
+        last_pre_ts, last_lat, last_lon = pre[-1]
+        # During maneuver: stall — positions barely move
+        during = [(last_pre_ts + timedelta(seconds=i + 1), last_lat, last_lon) for i in range(10)]
+        last_during = during[-1]
+        post = _straight_positions(last_during[1], last_during[2], 270.0, 5.0, 30, offset_s=40)
+        positions = pre + during + post
+
+        hdg = _const(30, 0.0) + _const(10, 315.0, 30) + _const(30, 270.0, 40)
+        bsp = _const(30, 6.0) + _const(10, 1.0, 30) + _const(30, 5.0, 40)
+        twa = _const(70, 40.0)
+        tws = _const(70, 12.0)
+
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=twa,
+            tws=tws,
+            positions=positions,
+        )
+        assert m.distance_loss_m is not None
+        # Boat should have lost at least ~10m of forward progress along the 0° axis.
+        assert m.distance_loss_m > 10.0
+
+    def test_missing_data_returns_none_fields_no_crash(self) -> None:
+        hdg = _const(70, 10.0)
+        bsp = _const(70, 6.0)
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=_BASE_TS + timedelta(seconds=40),
+            hdg=hdg,
+            bsp=bsp,
+            twa=[],
+            tws=[],
+            positions=[],
+        )
+        assert m.entry_twa is None
+        assert m.entry_tws is None
+        assert m.distance_loss_m is None
+
+    def test_exit_ts_none_uses_fallback_window(self) -> None:
+        hdg = _const(30, 0.0) + _const(10, 45.0, 30) + _const(30, 90.0, 40)
+        bsp = _const(70, 5.0)
+        m = enrich_maneuver(
+            maneuver_ts=_BASE_TS + timedelta(seconds=30),
+            exit_ts=None,
+            hdg=hdg,
+            bsp=bsp,
+            twa=[],
+            tws=[],
+            positions=[],
+        )
+        # Should still compute entry_bsp from pre-window
+        assert m.entry_bsp is not None and abs(m.entry_bsp - 5.0) < 0.01
+
+
+class TestRankManeuvers:
+    def _mk(self, distance_loss: float | None, bsp_loss: float | None) -> dict:
+        return {
+            "type": "tack",
+            "ts": _BASE_TS.isoformat(),
+            "distance_loss_m": distance_loss,
+            "loss_kts": bsp_loss,
+        }
+
+    def test_quartile_labels_assigned(self) -> None:
+        items = [self._mk(float(i), float(i) / 10) for i in range(8)]
+        ranked = rank_maneuvers(items)
+        # Lowest-loss quartile → "good", highest → "bad", middle → "avg"
+        labels = [m["rank"] for m in ranked]
+        assert "good" in labels and "bad" in labels
+        # The highest distance_loss entry should be 'bad'
+        bad = next(m for m in ranked if m["distance_loss_m"] == 7.0)
+        assert bad["rank"] == "bad"
+        good = next(m for m in ranked if m["distance_loss_m"] == 0.0)
+        assert good["rank"] == "good"
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert rank_maneuvers([]) == []
+
+    def test_all_none_loss_falls_back_to_bsp_loss(self) -> None:
+        items = [
+            {"type": "tack", "distance_loss_m": None, "loss_kts": 0.1},
+            {"type": "tack", "distance_loss_m": None, "loss_kts": 0.5},
+            {"type": "tack", "distance_loss_m": None, "loss_kts": 1.0},
+            {"type": "tack", "distance_loss_m": None, "loss_kts": 2.0},
+        ]
+        ranked = rank_maneuvers(items)
+        worst = max(ranked, key=lambda m: m["loss_kts"] or 0)
+        assert worst["rank"] == "bad"

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
 
 from helmlog.analysis.maneuvers import (
     enrich_maneuver,
+    enrich_session_maneuvers,
     extract_local_track,
     rank_maneuvers,
 )
@@ -264,6 +271,91 @@ class TestExtractLocalTrack:
             bsp=bsp,
         )
         assert any("bsp" in p and abs(p["bsp"] - 4.2) < 0.01 for p in track)
+
+
+class TestEnrichSessionManeuversWindRefZero:
+    """Regression for a falsy-zero bug where ``reference=0`` wind rows were
+    skipped by ``int(r.get("reference", -1) or -1)`` because ``0 or -1 == -1``,
+    leaving ``entry_tws`` / ``entry_twa`` blank on every maneuver in a session
+    whose B&G feed publishes boat-referenced true wind (the common case).
+    """
+
+    @pytest.mark.asyncio
+    async def test_reference_zero_wind_rows_populate_entry_tws(self, storage: Storage) -> None:
+        db = storage._conn()
+        start = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+        end = start + timedelta(seconds=120)
+
+        await db.execute(
+            "INSERT INTO races"
+            " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                1,
+                "test-session",
+                "test-event",
+                1,
+                start.date().isoformat(),
+                "race",
+                start.isoformat(),
+                end.isoformat(),
+            ),
+        )
+
+        # Seed 120s of 1Hz instrument data across a 60-second tack.
+        for i in range(121):
+            ts = (start + timedelta(seconds=i)).isoformat()
+            hdg = 10.0 if i < 60 else 280.0
+            bsp = 6.0 if i < 55 or i > 70 else 3.0
+            await db.execute(
+                "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+                (ts, 0x05, hdg),
+            )
+            await db.execute(
+                "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+                (ts, 0x05, bsp),
+            )
+            # Crucially: reference=0, the falsy value that used to be dropped.
+            await db.execute(
+                "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference)"
+                " VALUES (?, ?, ?, ?, 0)",
+                (ts, 0x05, 12.5, 40.0),
+            )
+            await db.execute(
+                "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
+                " VALUES (?, ?, ?, ?)",
+                (ts, 0x05, 37.0 + i * 1e-5, -122.0),
+            )
+
+        # Seed one stored maneuver at t=60.
+        await db.execute(
+            "INSERT INTO maneuvers"
+            " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+            "  vmg_loss_kts, tws_bin, twa_bin, details)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                1,
+                "tack",
+                (start + timedelta(seconds=60)).isoformat(),
+                (start + timedelta(seconds=70)).isoformat(),
+                10.0,
+                3.0,
+                None,
+                12,
+                40,
+                None,
+            ),
+        )
+        await db.commit()
+
+        enriched, _video = await enrich_session_maneuvers(storage, 1)
+
+        assert len(enriched) == 1
+        m = enriched[0]
+        assert m["entry_tws"] is not None
+        assert abs(m["entry_tws"] - 12.5) < 0.1
+        assert m["entry_twa"] is not None
+        assert abs(m["entry_twa"] - 40.0) < 1.0
 
 
 class TestRankManeuvers:


### PR DESCRIPTION
## Summary

Adds a new `helmlog.analysis.maneuvers` module that enriches the existing tack/gybe detector output with the per-maneuver metrics requested in #456, ranks each maneuver into good/avg/bad quartiles, and wires the result into the session detail page and a CSV export.

- **New `analysis/maneuvers.py`** — pure `enrich_maneuver()` + `rank_maneuvers()` and a storage-integrated `enrich_session_maneuvers()` that loads instrument timeseries once per request.
- **Per-maneuver metrics**: entry/exit BSP, HDG, TWA, TWS, min BSP during maneuver, turn angle and rate, time-to-recover, and `distance_loss_m` computed against an entry-vector projection (simplest model — see Design notes).
- **Ranking**: top quartile by loss → `good`, bottom quartile → `bad`, middle → `avg`, falling back to `loss_kts` when distance loss is unavailable.
- **`/api/sessions/{id}/maneuvers`** now returns the enriched, ranked list, with a per-maneuver `youtube_url` deep-link built from the session's `race_videos.sync_utc` / `sync_offset_s` so each tack can jump straight to the correct video offset.
- **New `/api/sessions/{id}/maneuvers.csv`** endpoint — CSV export of the same enriched list.
- **Session UI**: sortable columns (time, duration, turn angle, BSP loss, distance loss), filter chips (`all` / `tack` / `gybe` / `rounding` / `good` / `bad`), good/bad dot badges, per-row play button, CSV download link, and a detail panel showing full entry/exit state when a row is selected. Row click also seeks the embedded YouTube player.

## Design notes (addressing the open questions in #456)

- **Module location**: new `analysis/maneuvers.py` inside the existing `helmlog.analysis` package, leaving `maneuver_detector.py` untouched so detection stays a single-purpose module and the analysis package can grow (mark roundings, starts, cross-session) later.
- **Distance-loss reference**: simplest useful model — forward progress along the entry COG vector. The idealized "instant turn" boat keeps going at entry SOG on the entry bearing for the maneuver duration; distance loss is `(ideal forward distance) − (actual projection onto entry bearing)`. Verified against a synthetic stalled tack in tests. We can iterate to polar-based references once polar confidence is solid.
- **UI surface**: reused the existing Maneuvers card on the session detail page rather than adding a new tab — keeps the interaction local to the same scroll position as the map/video.

## Test plan

- [x] `uv run pytest` — 1641 passed, 2 skipped (11 new unit tests in `tests/test_analysis_maneuvers.py`)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] Smoke test in browser: load a session with tacks, verify sort/filter/rank/CSV/play-button
- [ ] Verify mypy — pre-existing storage.py errors unchanged, no new errors from this PR

## Acceptance criteria from #456

- [x] Given a session with tacks/gybes, the analysis produces a list of all maneuvers with entry/exit metrics and a loss figure
- [x] Each maneuver links to the session YouTube video at the correct offset
- [x] Maneuvers can be sorted/filtered to surface the best and worst
- [x] Unit tests cover detection, metric computation, and loss calculation against synthetic tracks
- [x] Results are accessible from the session detail page in the web UI

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)