### PR TITLE
fix: backup.sh first-run + .env, Signal K coverage

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -34,7 +34,7 @@ log() { echo "[$(date -u +%H:%M:%SZ)] $*"; }
 # rsync --link-dest creates hardlinks for files that are byte-for-byte identical
 # to the previous snapshot, so unchanged files (photos, WAVs, etc.) cost zero
 # extra disk space across snapshots.
-PREV=$(ls -1dt "$BACKUP_DEST"/20* 2>/dev/null | head -1)
+PREV=$(ls -1dt "$BACKUP_DEST"/20* 2>/dev/null | head -1 || true)
 
 # Pre-compute link-dest flags as variables to avoid command substitution
 # inside &&-chains (which interacts badly with inline comments).
@@ -61,7 +61,7 @@ log "Source: $PI"
 [ -n "$PREV" ] && log "Link-dest (hardlink base): $PREV"
 
 # ── 1. SQLite — WAL checkpoint then rsync ────────────────────────────────────
-log "Step 1/4: SQLite WAL checkpoint + rsync"
+log "Step 1/5: SQLite WAL checkpoint + rsync"
 ssh "$PI" "sqlite3 ~/helmlog/data/logger.db 'PRAGMA wal_checkpoint(TRUNCATE);'" 2>/dev/null || \
   log "  WARNING: WAL checkpoint failed (DB may not exist yet); continuing"
 
@@ -72,7 +72,7 @@ rsync -az $RSYNC_PROGRESS $LINK_DATA \
 log "  SQLite + file data done"
 
 # ── 2. InfluxDB — remote backup then rsync ───────────────────────────────────
-log "Step 2/4: InfluxDB backup"
+log "Step 2/5: InfluxDB backup"
 if ssh "$PI" "test -f $INFLUX_TOKEN_FILE" 2>/dev/null; then
   ssh "$PI" "influx backup /tmp/influx-backup \
     --host http://localhost:8086 \
@@ -87,8 +87,29 @@ else
   log "  WARNING: $INFLUX_TOKEN_FILE not found on Pi; skipping InfluxDB backup"
 fi
 
-# ── 3. Grafana — rsync with sudo ─────────────────────────────────────────────
-log "Step 3/4: Grafana data dir"
+# ── 3. Config — .env and Signal K ────────────────────────────────────────────
+log "Step 3/5: Config (.env + Signal K)"
+mkdir -p "$SNAP/config"
+rsync -az $RSYNC_PROGRESS \
+  "$PI:~/helmlog/.env" \
+  "$SNAP/config/helmlog.env" 2>/dev/null && \
+  log "  helmlog .env done" || \
+  log "  WARNING: .env rsync failed; skipping"
+
+# Signal K — exclude node_modules (huge, reinstallable via npm install)
+LINK_SK=""
+[ -n "$PREV" ] && [ -d "$PREV/signalk" ] && LINK_SK="--link-dest=$PREV/signalk"
+# shellcheck disable=SC2086
+rsync -az $RSYNC_PROGRESS $LINK_SK \
+  --exclude='node_modules/' \
+  --exclude='package-lock.json' \
+  "$PI:~/.signalk/" \
+  "$SNAP/signalk/" 2>/dev/null && \
+  log "  Signal K config + data done" || \
+  log "  WARNING: Signal K rsync failed; skipping"
+
+# ── 4. Grafana — rsync with sudo ─────────────────────────────────────────────
+log "Step 4/5: Grafana data dir"
 # shellcheck disable=SC2046
 if rsync -az $RSYNC_PROGRESS \
     --rsync-path='sudo rsync' \
@@ -100,8 +121,8 @@ else
   log "  WARNING: Grafana rsync failed (sudo rsync not configured?); skipping"
 fi
 
-# ── 4. Rotate old snapshots ───────────────────────────────────────────────────
-log "Step 4/4: Rotating snapshots (keeping $KEEP_SNAPSHOTS)"
+# ── 5. Rotate old snapshots ───────────────────────────────────────────────────
+log "Step 5/5: Rotating snapshots (keeping $KEEP_SNAPSHOTS)"
 # shellcheck disable=SC2012
 STALE=$(ls -1dt "$BACKUP_DEST"/20* 2>/dev/null | tail -n +"$((KEEP_SNAPSHOTS + 1))")
 if [ -n "$STALE" ]; then


### PR DESCRIPTION
## Summary
- Fix `backup.sh` exiting silently on first run (no prior snapshot) — `ls | head` under `set -euo pipefail` was killing the script before any step ran
- Pull `~/helmlog/.env` into the snapshot under `config/helmlog.env`
- Pull `~/.signalk/` (config + plugin data), excluding `node_modules/` and `package-lock.json` since those are reinstallable via `npm install`
- Renumber steps from 1/4..4/4 → 1/5..5/5 to reflect the new config step

Verified end-to-end against `corvopi-live`: 1.2 GB snapshot, all 5 steps clean (data 762M, influxdb 436M, grafana 54M, signalk 552K, config 8K).

## Test plan
- [x] Run `PI=weaties@corvopi-live ./scripts/backup.sh` from a clean `~/backups/helmlog` (first-run path)
- [x] Verify `config/helmlog.env` and `signalk/settings.json` present in snapshot
- [x] Verify `signalk/node_modules` not pulled
- [ ] Re-run to confirm `--link-dest` hardlinking still works on the second snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)