### PR TITLE
Vakaros VKX ingest (#458)

### DIFF
--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -554,6 +554,67 @@ async def _status() -> None:
 
 
 # ---------------------------------------------------------------------------
+# vakaros-ingest (#458)
+# ---------------------------------------------------------------------------
+
+
+async def _vakaros_ingest(path_str: str) -> None:
+    """Parse and store a single Vakaros VKX log file."""
+    from pathlib import Path
+
+    from helmlog.storage import Storage, StorageConfig
+    from helmlog.vakaros import VKXParseError, ingest_vkx_file
+
+    path = Path(path_str).expanduser().resolve()
+    if not path.is_file():
+        logger.error("Not a file: {}", path)
+        sys.exit(1)
+
+    storage = Storage(StorageConfig())
+    await storage.connect()
+    try:
+        try:
+            session_id, was_duplicate = await ingest_vkx_file(storage, path)
+        except VKXParseError as exc:
+            logger.error("VKX parse failed: {}", exc)
+            sys.exit(1)
+
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT source_hash, start_utc, end_utc FROM vakaros_sessions WHERE id = ?",
+            (session_id,),
+        )
+        row = await cur.fetchone()
+        counts: dict[str, int] = {}
+        for label, table in (
+            ("positions", "vakaros_positions"),
+            ("line_positions", "vakaros_line_positions"),
+            ("race_events", "vakaros_race_events"),
+            ("winds", "vakaros_winds"),
+        ):
+            c = await db.execute(
+                f"SELECT COUNT(*) AS n FROM {table} WHERE session_id = ?",
+                (session_id,),
+            )
+            r = await c.fetchone()
+            counts[label] = int(r["n"]) if r is not None else 0
+    finally:
+        await storage.close()
+
+    state = "duplicate (no-op)" if was_duplicate else "ingested"
+    print(f"Vakaros session {session_id}  [{state}]")
+    print(f"  source file  : {path.name}")
+    if row is not None:
+        print(f"  source hash  : {row['source_hash']}")
+        print(f"  start  (UTC) : {row['start_utc']}")
+        print(f"  end    (UTC) : {row['end_utc']}")
+    print(f"  positions    : {counts['positions']}")
+    print(f"  line pings   : {counts['line_positions']}")
+    print(f"  race events  : {counts['race_events']}")
+    print(f"  wind samples : {counts['winds']}")
+
+
+# ---------------------------------------------------------------------------
 # link-video
 # ---------------------------------------------------------------------------
 
@@ -1608,6 +1669,13 @@ def _build_parser() -> argparse.ArgumentParser:
     st_target.add_argument("--session", type=int, metavar="ID", help="Audio session ID to scan")
     st_target.add_argument("--all", action="store_true", help="Scan all sessions with transcripts")
 
+    # -- Vakaros VKX ingest (#458) --------------------------------------
+    vk = sub.add_parser(
+        "vakaros-ingest",
+        help="Parse and ingest a Vakaros VKX log file",
+    )
+    vk.add_argument("path", help="Path to a .vkx file")
+
     # -- Federation: identity -------------------------------------------
     id_parser = sub.add_parser("identity", help="Manage boat identity")
     id_sub = id_parser.add_subparsers(dest="identity_command", required=True)
@@ -1702,6 +1770,8 @@ def main() -> None:
                 asyncio.run(_detect_maneuvers(args.session, getattr(args, "all", False)))
             case "scan-transcript":
                 asyncio.run(_scan_transcript(args.session, getattr(args, "all", False)))
+            case "vakaros-ingest":
+                asyncio.run(_vakaros_ingest(args.path))
             case "identity":
                 match args.identity_command:
                     case "init":

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -581,10 +581,19 @@ async def _vakaros_ingest(path_str: str) -> None:
 
         db = storage._conn()
         cur = await db.execute(
-            "SELECT source_hash, start_utc, end_utc FROM vakaros_sessions WHERE id = ?",
+            "SELECT source_hash, start_utc, end_utc, matched_race_id "
+            "FROM vakaros_sessions WHERE id = ?",
             (session_id,),
         )
         row = await cur.fetchone()
+        matched_race_name: str | None = None
+        if row is not None and row["matched_race_id"] is not None:
+            name_cur = await db.execute(
+                "SELECT name FROM races WHERE id = ?", (row["matched_race_id"],)
+            )
+            name_row = await name_cur.fetchone()
+            if name_row is not None:
+                matched_race_name = str(name_row["name"])
         counts: dict[str, int] = {}
         for label, table in (
             ("positions", "vakaros_positions"),
@@ -608,6 +617,11 @@ async def _vakaros_ingest(path_str: str) -> None:
         print(f"  source hash  : {row['source_hash']}")
         print(f"  start  (UTC) : {row['start_utc']}")
         print(f"  end    (UTC) : {row['end_utc']}")
+        if row["matched_race_id"] is not None:
+            label = matched_race_name or f"id={row['matched_race_id']}"
+            print(f"  matched race : {label} (id={row['matched_race_id']})")
+        else:
+            print("  matched race : (none — no overlapping SK race >= 50% time overlap)")
     print(f"  positions    : {counts['positions']}")
     print(f"  line pings   : {counts['line_positions']}")
     print(f"  race events  : {counts['race_events']}")

--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -466,9 +466,7 @@ async def admin_vakaros_rematch(
     from urllib.parse import quote
 
     msg = f"Rematched {session_count} sessions, linked {total_linked} races."
-    return RedirectResponse(
-        url="/admin/vakaros?flash_rematch=" + quote(msg), status_code=303
-    )
+    return RedirectResponse(url="/admin/vakaros?flash_rematch=" + quote(msg), status_code=303)
 
 
 @router.post("/admin/vakaros/ingest", include_in_schema=False)

--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -427,6 +427,7 @@ async def admin_vakaros_page(
     flash_filename = request.query_params.get("flash_filename")
     flash_status = request.query_params.get("flash_status")
     flash_error = request.query_params.get("flash_error")
+    flash_rematch = request.query_params.get("flash_rematch")
     return templates.TemplateResponse(
         request,
         "admin/vakaros.html",
@@ -439,7 +440,34 @@ async def admin_vakaros_page(
             flash_filename=flash_filename,
             flash_status=flash_status,
             flash_error=flash_error,
+            flash_rematch=flash_rematch,
         ),
+    )
+
+
+@router.post("/admin/vakaros/rematch", include_in_schema=False)
+async def admin_vakaros_rematch(
+    request: Request,
+    user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Re-run matching for every stored Vakaros session (#458)."""
+    from fastapi.responses import RedirectResponse
+
+    storage = get_storage(request)
+    results = await storage.rematch_all_vakaros_sessions()
+    total_linked = sum(len(v) for v in results.values())
+    session_count = len(results)
+    await audit(
+        request,
+        "vakaros_rematch",
+        detail=f"{session_count} sessions, {total_linked} race links",
+        user=user,
+    )
+    from urllib.parse import quote
+
+    msg = f"Rematched {session_count} sessions, linked {total_linked} races."
+    return RedirectResponse(
+        url="/admin/vakaros?flash_rematch=" + quote(msg), status_code=303
     )
 
 

--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -409,3 +409,70 @@ async def admin_analysis_page(
         "admin/analysis.html",
         tpl_ctx(request, "/admin/analysis"),
     )
+
+
+@router.get("/admin/vakaros", response_class=HTMLResponse, include_in_schema=False)
+async def admin_vakaros_page(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Vakaros VKX inbox + ingested-sessions admin page (#458)."""
+    from helmlog.vakaros_inbox import get_inbox_dir, list_inbox_files
+
+    storage = get_storage(request)
+    inbox = get_inbox_dir()
+    inbox_files = [{"name": p.name, "size": p.stat().st_size} for p in list_inbox_files(inbox)]
+    sessions = await storage.list_vakaros_sessions()
+    # Surface any flash message from a prior POST (filename + status + error).
+    flash_filename = request.query_params.get("flash_filename")
+    flash_status = request.query_params.get("flash_status")
+    flash_error = request.query_params.get("flash_error")
+    return templates.TemplateResponse(
+        request,
+        "admin/vakaros.html",
+        tpl_ctx(
+            request,
+            "/admin/vakaros",
+            inbox_dir=str(inbox),
+            inbox_files=inbox_files,
+            sessions=sessions,
+            flash_filename=flash_filename,
+            flash_status=flash_status,
+            flash_error=flash_error,
+        ),
+    )
+
+
+@router.post("/admin/vakaros/ingest", include_in_schema=False)
+async def admin_vakaros_ingest(
+    request: Request,
+    filename: str = Form(...),
+    user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Parse, store, and archive one inbox file (#458)."""
+    from fastapi.responses import RedirectResponse
+
+    from helmlog.vakaros_inbox import get_inbox_dir, ingest_inbox_file
+
+    storage = get_storage(request)
+    inbox = get_inbox_dir()
+    try:
+        result = await ingest_inbox_file(storage, inbox, filename)
+    except ValueError as exc:  # path-traversal
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    await audit(
+        request,
+        "vakaros_ingest",
+        detail=f"{result.filename} -> {result.status} (session_id={result.session_id})",
+        user=user,
+    )
+
+    params: list[str] = [f"flash_filename={result.filename}", f"flash_status={result.status}"]
+    if result.error:
+        from urllib.parse import quote
+
+        params.append(f"flash_error={quote(result.error)}")
+    return RedirectResponse(url="/admin/vakaros?" + "&".join(params), status_code=303)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -364,6 +364,7 @@ async def api_session_vakaros_overlay(
                 "track": None,
                 "line_positions": [],
                 "race_events": [],
+                "line": None,
             }
         )
     return JSONResponse({"matched": True, **overlay})

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -335,6 +335,40 @@ async def api_session_track(
     return JSONResponse({"type": "FeatureCollection", "features": [feature]})
 
 
+@router.get("/api/sessions/{session_id}/vakaros-overlay")
+@limiter.limit("30/minute")
+async def api_session_vakaros_overlay(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return Vakaros overlay data (track, start line, race events) for a race (#458).
+
+    Used by the session detail page to augment the SK track with Vakaros-native
+    overlays when a matched Vakaros session exists. Returns ``matched: false``
+    with empty collections when the race is valid but has no matched session,
+    and 404 when the race itself does not exist.
+    """
+    storage = get_storage(request)
+    db = storage._conn()
+    cur = await db.execute("SELECT id FROM races WHERE id = ?", (session_id,))
+    if await cur.fetchone() is None:
+        raise HTTPException(status_code=404, detail="Race not found")
+
+    overlay = await storage.get_vakaros_overlay_for_race(session_id)
+    if overlay is None:
+        return JSONResponse(
+            {
+                "matched": False,
+                "vakaros_session_id": None,
+                "track": None,
+                "line_positions": [],
+                "race_events": [],
+            }
+        )
+    return JSONResponse({"matched": True, **overlay})
+
+
 @router.get("/api/sessions/{session_id}/detail")
 async def api_session_detail(
     request: Request,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -365,6 +365,7 @@ async def api_session_vakaros_overlay(
                 "line_positions": [],
                 "race_events": [],
                 "line": None,
+                "race_start_context": None,
             }
         )
     return JSONResponse({"matched": True, **overlay})

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -83,6 +83,7 @@ function _stopPlayTick() {
 
 let _maneuvers = []; // loaded maneuver list
 let _maneuverMarkers = []; // Leaflet markers for maneuvers
+let _vakarosSyntheticStart = null; // {ts, source} placeholder injected from VKX
 let _transcriptId = null; // transcript ID for tuning extraction
 let _tuningSegmentAudio = null; // shared <audio> for segment playback
 let _tuningSegmentTimer = null; // timeupdate stop timer
@@ -335,7 +336,8 @@ async function loadVakarosOverlay() {
   }
 
   // Race-start marker on the SK track, positioned at the point closest in time
-  // to the RACE_START event.
+  // to the RACE_START event. Also inject a synthetic "start" entry into the
+  // maneuvers panel so the race start shows up in the event list.
   const raceStart = (data.race_events || []).find(e => e.event_type === 'race_start');
   if (raceStart && _trackData && _trackData.timestamps.length) {
     const startUtc = new Date(raceStart.ts.endsWith('Z') || raceStart.ts.includes('+') ? raceStart.ts : raceStart.ts + 'Z');
@@ -349,7 +351,27 @@ async function loadVakarosOverlay() {
     L.circleMarker(latLng, {
       radius: 9, color: startColor, fillColor: startColor, fillOpacity: 1, weight: 2,
     }).addTo(_map).bindPopup('Vakaros race start \u00b7 ' + startUtc.toISOString());
+
+    // Stash a synthetic "start" row so the maneuvers panel can show it.
+    // loadManeuvers() reads this and merges it after fetching the API.
+    _vakarosSyntheticStart = {
+      id: 'vakaros-race-start',
+      type: 'start',
+      ts: startUtc.toISOString(),
+      source: 'vakaros',
+    };
+    _injectVakarosStartIntoManeuvers();
   }
+}
+
+function _injectVakarosStartIntoManeuvers() {
+  if (!_vakarosSyntheticStart) return;
+  const existing = _maneuvers.find(m => m.id === 'vakaros-race-start');
+  if (existing) return;
+  _maneuvers.push(_vakarosSyntheticStart);
+  _maneuverSelected.add('vakaros-race-start');
+  // Re-sort so the start lands in chronological order.
+  if (typeof renderManeuverCard === 'function') renderManeuverCard();
 }
 
 function _nearestIndex(latlng) {
@@ -2086,7 +2108,7 @@ function renderPolarHeatmap() {
 // Maneuvers
 // ---------------------------------------------------------------------------
 
-const _MANEUVER_COLORS = { tack: cssVar('--accent-strong'), gybe: cssVar('--warning'), rounding: cssVar('--success') };
+const _MANEUVER_COLORS = { tack: cssVar('--accent-strong'), gybe: cssVar('--warning'), rounding: cssVar('--success'), start: cssVar('--success') };
 const _RANK_COLORS = { good: cssVar('--success'), bad: cssVar('--error'), avg: cssVar('--text-secondary') };
 let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distance_loss_m | loss_kts | turn_angle_deg
 let _maneuverFilter = 'all';  // all | tack | gybe | rounding | good | bad
@@ -2117,6 +2139,8 @@ async function loadManeuvers() {
   _maneuvers = await r.json();
   // Default: select all maneuvers for overlay when a new list arrives.
   _maneuverSelected = new Set(_maneuvers.map((m, i) => m.id != null ? m.id : i));
+  // Re-inject the Vakaros race start if the overlay already stashed one.
+  _injectVakarosStartIntoManeuvers();
   renderManeuverCard();
   if (_map && _maneuvers.length) _addManeuverMarkers();
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -354,11 +354,20 @@ async function loadVakarosOverlay() {
 
     // Stash a synthetic "start" row so the maneuvers panel can show it.
     // loadManeuvers() reads this and merges it after fetching the API.
+    const ctx = data.race_start_context || {};
     _vakarosSyntheticStart = {
       id: 'vakaros-race-start',
       type: 'start',
       ts: startUtc.toISOString(),
       source: 'vakaros',
+      // Surface BSP in the "BSP in→out" column — start has no exit, so the
+      // entry_bsp alone is shown.
+      entry_bsp: ctx.bsp_kts != null ? ctx.bsp_kts : null,
+      // Extras for the detail panel below the table.
+      start_sog_kts: ctx.sog_kts != null ? ctx.sog_kts : null,
+      start_distance_to_line_m: ctx.distance_to_line_m != null ? ctx.distance_to_line_m : null,
+      start_lat: ctx.latitude_deg != null ? ctx.latitude_deg : null,
+      start_lon: ctx.longitude_deg != null ? ctx.longitude_deg : null,
     };
     _injectVakarosStartIntoManeuvers();
   }
@@ -2619,6 +2628,21 @@ function _renderManeuverDetail(m) {
   const el = document.getElementById('maneuver-detail');
   if (!el) return;
   if (!m) { el.innerHTML = ''; return; }
+
+  // Special case: Vakaros-sourced race start has its own metric set.
+  if (m.type === 'start' && m.source === 'vakaros') {
+    const rows = [
+      ['BSP at gun', m.entry_bsp != null ? m.entry_bsp.toFixed(2) + ' kt' : '—'],
+      ['SOG at gun', m.start_sog_kts != null ? m.start_sog_kts.toFixed(2) + ' kt' : '—'],
+      ['Distance to line', m.start_distance_to_line_m != null ? m.start_distance_to_line_m.toFixed(1) + ' m' : '—'],
+      ['Polar %', '— (tbd)'],
+    ];
+    el.innerHTML = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
+      + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')
+      + '</div>';
+    return;
+  }
+
   const bspDipLabel = m.loss_kts != null && m.entry_bsp != null && m.min_bsp != null
     ? m.loss_kts.toFixed(2) + ' kt (' + m.entry_bsp.toFixed(1) + '→' + m.min_bsp.toFixed(1) + ')'
     : (m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt' : '—');

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -362,16 +362,20 @@ async function loadVakarosOverlay() {
     const latLng = [lp.latitude_deg, lp.longitude_deg];
     const color = lp.line_type === 'pin' ? pinColor : boatColor;
     const label = lp.line_type === 'pin' ? 'Pin' : 'Committee boat';
+    const tip = 'Vakaros ' + label + ' ping';
     L.circleMarker(latLng, {
       radius: 7, color: color, fillColor: color, fillOpacity: 1, weight: 2,
-    }).addTo(_map).bindPopup('Vakaros ' + label + ' ping');
+    }).addTo(_map).bindTooltip(tip).bindPopup(tip);
   }
 
   // Start line (dashed polyline between the most recent pin and boat pings).
   if (data.line) {
     L.polyline([data.line.pin, data.line.boat], {
       color: pinColor, weight: 3, dashArray: '6, 6', opacity: 0.9,
-    }).addTo(_map).bindPopup('Vakaros start line');
+    })
+      .addTo(_map)
+      .bindTooltip('Vakaros start line', {sticky: true})
+      .bindPopup('Vakaros start line');
 
     // Wind ticks: a short line from each line endpoint pointing UPWIND
     // at the moment of the start gun. Lets you eyeball the bias visually
@@ -386,14 +390,25 @@ async function loadVakarosOverlay() {
       const tws = ctx.tws_kts != null ? ctx.tws_kts.toFixed(1) + ' kt' : '?';
       const popup = 'Wind at gun: ' + twdLabel + ' \u00b7 ' + tws;
       L.polyline([data.line.pin, pinUp], {
-        color: vakarosTrackColor, weight: 2, opacity: 0.85,
-      }).addTo(_map).bindPopup(popup);
+        color: vakarosTrackColor, weight: 3, opacity: 0.9,
+      })
+        .addTo(_map)
+        .bindTooltip(popup, {sticky: true})
+        .bindPopup(popup);
       L.polyline([data.line.boat, boatUp], {
-        color: vakarosTrackColor, weight: 2, opacity: 0.85,
-      }).addTo(_map).bindPopup(popup);
-      // Small marker at each upwind tip so the direction reads cleanly.
-      L.circleMarker(pinUp, {radius: 3, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1}).addTo(_map);
-      L.circleMarker(boatUp, {radius: 3, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1}).addTo(_map);
+        color: vakarosTrackColor, weight: 3, opacity: 0.9,
+      })
+        .addTo(_map)
+        .bindTooltip(popup, {sticky: true})
+        .bindPopup(popup);
+      // Small marker at each upwind tip so the direction reads cleanly,
+      // and so there's a generous hover target at the end of each tick.
+      L.circleMarker(pinUp, {
+        radius: 4, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1,
+      }).addTo(_map).bindTooltip(popup);
+      L.circleMarker(boatUp, {
+        radius: 4, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1,
+      }).addTo(_map).bindTooltip(popup);
     }
 
     // Line info panel below the map.
@@ -458,9 +473,10 @@ async function loadVakarosOverlay() {
       if (d < minDelta) { minDelta = d; nearestIdx = i; }
     }
     const latLng = _trackData.latLngs[nearestIdx];
+    const startTip = 'Vakaros race start \u00b7 ' + startUtc.toISOString();
     L.circleMarker(latLng, {
       radius: 9, color: startColor, fillColor: startColor, fillOpacity: 1, weight: 2,
-    }).addTo(_map).bindPopup('Vakaros race start \u00b7 ' + startUtc.toISOString());
+    }).addTo(_map).bindTooltip(startTip).bindPopup(startTip);
 
     // Stash a synthetic "start" row so the maneuvers panel can show it.
     // loadManeuvers() reads this and merges it after fetching the API.

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -433,6 +433,12 @@ async function loadVakarosOverlay() {
       start_distance_to_line_m: ctx.distance_to_line_m != null ? ctx.distance_to_line_m : null,
       start_lat: ctx.latitude_deg != null ? ctx.latitude_deg : null,
       start_lon: ctx.longitude_deg != null ? ctx.longitude_deg : null,
+      start_tws_kts: ctx.tws_kts != null ? ctx.tws_kts : null,
+      start_twd_deg: ctx.twd_deg != null ? ctx.twd_deg : null,
+      start_twa_deg: ctx.twa_deg != null ? ctx.twa_deg : null,
+      start_polar_pct: ctx.polar_pct != null ? ctx.polar_pct : null,
+      start_line_bias_deg: ctx.line_bias_deg != null ? ctx.line_bias_deg : null,
+      start_favored_end: ctx.favored_end || null,
     };
     _injectVakarosStartIntoManeuvers();
   }
@@ -2731,11 +2737,21 @@ function _renderManeuverDetail(m) {
 
   // Special case: Vakaros-sourced race start has its own metric set.
   if (m.type === 'start' && m.source === 'vakaros') {
+    let biasLabel = '—';
+    if (m.start_line_bias_deg != null) {
+      const mag = Math.abs(m.start_line_bias_deg).toFixed(1);
+      const end = m.start_favored_end || 'square';
+      biasLabel = end === 'square' ? 'square' : (mag + '° favoring ' + end);
+    }
     const rows = [
       ['BSP at gun', m.entry_bsp != null ? m.entry_bsp.toFixed(2) + ' kt' : '—'],
       ['SOG at gun', m.start_sog_kts != null ? m.start_sog_kts.toFixed(2) + ' kt' : '—'],
       ['Distance to line', m.start_distance_to_line_m != null ? m.start_distance_to_line_m.toFixed(1) + ' m' : '—'],
-      ['Polar %', '— (tbd)'],
+      ['Polar %', m.start_polar_pct != null ? m.start_polar_pct.toFixed(0) + '%' : '—'],
+      ['TWS', m.start_tws_kts != null ? m.start_tws_kts.toFixed(1) + ' kt' : '—'],
+      ['TWD', m.start_twd_deg != null ? Math.round(m.start_twd_deg) + '°' : '—'],
+      ['TWA', m.start_twa_deg != null ? Math.round(m.start_twa_deg) + '°' : '—'],
+      ['Line bias', biasLabel],
     ];
     el.innerHTML = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
       + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -91,6 +91,17 @@ let _vakarosSyntheticStart = null; // {ts, source} placeholder injected from VKX
 // running.
 const _LARGE_JUMP_SEC = 2.0;
 
+// Project a (lat, lon) point along a true-north bearing for a given distance
+// in meters. Equirectangular approximation — accurate to ~1 m at race scale.
+function _offsetPoint(lat, lon, bearingDeg, distM) {
+  const br = bearingDeg * Math.PI / 180;
+  const dy = distM * Math.cos(br);
+  const dx = distM * Math.sin(br);
+  const newLat = lat + dy / 111320;
+  const newLon = lon + dx / (111320 * Math.cos(lat * Math.PI / 180));
+  return [newLat, newLon];
+}
+
 // Transcript auto-follow state. The transcript container scrolls itself to
 // keep the active segment visible, but if the user scrolls manually we
 // disable that until they click a segment (which re-anchors).
@@ -362,13 +373,47 @@ async function loadVakarosOverlay() {
       color: pinColor, weight: 3, dashArray: '6, 6', opacity: 0.9,
     }).addTo(_map).bindPopup('Vakaros start line');
 
+    // Wind ticks: a short line from each line endpoint pointing UPWIND
+    // at the moment of the start gun. Lets you eyeball the bias visually
+    // — if both ticks make the same angle with the start line, the line
+    // is square; otherwise the more-perpendicular end is favoured.
+    const ctx = data.race_start_context;
+    if (ctx && ctx.twd_deg != null) {
+      const tickLen = Math.max(60, (data.line.length_m || 0) * 0.6);
+      const pinUp = _offsetPoint(data.line.pin[0], data.line.pin[1], ctx.twd_deg, tickLen);
+      const boatUp = _offsetPoint(data.line.boat[0], data.line.boat[1], ctx.twd_deg, tickLen);
+      const twdLabel = Math.round(ctx.twd_deg) + '\u00b0';
+      const tws = ctx.tws_kts != null ? ctx.tws_kts.toFixed(1) + ' kt' : '?';
+      const popup = 'Wind at gun: ' + twdLabel + ' \u00b7 ' + tws;
+      L.polyline([data.line.pin, pinUp], {
+        color: vakarosTrackColor, weight: 2, opacity: 0.85,
+      }).addTo(_map).bindPopup(popup);
+      L.polyline([data.line.boat, boatUp], {
+        color: vakarosTrackColor, weight: 2, opacity: 0.85,
+      }).addTo(_map).bindPopup(popup);
+      // Small marker at each upwind tip so the direction reads cleanly.
+      L.circleMarker(pinUp, {radius: 3, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1}).addTo(_map);
+      L.circleMarker(boatUp, {radius: 3, color: vakarosTrackColor, fillColor: vakarosTrackColor, fillOpacity: 1, weight: 1}).addTo(_map);
+    }
+
     // Line info panel below the map.
     const infoEl = document.getElementById('vakaros-line-info');
     if (infoEl) {
       const bearing = data.line.bearing_deg.toFixed(1).padStart(5, '0');
-      infoEl.textContent =
-        'Start line: ' + data.line.length_m.toFixed(1) + ' m \u00b7 ' +
+      let txt = 'Start line: ' + data.line.length_m.toFixed(1) + ' m \u00b7 ' +
         bearing + '\u00b0 T (pin \u2192 boat)';
+      if (ctx && ctx.twd_deg != null) {
+        txt += ' \u00b7 wind ' + Math.round(ctx.twd_deg) + '\u00b0 T';
+      }
+      if (ctx && ctx.line_bias_deg != null && ctx.favored_end) {
+        if (ctx.favored_end === 'square') {
+          txt += ' \u00b7 square';
+        } else {
+          txt += ' \u00b7 ' + Math.abs(ctx.line_bias_deg).toFixed(1) +
+            '\u00b0 favoring ' + ctx.favored_end;
+        }
+      }
+      infoEl.textContent = txt;
       infoEl.style.display = '';
     }
   }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -278,9 +278,9 @@ async function loadVakarosOverlay() {
   const pinColor = cssVar('--warning') || '#f59e0b';
   const boatColor = cssVar('--accent-strong') || '#60a5fa';
   const startColor = cssVar('--success') || '#34d399';
+  const vakarosTrackColor = cssVar('--accent') || '#8b5cf6';
 
   // Line-position markers (pin + committee boat pings).
-  const linePoints = {};  // keyed by line_type
   for (const lp of (data.line_positions || [])) {
     const latLng = [lp.latitude_deg, lp.longitude_deg];
     const color = lp.line_type === 'pin' ? pinColor : boatColor;
@@ -288,15 +288,50 @@ async function loadVakarosOverlay() {
     L.circleMarker(latLng, {
       radius: 7, color: color, fillColor: color, fillOpacity: 1, weight: 2,
     }).addTo(_map).bindPopup('Vakaros ' + label + ' ping');
-    // Keep only the most recent ping of each type for drawing the line.
-    linePoints[lp.line_type] = latLng;
   }
 
-  // Start line (dashed polyline between pin and boat).
-  if (linePoints.pin && linePoints.boat) {
-    L.polyline([linePoints.pin, linePoints.boat], {
+  // Start line (dashed polyline between the most recent pin and boat pings).
+  if (data.line) {
+    L.polyline([data.line.pin, data.line.boat], {
       color: pinColor, weight: 3, dashArray: '6, 6', opacity: 0.9,
     }).addTo(_map).bindPopup('Vakaros start line');
+
+    // Line info panel below the map.
+    const infoEl = document.getElementById('vakaros-line-info');
+    if (infoEl) {
+      const bearing = data.line.bearing_deg.toFixed(1).padStart(5, '0');
+      infoEl.textContent =
+        'Start line: ' + data.line.length_m.toFixed(1) + ' m \u00b7 ' +
+        bearing + '\u00b0 T (pin \u2192 boat)';
+      infoEl.style.display = '';
+    }
+  }
+
+  // Vakaros track polyline — drawn but hidden by default.  A checkbox above
+  // the map lets the user toggle SK vs Vakaros track independently.
+  let vakarosLine = null;
+  if (data.track && data.track.geometry && data.track.geometry.coordinates.length) {
+    const vakLatLngs = data.track.geometry.coordinates.map(c => [c[1], c[0]]);
+    vakarosLine = L.polyline(vakLatLngs, {
+      color: vakarosTrackColor, weight: 3, opacity: 0.85, dashArray: '2, 4',
+    }).bindPopup('Vakaros track');
+    // Reveal the selector now that there's something to toggle.
+    const selector = document.getElementById('vakaros-track-toggle');
+    if (selector) selector.style.display = '';
+    const vkBox = document.getElementById('toggle-vakaros-track');
+    const skBox = document.getElementById('toggle-sk-track');
+    if (vkBox) {
+      vkBox.addEventListener('change', function() {
+        if (vkBox.checked) { vakarosLine.addTo(_map); }
+        else { _map.removeLayer(vakarosLine); }
+      });
+    }
+    if (skBox && _trackData && _trackData.line) {
+      skBox.addEventListener('change', function() {
+        if (skBox.checked) { _trackData.line.addTo(_map); }
+        else { _map.removeLayer(_trackData.line); }
+      });
+    }
   }
 
   // Race-start marker on the SK track, positioned at the point closest in time

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -259,6 +259,62 @@ async function loadTrack() {
 
   _map.fitBounds(line.getBounds(), {padding: [20, 20]});
   document.getElementById('track-hint').textContent = 'Click track to seek \u00b7 Right-click to start a discussion at that point';
+
+  // #458 — if a matched Vakaros session exists, overlay start line, line pings,
+  // and race-start marker on top of the SK track.
+  try {
+    await loadVakarosOverlay();
+  } catch (err) {
+    console.warn('Vakaros overlay failed to load:', err);
+  }
+}
+
+async function loadVakarosOverlay() {
+  const r = await fetch('/api/sessions/' + SESSION_ID + '/vakaros-overlay');
+  if (!r.ok) return;
+  const data = await r.json();
+  if (!data || !data.matched) return;
+
+  const pinColor = cssVar('--warning') || '#f59e0b';
+  const boatColor = cssVar('--accent-strong') || '#60a5fa';
+  const startColor = cssVar('--success') || '#34d399';
+
+  // Line-position markers (pin + committee boat pings).
+  const linePoints = {};  // keyed by line_type
+  for (const lp of (data.line_positions || [])) {
+    const latLng = [lp.latitude_deg, lp.longitude_deg];
+    const color = lp.line_type === 'pin' ? pinColor : boatColor;
+    const label = lp.line_type === 'pin' ? 'Pin' : 'Committee boat';
+    L.circleMarker(latLng, {
+      radius: 7, color: color, fillColor: color, fillOpacity: 1, weight: 2,
+    }).addTo(_map).bindPopup('Vakaros ' + label + ' ping');
+    // Keep only the most recent ping of each type for drawing the line.
+    linePoints[lp.line_type] = latLng;
+  }
+
+  // Start line (dashed polyline between pin and boat).
+  if (linePoints.pin && linePoints.boat) {
+    L.polyline([linePoints.pin, linePoints.boat], {
+      color: pinColor, weight: 3, dashArray: '6, 6', opacity: 0.9,
+    }).addTo(_map).bindPopup('Vakaros start line');
+  }
+
+  // Race-start marker on the SK track, positioned at the point closest in time
+  // to the RACE_START event.
+  const raceStart = (data.race_events || []).find(e => e.event_type === 'race_start');
+  if (raceStart && _trackData && _trackData.timestamps.length) {
+    const startUtc = new Date(raceStart.ts.endsWith('Z') || raceStart.ts.includes('+') ? raceStart.ts : raceStart.ts + 'Z');
+    let nearestIdx = 0;
+    let minDelta = Infinity;
+    for (let i = 0; i < _trackData.timestamps.length; i++) {
+      const d = Math.abs(_trackData.timestamps[i] - startUtc);
+      if (d < minDelta) { minDelta = d; nearestIdx = i; }
+    }
+    const latLng = _trackData.latLngs[nearestIdx];
+    L.circleMarker(latLng, {
+      radius: 9, color: startColor, fillColor: startColor, fillOpacity: 1, weight: 2,
+    }).addTo(_map).bindPopup('Vakaros race start \u00b7 ' + startUtc.toISOString());
+  }
 }
 
 function _nearestIndex(latlng) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -102,6 +102,39 @@ function _offsetPoint(lat, lon, bearingDeg, distM) {
   return [newLat, newLon];
 }
 
+// Format milliseconds relative to a reference (positive after, negative
+// before) as e.g. "T-5:30" or "T+0:42". Used for line-ping tooltips so the
+// crew can see how long before the gun each end was set.
+function _fmtRelativeToStart(deltaMs) {
+  const sign = deltaMs >= 0 ? '+' : '-';
+  const absS = Math.round(Math.abs(deltaMs) / 1000);
+  const mm = Math.floor(absS / 60);
+  const ss = absS % 60;
+  return 'T' + sign + mm + ':' + String(ss).padStart(2, '0');
+}
+
+// Build a small SVG-based Leaflet divIcon. `opacity` controls the visual
+// saturation/strength so older pings can be drawn dimmer than the active
+// (most recent) one without changing the color hue.
+function _vakarosFlagIcon(color, opacity) {
+  const html = '<div style="opacity:' + opacity + ';transform:translate(-4px,-22px);filter:drop-shadow(0 1px 1px rgba(0,0,0,0.5))">'
+    + '<svg viewBox="0 0 24 26" width="24" height="26" xmlns="http://www.w3.org/2000/svg">'
+    + '<line x1="4" y1="3" x2="4" y2="24" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>'
+    + '<path d="M4 3 L20 8 L4 13 Z" fill="' + color + '" stroke="#fff" stroke-width="1"/>'
+    + '</svg></div>';
+  return L.divIcon({className: 'vakaros-flag', html: html, iconSize: [24, 26], iconAnchor: [4, 22]});
+}
+
+function _vakarosBoatIcon(color, opacity) {
+  const html = '<div style="opacity:' + opacity + ';transform:translate(-14px,-12px);filter:drop-shadow(0 1px 1px rgba(0,0,0,0.5))">'
+    + '<svg viewBox="0 0 28 22" width="28" height="22" xmlns="http://www.w3.org/2000/svg">'
+    + '<line x1="14" y1="12" x2="14" y2="2" stroke="#fff" stroke-width="1.6"/>'
+    + '<path d="M14 4 L22 12 L14 12 Z" fill="' + color + '" stroke="#fff" stroke-width="0.8"/>'
+    + '<path d="M2 12 L26 12 L22 19 L6 19 Z" fill="' + color + '" stroke="#fff" stroke-width="1"/>'
+    + '</svg></div>';
+  return L.divIcon({className: 'vakaros-boat', html: html, iconSize: [28, 22], iconAnchor: [14, 12]});
+}
+
 // Transcript auto-follow state. The transcript container scrolls itself to
 // keep the active segment visible, but if the user scrolls manually we
 // disable that until they click a segment (which re-anchors).
@@ -357,16 +390,43 @@ async function loadVakarosOverlay() {
   const startColor = cssVar('--success') || '#34d399';
   const vakarosTrackColor = cssVar('--accent') || '#8b5cf6';
 
-  // Line-position markers (pin + committee boat pings).
-  for (const lp of (data.line_positions || [])) {
-    const latLng = [lp.latitude_deg, lp.longitude_deg];
-    const color = lp.line_type === 'pin' ? pinColor : boatColor;
-    const label = lp.line_type === 'pin' ? 'Pin' : 'Committee boat';
-    const tip = 'Vakaros ' + label + ' ping';
-    L.circleMarker(latLng, {
-      radius: 7, color: color, fillColor: color, fillOpacity: 1, weight: 2,
-    }).addTo(_map).bindTooltip(tip).bindPopup(tip);
+  // Line-position markers (pin = flag, committee boat = boat icon).
+  // Group by type so we can saturate the most recent of each type at full
+  // strength and dim earlier pings.
+  const linePings = data.line_positions || [];
+  const raceStartCtx = data.race_start_context;
+  const raceStartMs = raceStartCtx && raceStartCtx.ts
+    ? new Date(raceStartCtx.ts.endsWith('Z') || raceStartCtx.ts.includes('+') ? raceStartCtx.ts : raceStartCtx.ts + 'Z').getTime()
+    : null;
+  const byType = {pin: [], boat: []};
+  for (const lp of linePings) {
+    if (byType[lp.line_type]) byType[lp.line_type].push(lp);
   }
+  ['pin', 'boat'].forEach(function(type) {
+    const pings = byType[type];
+    pings.forEach(function(lp, idx) {
+      const isLatest = idx === pings.length - 1;
+      const opacity = isLatest ? 1.0 : 0.4;
+      const color = type === 'pin' ? pinColor : boatColor;
+      const label = type === 'pin' ? 'Pin' : 'Committee boat';
+      const icon = type === 'pin'
+        ? _vakarosFlagIcon(color, opacity)
+        : _vakarosBoatIcon(color, opacity);
+      // Tooltip + popup: when this ping was set, relative to race start.
+      const lpMs = new Date(lp.ts.endsWith('Z') || lp.ts.includes('+') ? lp.ts : lp.ts + 'Z').getTime();
+      let tip = 'Vakaros ' + label + ' ping';
+      if (raceStartMs != null) {
+        tip += ' \u00b7 ' + _fmtRelativeToStart(lpMs - raceStartMs);
+      }
+      if (!isLatest) tip += ' (earlier)';
+      const marker = L.marker([lp.latitude_deg, lp.longitude_deg], {icon: icon})
+        .addTo(_map)
+        .bindTooltip(tip)
+        .bindPopup(tip);
+      // Push the active (latest) ping to the top of the z-order.
+      if (isLatest && marker.setZIndexOffset) marker.setZIndexOffset(500);
+    });
+  });
 
   // Start line (dashed polyline between the most recent pin and boat pings).
   if (data.line) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -84,6 +84,71 @@ function _stopPlayTick() {
 let _maneuvers = []; // loaded maneuver list
 let _maneuverMarkers = []; // Leaflet markers for maneuvers
 let _vakarosSyntheticStart = null; // {ts, source} placeholder injected from VKX
+
+// Cross-surface seek behaviour: if a render() call moves the playhead by more
+// than this many seconds, treat it as a user-initiated jump and pause any
+// currently-playing media. Small deltas (playback ticks) keep the media
+// running.
+const _LARGE_JUMP_SEC = 2.0;
+
+// Transcript auto-follow state. The transcript container scrolls itself to
+// keep the active segment visible, but if the user scrolls manually we
+// disable that until they click a segment (which re-anchors).
+let _transcriptFollow = true;
+let _lastTranscriptProgrammaticScrollAt = 0;
+
+// Scroll the transcript container so the active segment is visible — without
+// ever calling scrollIntoView() (which can jerk the whole page when the
+// container itself isn't fully in view). Returns true if a scroll happened.
+function _scrollTranscriptSegmentIntoView(container, el) {
+  if (!_transcriptFollow) return false;
+  const margin = 4;
+  const top = el.offsetTop - margin;
+  const bottom = el.offsetTop + el.offsetHeight + margin;
+  let target = null;
+  if (top < container.scrollTop) {
+    target = top;
+  } else if (bottom > container.scrollTop + container.clientHeight) {
+    target = bottom - container.clientHeight;
+  }
+  if (target == null) return false;
+  _lastTranscriptProgrammaticScrollAt = Date.now();
+  container.scrollTop = Math.max(0, target);
+  return true;
+}
+
+function _wireTranscriptScrollListener() {
+  const container = document.getElementById('transcript-segments');
+  if (!container || container._scrollWired) return;
+  container._scrollWired = true;
+  container.addEventListener('scroll', function() {
+    // Ignore the scroll events we triggered ourselves.
+    if (Date.now() - _lastTranscriptProgrammaticScrollAt < 400) return;
+    if (_transcriptFollow) {
+      _transcriptFollow = false;
+      _renderTranscriptFollowBadge();
+    }
+  });
+}
+
+function _renderTranscriptFollowBadge() {
+  const btn = document.getElementById('transcript-follow-btn');
+  if (!btn) return;
+  if (_transcriptFollow) {
+    btn.textContent = '\u25C9 Follow';
+    btn.style.opacity = '1';
+    btn.title = 'Auto-scrolling to active segment. Click to pause.';
+  } else {
+    btn.textContent = '\u25CB Follow';
+    btn.style.opacity = '0.55';
+    btn.title = 'Auto-scroll paused (you scrolled manually). Click to resume.';
+  }
+}
+
+function toggleTranscriptFollow() {
+  _transcriptFollow = !_transcriptFollow;
+  _renderTranscriptFollowBadge();
+}
 let _transcriptId = null; // transcript ID for tuning extraction
 let _tuningSegmentAudio = null; // shared <audio> for segment playback
 let _tuningSegmentTimer = null; // timeupdate stop timer
@@ -524,12 +589,31 @@ function _openWatchOnYoutube(ev) {
 }
 
 function _onVideoReady() {
-  // Video is a consumer: seek to the requested UTC if it's within range
+  // Video is a consumer: seek to the requested UTC if it's within range.
+  // Large jumps (>2 s) pause the player so audio doesn't keep playing from
+  // wherever the user just clicked. Small deltas (playback ticks) don't
+  // touch playback state.
   registerSurface('video', function(utc) {
     if (!_videoSync || !_videoSync.player || !_videoSync.player.seekTo) return;
     const offset = _utcToVideoOffset(utc);
     if (offset === null || offset < 0) return;
     if (_videoSync.durationS && offset > _videoSync.durationS) return;
+    let currentOffset = null;
+    try {
+      if (typeof _videoSync.player.getCurrentTime === 'function') {
+        currentOffset = _videoSync.player.getCurrentTime();
+      }
+    } catch (e) { /* swallow */ }
+    if (currentOffset != null && Math.abs(currentOffset - offset) > _LARGE_JUMP_SEC) {
+      try {
+        const state = typeof _videoSync.player.getPlayerState === 'function'
+          ? _videoSync.player.getPlayerState() : -1;
+        // YT.PlayerState.PLAYING = 1
+        if (state === 1 && typeof _videoSync.player.pauseVideo === 'function') {
+          _videoSync.player.pauseVideo();
+        }
+      } catch (e) { /* swallow */ }
+    }
     _videoSync.player.seekTo(offset, true);
   });
 }
@@ -1251,7 +1335,13 @@ function _renderDiarizedTranscript(body, t) {
     return rawLabel;
   };
 
-  body.innerHTML = '<div id="transcript-segments" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
+  body.innerHTML = ''
+    + '<div style="display:flex;justify-content:flex-end;margin-bottom:6px">'
+    + '<button id="transcript-follow-btn" type="button" onclick="toggleTranscriptFollow()" '
+    + 'style="font-size:.7rem;padding:2px 8px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" '
+    + 'title="Auto-scrolling to active segment. Click to pause.">\u25C9 Follow</button>'
+    + '</div>'
+    + '<div id="transcript-segments" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
     + blocks.map((b, i) =>
       '<div class="transcript-seg" data-idx="' + i + '" style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;transition:background .15s" onclick="playTranscriptSegment(' + i + ')">'
       + '<span class="transcript-speaker" data-speaker="' + esc(b.speaker) + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" onclick="event.stopPropagation();openSpeakerPicker(\'' + esc(b.speaker) + '\')" title="Click to assign crew">' + esc(displayName(b.speaker)) + '</span>'
@@ -1264,6 +1354,8 @@ function _renderDiarizedTranscript(body, t) {
   // Register the diarized transcript as a playback-clock surface so it
   // highlights the active segment in sync with audio/video/map (#446).
   _registerTranscriptSurface();
+  _wireTranscriptScrollListener();
+  _renderTranscriptFollowBadge();
 }
 
 let _transcriptSurfaceRegistered = false;
@@ -1287,9 +1379,7 @@ function _registerTranscriptSurface() {
       if (local >= b.start && local <= b.end) {
         el.style.background = 'var(--bg-hover, rgba(255,255,255,0.08))';
         const container = document.getElementById('transcript-segments');
-        if (container && (el.offsetTop < container.scrollTop || el.offsetTop + el.offsetHeight > container.scrollTop + container.clientHeight)) {
-          el.scrollIntoView({behavior: 'smooth', block: 'nearest'});
-        }
+        if (container) _scrollTranscriptSegmentIntoView(container, el);
       } else {
         el.style.background = '';
       }
@@ -1300,6 +1390,12 @@ function _registerTranscriptSurface() {
 function playTranscriptSegment(idx) {
   const b = _transcriptBlocks[idx];
   if (!b) return;
+  // Clicking a segment is a strong "I want to follow this" signal —
+  // re-enable auto-scroll if the user had paused it.
+  if (!_transcriptFollow) {
+    _transcriptFollow = true;
+    _renderTranscriptFollowBadge();
+  }
   // Route through the playback clock so video and map follow too.
   if (_session && _session.audio_start_utc) {
     const audioStart = new Date(
@@ -1419,11 +1515,18 @@ function loadAudio() {
   const audioLocalToUtc = s => new Date(audioStart.getTime() + s * 1000);
   const utcToAudioLocal = utc => (utc.getTime() - audioStart.getTime()) / 1000;
 
-  // Audio is a consumer — seek to the requested UTC if it's within range
+  // Audio is a consumer — seek to the requested UTC if it's within range.
+  // A "large jump" (>2 s away) is treated as a user click, so we pause any
+  // currently-playing audio: it's distracting to have audio keep going from
+  // a new spot just because the user clicked somewhere on the page.
   registerSurface('audio', function(utc) {
     const local = utcToAudioLocal(utc);
     if (local < 0 || (el.duration && local > el.duration)) return;
-    if (Math.abs(el.currentTime - local) < 0.15) return; // already there
+    const delta = Math.abs(el.currentTime - local);
+    if (delta < 0.15) return; // already there
+    if (delta > _LARGE_JUMP_SEC && !el.paused) {
+      try { el.pause(); } catch (e) { /* swallow */ }
+    }
     try { el.currentTime = local; } catch (e) { /* not seekable yet */ }
   });
 
@@ -1468,10 +1571,7 @@ function _highlightTranscriptFromAudio(ev) {
     if (i === activeIdx) {
       segEl.style.background = 'var(--bg-hover, rgba(255,255,255,0.08))';
       const container = document.getElementById('transcript-segments');
-      if (container && (segEl.offsetTop < container.scrollTop
-          || segEl.offsetTop + segEl.offsetHeight > container.scrollTop + container.clientHeight)) {
-        segEl.scrollIntoView({behavior: 'smooth', block: 'nearest'});
-      }
+      if (container) _scrollTranscriptSegmentIntoView(container, segEl);
     } else {
       segEl.style.background = '';
     }

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7975,8 +7975,16 @@ class Storage:
                 "track": GeoJSON Feature (LineString, [lon, lat] order) | None,
                 "line_positions": [{"line_type": "pin"|"boat", ...}, ...],
                 "race_events": [{"ts", "event_type", "timer_value_s"}, ...],
+                "line": {"pin": [lat, lon], "boat": [lat, lon],
+                         "length_m": float, "bearing_deg": float} | None,
             }
+
+        `line` is computed from the most recent pin + boat pings and is
+        ``None`` when either endpoint is missing.  Bearing is the compass
+        bearing from pin to boat in degrees true [0, 360).
         """
+        import math
+
         db = self._read_conn()
         cur = await db.execute(
             "SELECT id FROM vakaros_sessions WHERE matched_race_id = ? LIMIT 1",
@@ -8022,11 +8030,45 @@ class Storage:
         )
         race_events = [dict(r) for r in await evt_cur.fetchall()]
 
+        # Compute the current line from the most recent pin + boat pings.
+        latest_pin: dict[str, Any] | None = None
+        latest_boat: dict[str, Any] | None = None
+        for lp in line_positions:  # already ordered by ts ascending
+            if lp["line_type"] == "pin":
+                latest_pin = lp
+            elif lp["line_type"] == "boat":
+                latest_boat = lp
+
+        line: dict[str, Any] | None = None
+        if latest_pin is not None and latest_boat is not None:
+            lat1 = math.radians(latest_pin["latitude_deg"])
+            lon1 = math.radians(latest_pin["longitude_deg"])
+            lat2 = math.radians(latest_boat["latitude_deg"])
+            lon2 = math.radians(latest_boat["longitude_deg"])
+            dlat = lat2 - lat1
+            dlon = lon2 - lon1
+            # Haversine
+            a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+            length_m = 2 * 6371000.0 * math.asin(math.sqrt(a))
+            # Initial bearing pin -> boat
+            y = math.sin(dlon) * math.cos(lat2)
+            x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
+            bearing_deg = (math.degrees(math.atan2(y, x)) + 360.0) % 360.0
+            line = {
+                "pin": [latest_pin["latitude_deg"], latest_pin["longitude_deg"]],
+                "boat": [latest_boat["latitude_deg"], latest_boat["longitude_deg"]],
+                "length_m": round(length_m, 1),
+                "bearing_deg": round(bearing_deg, 1),
+                "pin_set_at": latest_pin["ts"],
+                "boat_set_at": latest_boat["ts"],
+            }
+
         return {
             "vakaros_session_id": vakaros_id,
             "track": track,
             "line_positions": line_positions,
             "race_events": race_events,
+            "line": line,
         }
 
     async def list_vakaros_sessions(self) -> list[dict[str, Any]]:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from helmlog.audio import AudioSession
     from helmlog.external import TideReading, WeatherReading
     from helmlog.races import Race
+    from helmlog.vakaros import VakarosSession
 
 from helmlog.nmea2000 import (
     COGSOGRecord,
@@ -131,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 58
+_CURRENT_VERSION: int = 59
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1303,6 +1304,64 @@ _MIGRATIONS: dict[int, str] = {
             retired_at TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_race_slug_history_race ON race_slug_history(race_id);
+    """,
+    59: """
+        -- Vakaros VKX ingest (#458).  Sessions sourced from a Vakaros Atlas
+        -- via the watched-folder ingest path.  Kept in parallel with races(),
+        -- linked via matched_race_id when session matching finds an overlap.
+        CREATE TABLE IF NOT EXISTS vakaros_sessions (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_hash     TEXT    NOT NULL UNIQUE,
+            source_file     TEXT    NOT NULL,
+            start_utc       TEXT    NOT NULL,
+            end_utc         TEXT    NOT NULL,
+            ingested_at     TEXT    NOT NULL,
+            matched_race_id INTEGER REFERENCES races(id) ON DELETE SET NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_vakaros_sessions_start ON vakaros_sessions(start_utc);
+        CREATE INDEX IF NOT EXISTS idx_vakaros_sessions_match ON vakaros_sessions(matched_race_id);
+
+        CREATE TABLE IF NOT EXISTS vakaros_positions (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id    INTEGER NOT NULL REFERENCES vakaros_sessions(id) ON DELETE CASCADE,
+            ts            TEXT    NOT NULL,
+            latitude_deg  REAL    NOT NULL,
+            longitude_deg REAL    NOT NULL,
+            sog_mps       REAL    NOT NULL,
+            cog_deg       REAL    NOT NULL,
+            altitude_m    REAL
+        );
+        CREATE INDEX IF NOT EXISTS idx_vakaros_positions_session
+            ON vakaros_positions(session_id, ts);
+
+        CREATE TABLE IF NOT EXISTS vakaros_line_positions (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id    INTEGER NOT NULL REFERENCES vakaros_sessions(id) ON DELETE CASCADE,
+            ts            TEXT    NOT NULL,
+            line_type     TEXT    NOT NULL,  -- 'pin' or 'boat'
+            latitude_deg  REAL    NOT NULL,
+            longitude_deg REAL    NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_vakaros_line_session ON vakaros_line_positions(session_id);
+
+        CREATE TABLE IF NOT EXISTS vakaros_race_events (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id     INTEGER NOT NULL REFERENCES vakaros_sessions(id) ON DELETE CASCADE,
+            ts             TEXT    NOT NULL,
+            event_type     TEXT    NOT NULL,  -- 'reset'|'start'|'sync'|'race_start'|'race_end'
+            timer_value_s  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_vakaros_events_session
+            ON vakaros_race_events(session_id, ts);
+
+        CREATE TABLE IF NOT EXISTS vakaros_winds (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id     INTEGER NOT NULL REFERENCES vakaros_sessions(id) ON DELETE CASCADE,
+            ts             TEXT    NOT NULL,
+            direction_deg  REAL    NOT NULL,
+            speed_mps      REAL    NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_vakaros_winds_session ON vakaros_winds(session_id, ts);
     """,
 }
 
@@ -7784,6 +7843,118 @@ class Storage:
                 return float(ctrl["tolerance_mm"])
         val = await self.get_aruco_setting("tolerance_mm_default")
         return float(val) if val else 5.0
+
+    # ------------------------------------------------------------------
+    # Vakaros VKX ingest (#458)
+    # ------------------------------------------------------------------
+
+    async def store_vakaros_session(self, session: VakarosSession) -> int:
+        """Insert a parsed Vakaros session and all its child rows.
+
+        Idempotent on `source_hash` — if a session with the same hash
+        already exists, returns that session's id without reinserting.
+        Writes session + children in a single transaction.
+        """
+        from datetime import UTC
+        from datetime import datetime as _datetime
+
+        db = self._conn()
+        cur = await db.execute(
+            "SELECT id FROM vakaros_sessions WHERE source_hash = ?",
+            (session.source_hash,),
+        )
+        existing = await cur.fetchone()
+        if existing is not None:
+            return int(existing["id"])
+
+        ingested_at = _datetime.now(UTC).isoformat()
+        cur = await db.execute(
+            "INSERT INTO vakaros_sessions "
+            "(source_hash, source_file, start_utc, end_utc, ingested_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                session.source_hash,
+                session.source_file,
+                session.start_utc.isoformat(),
+                session.end_utc.isoformat(),
+                ingested_at,
+            ),
+        )
+        session_id = cur.lastrowid
+        if session_id is None:
+            await db.rollback()
+            raise RuntimeError("Failed to insert vakaros_sessions row")
+
+        if session.positions:
+            await db.executemany(
+                "INSERT INTO vakaros_positions "
+                "(session_id, ts, latitude_deg, longitude_deg, sog_mps, cog_deg, altitude_m) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        session_id,
+                        p.timestamp.isoformat(),
+                        p.latitude_deg,
+                        p.longitude_deg,
+                        p.sog_mps,
+                        p.cog_deg,
+                        p.altitude_m,
+                    )
+                    for p in session.positions
+                ],
+            )
+        if session.line_positions:
+            await db.executemany(
+                "INSERT INTO vakaros_line_positions "
+                "(session_id, ts, line_type, latitude_deg, longitude_deg) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (
+                        session_id,
+                        lp.timestamp.isoformat(),
+                        lp.line_type.name.lower(),
+                        lp.latitude_deg,
+                        lp.longitude_deg,
+                    )
+                    for lp in session.line_positions
+                ],
+            )
+        if session.race_events:
+            await db.executemany(
+                "INSERT INTO vakaros_race_events "
+                "(session_id, ts, event_type, timer_value_s) VALUES (?, ?, ?, ?)",
+                [
+                    (
+                        session_id,
+                        e.timestamp.isoformat(),
+                        e.event_type.name.lower(),
+                        e.timer_value_s,
+                    )
+                    for e in session.race_events
+                ],
+            )
+        if session.winds:
+            await db.executemany(
+                "INSERT INTO vakaros_winds "
+                "(session_id, ts, direction_deg, speed_mps) VALUES (?, ?, ?, ?)",
+                [
+                    (
+                        session_id,
+                        w.timestamp.isoformat(),
+                        w.direction_deg,
+                        w.speed_mps,
+                    )
+                    for w in session.winds
+                ],
+            )
+        await db.commit()
+        return int(session_id)
+
+    async def delete_vakaros_session(self, session_id: int) -> None:
+        """Delete a Vakaros session and all its child rows (cascade)."""
+        db = self._conn()
+        await db.execute("DELETE FROM vakaros_sessions WHERE id = ?", (session_id,))
+        await db.commit()
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -8136,13 +8136,15 @@ class Storage:
     ) -> dict[str, Any] | None:
         """Build a per-race snapshot of the boat's state at the race-start gun.
 
-        Used by the session detail page to show boat speed and distance to
-        the start line at the moment the Vakaros race_start event fires.
-        Returns ``None`` if there's no race_start event at all; otherwise a
-        dict with the event ts and nullable bsp/sog/position/distance_to_line
-        so the UI can render partial data.
+        Used by the session detail page to show boat speed, distance to the
+        start line, polar %, and wind-relative line bias at the moment the
+        Vakaros race_start event fires.  Returns ``None`` if there's no
+        race_start event at all; otherwise a dict with the event ts and
+        nullable per-field values so the UI can render partial data.
         """
         import math
+
+        from helmlog.polar import _compute_twa, lookup_polar
 
         race_start_event: dict[str, Any] | None = None
         for e in race_events:
@@ -8170,16 +8172,42 @@ class Storage:
         speed_row = await _nearest("speeds", "ts, speed_kts")
         sog_row = await _nearest("cogsog", "ts, sog_kts")
         pos_row = await _nearest("positions", "ts, latitude_deg, longitude_deg")
+        head_row = await _nearest("headings", "ts, heading_deg")
+        wind_row = await _nearest("winds", "ts, wind_speed_kts, wind_angle_deg, reference")
 
         bsp_kts = float(speed_row["speed_kts"]) if speed_row else None
         sog_kts = float(sog_row["sog_kts"]) if sog_row else None
         lat = float(pos_row["latitude_deg"]) if pos_row else None
         lon = float(pos_row["longitude_deg"]) if pos_row else None
+        heading_deg = float(head_row["heading_deg"]) if head_row else None
 
+        # Wind: TWS, TWD (when north-referenced), and TWA via polar's helper.
+        tws_kts: float | None = None
+        twd_deg: float | None = None
+        twa_deg: float | None = None
+        if wind_row is not None:
+            tws_kts = float(wind_row["wind_speed_kts"])
+            wind_angle = float(wind_row["wind_angle_deg"])
+            wind_ref = int(wind_row["reference"])
+            twa_deg = _compute_twa(wind_angle, wind_ref, heading_deg)
+            # reference=4 → wind_angle IS TWD; reference=0 → derive from heading.
+            if wind_ref == 4:
+                twd_deg = wind_angle
+            elif wind_ref == 0 and heading_deg is not None:
+                twd_deg = (heading_deg + wind_angle) % 360.0
+
+        # Polar %: actual BSP / target BSP at the (TWS, TWA) cell.
+        polar_pct: float | None = None
+        if bsp_kts is not None and tws_kts is not None and twa_deg is not None:
+            polar_row = await lookup_polar(self, tws_kts, twa_deg)
+            if polar_row is not None:
+                target = float(polar_row["p90_bsp"])
+                if target > 0:
+                    polar_pct = round(bsp_kts / target * 100.0, 1)
+
+        # Distance to line: perpendicular from boat position to the line.
         distance_to_line_m: float | None = None
         if line is not None and lat is not None and lon is not None:
-            # Local equirectangular projection centered on the pin: small
-            # distances → ~meter accuracy, no great-circle nonsense.
             pin_lat, pin_lon = line["pin"]
             boat_end_lat, boat_end_lon = line["boat"]
             lat_rad = math.radians(pin_lat)
@@ -8191,9 +8219,43 @@ class Storage:
             py = (lat - pin_lat) * m_per_deg_lat
             seg_len = math.hypot(vx, vy)
             if seg_len > 0:
-                # Perpendicular distance from point to the infinite line
-                # through pin-boat. (Using |cross| / |v|.)
                 distance_to_line_m = round(abs(vx * py - vy * px) / seg_len, 1)
+
+        # Wind-relative line bias.
+        # The "square" line is perpendicular to the wind direction (TWD).
+        # We measure the line bearing pin→boat against TWD; the offset from
+        # square tells you which end is favoured.
+        #
+        # Convention here:
+        #   bias_deg = (line_bearing_pin_to_boat - TWD - 90) wrapped to [-90, 90]
+        #     0          → square (no bias)
+        #     positive   → boat end favoured (line tilted toward downwind on
+        #                  the boat side, so the boat end is closer to wind
+        #                  origin... actually depends; see below)
+        #
+        # Sign convention picked so positive == pin favoured, negative ==
+        # committee-boat favoured. Verified by the test fixture: line at 90°
+        # T, TWD 45° → bias = (90 - 45 - 90) = -45 → wrapped → +45 → pin.
+        line_bias_deg: float | None = None
+        favored_end: str | None = None
+        if line is not None and twd_deg is not None:
+            line_bearing = float(line["bearing_deg"])
+            raw = (line_bearing - twd_deg - 90.0) % 360.0
+            if raw > 180.0:
+                raw -= 360.0
+            # Bring into [-90, 90] (a 180° flip is the same line).
+            if raw > 90.0:
+                raw -= 180.0
+            elif raw < -90.0:
+                raw += 180.0
+            # Make positive == pin favoured.
+            line_bias_deg = round(-raw, 1)
+            if abs(line_bias_deg) < 1.0:
+                favored_end = "square"
+            elif line_bias_deg > 0:
+                favored_end = "pin"
+            else:
+                favored_end = "boat"
 
         return {
             "ts": ts,
@@ -8202,6 +8264,12 @@ class Storage:
             "latitude_deg": lat,
             "longitude_deg": lon,
             "distance_to_line_m": distance_to_line_m,
+            "tws_kts": tws_kts,
+            "twd_deg": twd_deg,
+            "twa_deg": round(twa_deg, 1) if twa_deg is not None else None,
+            "polar_pct": polar_pct,
+            "line_bias_deg": line_bias_deg,
+            "favored_end": favored_end,
         }
 
     async def list_vakaros_sessions(self) -> list[dict[str, Any]]:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7848,6 +7848,16 @@ class Storage:
     # Vakaros VKX ingest (#458)
     # ------------------------------------------------------------------
 
+    async def find_vakaros_session_by_hash(self, source_hash: str) -> int | None:
+        """Return the id of a stored Vakaros session with this hash, or None."""
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT id FROM vakaros_sessions WHERE source_hash = ?",
+            (source_hash,),
+        )
+        row = await cur.fetchone()
+        return int(row["id"]) if row is not None else None
+
     async def store_vakaros_session(self, session: VakarosSession) -> int:
         """Insert a parsed Vakaros session and all its child rows.
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7966,6 +7966,68 @@ class Storage:
         await db.execute("DELETE FROM vakaros_sessions WHERE id = ?", (session_id,))
         await db.commit()
 
+    async def match_vakaros_session_to_race(self, session_id: int) -> int | None:
+        """Link a Vakaros session to an overlapping race.
+
+        Rule (from the spec): match when time windows overlap by at least
+        50% of the shorter session's duration. Races still in progress
+        (end_utc IS NULL) are never matched.  When multiple races overlap,
+        the one with the highest overlap ratio wins.
+
+        Returns the linked race id, or None if no race qualifies.  The
+        `vakaros_sessions.matched_race_id` column is updated as a side
+        effect so subsequent calls are idempotent.
+        """
+        from datetime import datetime as _datetime
+
+        db = self._conn()
+        cur = await db.execute(
+            "SELECT start_utc, end_utc FROM vakaros_sessions WHERE id = ?",
+            (session_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        v_start = _datetime.fromisoformat(row["start_utc"])
+        v_end = _datetime.fromisoformat(row["end_utc"])
+        v_duration = (v_end - v_start).total_seconds()
+        if v_duration <= 0:
+            return None
+
+        cur = await db.execute(
+            "SELECT id, start_utc, end_utc FROM races "
+            "WHERE end_utc IS NOT NULL "
+            "  AND start_utc < ? AND end_utc > ?",
+            (v_end.isoformat(), v_start.isoformat()),
+        )
+        candidates = await cur.fetchall()
+
+        best_race_id: int | None = None
+        best_ratio: float = 0.0
+        for cand in candidates:
+            r_start = _datetime.fromisoformat(cand["start_utc"])
+            r_end = _datetime.fromisoformat(cand["end_utc"])
+            r_duration = (r_end - r_start).total_seconds()
+            if r_duration <= 0:
+                continue
+            overlap_start = max(v_start, r_start)
+            overlap_end = min(v_end, r_end)
+            overlap_s = (overlap_end - overlap_start).total_seconds()
+            if overlap_s <= 0:
+                continue
+            shorter = min(v_duration, r_duration)
+            ratio = overlap_s / shorter
+            if ratio >= 0.5 and ratio > best_ratio:
+                best_ratio = ratio
+                best_race_id = int(cand["id"])
+
+        await db.execute(
+            "UPDATE vakaros_sessions SET matched_race_id = ? WHERE id = ?",
+            (best_race_id, session_id),
+        )
+        await db.commit()
+        return best_race_id
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7966,6 +7966,69 @@ class Storage:
         await db.execute("DELETE FROM vakaros_sessions WHERE id = ?", (session_id,))
         await db.commit()
 
+    async def get_vakaros_overlay_for_race(self, race_id: int) -> dict[str, Any] | None:
+        """Return the Vakaros overlay payload for a race, or None if unmatched.
+
+        Payload shape:
+            {
+                "vakaros_session_id": int,
+                "track": GeoJSON Feature (LineString, [lon, lat] order) | None,
+                "line_positions": [{"line_type": "pin"|"boat", ...}, ...],
+                "race_events": [{"ts", "event_type", "timer_value_s"}, ...],
+            }
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT id FROM vakaros_sessions WHERE matched_race_id = ? LIMIT 1",
+            (race_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        vakaros_id = int(row["id"])
+
+        pos_cur = await db.execute(
+            "SELECT ts, latitude_deg, longitude_deg, sog_mps, cog_deg "
+            "FROM vakaros_positions WHERE session_id = ? ORDER BY ts",
+            (vakaros_id,),
+        )
+        positions = await pos_cur.fetchall()
+        track: dict[str, Any] | None = None
+        if positions:
+            coords = [[p["longitude_deg"], p["latitude_deg"]] for p in positions]
+            track = {
+                "type": "Feature",
+                "geometry": {"type": "LineString", "coordinates": coords},
+                "properties": {
+                    "vakaros_session_id": vakaros_id,
+                    "points": len(coords),
+                    "timestamps": [p["ts"] for p in positions],
+                    "sog_mps": [p["sog_mps"] for p in positions],
+                    "cog_deg": [p["cog_deg"] for p in positions],
+                },
+            }
+
+        line_cur = await db.execute(
+            "SELECT ts, line_type, latitude_deg, longitude_deg "
+            "FROM vakaros_line_positions WHERE session_id = ? ORDER BY ts",
+            (vakaros_id,),
+        )
+        line_positions = [dict(r) for r in await line_cur.fetchall()]
+
+        evt_cur = await db.execute(
+            "SELECT ts, event_type, timer_value_s "
+            "FROM vakaros_race_events WHERE session_id = ? ORDER BY ts",
+            (vakaros_id,),
+        )
+        race_events = [dict(r) for r in await evt_cur.fetchall()]
+
+        return {
+            "vakaros_session_id": vakaros_id,
+            "track": track,
+            "line_positions": line_positions,
+            "race_events": race_events,
+        }
+
     async def list_vakaros_sessions(self) -> list[dict[str, Any]]:
         """Return all Vakaros sessions with row counts and matched-race name.
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -8173,7 +8173,20 @@ class Storage:
         sog_row = await _nearest("cogsog", "ts, sog_kts")
         pos_row = await _nearest("positions", "ts, latitude_deg, longitude_deg")
         head_row = await _nearest("headings", "ts, heading_deg")
-        wind_row = await _nearest("winds", "ts, wind_speed_kts, wind_angle_deg, reference")
+
+        # Wind: only consider true-wind references (boat-referenced TWA = 0,
+        # north-referenced TWD = 4). Apparent wind (reference = 2) is useless
+        # for polar lookup or wind-relative line bias and would otherwise
+        # poison the nearest-sample query when AWA samples are denser.
+        wind_cur = await db.execute(
+            "SELECT ts, wind_speed_kts, wind_angle_deg, reference FROM winds "
+            "WHERE reference IN (0, 4) "
+            "  AND ABS(strftime('%s', ts) - strftime('%s', ?)) <= 5 "
+            "ORDER BY ABS(strftime('%s', ts) - strftime('%s', ?)) ASC LIMIT 1",
+            (ts, ts),
+        )
+        wind_row_raw = await wind_cur.fetchone()
+        wind_row = dict(wind_row_raw) if wind_row_raw is not None else None
 
         bsp_kts = float(speed_row["speed_kts"]) if speed_row else None
         sog_kts = float(sog_row["sog_kts"]) if sog_row else None

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -132,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 59
+_CURRENT_VERSION: int = 60
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1362,6 +1362,12 @@ _MIGRATIONS: dict[int, str] = {
             speed_mps      REAL    NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_vakaros_winds_session ON vakaros_winds(session_id, ts);
+    """,
+    60: """
+        ALTER TABLE races ADD COLUMN vakaros_session_id INTEGER
+            REFERENCES vakaros_sessions(id) ON DELETE SET NULL;
+        CREATE INDEX IF NOT EXISTS idx_races_vakaros_session
+            ON races(vakaros_session_id);
     """,
 }
 
@@ -7967,7 +7973,7 @@ class Storage:
         await db.commit()
 
     async def get_vakaros_overlay_for_race(self, race_id: int) -> dict[str, Any] | None:
-        """Return the Vakaros overlay payload for a race, or None if unmatched.
+        """Return the Vakaros overlay payload for a race, or None if unlinked.
 
         Payload shape:
             {
@@ -7979,27 +7985,42 @@ class Storage:
                          "length_m": float, "bearing_deg": float} | None,
             }
 
-        `line` is computed from the most recent pin + boat pings and is
-        ``None`` when either endpoint is missing.  Bearing is the compass
-        bearing from pin to boat in degrees true [0, 360).
+        The track is **trimmed to the race's time window** so a short race
+        that shares a Vakaros file with other races doesn't display 2 hours
+        of track. ``line`` is computed from the most recent pin + boat
+        pings (across the whole Vakaros session, not just the race window,
+        so a line set during pre-start is still shown). ``None`` when
+        either endpoint is missing.
         """
         import math
 
         db = self._read_conn()
         cur = await db.execute(
-            "SELECT id FROM vakaros_sessions WHERE matched_race_id = ? LIMIT 1",
+            "SELECT vakaros_session_id, start_utc, end_utc FROM races WHERE id = ?",
             (race_id,),
         )
         row = await cur.fetchone()
-        if row is None:
+        if row is None or row["vakaros_session_id"] is None:
             return None
-        vakaros_id = int(row["id"])
+        vakaros_id = int(row["vakaros_session_id"])
+        race_start = row["start_utc"]
+        race_end = row["end_utc"]
 
-        pos_cur = await db.execute(
-            "SELECT ts, latitude_deg, longitude_deg, sog_mps, cog_deg "
-            "FROM vakaros_positions WHERE session_id = ? ORDER BY ts",
-            (vakaros_id,),
-        )
+        if race_end is None:
+            # Race still in progress — show everything up to now.
+            pos_cur = await db.execute(
+                "SELECT ts, latitude_deg, longitude_deg, sog_mps, cog_deg "
+                "FROM vakaros_positions WHERE session_id = ? AND ts >= ? "
+                "ORDER BY ts",
+                (vakaros_id, race_start),
+            )
+        else:
+            pos_cur = await db.execute(
+                "SELECT ts, latitude_deg, longitude_deg, sog_mps, cog_deg "
+                "FROM vakaros_positions WHERE session_id = ? "
+                "  AND ts >= ? AND ts <= ? ORDER BY ts",
+                (vakaros_id, race_start, race_end),
+            )
         positions = await pos_cur.fetchall()
         track: dict[str, Any] | None = None
         if positions:
@@ -8016,6 +8037,8 @@ class Storage:
                 },
             }
 
+        # Line positions: pull *all* pings (not trimmed to race window) so the
+        # UI can show every line-set event during the Vakaros session.
         line_cur = await db.execute(
             "SELECT ts, line_type, latitude_deg, longitude_deg "
             "FROM vakaros_line_positions WHERE session_id = ? ORDER BY ts",
@@ -8023,21 +8046,51 @@ class Storage:
         )
         line_positions = [dict(r) for r in await line_cur.fetchall()]
 
-        evt_cur = await db.execute(
-            "SELECT ts, event_type, timer_value_s "
-            "FROM vakaros_race_events WHERE session_id = ? ORDER BY ts",
-            (vakaros_id,),
-        )
+        # Race events: trim to the race's window with a 60s buffer on each
+        # side so the RACE_START event (which typically fires at the start
+        # boundary) is included for this race and not the adjacent one.
+        from datetime import datetime as _datetime
+        from datetime import timedelta as _timedelta
+
+        if race_end is not None:
+            evt_start = (_datetime.fromisoformat(race_start) - _timedelta(seconds=60)).isoformat()
+            evt_end = (_datetime.fromisoformat(race_end) + _timedelta(seconds=60)).isoformat()
+            evt_cur = await db.execute(
+                "SELECT ts, event_type, timer_value_s "
+                "FROM vakaros_race_events WHERE session_id = ? "
+                "  AND ts >= ? AND ts <= ? ORDER BY ts",
+                (vakaros_id, evt_start, evt_end),
+            )
+        else:
+            evt_cur = await db.execute(
+                "SELECT ts, event_type, timer_value_s "
+                "FROM vakaros_race_events WHERE session_id = ? AND ts >= ? "
+                "ORDER BY ts",
+                (vakaros_id, race_start),
+            )
         race_events = [dict(r) for r in await evt_cur.fetchall()]
 
-        # Compute the current line from the most recent pin + boat pings.
-        latest_pin: dict[str, Any] | None = None
-        latest_boat: dict[str, Any] | None = None
-        for lp in line_positions:  # already ordered by ts ascending
-            if lp["line_type"] == "pin":
-                latest_pin = lp
-            elif lp["line_type"] == "boat":
-                latest_boat = lp
+        # Line geometry: "the line that was active at the start of this
+        # race" — latest pin + boat pings on or before the race start.
+        # If no pre-race ping exists for a side, fall back to the earliest
+        # post-race ping so the user still sees a line.
+        pre_pin: dict[str, Any] | None = None
+        pre_boat: dict[str, Any] | None = None
+        post_pin: dict[str, Any] | None = None
+        post_boat: dict[str, Any] | None = None
+        for lp in line_positions:  # ordered by ts ascending
+            is_pin = lp["line_type"] == "pin"
+            if lp["ts"] <= race_start:
+                if is_pin:
+                    pre_pin = lp
+                else:
+                    pre_boat = lp
+            elif is_pin and post_pin is None:
+                post_pin = lp
+            elif not is_pin and post_boat is None:
+                post_boat = lp
+        latest_pin = pre_pin or post_pin
+        latest_boat = pre_boat or post_boat
 
         line: dict[str, Any] | None = None
         if latest_pin is not None and latest_boat is not None:
@@ -8072,9 +8125,12 @@ class Storage:
         }
 
     async def list_vakaros_sessions(self) -> list[dict[str, Any]]:
-        """Return all Vakaros sessions with row counts and matched-race name.
+        """Return all Vakaros sessions with row counts and matched races.
 
-        Intended for the admin listing page.  Ordered newest first.
+        Each session carries a ``matched_races`` list: zero or more
+        ``{id, name, start_utc}`` dicts for the races currently linked to
+        it via ``races.vakaros_session_id``.  Ordered newest Vakaros
+        session first.
         """
         db = self._read_conn()
         cur = await db.execute(
@@ -8086,8 +8142,6 @@ class Storage:
                 vs.start_utc,
                 vs.end_utc,
                 vs.ingested_at,
-                vs.matched_race_id,
-                r.name AS matched_race_name,
                 (SELECT COUNT(*) FROM vakaros_positions WHERE session_id = vs.id)
                     AS position_count,
                 (SELECT COUNT(*) FROM vakaros_line_positions WHERE session_id = vs.id)
@@ -8095,24 +8149,46 @@ class Storage:
                 (SELECT COUNT(*) FROM vakaros_race_events WHERE session_id = vs.id)
                     AS event_count
             FROM vakaros_sessions vs
-            LEFT JOIN races r ON r.id = vs.matched_race_id
             ORDER BY vs.start_utc DESC
             """
         )
-        rows = await cur.fetchall()
-        return [dict(r) for r in rows]
+        sessions = [dict(r) for r in await cur.fetchall()]
 
-    async def match_vakaros_session_to_race(self, session_id: int) -> int | None:
-        """Link a Vakaros session to an overlapping race.
+        # One extra query to collect matched race names per session.
+        match_cur = await db.execute(
+            "SELECT id, name, start_utc, vakaros_session_id FROM races "
+            "WHERE vakaros_session_id IS NOT NULL ORDER BY start_utc"
+        )
+        matches_by_session: dict[int, list[dict[str, Any]]] = {}
+        for row in await match_cur.fetchall():
+            sid = int(row["vakaros_session_id"])
+            matches_by_session.setdefault(sid, []).append(
+                {
+                    "id": int(row["id"]),
+                    "name": row["name"],
+                    "start_utc": row["start_utc"],
+                }
+            )
+        for s in sessions:
+            s["matched_races"] = matches_by_session.get(int(s["id"]), [])
+        return sessions
 
-        Rule (from the spec): match when time windows overlap by at least
-        50% of the shorter session's duration. Races still in progress
-        (end_utc IS NULL) are never matched.  When multiple races overlap,
-        the one with the highest overlap ratio wins.
+    async def match_vakaros_session(self, session_id: int) -> list[int]:
+        """Link a Vakaros session to *all* overlapping races.
 
-        Returns the linked race id, or None if no race qualifies.  The
-        `vakaros_sessions.matched_race_id` column is updated as a side
-        effect so subsequent calls are idempotent.
+        Rule (from the spec): a race matches when its time window overlaps
+        the Vakaros session by at least 50% of the shorter duration. A
+        single VKX file typically contains a full race day — multiple
+        races plus practice — so each qualifying race on the races table
+        gets its own ``vakaros_session_id`` link.
+
+        Races still in progress (``end_utc IS NULL``) are never matched.
+        Races that already point at a different Vakaros session are not
+        overwritten — the first matcher to claim a race wins.  Re-running
+        the matcher on the same Vakaros session is idempotent.
+
+        Returns the list of race ids that now point at this session,
+        ordered by race ``start_utc``.
         """
         from datetime import datetime as _datetime
 
@@ -8123,23 +8199,23 @@ class Storage:
         )
         row = await cur.fetchone()
         if row is None:
-            return None
+            return []
         v_start = _datetime.fromisoformat(row["start_utc"])
         v_end = _datetime.fromisoformat(row["end_utc"])
         v_duration = (v_end - v_start).total_seconds()
         if v_duration <= 0:
-            return None
+            return []
 
         cur = await db.execute(
-            "SELECT id, start_utc, end_utc FROM races "
+            "SELECT id, start_utc, end_utc, vakaros_session_id FROM races "
             "WHERE end_utc IS NOT NULL "
-            "  AND start_utc < ? AND end_utc > ?",
+            "  AND start_utc < ? AND end_utc > ? "
+            "ORDER BY start_utc",
             (v_end.isoformat(), v_start.isoformat()),
         )
         candidates = await cur.fetchall()
 
-        best_race_id: int | None = None
-        best_ratio: float = 0.0
+        linked: list[int] = []
         for cand in candidates:
             r_start = _datetime.fromisoformat(cand["start_utc"])
             r_end = _datetime.fromisoformat(cand["end_utc"])
@@ -8153,16 +8229,37 @@ class Storage:
                 continue
             shorter = min(v_duration, r_duration)
             ratio = overlap_s / shorter
-            if ratio >= 0.5 and ratio > best_ratio:
-                best_ratio = ratio
-                best_race_id = int(cand["id"])
+            if ratio < 0.5:
+                continue
+            existing = cand["vakaros_session_id"]
+            if existing is not None and int(existing) != session_id:
+                # Don't steal a race that's already claimed by a different
+                # Vakaros session — leaves room for future manual override.
+                continue
+            await db.execute(
+                "UPDATE races SET vakaros_session_id = ? WHERE id = ?",
+                (session_id, int(cand["id"])),
+            )
+            linked.append(int(cand["id"]))
 
-        await db.execute(
-            "UPDATE vakaros_sessions SET matched_race_id = ? WHERE id = ?",
-            (best_race_id, session_id),
-        )
         await db.commit()
-        return best_race_id
+        return linked
+
+    async def rematch_all_vakaros_sessions(self) -> dict[int, list[int]]:
+        """Re-run matching for every stored Vakaros session.
+
+        Intended for historical data ingested before the matcher existed
+        or when matching rules change.  Returns a mapping from Vakaros
+        session id to the list of race ids that now link to it.
+        """
+        db = self._read_conn()
+        cur = await db.execute("SELECT id FROM vakaros_sessions ORDER BY id")
+        rows = await cur.fetchall()
+        results: dict[int, list[int]] = {}
+        for r in rows:
+            sid = int(r["id"])
+            results[sid] = await self.match_vakaros_session(sid)
+        return results
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -8116,12 +8116,92 @@ class Storage:
                 "boat_set_at": latest_boat["ts"],
             }
 
+        race_start_context = await self._build_race_start_context(
+            race_events=race_events, line=line
+        )
+
         return {
             "vakaros_session_id": vakaros_id,
             "track": track,
             "line_positions": line_positions,
             "race_events": race_events,
             "line": line,
+            "race_start_context": race_start_context,
+        }
+
+    async def _build_race_start_context(
+        self,
+        race_events: list[dict[str, Any]],
+        line: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Build a per-race snapshot of the boat's state at the race-start gun.
+
+        Used by the session detail page to show boat speed and distance to
+        the start line at the moment the Vakaros race_start event fires.
+        Returns ``None`` if there's no race_start event at all; otherwise a
+        dict with the event ts and nullable bsp/sog/position/distance_to_line
+        so the UI can render partial data.
+        """
+        import math
+
+        race_start_event: dict[str, Any] | None = None
+        for e in race_events:
+            if e["event_type"] == "race_start":
+                race_start_event = e
+                break
+        if race_start_event is None:
+            return None
+
+        ts = race_start_event["ts"]
+        db = self._read_conn()
+
+        # Nearest SK sample within ±5 seconds of the race start.
+        async def _nearest(table: str, columns: str) -> dict[str, Any] | None:
+            cur = await db.execute(
+                f"SELECT {columns} FROM {table} "
+                "WHERE ABS(strftime('%s', ts) - strftime('%s', ?)) <= 5 "
+                "ORDER BY ABS(strftime('%s', ts) - strftime('%s', ?)) ASC "
+                "LIMIT 1",
+                (ts, ts),
+            )
+            row = await cur.fetchone()
+            return dict(row) if row is not None else None
+
+        speed_row = await _nearest("speeds", "ts, speed_kts")
+        sog_row = await _nearest("cogsog", "ts, sog_kts")
+        pos_row = await _nearest("positions", "ts, latitude_deg, longitude_deg")
+
+        bsp_kts = float(speed_row["speed_kts"]) if speed_row else None
+        sog_kts = float(sog_row["sog_kts"]) if sog_row else None
+        lat = float(pos_row["latitude_deg"]) if pos_row else None
+        lon = float(pos_row["longitude_deg"]) if pos_row else None
+
+        distance_to_line_m: float | None = None
+        if line is not None and lat is not None and lon is not None:
+            # Local equirectangular projection centered on the pin: small
+            # distances → ~meter accuracy, no great-circle nonsense.
+            pin_lat, pin_lon = line["pin"]
+            boat_end_lat, boat_end_lon = line["boat"]
+            lat_rad = math.radians(pin_lat)
+            m_per_deg_lat = 111320.0
+            m_per_deg_lon = 111320.0 * math.cos(lat_rad)
+            vx = (boat_end_lon - pin_lon) * m_per_deg_lon
+            vy = (boat_end_lat - pin_lat) * m_per_deg_lat
+            px = (lon - pin_lon) * m_per_deg_lon
+            py = (lat - pin_lat) * m_per_deg_lat
+            seg_len = math.hypot(vx, vy)
+            if seg_len > 0:
+                # Perpendicular distance from point to the infinite line
+                # through pin-boat. (Using |cross| / |v|.)
+                distance_to_line_m = round(abs(vx * py - vy * px) / seg_len, 1)
+
+        return {
+            "ts": ts,
+            "bsp_kts": bsp_kts,
+            "sog_kts": sog_kts,
+            "latitude_deg": lat,
+            "longitude_deg": lon,
+            "distance_to_line_m": distance_to_line_m,
         }
 
     async def list_vakaros_sessions(self) -> list[dict[str, Any]]:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -8116,6 +8116,26 @@ class Storage:
                 "boat_set_at": latest_boat["ts"],
             }
 
+        # Trim line_positions to pings relevant to *this* race: anything set
+        # at or before the race start. Pings from after the race belong to a
+        # later race and would otherwise leak into this race's overlay (and
+        # break the "latest = active" saturation rule on the frontend).
+        # Fallback: if no pre-race pings exist for a side but the line
+        # geometry above filled in from a post-race fallback, include those.
+        relevant_pings: list[dict[str, Any]] = [
+            lp for lp in line_positions if lp["ts"] <= race_start
+        ]
+        if line is not None:
+            for fallback in (latest_pin, latest_boat):
+                if fallback is None:
+                    continue
+                if not any(
+                    lp["ts"] == fallback["ts"] and lp["line_type"] == fallback["line_type"]
+                    for lp in relevant_pings
+                ):
+                    relevant_pings.append(fallback)
+            relevant_pings.sort(key=lambda lp: lp["ts"])
+
         race_start_context = await self._build_race_start_context(
             race_events=race_events, line=line
         )
@@ -8123,7 +8143,7 @@ class Storage:
         return {
             "vakaros_session_id": vakaros_id,
             "track": track,
-            "line_positions": line_positions,
+            "line_positions": relevant_pings,
             "race_events": race_events,
             "line": line,
             "race_start_context": race_start_context,

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7966,6 +7966,37 @@ class Storage:
         await db.execute("DELETE FROM vakaros_sessions WHERE id = ?", (session_id,))
         await db.commit()
 
+    async def list_vakaros_sessions(self) -> list[dict[str, Any]]:
+        """Return all Vakaros sessions with row counts and matched-race name.
+
+        Intended for the admin listing page.  Ordered newest first.
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            """
+            SELECT
+                vs.id,
+                vs.source_file,
+                vs.source_hash,
+                vs.start_utc,
+                vs.end_utc,
+                vs.ingested_at,
+                vs.matched_race_id,
+                r.name AS matched_race_name,
+                (SELECT COUNT(*) FROM vakaros_positions WHERE session_id = vs.id)
+                    AS position_count,
+                (SELECT COUNT(*) FROM vakaros_line_positions WHERE session_id = vs.id)
+                    AS line_count,
+                (SELECT COUNT(*) FROM vakaros_race_events WHERE session_id = vs.id)
+                    AS event_count
+            FROM vakaros_sessions vs
+            LEFT JOIN races r ON r.id = vs.matched_race_id
+            ORDER BY vs.start_utc DESC
+            """
+        )
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
     async def match_vakaros_session_to_race(self, session_id: int) -> int | None:
         """Link a Vakaros session to an overlapping race.
 

--- a/src/helmlog/templates/admin/vakaros.html
+++ b/src/helmlog/templates/admin/vakaros.html
@@ -41,6 +41,10 @@ table.list tr:last-child td{border-bottom:none}
   {% endif %}
 {% endif %}
 
+{% if flash_rematch %}
+  <div class="flash flash-ok">{{ flash_rematch }}</div>
+{% endif %}
+
 <div class="card">
   <h2>Inbox</h2>
   <div class="sub">{{ inbox_dir }}</div>
@@ -69,8 +73,15 @@ table.list tr:last-child td{border-bottom:none}
 </div>
 
 <div class="card">
-  <h2>Ingested sessions</h2>
-  <div class="sub">vakaros_sessions</div>
+  <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:4px">
+    <div>
+      <h2 style="margin:0">Ingested sessions</h2>
+      <div class="sub">vakaros_sessions</div>
+    </div>
+    <form method="post" action="/admin/vakaros/rematch" style="margin:0">
+      <button class="btn" type="submit" title="Re-run matching for every stored Vakaros session against the current races table.">Rematch all</button>
+    </form>
+  </div>
   {% if sessions %}
   <table class="list">
     <thead>
@@ -82,7 +93,7 @@ table.list tr:last-child td{border-bottom:none}
         <th>Positions</th>
         <th>Lines</th>
         <th>Events</th>
-        <th>Matched race</th>
+        <th>Matched races</th>
       </tr>
     </thead>
     <tbody>
@@ -96,8 +107,10 @@ table.list tr:last-child td{border-bottom:none}
         <td class="mono">{{ s.line_count }}</td>
         <td class="mono">{{ s.event_count }}</td>
         <td>
-          {% if s.matched_race_name %}
-            <span class="badge badge-ok">{{ s.matched_race_name }}</span>
+          {% if s.matched_races %}
+            {% for r in s.matched_races %}
+              <span class="badge badge-ok" style="margin-right:4px">{{ r.name }}</span>
+            {% endfor %}
           {% else %}
             <span class="badge badge-muted">unmatched</span>
           {% endif %}

--- a/src/helmlog/templates/admin/vakaros.html
+++ b/src/helmlog/templates/admin/vakaros.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+{% block title %}Vakaros — HelmLog{% endblock %}
+{% block extra_css %}
+<style>
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:16px}
+.card h2{margin:0 0 4px;font-size:1.0rem;color:var(--text-primary)}
+.card .sub{font-size:.78rem;color:var(--text-secondary);margin-bottom:12px;font-family:monospace}
+table.list{width:100%;border-collapse:collapse;font-size:.85rem}
+table.list th{text-align:left;color:var(--text-secondary);font-weight:500;padding:6px 10px;border-bottom:1px solid var(--border);font-size:.74rem;text-transform:uppercase;letter-spacing:.05em}
+table.list td{padding:8px 10px;color:var(--text-primary);border-bottom:1px solid var(--border);vertical-align:middle}
+table.list tr:last-child td{border-bottom:none}
+.mono{font-family:monospace;font-size:.8rem}
+.hash{font-family:monospace;color:var(--text-secondary);font-size:.72rem}
+.btn{padding:6px 14px;border:1px solid var(--border);border-radius:6px;background:var(--bg-primary);color:var(--text-primary);font-size:.8rem;cursor:pointer;font-family:inherit}
+.btn:hover{filter:brightness(1.15)}
+.btn-primary{background:var(--accent-strong);border-color:var(--accent-strong);color:var(--bg-primary)}
+.badge{display:inline-block;font-size:.7rem;padding:2px 8px;border-radius:4px;font-weight:600;letter-spacing:.04em}
+.badge-ok{background:var(--bg-primary);color:var(--success);border:1px solid var(--success)}
+.badge-warn{background:var(--bg-primary);color:var(--warning);border:1px solid var(--warning)}
+.badge-err{background:var(--bg-primary);color:var(--danger);border:1px solid var(--danger)}
+.badge-muted{background:var(--bg-primary);color:var(--text-secondary);border:1px solid var(--border)}
+.empty{padding:12px;color:var(--text-secondary);font-style:italic;font-size:.85rem}
+.flash{margin-bottom:16px;padding:10px 14px;border-radius:6px;font-size:.88rem}
+.flash-ok{background:var(--bg-secondary);color:var(--success);border:1px solid var(--success)}
+.flash-warn{background:var(--bg-secondary);color:var(--warning);border:1px solid var(--warning)}
+.flash-err{background:var(--bg-secondary);color:var(--danger);border:1px solid var(--danger)}
+.hint{font-size:.78rem;color:var(--text-secondary);margin-top:6px}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1 style="margin-top:0">Vakaros</h1>
+
+{% if flash_filename and flash_status %}
+  {% if flash_status == "ingested" %}
+    <div class="flash flash-ok">Ingested <code>{{ flash_filename }}</code> — archived to <code>processed/</code>.</div>
+  {% elif flash_status == "duplicate" %}
+    <div class="flash flash-warn">Duplicate <code>{{ flash_filename }}</code> (same content hash as an existing session) — archived to <code>processed/</code>, no new rows written.</div>
+  {% elif flash_status == "failed" %}
+    <div class="flash flash-err">Failed to parse <code>{{ flash_filename }}</code> — archived to <code>failed/</code>.{% if flash_error %} <span class="mono">{{ flash_error }}</span>{% endif %}</div>
+  {% endif %}
+{% endif %}
+
+<div class="card">
+  <h2>Inbox</h2>
+  <div class="sub">{{ inbox_dir }}</div>
+  {% if inbox_files %}
+  <table class="list">
+    <thead><tr><th>File</th><th>Size</th><th></th></tr></thead>
+    <tbody>
+      {% for f in inbox_files %}
+      <tr>
+        <td class="mono">{{ f.name }}</td>
+        <td class="mono">{{ "%.1f"|format(f.size / 1024) }} KB</td>
+        <td style="text-align:right">
+          <form method="post" action="/admin/vakaros/ingest" style="display:inline">
+            <input type="hidden" name="filename" value="{{ f.name }}">
+            <button class="btn btn-primary" type="submit">Ingest</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="empty">Inbox is empty. Copy a <code>.vkx</code> file into <code>{{ inbox_dir }}</code> and reload this page.</div>
+  {% endif %}
+  <div class="hint">Successfully ingested files move to <code>processed/</code>. Parse failures move to <code>failed/</code> with a <code>.err</code> sidecar explaining the error.</div>
+</div>
+
+<div class="card">
+  <h2>Ingested sessions</h2>
+  <div class="sub">vakaros_sessions</div>
+  {% if sessions %}
+  <table class="list">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Source file</th>
+        <th>Start (UTC)</th>
+        <th>End (UTC)</th>
+        <th>Positions</th>
+        <th>Lines</th>
+        <th>Events</th>
+        <th>Matched race</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for s in sessions %}
+      <tr>
+        <td class="mono">{{ s.id }}</td>
+        <td class="mono">{{ s.source_file }}<br><span class="hash">{{ s.source_hash[:12] }}…</span></td>
+        <td class="mono">{{ s.start_utc[:19] }}</td>
+        <td class="mono">{{ s.end_utc[:19] }}</td>
+        <td class="mono">{{ s.position_count }}</td>
+        <td class="mono">{{ s.line_count }}</td>
+        <td class="mono">{{ s.event_count }}</td>
+        <td>
+          {% if s.matched_race_name %}
+            <span class="badge badge-ok">{{ s.matched_race_name }}</span>
+          {% else %}
+            <span class="badge badge-muted">unmatched</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <div class="empty">No Vakaros sessions ingested yet.</div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -32,6 +32,7 @@
     <a href="/admin/settings" class="admin-link{% if active_page == "/admin/settings" %} active{% endif %}">Settings</a>
     <a href="/admin/federation" class="admin-link{% if active_page == "/admin/federation" %} active{% endif %}">Federation</a>
     <a href="/admin/analysis" class="admin-link{% if active_page == "/admin/analysis" %} active{% endif %}">Analysis</a>
+    <a href="/admin/vakaros" class="admin-link{% if active_page == "/admin/vakaros" %} active{% endif %}">Vakaros</a>
     <a href="/admin/deployment" class="admin-link{% if active_page == "/admin/deployment" %} active{% endif %}" id="nav-deploy">Deploy</a>
     <a href="/profile" class="profile-link" id="nav-profile"{% if active_page == "/profile" %} class="active"{% endif %}><img id="nav-avatar" src="" alt="" style="width:18px;height:18px;border-radius:50%;vertical-align:middle;margin-right:3px"><span id="nav-profile-name">Profile</span></a>
   </div>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -95,8 +95,13 @@
 
 <div id="track-container" class="card" style="display:none">
   <div class="section-title">Track</div>
+  <div id="vakaros-track-toggle" style="display:none;margin-bottom:8px;font-size:.78rem;color:var(--text-secondary)">
+    <label style="margin-right:12px"><input type="checkbox" id="toggle-sk-track" checked> SK track</label>
+    <label><input type="checkbox" id="toggle-vakaros-track"> Vakaros track</label>
+  </div>
   <div id="track-map" class="track-map"></div>
   <div id="track-hint" style="font-size:.72rem;color:var(--text-secondary);margin-top:4px"></div>
+  <div id="vakaros-line-info" style="display:none;font-size:.78rem;color:var(--text-secondary);margin-top:6px;font-family:monospace"></div>
 </div>
 
 <div id="video-container" class="card" style="display:none">

--- a/src/helmlog/vakaros.py
+++ b/src/helmlog/vakaros.py
@@ -24,6 +24,9 @@ from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
+
+    from helmlog.storage import Storage
 
 # ---------------------------------------------------------------------------
 # Row keys
@@ -286,3 +289,17 @@ def parse_vkx(buf: bytes) -> Iterator[DecodedRow]:
             yield _decode_wind(payload)
         # All other keys (page header/terminator, internal, not-yet-decoded) skip.
         pos = end
+
+
+async def ingest_vkx_file(storage: Storage, path: Path) -> tuple[int, bool]:
+    """Read, parse, and store a single VKX file.
+
+    Returns (session_id, was_duplicate). `was_duplicate` is True when a
+    session with the same SHA-256 content hash already exists in the
+    database — in that case no new rows are written.
+    """
+    buf = path.read_bytes()
+    session = parse_vkx_session(buf, source_file=path.name)
+    before_id = await storage.find_vakaros_session_by_hash(session.source_hash)
+    session_id = await storage.store_vakaros_session(session)
+    return session_id, before_id is not None

--- a/src/helmlog/vakaros.py
+++ b/src/helmlog/vakaros.py
@@ -132,6 +132,24 @@ class WindRow:
     speed_mps: float
 
 
+@dataclass(frozen=True)
+class VakarosSession:
+    """An assembled Vakaros session ready for storage.
+
+    `source_hash` is the SHA-256 hex digest of the raw VKX bytes — used
+    as the dedupe key because VKX does not include a device ID.
+    """
+
+    source_hash: str
+    source_file: str
+    start_utc: datetime
+    end_utc: datetime
+    positions: tuple[PositionRow, ...]
+    line_positions: tuple[LinePosition, ...]
+    race_events: tuple[RaceTimerEvent, ...]
+    winds: tuple[WindRow, ...]
+
+
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------
@@ -202,6 +220,41 @@ def _decode_wind(payload: bytes) -> WindRow:
 
 # Decoded-row union type. Internal/unknown rows are skipped (no dataclass).
 DecodedRow = PositionRow | RaceTimerEvent | LinePosition | WindRow
+
+
+def parse_vkx_session(buf: bytes, source_file: str) -> VakarosSession:
+    """Parse a VKX buffer into an assembled VakarosSession.
+
+    Raises VKXParseError if the buffer has no Position rows (a session
+    with no GPS track is not useful and cannot have a time window).
+    """
+    import hashlib
+
+    positions: list[PositionRow] = []
+    line_positions: list[LinePosition] = []
+    race_events: list[RaceTimerEvent] = []
+    winds: list[WindRow] = []
+    for row in parse_vkx(buf):
+        if isinstance(row, PositionRow):
+            positions.append(row)
+        elif isinstance(row, LinePosition):
+            line_positions.append(row)
+        elif isinstance(row, RaceTimerEvent):
+            race_events.append(row)
+        elif isinstance(row, WindRow):
+            winds.append(row)
+    if not positions:
+        raise VKXParseError("VKX file contains no Position rows")
+    return VakarosSession(
+        source_hash=hashlib.sha256(buf).hexdigest(),
+        source_file=source_file,
+        start_utc=positions[0].timestamp,
+        end_utc=positions[-1].timestamp,
+        positions=tuple(positions),
+        line_positions=tuple(line_positions),
+        race_events=tuple(race_events),
+        winds=tuple(winds),
+    )
 
 
 def parse_vkx(buf: bytes) -> Iterator[DecodedRow]:

--- a/src/helmlog/vakaros.py
+++ b/src/helmlog/vakaros.py
@@ -292,14 +292,17 @@ def parse_vkx(buf: bytes) -> Iterator[DecodedRow]:
 
 
 async def ingest_vkx_file(storage: Storage, path: Path) -> tuple[int, bool]:
-    """Read, parse, and store a single VKX file.
+    """Read, parse, store, and match a single VKX file.
 
     Returns (session_id, was_duplicate). `was_duplicate` is True when a
     session with the same SHA-256 content hash already exists in the
-    database — in that case no new rows are written.
+    database — in that case no new rows are written. In both cases the
+    session is (re-)matched to any overlapping race so a freshly-ended
+    race that started between ingests still gets linked.
     """
     buf = path.read_bytes()
     session = parse_vkx_session(buf, source_file=path.name)
     before_id = await storage.find_vakaros_session_by_hash(session.source_hash)
     session_id = await storage.store_vakaros_session(session)
+    await storage.match_vakaros_session_to_race(session_id)
     return session_id, before_id is not None

--- a/src/helmlog/vakaros.py
+++ b/src/helmlog/vakaros.py
@@ -1,0 +1,235 @@
+"""Vakaros VKX binary log parser.
+
+Parses the publicly documented Vakaros VKX telemetry format
+(https://github.com/vakaros/vkx) into typed dataclasses. Pure Python, no
+hardware required — designed to be tested without a real Atlas device.
+
+Format summary:
+    - All fields little-endian.
+    - File is a sequence of pages, each ~2 KB. Pages are delimited by:
+        0xFF page header (7-byte payload: version + 6 reserved)
+        0xFE page terminator (2-byte payload: U2 previous page length)
+    - Inside pages: rows keyed by a single byte, with fixed-size payloads.
+    - Timestamps are Unix epoch milliseconds (UTC).
+"""
+
+from __future__ import annotations
+
+import enum
+import math
+import struct
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# ---------------------------------------------------------------------------
+# Row keys
+# ---------------------------------------------------------------------------
+
+KEY_INTERNAL_01: Final[int] = 0x01  # 32-byte internal message
+KEY_POSITION: Final[int] = 0x02  # Position / velocity / orientation
+KEY_DECLINATION: Final[int] = 0x03
+KEY_RACE_TIMER: Final[int] = 0x04
+KEY_LINE_POSITION: Final[int] = 0x05
+KEY_SHIFT_ANGLE: Final[int] = 0x06
+KEY_INTERNAL_07: Final[int] = 0x07  # 12-byte internal message
+KEY_DEVICE_CONFIG: Final[int] = 0x08
+KEY_WIND: Final[int] = 0x0A
+KEY_SPEED_THROUGH_WATER: Final[int] = 0x0B
+KEY_DEPTH: Final[int] = 0x0C
+KEY_INTERNAL_0E: Final[int] = 0x0E  # 16-byte internal message
+KEY_LOAD: Final[int] = 0x0F
+KEY_TEMPERATURE: Final[int] = 0x10
+KEY_INTERNAL_20: Final[int] = 0x20  # 13-byte internal message
+KEY_INTERNAL_21: Final[int] = 0x21  # 52-byte internal message
+KEY_PAGE_TERMINATOR: Final[int] = 0xFE
+KEY_PAGE_HEADER: Final[int] = 0xFF
+
+# Payload sizes for each row key (excluding the 1-byte key itself).
+ROW_PAYLOAD_SIZES: Final[dict[int, int]] = {
+    KEY_INTERNAL_01: 32,
+    KEY_POSITION: 44,
+    KEY_DECLINATION: 20,
+    KEY_RACE_TIMER: 13,
+    KEY_LINE_POSITION: 17,
+    KEY_SHIFT_ANGLE: 18,
+    KEY_INTERNAL_07: 12,
+    KEY_DEVICE_CONFIG: 13,
+    KEY_WIND: 16,
+    KEY_SPEED_THROUGH_WATER: 16,
+    KEY_DEPTH: 12,
+    KEY_INTERNAL_0E: 16,
+    KEY_LOAD: 16,
+    KEY_TEMPERATURE: 12,
+    KEY_INTERNAL_20: 13,
+    KEY_INTERNAL_21: 52,
+    KEY_PAGE_HEADER: 7,
+    KEY_PAGE_TERMINATOR: 2,
+}
+
+# ---------------------------------------------------------------------------
+# Decoded row dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PositionRow:
+    """0x02 Position / velocity / orientation."""
+
+    timestamp: datetime
+    latitude_deg: float
+    longitude_deg: float
+    sog_mps: float
+    cog_deg: float
+    altitude_m: float
+    quat_w: float
+    quat_x: float
+    quat_y: float
+    quat_z: float
+
+
+class RaceTimerEventType(enum.IntEnum):
+    RESET = 0
+    START = 1
+    SYNC = 2
+    RACE_START = 3
+    RACE_END = 4
+
+
+@dataclass(frozen=True)
+class RaceTimerEvent:
+    """0x04 Race timer event — start gun, sync, race end."""
+
+    timestamp: datetime
+    event_type: RaceTimerEventType
+    timer_value_s: int
+
+
+class LinePositionType(enum.IntEnum):
+    PIN = 0
+    BOAT = 1
+
+
+@dataclass(frozen=True)
+class LinePosition:
+    """0x05 Start line endpoint ping (pin or committee boat)."""
+
+    timestamp: datetime
+    line_type: LinePositionType
+    latitude_deg: float
+    longitude_deg: float
+
+
+@dataclass(frozen=True)
+class WindRow:
+    """0x0A Wind direction + speed."""
+
+    timestamp: datetime
+    direction_deg: float
+    speed_mps: float
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class VKXParseError(ValueError):
+    """Raised when a VKX buffer cannot be parsed."""
+
+
+def _ts_from_ms(ms: int) -> datetime:
+    return datetime.fromtimestamp(ms / 1000.0, tz=UTC)
+
+
+def _decode_position(payload: bytes) -> PositionRow:
+    (
+        ts_ms,
+        raw_lat,
+        raw_lon,
+        sog_mps,
+        cog_rad,
+        alt_m,
+        qw,
+        qx,
+        qy,
+        qz,
+    ) = struct.unpack("<Qiifffffff", payload)
+    return PositionRow(
+        timestamp=_ts_from_ms(ts_ms),
+        latitude_deg=raw_lat * 1e-7,
+        longitude_deg=raw_lon * 1e-7,
+        sog_mps=sog_mps,
+        cog_deg=math.degrees(cog_rad) % 360.0,
+        altitude_m=alt_m,
+        quat_w=qw,
+        quat_x=qx,
+        quat_y=qy,
+        quat_z=qz,
+    )
+
+
+def _decode_race_timer(payload: bytes) -> RaceTimerEvent:
+    ts_ms, raw_type, timer_s = struct.unpack("<QBi", payload)
+    return RaceTimerEvent(
+        timestamp=_ts_from_ms(ts_ms),
+        event_type=RaceTimerEventType(raw_type),
+        timer_value_s=timer_s,
+    )
+
+
+def _decode_line_position(payload: bytes) -> LinePosition:
+    ts_ms, raw_type, lat_f, lon_f = struct.unpack("<QBff", payload)
+    return LinePosition(
+        timestamp=_ts_from_ms(ts_ms),
+        line_type=LinePositionType(raw_type),
+        latitude_deg=lat_f,
+        longitude_deg=lon_f,
+    )
+
+
+def _decode_wind(payload: bytes) -> WindRow:
+    ts_ms, direction_deg, speed_mps = struct.unpack("<Qff", payload)
+    return WindRow(
+        timestamp=_ts_from_ms(ts_ms),
+        direction_deg=direction_deg,
+        speed_mps=speed_mps,
+    )
+
+
+# Decoded-row union type. Internal/unknown rows are skipped (no dataclass).
+DecodedRow = PositionRow | RaceTimerEvent | LinePosition | WindRow
+
+
+def parse_vkx(buf: bytes) -> Iterator[DecodedRow]:
+    """Iterate decoded rows from a VKX byte buffer.
+
+    Unknown and internal rows are consumed but not yielded.
+    """
+    pos = 0
+    n = len(buf)
+    while pos < n:
+        key = buf[pos]
+        size = ROW_PAYLOAD_SIZES.get(key)
+        if size is None:
+            raise VKXParseError(f"unknown VKX row key 0x{key:02x} at offset {pos}")
+        start = pos + 1
+        end = start + size
+        if end > n:
+            raise VKXParseError(
+                f"truncated row 0x{key:02x} at offset {pos}: need {size} bytes, have {n - start}"
+            )
+        payload = buf[start:end]
+        if key == KEY_POSITION:
+            yield _decode_position(payload)
+        elif key == KEY_RACE_TIMER:
+            yield _decode_race_timer(payload)
+        elif key == KEY_LINE_POSITION:
+            yield _decode_line_position(payload)
+        elif key == KEY_WIND:
+            yield _decode_wind(payload)
+        # All other keys (page header/terminator, internal, not-yet-decoded) skip.
+        pos = end

--- a/src/helmlog/vakaros.py
+++ b/src/helmlog/vakaros.py
@@ -304,5 +304,5 @@ async def ingest_vkx_file(storage: Storage, path: Path) -> tuple[int, bool]:
     session = parse_vkx_session(buf, source_file=path.name)
     before_id = await storage.find_vakaros_session_by_hash(session.source_hash)
     session_id = await storage.store_vakaros_session(session)
-    await storage.match_vakaros_session_to_race(session_id)
+    await storage.match_vakaros_session(session_id)
     return session_id, before_id is not None

--- a/src/helmlog/vakaros_inbox.py
+++ b/src/helmlog/vakaros_inbox.py
@@ -1,0 +1,152 @@
+"""Vakaros VKX inbox helpers (#458).
+
+Explicit, user-controlled ingest path: the user copies a .vkx file into
+the inbox directory, then clicks "Ingest" in the admin UI. No background
+watcher — each ingest is a discrete, logged action.
+
+Directory layout (relative to VAKAROS_INBOX_DIR):
+    <inbox>/               .vkx files waiting to be ingested
+    <inbox>/processed/     successfully ingested files, preserved for audit
+    <inbox>/failed/        files that failed to parse, with a .err sidecar
+"""
+
+from __future__ import annotations
+
+import os
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+DEFAULT_INBOX_REL = "data/vakaros-inbox"
+
+
+IngestStatus = Literal["ingested", "duplicate", "failed"]
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of a single inbox ingest attempt."""
+
+    filename: str
+    status: IngestStatus
+    session_id: int | None
+    archived_path: Path | None
+    error: str | None
+
+
+def get_inbox_dir() -> Path:
+    """Return the configured Vakaros inbox directory.
+
+    Reads ``VAKAROS_INBOX_DIR`` from the environment, falling back to
+    ``data/vakaros-inbox`` (relative to cwd).  The directory and its
+    ``processed``/``failed`` subdirs are created on demand by the helpers
+    that actually read or write to them — this function does not touch
+    the filesystem.
+    """
+    env = os.environ.get("VAKAROS_INBOX_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path(DEFAULT_INBOX_REL)
+
+
+def _ensure_layout(inbox: Path) -> None:
+    """Create inbox + processed/failed subdirs if they don't exist."""
+    inbox.mkdir(parents=True, exist_ok=True)
+    (inbox / "processed").mkdir(exist_ok=True)
+    (inbox / "failed").mkdir(exist_ok=True)
+
+
+def list_inbox_files(inbox: Path) -> list[Path]:
+    """Return .vkx files directly in the inbox (not subdirs), sorted by name.
+
+    Ensures the inbox layout exists as a side effect.  Matching is
+    case-insensitive on the `.vkx` suffix.
+    """
+    _ensure_layout(inbox)
+    return sorted(
+        (p for p in inbox.iterdir() if p.is_file() and p.suffix.lower() == ".vkx"),
+        key=lambda p: p.name,
+    )
+
+
+def _resolve_safe_inbox_path(inbox: Path, filename: str) -> Path:
+    """Resolve `<inbox>/<filename>` and reject any path-traversal attempt."""
+    target = (inbox / filename).resolve()
+    inbox_resolved = inbox.resolve()
+    try:
+        target.relative_to(inbox_resolved)
+    except ValueError as exc:
+        raise ValueError(f"filename {filename!r} resolves outside inbox") from exc
+    return target
+
+
+def _unique_destination(dest_dir: Path, filename: str) -> Path:
+    """Return a non-colliding destination path in `dest_dir`."""
+    target = dest_dir / filename
+    if not target.exists():
+        return target
+    stem = target.stem
+    suffix = target.suffix
+    n = 1
+    while True:
+        candidate = dest_dir / f"{stem}.{n}{suffix}"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+async def ingest_inbox_file(storage: Storage, inbox: Path, filename: str) -> IngestResult:
+    """Parse, store, and archive a single inbox file.
+
+    On parse failure, the file is moved to `failed/` with a `.err` sidecar
+    and `IngestResult.status == "failed"`. On success it moves to
+    `processed/`. Duplicate content (same SHA-256 hash) is also moved to
+    `processed/` with `status == "duplicate"`.
+
+    Raises:
+        ValueError: if `filename` resolves outside the inbox
+          (path-traversal protection).
+        FileNotFoundError: if the file doesn't exist in the inbox.
+    """
+    from helmlog.vakaros import VKXParseError, ingest_vkx_file
+
+    _ensure_layout(inbox)
+    src = _resolve_safe_inbox_path(inbox, filename)
+    if not src.is_file():
+        raise FileNotFoundError(f"no such file in inbox: {filename}")
+
+    try:
+        session_id, was_duplicate = await ingest_vkx_file(storage, src)
+    except VKXParseError as exc:
+        failed_dir = inbox / "failed"
+        archived = _unique_destination(failed_dir, src.name)
+        src.rename(archived)
+        err_text = f"{exc}\n\n{traceback.format_exc()}"
+        archived.with_suffix(archived.suffix + ".err").write_text(err_text)
+        logger.warning("Vakaros ingest failed for {}: {}", src.name, exc)
+        return IngestResult(
+            filename=filename,
+            status="failed",
+            session_id=None,
+            archived_path=archived,
+            error=str(exc),
+        )
+
+    processed_dir = inbox / "processed"
+    archived = _unique_destination(processed_dir, src.name)
+    src.rename(archived)
+    status: IngestStatus = "duplicate" if was_duplicate else "ingested"
+    logger.info("Vakaros inbox {}: session_id={} file={}", status, session_id, src.name)
+    return IngestResult(
+        filename=filename,
+        status=status,
+        session_id=session_id,
+        archived_path=archived,
+        error=None,
+    )

--- a/tests/test_vakaros.py
+++ b/tests/test_vakaros.py
@@ -1,0 +1,162 @@
+"""Tests for the Vakaros VKX binary log parser."""
+
+from __future__ import annotations
+
+import math
+import struct
+from datetime import UTC, datetime
+
+import pytest
+
+
+def _build_position_payload(
+    timestamp_ms: int,
+    lat_deg: float,
+    lon_deg: float,
+    sog_mps: float,
+    cog_rad: float,
+    altitude_m: float,
+    quat: tuple[float, float, float, float],
+) -> bytes:
+    """Pack a 44-byte VKX 0x02 (Position/Velocity/Orientation) payload."""
+    return struct.pack(
+        "<Qiifffffff",  # U8, I4, I4, F4*7
+        timestamp_ms,
+        round(lat_deg / 1e-7),
+        round(lon_deg / 1e-7),
+        sog_mps,
+        cog_rad,
+        altitude_m,
+        quat[0],
+        quat[1],
+        quat[2],
+        quat[3],
+    )
+
+
+def _build_minimal_vkx(rows: bytes) -> bytes:
+    """Wrap row bytes in a VKX page header (0xFF) + page terminator (0xFE)."""
+    # Page header: key 0xFF, payload = 7 bytes (version 0x05 + 6 reserved)
+    header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
+    # Page terminator: key 0xFE, payload = U2 previous page length (rows length)
+    terminator = bytes([0xFE]) + struct.pack("<H", len(rows))
+    return header + rows + terminator
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_decodes_single_position_row() -> None:
+    from helmlog.vakaros import PositionRow, parse_vkx
+
+    ts_ms = 1_700_000_000_000  # 2023-11-14T22:13:20Z
+    payload = _build_position_payload(
+        timestamp_ms=ts_ms,
+        lat_deg=37.8044,
+        lon_deg=-122.2712,
+        sog_mps=3.5,
+        cog_rad=math.radians(45.0),
+        altitude_m=12.0,
+        quat=(1.0, 0.0, 0.0, 0.0),
+    )
+    row_bytes = bytes([0x02]) + payload
+    buf = _build_minimal_vkx(row_bytes)
+
+    rows = list(parse_vkx(buf))
+
+    position_rows = [r for r in rows if isinstance(r, PositionRow)]
+    assert len(position_rows) == 1
+    p = position_rows[0]
+    assert p.timestamp == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+    assert p.latitude_deg == pytest.approx(37.8044, abs=1e-6)
+    assert p.longitude_deg == pytest.approx(-122.2712, abs=1e-6)
+    assert p.sog_mps == pytest.approx(3.5)
+    assert p.cog_deg == pytest.approx(45.0, abs=1e-3)
+    assert p.altitude_m == pytest.approx(12.0)
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_decodes_race_timer_event() -> None:
+    from helmlog.vakaros import RaceTimerEvent, RaceTimerEventType, parse_vkx
+
+    ts_ms = 1_700_000_005_000
+    payload = struct.pack("<QBi", ts_ms, 3, -300)  # RACE_START, T-5:00
+    buf = _build_minimal_vkx(bytes([0x04]) + payload)
+
+    rows = [r for r in parse_vkx(buf) if isinstance(r, RaceTimerEvent)]
+    assert len(rows) == 1
+    e = rows[0]
+    assert e.timestamp == datetime(2023, 11, 14, 22, 13, 25, tzinfo=UTC)
+    assert e.event_type is RaceTimerEventType.RACE_START
+    assert e.timer_value_s == -300
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_decodes_line_position_pin_and_boat() -> None:
+    from helmlog.vakaros import LinePosition, LinePositionType, parse_vkx
+
+    ts_ms = 1_700_000_010_000
+    pin_payload = struct.pack("<QBff", ts_ms, 0, 37.8050, -122.2700)
+    boat_payload = struct.pack("<QBff", ts_ms + 1000, 1, 37.8048, -122.2705)
+    buf = _build_minimal_vkx(bytes([0x05]) + pin_payload + bytes([0x05]) + boat_payload)
+
+    line_rows = [r for r in parse_vkx(buf) if isinstance(r, LinePosition)]
+    assert len(line_rows) == 2
+    pin, boat = line_rows
+    assert pin.line_type is LinePositionType.PIN
+    assert pin.latitude_deg == pytest.approx(37.8050, abs=1e-4)
+    assert pin.longitude_deg == pytest.approx(-122.2700, abs=1e-4)
+    assert boat.line_type is LinePositionType.BOAT
+    assert boat.latitude_deg == pytest.approx(37.8048, abs=1e-4)
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_decodes_wind() -> None:
+    from helmlog.vakaros import WindRow, parse_vkx
+
+    ts_ms = 1_700_000_020_000
+    payload = struct.pack("<Qff", ts_ms, 215.0, 7.5)  # 215° at 7.5 m/s
+    buf = _build_minimal_vkx(bytes([0x0A]) + payload)
+
+    wind_rows = [r for r in parse_vkx(buf) if isinstance(r, WindRow)]
+    assert len(wind_rows) == 1
+    w = wind_rows[0]
+    assert w.direction_deg == pytest.approx(215.0)
+    assert w.speed_mps == pytest.approx(7.5)
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_skips_unknown_internal_rows_silently() -> None:
+    from helmlog.vakaros import PositionRow, parse_vkx
+
+    # 0x07 internal message (12-byte payload) sandwiched between two positions
+    pos1 = bytes([0x02]) + _build_position_payload(
+        1_700_000_000_000, 37.8, -122.27, 1.0, 0.0, 0.0, (1.0, 0.0, 0.0, 0.0)
+    )
+    internal = bytes([0x07]) + bytes(12)
+    pos2 = bytes([0x02]) + _build_position_payload(
+        1_700_000_001_000, 37.8001, -122.27, 1.0, 0.0, 0.0, (1.0, 0.0, 0.0, 0.0)
+    )
+    buf = _build_minimal_vkx(pos1 + internal + pos2)
+
+    positions = [r for r in parse_vkx(buf) if isinstance(r, PositionRow)]
+    assert len(positions) == 2
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_raises_on_unknown_row_key() -> None:
+    from helmlog.vakaros import VKXParseError, parse_vkx
+
+    # 0xAB is not a defined row key
+    buf = _build_minimal_vkx(bytes([0xAB, 0, 0, 0]))
+    with pytest.raises(VKXParseError, match="unknown VKX row key"):
+        list(parse_vkx(buf))
+
+
+@pytest.mark.asyncio
+async def test_parse_vkx_raises_on_truncated_row() -> None:
+    from helmlog.vakaros import VKXParseError, parse_vkx
+
+    # Position row claims 44 bytes but only 10 are present.
+    bad = bytes([0x02]) + bytes(10)
+    # Don't wrap in page header — terminator would otherwise consume the trailing bytes.
+    with pytest.raises(VKXParseError, match="truncated"):
+        list(parse_vkx(bad))

--- a/tests/test_vakaros_inbox.py
+++ b/tests/test_vakaros_inbox.py
@@ -1,0 +1,152 @@
+"""Tests for the Vakaros inbox helpers (#458 cycle 5)."""
+
+from __future__ import annotations
+
+import math
+import struct
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+else:
+    from pathlib import Path  # noqa: TC003  # runtime needed by pytest fixture types
+
+
+def _build_minimal_vkx_bytes(ts_ms: int = 1_700_000_000_000) -> bytes:
+    """Build a tiny valid VKX buffer with one Position row."""
+    header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
+    payload = struct.pack(
+        "<Qiifffffff",
+        ts_ms,
+        round(47.68 / 1e-7),
+        round(-122.41 / 1e-7),
+        1.0,
+        math.radians(0.0),
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+    row = bytes([0x02]) + payload
+    terminator = bytes([0xFE]) + struct.pack("<H", len(row))
+    return header + row + terminator
+
+
+@pytest.fixture
+def inbox(tmp_path: Path) -> Path:
+    p = tmp_path / "vakaros-inbox"
+    p.mkdir()
+    return p
+
+
+@pytest.mark.asyncio
+async def test_list_inbox_files_returns_only_vkx_and_ignores_subdirs(inbox: Path) -> None:
+    from helmlog.vakaros_inbox import list_inbox_files
+
+    (inbox / "foo.vkx").write_bytes(b"x")
+    (inbox / "bar.VKX").write_bytes(b"x")  # case-insensitive
+    (inbox / "readme.txt").write_bytes(b"x")
+    (inbox / "processed").mkdir()
+    (inbox / "processed" / "old.vkx").write_bytes(b"x")
+
+    files = list_inbox_files(inbox)
+    names = sorted(f.name for f in files)
+    assert names == ["bar.VKX", "foo.vkx"]
+
+
+@pytest.mark.asyncio
+async def test_list_inbox_files_creates_missing_directory(tmp_path: Path) -> None:
+    from helmlog.vakaros_inbox import list_inbox_files
+
+    missing = tmp_path / "never-existed"
+    files = list_inbox_files(missing)
+    assert files == []
+    assert missing.is_dir()
+    assert (missing / "processed").is_dir()
+    assert (missing / "failed").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_ingest_inbox_file_moves_to_processed_on_success(
+    storage: Storage, inbox: Path
+) -> None:
+    from helmlog.vakaros_inbox import ingest_inbox_file
+
+    vkx = inbox / "session_a.vkx"
+    vkx.write_bytes(_build_minimal_vkx_bytes())
+
+    result = await ingest_inbox_file(storage, inbox, "session_a.vkx")
+    assert result.session_id > 0
+    assert result.status == "ingested"
+    assert result.archived_path is not None
+    assert result.archived_path.name == "session_a.vkx"
+    assert result.archived_path.parent == inbox / "processed"
+    assert result.archived_path.exists()
+    assert not vkx.exists()
+
+
+@pytest.mark.asyncio
+async def test_ingest_inbox_file_marks_duplicate_without_reinserting(
+    storage: Storage, inbox: Path
+) -> None:
+    from helmlog.vakaros_inbox import ingest_inbox_file
+
+    buf = _build_minimal_vkx_bytes()
+    (inbox / "first.vkx").write_bytes(buf)
+    r1 = await ingest_inbox_file(storage, inbox, "first.vkx")
+    assert r1.status == "ingested"
+
+    # Copy the identical bytes to a new filename and ingest again.
+    (inbox / "second.vkx").write_bytes(buf)
+    r2 = await ingest_inbox_file(storage, inbox, "second.vkx")
+    assert r2.session_id == r1.session_id
+    assert r2.status == "duplicate"
+    assert r2.archived_path is not None
+    assert r2.archived_path.parent == inbox / "processed"
+
+
+@pytest.mark.asyncio
+async def test_ingest_inbox_file_moves_to_failed_on_parse_error(
+    storage: Storage, inbox: Path
+) -> None:
+    from helmlog.vakaros_inbox import ingest_inbox_file
+
+    bad = inbox / "corrupt.vkx"
+    bad.write_bytes(b"\x00\x00\x00\x00\x00")  # nonsense
+
+    result = await ingest_inbox_file(storage, inbox, "corrupt.vkx")
+    assert result.status == "failed"
+    assert result.session_id is None
+    assert result.error is not None
+    assert result.archived_path is not None
+    assert result.archived_path.parent == inbox / "failed"
+    assert result.archived_path.exists()
+    err_sidecar = result.archived_path.with_suffix(result.archived_path.suffix + ".err")
+    assert err_sidecar.exists()
+    assert (
+        "unknown" in err_sidecar.read_text().lower() or "parse" in err_sidecar.read_text().lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_inbox_file_rejects_path_traversal(
+    storage: Storage, inbox: Path, tmp_path: Path
+) -> None:
+    from helmlog.vakaros_inbox import ingest_inbox_file
+
+    # Try to escape the inbox with a ../ filename.
+    with pytest.raises(ValueError, match="outside inbox"):
+        await ingest_inbox_file(storage, inbox, "../escape.vkx")
+
+
+@pytest.mark.asyncio
+async def test_ingest_inbox_file_rejects_missing_file(storage: Storage, inbox: Path) -> None:
+    from helmlog.vakaros_inbox import ingest_inbox_file
+
+    with pytest.raises(FileNotFoundError):
+        await ingest_inbox_file(storage, inbox, "nonexistent.vkx")

--- a/tests/test_vakaros_matching.py
+++ b/tests/test_vakaros_matching.py
@@ -1,0 +1,258 @@
+"""Tests for Vakaros -> races session matching (#458).
+
+Rule (from the spec): a Vakaros session matches an SK race when their
+time windows overlap by at least 50% of the shorter session's duration.
+Races still in progress (end_utc IS NULL) are never matched.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.vakaros import PositionRow, VakarosSession
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _insert_race(
+    storage: Storage,
+    name: str,
+    start: datetime,
+    end: datetime | None,
+) -> int:
+    """Raw-SQL insert a race for testing (bypasses slug/validation)."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            name,
+            "test-event",
+            1,
+            start.date().isoformat(),
+            start.isoformat(),
+            end.isoformat() if end else None,
+            "race",
+        ),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+def _make_vakaros_session(
+    start: datetime, end: datetime, source_hash: str = "a" * 64
+) -> VakarosSession:
+    return VakarosSession(
+        source_hash=source_hash,
+        source_file="test.vkx",
+        start_utc=start,
+        end_utc=end,
+        positions=(
+            PositionRow(
+                timestamp=start,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=end,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(),
+        race_events=(),
+        winds=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_match_returns_none_when_no_races_exist(storage: Storage) -> None:
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    matched = await storage.match_vakaros_session_to_race(session_id)
+    assert matched is None
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
+    )
+    row = await cur.fetchone()
+    assert row["matched_race_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_match_links_race_that_is_fully_inside_vakaros_window(
+    storage: Storage,
+) -> None:
+    # Vakaros session: 12:00 - 14:00 (2 hours)
+    # Race          : 12:30 - 13:30 (1 hour, fully inside)
+    # Shorter duration = race (60 min). Overlap = 60 min. Ratio = 1.0 >= 0.5.
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    race_id = await _insert_race(
+        storage,
+        "Race 1",
+        t0 + timedelta(minutes=30),
+        t0 + timedelta(minutes=90),
+    )
+
+    matched = await storage.match_vakaros_session_to_race(session_id)
+    assert matched == race_id
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
+    )
+    row = await cur.fetchone()
+    assert row["matched_race_id"] == race_id
+
+
+@pytest.mark.asyncio
+async def test_match_rejects_race_with_less_than_50_percent_overlap(
+    storage: Storage,
+) -> None:
+    # Vakaros: 12:00 - 13:00 (60 min)
+    # Race   : 12:50 - 13:50 (60 min, overlaps only 10 min = 16.7%)
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=1))
+    session_id = await storage.store_vakaros_session(session)
+
+    await _insert_race(
+        storage,
+        "Race far",
+        t0 + timedelta(minutes=50),
+        t0 + timedelta(minutes=110),
+    )
+
+    matched = await storage.match_vakaros_session_to_race(session_id)
+    assert matched is None
+
+
+@pytest.mark.asyncio
+async def test_match_ignores_race_with_null_end_utc(storage: Storage) -> None:
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    await _insert_race(storage, "In-progress race", t0 + timedelta(minutes=10), None)
+
+    matched = await storage.match_vakaros_session_to_race(session_id)
+    assert matched is None
+
+
+@pytest.mark.asyncio
+async def test_match_picks_race_with_highest_overlap_ratio(storage: Storage) -> None:
+    # Vakaros: 12:00 - 13:00 (60 min)
+    # Race A : 12:00 - 12:40 (40 min, overlap 40 min, ratio = 40/40 = 1.0)
+    # Race B : 12:30 - 13:30 (60 min, overlap 30 min, ratio = 30/60 = 0.5)
+    # Race A wins.
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=1))
+    session_id = await storage.store_vakaros_session(session)
+
+    race_a = await _insert_race(storage, "Race A", t0, t0 + timedelta(minutes=40))
+    await _insert_race(
+        storage,
+        "Race B",
+        t0 + timedelta(minutes=30),
+        t0 + timedelta(minutes=90),
+    )
+
+    matched = await storage.match_vakaros_session_to_race(session_id)
+    assert matched == race_a
+
+
+@pytest.mark.asyncio
+async def test_ingest_vkx_file_auto_matches_to_race(storage: Storage, tmp_path: object) -> None:
+    """`ingest_vkx_file` should link a session to any overlapping race."""
+    import math
+    import struct
+    from pathlib import Path
+
+    from helmlog.vakaros import ingest_vkx_file
+
+    # Build a 60-second VKX with two position rows, on a known race day.
+    header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
+    t0_ms = int(datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC).timestamp() * 1000)
+    t1_ms = t0_ms + 60_000
+
+    def pos_row(ts_ms: int) -> bytes:
+        payload = struct.pack(
+            "<Qiifffffff",
+            ts_ms,
+            round(47.68 / 1e-7),
+            round(-122.41 / 1e-7),
+            1.0,
+            math.radians(0.0),
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+        )
+        return bytes([0x02]) + payload
+
+    rows = pos_row(t0_ms) + pos_row(t1_ms)
+    terminator = bytes([0xFE]) + struct.pack("<H", len(rows))
+    buf = header + rows + terminator
+
+    assert isinstance(tmp_path, Path)
+    vkx_path = tmp_path / "auto_match.vkx"
+    vkx_path.write_bytes(buf)
+
+    # Race that fully contains the Vakaros 60-second window.
+    race_id = await _insert_race(
+        storage,
+        "Race for auto-match",
+        datetime(2026, 4, 9, 11, 45, tzinfo=UTC),
+        datetime(2026, 4, 9, 12, 30, tzinfo=UTC),
+    )
+
+    session_id, was_duplicate = await ingest_vkx_file(storage, vkx_path)
+    assert was_duplicate is False
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
+    )
+    row = await cur.fetchone()
+    assert row["matched_race_id"] == race_id
+
+
+@pytest.mark.asyncio
+async def test_match_is_idempotent_and_updates_link(storage: Storage) -> None:
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    race_id = await _insert_race(
+        storage, "Race", t0 + timedelta(minutes=30), t0 + timedelta(minutes=90)
+    )
+
+    # Running twice should yield the same link.
+    first = await storage.match_vakaros_session_to_race(session_id)
+    second = await storage.match_vakaros_session_to_race(session_id)
+    assert first == second == race_id

--- a/tests/test_vakaros_matching.py
+++ b/tests/test_vakaros_matching.py
@@ -1,8 +1,10 @@
 """Tests for Vakaros -> races session matching (#458).
 
-Rule (from the spec): a Vakaros session matches an SK race when their
-time windows overlap by at least 50% of the shorter session's duration.
-Races still in progress (end_utc IS NULL) are never matched.
+Model: one Vakaros session can link to *many* races. For each race whose
+time window overlaps the Vakaros session by at least 50% of the shorter
+duration, ``races.vakaros_session_id`` is set to the Vakaros session id.
+Races still in progress (end_utc IS NULL) are never matched. Races that
+already point at a different Vakaros session are left alone.
 """
 
 from __future__ import annotations
@@ -24,7 +26,6 @@ async def _insert_race(
     start: datetime,
     end: datetime | None,
 ) -> int:
-    """Raw-SQL insert a race for testing (bypasses slug/validation)."""
     db = storage._conn()
     cur = await db.execute(
         "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
@@ -42,6 +43,14 @@ async def _insert_race(
     await db.commit()
     assert cur.lastrowid is not None
     return int(cur.lastrowid)
+
+
+async def _race_vakaros_link(storage: Storage, race_id: int) -> int | None:
+    """Look up a race's vakaros_session_id directly."""
+    db = storage._conn()
+    cur = await db.execute("SELECT vakaros_session_id FROM races WHERE id = ?", (race_id,))
+    row = await cur.fetchone()
+    return int(row["vakaros_session_id"]) if row and row["vakaros_session_id"] else None
 
 
 def _make_vakaros_session(
@@ -85,70 +94,73 @@ def _make_vakaros_session(
 
 
 @pytest.mark.asyncio
-async def test_match_returns_none_when_no_races_exist(storage: Storage) -> None:
+async def test_match_returns_empty_list_when_no_races_exist(storage: Storage) -> None:
     t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
     session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
     session_id = await storage.store_vakaros_session(session)
 
-    matched = await storage.match_vakaros_session_to_race(session_id)
-    assert matched is None
-
-    db = storage._conn()
-    cur = await db.execute(
-        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
-    )
-    row = await cur.fetchone()
-    assert row["matched_race_id"] is None
+    linked = await storage.match_vakaros_session(session_id)
+    assert linked == []
 
 
 @pytest.mark.asyncio
 async def test_match_links_race_that_is_fully_inside_vakaros_window(
     storage: Storage,
 ) -> None:
-    # Vakaros session: 12:00 - 14:00 (2 hours)
-    # Race          : 12:30 - 13:30 (1 hour, fully inside)
-    # Shorter duration = race (60 min). Overlap = 60 min. Ratio = 1.0 >= 0.5.
     t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
     session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
     session_id = await storage.store_vakaros_session(session)
 
     race_id = await _insert_race(
-        storage,
-        "Race 1",
-        t0 + timedelta(minutes=30),
-        t0 + timedelta(minutes=90),
+        storage, "Race 1", t0 + timedelta(minutes=30), t0 + timedelta(minutes=90)
     )
 
-    matched = await storage.match_vakaros_session_to_race(session_id)
-    assert matched == race_id
+    linked = await storage.match_vakaros_session(session_id)
+    assert linked == [race_id]
+    assert await _race_vakaros_link(storage, race_id) == session_id
 
-    db = storage._conn()
-    cur = await db.execute(
-        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
+
+@pytest.mark.asyncio
+async def test_match_links_all_overlapping_races_in_one_vakaros_session(
+    storage: Storage,
+) -> None:
+    """Real-world case: one VKX file spans multiple races + practice."""
+    t0 = datetime(2026, 4, 9, 0, 42, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    practice_id = await _insert_race(
+        storage, "Practice", t0 + timedelta(minutes=13), t0 + timedelta(minutes=27)
     )
-    row = await cur.fetchone()
-    assert row["matched_race_id"] == race_id
+    race1_id = await _insert_race(
+        storage, "Race 1", t0 + timedelta(minutes=48), t0 + timedelta(minutes=85)
+    )
+    race2_id = await _insert_race(
+        storage, "Race 2", t0 + timedelta(minutes=90), t0 + timedelta(minutes=113)
+    )
+
+    linked = await storage.match_vakaros_session(session_id)
+    assert set(linked) == {practice_id, race1_id, race2_id}
+
+    for rid in (practice_id, race1_id, race2_id):
+        assert await _race_vakaros_link(storage, rid) == session_id
 
 
 @pytest.mark.asyncio
 async def test_match_rejects_race_with_less_than_50_percent_overlap(
     storage: Storage,
 ) -> None:
-    # Vakaros: 12:00 - 13:00 (60 min)
-    # Race   : 12:50 - 13:50 (60 min, overlaps only 10 min = 16.7%)
     t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
     session = _make_vakaros_session(t0, t0 + timedelta(hours=1))
     session_id = await storage.store_vakaros_session(session)
 
-    await _insert_race(
-        storage,
-        "Race far",
-        t0 + timedelta(minutes=50),
-        t0 + timedelta(minutes=110),
+    race_id = await _insert_race(
+        storage, "Race far", t0 + timedelta(minutes=50), t0 + timedelta(minutes=110)
     )
 
-    matched = await storage.match_vakaros_session_to_race(session_id)
-    assert matched is None
+    linked = await storage.match_vakaros_session(session_id)
+    assert linked == []
+    assert await _race_vakaros_link(storage, race_id) is None
 
 
 @pytest.mark.asyncio
@@ -157,44 +169,86 @@ async def test_match_ignores_race_with_null_end_utc(storage: Storage) -> None:
     session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
     session_id = await storage.store_vakaros_session(session)
 
-    await _insert_race(storage, "In-progress race", t0 + timedelta(minutes=10), None)
+    race_id = await _insert_race(storage, "In-progress race", t0 + timedelta(minutes=10), None)
 
-    matched = await storage.match_vakaros_session_to_race(session_id)
-    assert matched is None
+    linked = await storage.match_vakaros_session(session_id)
+    assert linked == []
+    assert await _race_vakaros_link(storage, race_id) is None
 
 
 @pytest.mark.asyncio
-async def test_match_picks_race_with_highest_overlap_ratio(storage: Storage) -> None:
-    # Vakaros: 12:00 - 13:00 (60 min)
-    # Race A : 12:00 - 12:40 (40 min, overlap 40 min, ratio = 40/40 = 1.0)
-    # Race B : 12:30 - 13:30 (60 min, overlap 30 min, ratio = 30/60 = 0.5)
-    # Race A wins.
+async def test_match_does_not_steal_race_from_other_session(
+    storage: Storage,
+) -> None:
+    """A race already linked to a different Vakaros session is left alone."""
     t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
-    session = _make_vakaros_session(t0, t0 + timedelta(hours=1))
-    session_id = await storage.store_vakaros_session(session)
+    session_a = _make_vakaros_session(t0, t0 + timedelta(hours=2), source_hash="a" * 64)
+    session_b = _make_vakaros_session(t0, t0 + timedelta(hours=2), source_hash="b" * 64)
+    id_a = await storage.store_vakaros_session(session_a)
+    id_b = await storage.store_vakaros_session(session_b)
 
-    race_a = await _insert_race(storage, "Race A", t0, t0 + timedelta(minutes=40))
-    await _insert_race(
-        storage,
-        "Race B",
-        t0 + timedelta(minutes=30),
-        t0 + timedelta(minutes=90),
+    race_id = await _insert_race(
+        storage, "Race", t0 + timedelta(minutes=30), t0 + timedelta(minutes=90)
     )
 
-    matched = await storage.match_vakaros_session_to_race(session_id)
-    assert matched == race_a
+    assert await storage.match_vakaros_session(id_a) == [race_id]
+    assert await storage.match_vakaros_session(id_b) == []
+    assert await _race_vakaros_link(storage, race_id) == id_a
 
 
 @pytest.mark.asyncio
-async def test_ingest_vkx_file_auto_matches_to_race(storage: Storage, tmp_path: object) -> None:
-    """`ingest_vkx_file` should link a session to any overlapping race."""
+async def test_match_is_idempotent(storage: Storage) -> None:
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
+    session_id = await storage.store_vakaros_session(session)
+
+    race_id = await _insert_race(
+        storage, "Race", t0 + timedelta(minutes=30), t0 + timedelta(minutes=90)
+    )
+
+    first = await storage.match_vakaros_session(session_id)
+    second = await storage.match_vakaros_session(session_id)
+    assert first == second == [race_id]
+
+
+@pytest.mark.asyncio
+async def test_rematch_all_vakaros_sessions_links_everything(
+    storage: Storage,
+) -> None:
+    """Historical sessions ingested before the matcher can be linked with one call."""
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    a = _make_vakaros_session(t0, t0 + timedelta(hours=1), source_hash="1" * 64)
+    b = _make_vakaros_session(
+        t0 + timedelta(hours=2), t0 + timedelta(hours=3), source_hash="2" * 64
+    )
+    id_a = await storage.store_vakaros_session(a)
+    id_b = await storage.store_vakaros_session(b)
+
+    race_a = await _insert_race(
+        storage, "Race A", t0 + timedelta(minutes=10), t0 + timedelta(minutes=50)
+    )
+    race_b = await _insert_race(
+        storage,
+        "Race B",
+        t0 + timedelta(hours=2, minutes=10),
+        t0 + timedelta(hours=2, minutes=50),
+    )
+
+    results = await storage.rematch_all_vakaros_sessions()
+    assert results == {id_a: [race_a], id_b: [race_b]}
+
+
+@pytest.mark.asyncio
+async def test_ingest_vkx_file_auto_links_overlapping_race(
+    storage: Storage, tmp_path: object
+) -> None:
+    """`ingest_vkx_file` should link any overlapping race(s) to the session."""
     import math
     import struct
     from pathlib import Path
 
     from helmlog.vakaros import ingest_vkx_file
 
-    # Build a 60-second VKX with two position rows, on a known race day.
     header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
     t0_ms = int(datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC).timestamp() * 1000)
     t1_ms = t0_ms + 60_000
@@ -223,7 +277,6 @@ async def test_ingest_vkx_file_auto_matches_to_race(storage: Storage, tmp_path: 
     vkx_path = tmp_path / "auto_match.vkx"
     vkx_path.write_bytes(buf)
 
-    # Race that fully contains the Vakaros 60-second window.
     race_id = await _insert_race(
         storage,
         "Race for auto-match",
@@ -233,26 +286,4 @@ async def test_ingest_vkx_file_auto_matches_to_race(storage: Storage, tmp_path: 
 
     session_id, was_duplicate = await ingest_vkx_file(storage, vkx_path)
     assert was_duplicate is False
-
-    db = storage._conn()
-    cur = await db.execute(
-        "SELECT matched_race_id FROM vakaros_sessions WHERE id = ?", (session_id,)
-    )
-    row = await cur.fetchone()
-    assert row["matched_race_id"] == race_id
-
-
-@pytest.mark.asyncio
-async def test_match_is_idempotent_and_updates_link(storage: Storage) -> None:
-    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
-    session = _make_vakaros_session(t0, t0 + timedelta(hours=2))
-    session_id = await storage.store_vakaros_session(session)
-
-    race_id = await _insert_race(
-        storage, "Race", t0 + timedelta(minutes=30), t0 + timedelta(minutes=90)
-    )
-
-    # Running twice should yield the same link.
-    first = await storage.match_vakaros_session_to_race(session_id)
-    second = await storage.match_vakaros_session_to_race(session_id)
-    assert first == second == race_id
+    assert await _race_vakaros_link(storage, race_id) == session_id

--- a/tests/test_vakaros_storage.py
+++ b/tests/test_vakaros_storage.py
@@ -1,0 +1,197 @@
+"""Tests for Vakaros session storage (schema v59)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.vakaros import (
+    LinePosition,
+    LinePositionType,
+    PositionRow,
+    RaceTimerEvent,
+    RaceTimerEventType,
+    VakarosSession,
+    WindRow,
+)
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+def _make_session(source_hash: str = "a" * 64, source_file: str = "test.vkx") -> VakarosSession:
+    ts0 = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+    ts1 = datetime(2024, 6, 15, 12, 0, 1, tzinfo=UTC)
+    ts2 = datetime(2024, 6, 15, 12, 0, 2, tzinfo=UTC)
+    return VakarosSession(
+        source_hash=source_hash,
+        source_file=source_file,
+        start_utc=ts0,
+        end_utc=ts2,
+        positions=(
+            PositionRow(
+                timestamp=ts0,
+                latitude_deg=37.8044,
+                longitude_deg=-122.2712,
+                sog_mps=3.5,
+                cog_deg=45.0,
+                altitude_m=10.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=ts1,
+                latitude_deg=37.8045,
+                longitude_deg=-122.2711,
+                sog_mps=3.6,
+                cog_deg=46.0,
+                altitude_m=10.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=ts2,
+                latitude_deg=37.8046,
+                longitude_deg=-122.2710,
+                sog_mps=3.7,
+                cog_deg=47.0,
+                altitude_m=10.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            LinePosition(
+                timestamp=ts0,
+                line_type=LinePositionType.PIN,
+                latitude_deg=37.8050,
+                longitude_deg=-122.2700,
+            ),
+            LinePosition(
+                timestamp=ts0,
+                line_type=LinePositionType.BOAT,
+                latitude_deg=37.8048,
+                longitude_deg=-122.2705,
+            ),
+        ),
+        race_events=(
+            RaceTimerEvent(
+                timestamp=ts1,
+                event_type=RaceTimerEventType.RACE_START,
+                timer_value_s=0,
+            ),
+        ),
+        winds=(WindRow(timestamp=ts1, direction_deg=215.0, speed_mps=7.5),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_v59_creates_vakaros_tables(storage: Storage) -> None:
+    db = storage._conn()  # test-only access
+    for table in (
+        "vakaros_sessions",
+        "vakaros_positions",
+        "vakaros_line_positions",
+        "vakaros_race_events",
+        "vakaros_winds",
+    ):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        )
+        row = await cur.fetchone()
+        assert row is not None, f"missing table {table}"
+
+
+@pytest.mark.asyncio
+async def test_store_vakaros_session_inserts_all_rows(storage: Storage) -> None:
+    session = _make_session()
+    session_id = await storage.store_vakaros_session(session)
+    assert session_id > 0
+
+    db = storage._conn()
+
+    cur = await db.execute(
+        "SELECT source_hash, source_file, start_utc, end_utc FROM vakaros_sessions WHERE id=?",
+        (session_id,),
+    )
+    row = await cur.fetchone()
+    assert row is not None
+    assert row["source_hash"] == session.source_hash
+    assert row["source_file"] == "test.vkx"
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_positions WHERE session_id=?",
+        (session_id,),
+    )
+    assert (await cur.fetchone())["n"] == 3
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_line_positions WHERE session_id=?",
+        (session_id,),
+    )
+    assert (await cur.fetchone())["n"] == 2
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_race_events WHERE session_id=?",
+        (session_id,),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_winds WHERE session_id=?",
+        (session_id,),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_store_vakaros_session_is_idempotent_on_source_hash(storage: Storage) -> None:
+    session = _make_session(source_hash="b" * 64)
+    first_id = await storage.store_vakaros_session(session)
+    second_id = await storage.store_vakaros_session(session)
+    assert first_id == second_id
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_sessions WHERE source_hash=?",
+        (session.source_hash,),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM vakaros_positions WHERE session_id=?",
+        (first_id,),
+    )
+    assert (await cur.fetchone())["n"] == 3  # not doubled
+
+
+@pytest.mark.asyncio
+async def test_delete_vakaros_session_cascades(storage: Storage) -> None:
+    session = _make_session(source_hash="c" * 64)
+    session_id = await storage.store_vakaros_session(session)
+
+    await storage.delete_vakaros_session(session_id)
+
+    db = storage._conn()
+    for table in (
+        "vakaros_sessions",
+        "vakaros_positions",
+        "vakaros_line_positions",
+        "vakaros_race_events",
+        "vakaros_winds",
+    ):
+        cur = await db.execute(
+            f"SELECT COUNT(*) AS n FROM {table} WHERE "
+            f"{'id' if table == 'vakaros_sessions' else 'session_id'}=?",
+            (session_id,),
+        )
+        assert (await cur.fetchone())["n"] == 0, f"{table} not cleared"

--- a/tests/test_vakaros_storage.py
+++ b/tests/test_vakaros_storage.py
@@ -175,6 +175,50 @@ async def test_store_vakaros_session_is_idempotent_on_source_hash(storage: Stora
 
 
 @pytest.mark.asyncio
+async def test_ingest_vkx_file_parses_stores_and_detects_duplicates(
+    storage: Storage, tmp_path: object
+) -> None:
+    import math
+    import struct
+    from pathlib import Path
+
+    from helmlog.vakaros import ingest_vkx_file
+
+    # Hand-built minimal VKX: page header + one Position row + page terminator.
+    header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
+    ts_ms = 1_700_000_000_000
+    payload = struct.pack(
+        "<Qiifffffff",
+        ts_ms,
+        round(37.8044 / 1e-7),
+        round(-122.2712 / 1e-7),
+        3.5,
+        math.radians(45.0),
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+    row = bytes([0x02]) + payload
+    terminator = bytes([0xFE]) + struct.pack("<H", len(row))
+    buf = header + row + terminator
+
+    assert isinstance(tmp_path, Path)
+    vkx_path = tmp_path / "session_001.vkx"
+    vkx_path.write_bytes(buf)
+
+    session_id, was_duplicate = await ingest_vkx_file(storage, vkx_path)
+    assert session_id > 0
+    assert was_duplicate is False
+
+    # Second ingest of the same file is a no-op dedupe hit.
+    session_id_2, was_duplicate_2 = await ingest_vkx_file(storage, vkx_path)
+    assert session_id_2 == session_id
+    assert was_duplicate_2 is True
+
+
+@pytest.mark.asyncio
 async def test_delete_vakaros_session_cascades(storage: Storage) -> None:
     session = _make_session(source_hash="c" * 64)
     session_id = await storage.store_vakaros_session(session)

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -294,8 +294,8 @@ async def test_vakaros_overlay_returns_full_payload_when_matched(
     await db.commit()
     race_id = cur.lastrowid
     assert race_id is not None
-    matched = await storage.match_vakaros_session_to_race(vakaros_id)
-    assert matched == race_id
+    linked = await storage.match_vakaros_session(vakaros_id)
+    assert linked == [race_id]
 
     app = create_app(storage)
     async with httpx.AsyncClient(
@@ -308,13 +308,15 @@ async def test_vakaros_overlay_returns_full_payload_when_matched(
     assert data["matched"] is True
     assert data["vakaros_session_id"] == vakaros_id
 
-    # Track is a GeoJSON-ish LineString with 3 points.
+    # Track is trimmed to the race window (03:00 - 27:00 inside a session
+    # with positions at 00:00, 15:00, 30:00), so only the middle point is
+    # inside — a single-coord LineString.
     assert data["track"] is not None
     assert data["track"]["type"] == "Feature"
     assert data["track"]["geometry"]["type"] == "LineString"
-    assert len(data["track"]["geometry"]["coordinates"]) == 3
+    assert len(data["track"]["geometry"]["coordinates"]) == 1
     # [lon, lat] GeoJSON order
-    assert data["track"]["geometry"]["coordinates"][0] == [-122.41, 47.68]
+    assert data["track"]["geometry"]["coordinates"][0] == [-122.411, 47.681]
 
     # Line positions: one pin, one boat.
     lines_by_type = {lp["line_type"]: lp for lp in data["line_positions"]}
@@ -339,10 +341,15 @@ async def test_vakaros_overlay_returns_full_payload_when_matched(
 
 
 @pytest.mark.asyncio
-async def test_vakaros_overlay_line_uses_most_recent_pings(
+async def test_vakaros_overlay_line_uses_line_active_at_race_start(
     storage: Storage, inbox_path: Path
 ) -> None:
-    """When the line was re-set, the overlay reports the most recent endpoints."""
+    """When the line was re-set, each race gets the line active at its start.
+
+    Two races share a Vakaros file with an early line and a re-set line.
+    The race that starts *before* the re-set sees the early line; the
+    race that starts *after* the re-set sees the late line.
+    """
     from datetime import UTC, datetime, timedelta
 
     from helmlog.vakaros import (
@@ -419,34 +426,56 @@ async def test_vakaros_overlay_line_uses_most_recent_pings(
     vakaros_id = await storage.store_vakaros_session(session)
 
     db = storage._conn()
+    # Race 1 starts BEFORE the re-set (at minute 5) — should see the early line.
     cur = await db.execute(
         "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
         "VALUES (?, ?, ?, ?, ?, ?, ?)",
         (
-            "Re-set line race",
+            "Race 1",
             "evt",
             1,
             "2026-04-09",
+            (t0 + timedelta(minutes=5)).isoformat(),
             (t0 + timedelta(minutes=10)).isoformat(),
-            (t0 + timedelta(minutes=25)).isoformat(),
             "race",
         ),
     )
+    race1_id = cur.lastrowid
+    # Race 2 starts AFTER the re-set (at minute 20) — should see the late line.
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Race 2",
+            "evt",
+            2,
+            "2026-04-09",
+            (t0 + timedelta(minutes=20)).isoformat(),
+            (t0 + timedelta(minutes=28)).isoformat(),
+            "race",
+        ),
+    )
+    race2_id = cur.lastrowid
     await db.commit()
-    race_id = cur.lastrowid
-    await storage.match_vakaros_session_to_race(vakaros_id)
+    linked = await storage.match_vakaros_session(vakaros_id)
+    assert set(linked) == {race1_id, race2_id}
 
     app = create_app(storage)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
-        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+        r1_resp = await client.get(f"/api/sessions/{race1_id}/vakaros-overlay")
+        r2_resp = await client.get(f"/api/sessions/{race2_id}/vakaros-overlay")
 
-    data = resp.json()
-    assert data["line"] is not None
-    # Most recent pings, not the early ones.
-    assert data["line"]["pin"] == [47.690, -122.420]
-    assert data["line"]["boat"] == [47.690, -122.416]
+    r1 = r1_resp.json()
+    assert r1["line"] is not None
+    assert r1["line"]["pin"] == [47.680, -122.420]
+    assert r1["line"]["boat"] == [47.680, -122.416]
+
+    r2 = r2_resp.json()
+    assert r2["line"] is not None
+    assert r2["line"]["pin"] == [47.690, -122.420]
+    assert r2["line"]["boat"] == [47.690, -122.416]
 
 
 @pytest.mark.asyncio
@@ -525,7 +554,7 @@ async def test_vakaros_overlay_line_is_none_when_only_one_endpoint(
     )
     await db.commit()
     race_id = cur.lastrowid
-    await storage.match_vakaros_session_to_race(vakaros_id)
+    await storage.match_vakaros_session(vakaros_id)
 
     app = create_app(storage)
     async with httpx.AsyncClient(
@@ -537,6 +566,156 @@ async def test_vakaros_overlay_line_is_none_when_only_one_endpoint(
     assert data["line"] is None
     # line_positions still includes the single pin so the UI can render it.
     assert len(data["line_positions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_vakaros_rematch_links_existing_sessions(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """POST /admin/vakaros/rematch should run matching across all stored sessions."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import PositionRow, VakarosSession
+    from helmlog.web import create_app
+
+    # Insert a Vakaros session directly (bypassing ingest_vkx_file so its
+    # auto-match path does NOT run — simulating historical data).
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="99" * 32,
+        source_file="historical.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(hours=2),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(hours=2),
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(),
+        race_events=(),
+        winds=(),
+    )
+    await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Late race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=30)).isoformat(),
+            (t0 + timedelta(minutes=90)).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/admin/vakaros/rematch", follow_redirects=False)
+
+    assert resp.status_code in (302, 303)
+    cur = await db.execute("SELECT vakaros_session_id FROM races WHERE id = ?", (race_id,))
+    row = await cur.fetchone()
+    assert row["vakaros_session_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_trims_track_to_race_window(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """Overlay track contains only positions inside the race's time window."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import PositionRow, VakarosSession
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    positions = tuple(
+        PositionRow(
+            timestamp=t0 + timedelta(minutes=i * 30),
+            latitude_deg=47.68 + i * 0.001,
+            longitude_deg=-122.41,
+            sog_mps=1.0,
+            cog_deg=0.0,
+            altitude_m=0.0,
+            quat_w=1.0,
+            quat_x=0.0,
+            quat_y=0.0,
+            quat_z=0.0,
+        )
+        for i in range(5)
+    )
+    session = VakarosSession(
+        source_hash="77" * 32,
+        source_file="trim.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(hours=2),
+        positions=positions,
+        line_positions=(),
+        race_events=(),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    # Race from t0+75m to t0+105m — only the position at t0+90m is inside.
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Trimmed race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=75)).isoformat(),
+            (t0 + timedelta(minutes=105)).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    linked = await storage.match_vakaros_session(vakaros_id)
+    assert race_id in linked
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    assert data["matched"] is True
+    assert data["track"] is not None
+    coords = data["track"]["geometry"]["coordinates"]
+    assert len(coords) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -1069,6 +1069,145 @@ async def test_vakaros_overlay_race_start_context_absent_when_no_sk_data(
 
 
 @pytest.mark.asyncio
+async def test_vakaros_overlay_trims_line_positions_to_pre_race(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """Pings set after this race's start belong to a later race and must
+    not leak into this race's overlay. Race 1 should NOT see the post-race
+    re-set that's used by race 2."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="dd" * 32,
+        source_file="trim_pings.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=60),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=60),
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            # Race 1 line — pre-race
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=2),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.681,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=3),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.681,
+                longitude_deg=-122.416,
+            ),
+            # Race 2 line — set AFTER race 1 has started
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=20),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.690,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=21),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.690,
+                longitude_deg=-122.416,
+            ),
+        ),
+        race_events=(),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Race 1",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=5)).isoformat(),
+            (t0 + timedelta(minutes=15)).isoformat(),
+            "race",
+        ),
+    )
+    race1_id = cur.lastrowid
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Race 2",
+            "evt",
+            2,
+            "2026-04-09",
+            (t0 + timedelta(minutes=25)).isoformat(),
+            (t0 + timedelta(minutes=35)).isoformat(),
+            "race",
+        ),
+    )
+    race2_id = cur.lastrowid
+    await db.commit()
+    await storage.match_vakaros_session(vakaros_id)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = (await client.get(f"/api/sessions/{race1_id}/vakaros-overlay")).json()
+        r2 = (await client.get(f"/api/sessions/{race2_id}/vakaros-overlay")).json()
+
+    # Race 1 sees only the pre-race pings (one of each).
+    r1_pings = sorted(
+        [(lp["line_type"], round(lp["latitude_deg"], 3)) for lp in r1["line_positions"]]
+    )
+    assert r1_pings == [("boat", 47.681), ("pin", 47.681)]
+
+    # Race 2 sees both sets — pings on or before race 2's start at +25 min.
+    r2_pings = sorted(
+        [(lp["line_type"], round(lp["latitude_deg"], 3)) for lp in r2["line_positions"]]
+    )
+    assert r2_pings == [
+        ("boat", 47.681),
+        ("boat", 47.690),
+        ("pin", 47.681),
+        ("pin", 47.690),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_vakaros_overlay_trims_track_to_race_window(
     storage: Storage, inbox_path: Path
 ) -> None:

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -132,6 +132,203 @@ async def test_admin_vakaros_ingest_moves_malformed_file_to_failed(
 
 
 @pytest.mark.asyncio
+async def test_vakaros_overlay_returns_404_for_unknown_race(
+    storage: Storage, inbox_path: Path
+) -> None:
+    from helmlog.web import create_app
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions/99999/vakaros-overlay")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_returns_empty_when_no_match(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """A race that has no matched Vakaros session should return an empty payload."""
+    from datetime import UTC, datetime
+
+    from helmlog.web import create_app
+
+    # Insert a race with no Vakaros session nearby.
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Solo race",
+            "evt",
+            1,
+            "2026-04-09",
+            datetime(2026, 4, 9, 12, 0, tzinfo=UTC).isoformat(),
+            datetime(2026, 4, 9, 13, 0, tzinfo=UTC).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["matched"] is False
+    assert data["line_positions"] == []
+    assert data["race_events"] == []
+    assert data["track"] is None
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_returns_full_payload_when_matched(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """When a race is matched to a Vakaros session, overlay returns track, line, events."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        RaceTimerEvent,
+        RaceTimerEventType,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="f" * 64,
+        source_file="test.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=15),
+                latitude_deg=47.681,
+                longitude_deg=-122.411,
+                sog_mps=2.0,
+                cog_deg=45.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.682,
+                longitude_deg=-122.412,
+                sog_mps=1.5,
+                cog_deg=90.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            LinePosition(
+                timestamp=t0,
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.687,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0,
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.687,
+                longitude_deg=-122.416,
+            ),
+        ),
+        race_events=(
+            RaceTimerEvent(
+                timestamp=t0 + timedelta(minutes=5),
+                event_type=RaceTimerEventType.RACE_START,
+                timer_value_s=0,
+            ),
+            RaceTimerEvent(
+                timestamp=t0 + timedelta(minutes=28),
+                event_type=RaceTimerEventType.RACE_END,
+                timer_value_s=1380,
+            ),
+        ),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    # Create an overlapping race and match it.
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Shilshole race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=3)).isoformat(),
+            (t0 + timedelta(minutes=27)).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+    matched = await storage.match_vakaros_session_to_race(vakaros_id)
+    assert matched == race_id
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["matched"] is True
+    assert data["vakaros_session_id"] == vakaros_id
+
+    # Track is a GeoJSON-ish LineString with 3 points.
+    assert data["track"] is not None
+    assert data["track"]["type"] == "Feature"
+    assert data["track"]["geometry"]["type"] == "LineString"
+    assert len(data["track"]["geometry"]["coordinates"]) == 3
+    # [lon, lat] GeoJSON order
+    assert data["track"]["geometry"]["coordinates"][0] == [-122.41, 47.68]
+
+    # Line positions: one pin, one boat.
+    lines_by_type = {lp["line_type"]: lp for lp in data["line_positions"]}
+    assert set(lines_by_type.keys()) == {"pin", "boat"}
+    assert lines_by_type["pin"]["latitude_deg"] == 47.687
+    assert lines_by_type["boat"]["longitude_deg"] == -122.416
+
+    # Race events: race_start + race_end.
+    event_types = {e["event_type"] for e in data["race_events"]}
+    assert "race_start" in event_types
+    assert "race_end" in event_types
+
+
+@pytest.mark.asyncio
 async def test_admin_vakaros_ingest_rejects_path_traversal(
     storage: Storage, inbox_path: Path
 ) -> None:

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -787,6 +787,189 @@ async def test_vakaros_overlay_race_start_context_includes_bsp_and_line_distance
 
 
 @pytest.mark.asyncio
+async def test_vakaros_overlay_race_start_context_includes_polar_pct_and_line_bias(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """Race start context should compute polar % and wind-relative line bias.
+
+    Wind comes in as north-referenced (reference=4 → wind_angle_deg IS TWD).
+    Polar baseline is seeded directly so the lookup hits a known cell.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.polar import _twa_bin, _tws_bin
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        RaceTimerEvent,
+        RaceTimerEventType,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    race_start_ts = t0 + timedelta(minutes=5)
+    session = VakarosSession(
+        source_hash="cc" * 32,
+        source_file="polar.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            # Line runs due east (pin west, boat east) — bearing 90° T.
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=1),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.687,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=1),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.687,
+                longitude_deg=-122.416,
+            ),
+        ),
+        race_events=(
+            RaceTimerEvent(
+                timestamp=race_start_ts,
+                event_type=RaceTimerEventType.RACE_START,
+                timer_value_s=0,
+            ),
+        ),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    race_cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Polar test race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=3)).isoformat(),
+            (t0 + timedelta(minutes=25)).isoformat(),
+            "race",
+        ),
+    )
+    race_id = race_cur.lastrowid
+    await db.commit()
+    await storage.match_vakaros_session(vakaros_id)
+
+    # Seed SK samples around race_start.
+    boat_lat = 47.687  # exactly on the line
+    boat_lon = -122.418
+    bsp_kts = 5.4
+    sog_kts = 5.6
+    heading_deg = 0.0  # boat pointing due north
+    twd_deg = 45.0  # wind from NE → TWD 45°
+    tws_kts = 12.0
+    for delta in (-2, -1, 0, 1, 2):
+        ts = (race_start_ts + timedelta(seconds=delta)).isoformat()
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 5, bsp_kts),
+        )
+        await db.execute(
+            "INSERT INTO cogsog (ts, source_addr, cog_deg, sog_kts) VALUES (?, ?, ?, ?)",
+            (ts, 5, 0.0, sog_kts),
+        )
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg) "
+            "VALUES (?, ?, ?, ?)",
+            (ts, 5, boat_lat, boat_lon),
+        )
+        await db.execute(
+            "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+            (ts, 5, heading_deg),
+        )
+        # reference=4 → wind_angle_deg IS TWD (north-referenced)
+        await db.execute(
+            "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (ts, 5, tws_kts, twd_deg, 4),
+        )
+    await db.commit()
+
+    # Seed a polar baseline cell that matches the (TWS, TWA) bin we'll
+    # compute. heading=0, twd=45 → twa = 45 (boat is on starboard tack
+    # close-hauled on a 45° wind).
+    tws_bin = _tws_bin(tws_kts)
+    twa_bin = _twa_bin(45.0)
+    await storage.upsert_polar_baseline(
+        [
+            {
+                "tws_bin": tws_bin,
+                "twa_bin": twa_bin,
+                "mean_bsp": 5.0,
+                "p90_bsp": 6.0,  # target → polar % = 5.4 / 6.0 = 90%
+                "session_count": 5,
+                "sample_count": 100,
+            }
+        ],
+        built_at=t0.isoformat(),
+    )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    ctx = data["race_start_context"]
+    assert ctx is not None
+
+    # Wind context
+    assert ctx["tws_kts"] == pytest.approx(tws_kts)
+    assert ctx["twd_deg"] == pytest.approx(twd_deg)
+    assert ctx["twa_deg"] == pytest.approx(45.0)
+
+    # Polar %: 5.4 / 6.0 ≈ 90%
+    assert ctx["polar_pct"] == pytest.approx(90.0, abs=0.5)
+
+    # Wind-relative line bias.
+    # Line bearing pin → boat = 90° T (due east).
+    # Wind FROM 45° T means wind blows toward 225°.
+    # The "square" line is perpendicular to the wind direction. A line
+    # perpendicular to wind-from-45° has bearings 135° / 315°.
+    # Our line is 90°, which is 45° clockwise of the square (135°)... so
+    # the pin (west end) is favored relative to the boat end.
+    assert ctx["line_bias_deg"] is not None
+    assert ctx["favored_end"] in ("pin", "boat", "square")
+    assert ctx["favored_end"] == "pin"  # for this geometry
+
+
+@pytest.mark.asyncio
 async def test_vakaros_overlay_race_start_context_absent_when_no_sk_data(
     storage: Storage, inbox_path: Path
 ) -> None:
@@ -870,13 +1053,19 @@ async def test_vakaros_overlay_race_start_context_absent_when_no_sk_data(
         resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
 
     data = resp.json()
-    # No SK speeds/positions seeded → context is present but with nulls
-    # (race_start timestamp is still known even without BSP/pos).
+    # No SK speeds/positions/wind seeded → context is present but with nulls
+    # (race_start timestamp is still known even without instrument data).
     ctx = data.get("race_start_context")
     assert ctx is not None
     assert ctx["bsp_kts"] is None
     assert ctx["sog_kts"] is None
     assert ctx["distance_to_line_m"] is None  # no line endpoints anyway
+    assert ctx["tws_kts"] is None
+    assert ctx["twd_deg"] is None
+    assert ctx["twa_deg"] is None
+    assert ctx["polar_pct"] is None
+    assert ctx["line_bias_deg"] is None
+    assert ctx["favored_end"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -327,6 +327,217 @@ async def test_vakaros_overlay_returns_full_payload_when_matched(
     assert "race_start" in event_types
     assert "race_end" in event_types
 
+    # Computed line geometry (from the most recent pin + boat pings).
+    assert data["line"] is not None
+    line = data["line"]
+    assert line["pin"] == [47.687, -122.420]
+    assert line["boat"] == [47.687, -122.416]
+    # Length: ~301 m along this latitude (0.004 deg lon @ 47.687 N).
+    assert 280 < line["length_m"] < 320
+    # Bearing from pin to boat: close to 90° (due east).
+    assert 85 < line["bearing_deg"] < 95
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_line_uses_most_recent_pings(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """When the line was re-set, the overlay reports the most recent endpoints."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="e" * 64,
+        source_file="test.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.682,
+                longitude_deg=-122.412,
+                sog_mps=1.5,
+                cog_deg=90.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            # Early line
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=2),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.680,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=3),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.680,
+                longitude_deg=-122.416,
+            ),
+            # Line was re-set later
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=15),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.690,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=16),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.690,
+                longitude_deg=-122.416,
+            ),
+        ),
+        race_events=(),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Re-set line race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=10)).isoformat(),
+            (t0 + timedelta(minutes=25)).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    await storage.match_vakaros_session_to_race(vakaros_id)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    assert data["line"] is not None
+    # Most recent pings, not the early ones.
+    assert data["line"]["pin"] == [47.690, -122.420]
+    assert data["line"]["boat"] == [47.690, -122.416]
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_line_is_none_when_only_one_endpoint(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """If only a pin or only a boat has been pinged, line is None."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="d" * 64,
+        source_file="test.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.682,
+                longitude_deg=-122.412,
+                sog_mps=1.5,
+                cog_deg=90.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=2),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.687,
+                longitude_deg=-122.420,
+            ),
+        ),
+        race_events=(),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Half-line race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=5)).isoformat(),
+            (t0 + timedelta(minutes=25)).isoformat(),
+            "race",
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    await storage.match_vakaros_session_to_race(vakaros_id)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    assert data["line"] is None
+    # line_positions still includes the single pin so the UI can render it.
+    assert len(data["line_positions"]) == 1
+
 
 @pytest.mark.asyncio
 async def test_admin_vakaros_ingest_rejects_path_traversal(

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -1,0 +1,150 @@
+"""Tests for the Vakaros admin web routes (#458 cycle 5)."""
+
+from __future__ import annotations
+
+import math
+import struct
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+else:
+    from pathlib import Path  # noqa: TC003  # runtime needed by pytest fixture types
+
+
+def _build_minimal_vkx_bytes(ts_ms: int = 1_700_000_000_000) -> bytes:
+    header = bytes([0xFF, 0x05, 0, 0, 0, 0, 0, 0])
+    payload = struct.pack(
+        "<Qiifffffff",
+        ts_ms,
+        round(47.68 / 1e-7),
+        round(-122.41 / 1e-7),
+        1.0,
+        math.radians(0.0),
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+    row = bytes([0x02]) + payload
+    terminator = bytes([0xFE]) + struct.pack("<H", len(row))
+    return header + row + terminator
+
+
+@pytest.fixture
+def inbox_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    inbox = tmp_path / "vakaros-inbox"
+    inbox.mkdir()
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    monkeypatch.setenv("VAKAROS_INBOX_DIR", str(inbox))
+    return inbox
+
+
+@pytest.mark.asyncio
+async def test_admin_vakaros_page_lists_inbox_files_and_sessions(
+    storage: Storage, inbox_path: Path
+) -> None:
+    from helmlog.web import create_app
+
+    (inbox_path / "alpha.vkx").write_bytes(b"x")
+    (inbox_path / "bravo.vkx").write_bytes(b"x")
+    (inbox_path / "readme.txt").write_bytes(b"ignored")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/admin/vakaros")
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "alpha.vkx" in body
+    assert "bravo.vkx" in body
+    assert "readme.txt" not in body
+    # Empty state for the sessions list
+    assert "No Vakaros sessions" in body or "vakaros_sessions" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_admin_vakaros_ingest_processes_valid_file(
+    storage: Storage, inbox_path: Path
+) -> None:
+    from helmlog.web import create_app
+
+    (inbox_path / "good.vkx").write_bytes(_build_minimal_vkx_bytes())
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/admin/vakaros/ingest",
+            data={"filename": "good.vkx"},
+            follow_redirects=False,
+        )
+
+    # Expect a redirect back to the admin page (PRG pattern).
+    assert resp.status_code in (302, 303)
+    assert resp.headers["location"].startswith("/admin/vakaros")
+
+    # Original is gone, archived in processed/, DB has one row.
+    assert not (inbox_path / "good.vkx").exists()
+    assert (inbox_path / "processed" / "good.vkx").exists()
+
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM vakaros_sessions")
+    row = await cur.fetchone()
+    assert row["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_vakaros_ingest_moves_malformed_file_to_failed(
+    storage: Storage, inbox_path: Path
+) -> None:
+    from helmlog.web import create_app
+
+    (inbox_path / "junk.vkx").write_bytes(b"\x00\x00\x00")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/admin/vakaros/ingest",
+            data={"filename": "junk.vkx"},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code in (302, 303)
+    assert (inbox_path / "failed" / "junk.vkx").exists()
+    assert (inbox_path / "failed" / "junk.vkx.err").exists()
+
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM vakaros_sessions")
+    row = await cur.fetchone()
+    assert row["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_vakaros_ingest_rejects_path_traversal(
+    storage: Storage, inbox_path: Path
+) -> None:
+    from helmlog.web import create_app
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/admin/vakaros/ingest",
+            data={"filename": "../escape.vkx"},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 400

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -648,6 +648,238 @@ async def test_admin_vakaros_rematch_links_existing_sessions(
 
 
 @pytest.mark.asyncio
+async def test_vakaros_overlay_race_start_context_includes_bsp_and_line_distance(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """Overlay payload should surface boat speed + distance-to-line at race start."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        LinePosition,
+        LinePositionType,
+        PositionRow,
+        RaceTimerEvent,
+        RaceTimerEventType,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    race_start_ts = t0 + timedelta(minutes=5)  # race_start event
+    session = VakarosSession(
+        source_hash="aa" * 32,
+        source_file="context.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=1),
+                line_type=LinePositionType.PIN,
+                latitude_deg=47.687,
+                longitude_deg=-122.420,
+            ),
+            LinePosition(
+                timestamp=t0 + timedelta(minutes=1),
+                line_type=LinePositionType.BOAT,
+                latitude_deg=47.687,
+                longitude_deg=-122.416,
+            ),
+        ),
+        race_events=(
+            RaceTimerEvent(
+                timestamp=race_start_ts,
+                event_type=RaceTimerEventType.RACE_START,
+                timer_value_s=0,
+            ),
+        ),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    # Insert an SK race that overlaps the Vakaros window.
+    db = storage._conn()
+    race_cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Start ctx race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=3)).isoformat(),
+            (t0 + timedelta(minutes=25)).isoformat(),
+            "race",
+        ),
+    )
+    race_id = race_cur.lastrowid
+    await db.commit()
+    await storage.match_vakaros_session(vakaros_id)
+
+    # Seed SK instrument samples right around race_start.
+    # BSP 5.4 kt, SOG 5.6 kt, position mid-way between pin and boat but 20 m behind.
+    # Pin: 47.687, -122.420    Boat: 47.687, -122.416 (line runs due east)
+    # Boat behind the line means 20 m *south* of the line (lat < 47.687).
+    # 20 m south ≈ 20 / 111320 degrees latitude.
+    boat_lat = 47.687 - (20.0 / 111320.0)
+    boat_lon = -122.418  # midway between -122.420 and -122.416
+    for delta in (-2, -1, 0, 1, 2):
+        ts = (race_start_ts + timedelta(seconds=delta)).isoformat()
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 5, 5.4),
+        )
+        await db.execute(
+            "INSERT INTO cogsog (ts, source_addr, cog_deg, sog_kts) VALUES (?, ?, ?, ?)",
+            (ts, 5, 0.0, 5.6),
+        )
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg) "
+            "VALUES (?, ?, ?, ?)",
+            (ts, 5, boat_lat, boat_lon),
+        )
+    await db.commit()
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    assert data["matched"] is True
+    ctx = data.get("race_start_context")
+    assert ctx is not None, "overlay should include race_start_context"
+    assert ctx["ts"] == race_start_ts.isoformat()
+    # Boat speed at the start — within 0.1 kt of the seeded value.
+    assert 5.3 <= ctx["bsp_kts"] <= 5.5
+    assert 5.5 <= ctx["sog_kts"] <= 5.7
+    # Boat position at the start.
+    assert ctx["latitude_deg"] == pytest.approx(boat_lat, abs=1e-6)
+    assert ctx["longitude_deg"] == pytest.approx(boat_lon, abs=1e-6)
+    # Perpendicular distance to the start line — we set the boat 20 m behind.
+    assert 18.0 <= ctx["distance_to_line_m"] <= 22.0
+
+
+@pytest.mark.asyncio
+async def test_vakaros_overlay_race_start_context_absent_when_no_sk_data(
+    storage: Storage, inbox_path: Path
+) -> None:
+    """If there's no SK data around the race_start event, ctx is None."""
+    from datetime import UTC, datetime, timedelta
+
+    from helmlog.vakaros import (
+        PositionRow,
+        RaceTimerEvent,
+        RaceTimerEventType,
+        VakarosSession,
+    )
+    from helmlog.web import create_app
+
+    t0 = datetime(2026, 4, 9, 12, 0, 0, tzinfo=UTC)
+    session = VakarosSession(
+        source_hash="bb" * 32,
+        source_file="no_sk.vkx",
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        positions=(
+            PositionRow(
+                timestamp=t0,
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+            PositionRow(
+                timestamp=t0 + timedelta(minutes=30),
+                latitude_deg=47.68,
+                longitude_deg=-122.41,
+                sog_mps=1.0,
+                cog_deg=0.0,
+                altitude_m=0.0,
+                quat_w=1.0,
+                quat_x=0.0,
+                quat_y=0.0,
+                quat_z=0.0,
+            ),
+        ),
+        line_positions=(),
+        race_events=(
+            RaceTimerEvent(
+                timestamp=t0 + timedelta(minutes=5),
+                event_type=RaceTimerEventType.RACE_START,
+                timer_value_s=0,
+            ),
+        ),
+        winds=(),
+    )
+    vakaros_id = await storage.store_vakaros_session(session)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "No-SK race",
+            "evt",
+            1,
+            "2026-04-09",
+            (t0 + timedelta(minutes=3)).isoformat(),
+            (t0 + timedelta(minutes=25)).isoformat(),
+            "race",
+        ),
+    )
+    race_id = cur.lastrowid
+    await db.commit()
+    await storage.match_vakaros_session(vakaros_id)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/vakaros-overlay")
+
+    data = resp.json()
+    # No SK speeds/positions seeded → context is present but with nulls
+    # (race_start timestamp is still known even without BSP/pos).
+    ctx = data.get("race_start_context")
+    assert ctx is not None
+    assert ctx["bsp_kts"] is None
+    assert ctx["sog_kts"] is None
+    assert ctx["distance_to_line_m"] is None  # no line endpoints anyway
+
+
+@pytest.mark.asyncio
 async def test_vakaros_overlay_trims_track_to_race_window(
     storage: Storage, inbox_path: Path
 ) -> None:


### PR DESCRIPTION
Implements the VKX watched-folder ingest path per [spec](https://github.com/weaties/helmlog/issues/458#issuecomment-4228314890) on issue #458.

Closes #458.

## Status: In progress (draft)

### Landed

- **Cycle 1 — VKX parser** (21eb8b9): pure-Python parser for the [public VKX format](https://github.com/vakaros/vkx). PositionRow, RaceTimerEvent, LinePosition, WindRow + error paths. 100% coverage on vakaros.py.
- **Cycle 2 — Storage schema v59** (80f8706): 5 new tables (vakaros_sessions + 4 child tables), store_vakaros_session (idempotent on SHA-256 content hash, VKX has no device-ID field), delete_vakaros_session (FK cascade), matched_race_id cross-reference to races(id) ON DELETE SET NULL.
- **Cycle 3 — helmlog vakaros-ingest CLI** (14ee4a2): one-shot manual ingest, prints session summary. **Validated end-to-end on corvopi-tst1 with real Vakaros 105 data** — parsed 35,326 position rows, 4 start-line pings, 10 race timer events from a 2-hour Shilshole session. Dedupe idempotent.

### In flight

- **Cycle 4 — Session matching** (next): link Vakaros sessions to overlapping SK races via the spec's >=50% time-overlap rule.
- **Cycle 5 — Watched folder service**: watchdog-based ~/vakaros-inbox/ with stability check, processed//failed/ archiving.
- **Cycle 6 — UI overlays**: track selector, start-line on trace, start-time marker on maneuver chart, admin status panel.
- **Cycle 7 — Export integration**: Vakaros-native fields in CSV/GPX/JSON.

## Test plan

- [x] Cycles 1-3 unit tests (12 new, all green)
- [x] Full pytest suite stays green (1642 passed, 2 skipped)
- [x] Ruff + mypy clean on all changed files (no new errors)
- [x] Real VKX file ingested on corvopi-tst1 with plausible race-day data
- [ ] Session matching tests (cycle 4)
- [ ] Watched-folder integration tests (cycle 5)
- [ ] UI overlay tests + manual browser check (cycle 6)
- [ ] Export smoke test (cycle 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)