### PR TITLE
fix: get mypy clean across src/

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -380,14 +380,14 @@ def extract_local_track(
         forward = ny * cos_b + ex * sin_b
         cross = ex * cos_b - ny * sin_b
         t_rel = (ts - maneuver_ts).total_seconds()
-        bv = bsp_by_sec.get(ts.isoformat()[:19])
+        bv_opt = bsp_by_sec.get(ts.isoformat()[:19])
         pt: dict[str, float] = {
             "t": round(t_rel, 1),
             "x": round(cross, 2),
             "y": round(forward, 2),
         }
-        if bv is not None:
-            pt["bsp"] = round(bv, 2)
+        if bv_opt is not None:
+            pt["bsp"] = round(bv_opt, 2)
         out.append(pt)
     return out
 
@@ -474,15 +474,15 @@ async def enrich_session_maneuvers(
             folded = abs(signed_twa) % 360.0
             twa.append((ts, folded if folded <= 180.0 else 360.0 - folded))
             # TWD = heading + signed TWA (wind_angle_deg is positive-starboard).
-            hv = hdg_by_sec.get(ts.isoformat()[:19])
-            if hv is not None:
-                twd.append((ts, (hv + signed_twa + 360.0) % 360.0))
+            hv_opt = hdg_by_sec.get(ts.isoformat()[:19])
+            if hv_opt is not None:
+                twd.append((ts, (hv_opt + signed_twa + 360.0) % 360.0))
         else:
             twd_val = float(r["wind_angle_deg"]) % 360.0
             twd.append((ts, twd_val))
-            hv = hdg_by_sec.get(ts.isoformat()[:19])
-            if hv is not None:
-                raw = (twd_val - hv + 360.0) % 360.0
+            hv_opt = hdg_by_sec.get(ts.isoformat()[:19])
+            if hv_opt is not None:
+                raw = (twd_val - hv_opt + 360.0) % 360.0
                 twa.append((ts, raw if raw <= 180.0 else 360.0 - raw))
 
     positions: list[tuple[datetime, float, float]] = [

--- a/src/helmlog/routes/aruco.py
+++ b/src/helmlog/routes/aruco.py
@@ -587,6 +587,7 @@ async def api_calibration_checkerboard(
 
     # Title text
     title = f"HelmLog Calibration Target — {cols}x{rows} inner corners, {square_mm}mm squares"
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont
     try:
         font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 28)
     except OSError:

--- a/src/helmlog/routes/network.py
+++ b/src/helmlog/routes/network.py
@@ -23,23 +23,25 @@ async def api_network_status(
     get_storage(request)
     import helmlog.network as net_mod
 
-    (
-        wlan_status,
-        interfaces,
-        internet,
-        tailscale,
-        cloudflare,
-        default_route,
-        dns,
-    ) = await asyncio.gather(
-        net_mod.get_wlan_status(),
-        net_mod.list_interfaces(),
-        net_mod.check_internet(),
-        net_mod.get_tailscale_status(),
-        net_mod.get_cloudflare_status(),
-        net_mod.get_default_route(),
-        net_mod.check_dns(),
-    )
+    # Kick off all probes concurrently. We await each task individually so
+    # mypy keeps the precise per-call return type instead of collapsing the
+    # asyncio.gather result into a union of all return types (the overloads
+    # stop at 6 awaitables, and we have 7).
+    wlan_task = asyncio.create_task(net_mod.get_wlan_status())
+    interfaces_task = asyncio.create_task(net_mod.list_interfaces())
+    internet_task = asyncio.create_task(net_mod.check_internet())
+    tailscale_task = asyncio.create_task(net_mod.get_tailscale_status())
+    cloudflare_task = asyncio.create_task(net_mod.get_cloudflare_status())
+    default_route_task = asyncio.create_task(net_mod.get_default_route())
+    dns_task = asyncio.create_task(net_mod.check_dns())
+
+    wlan_status = await wlan_task
+    interfaces = await interfaces_task
+    internet = await internet_task
+    tailscale = await tailscale_task
+    cloudflare = await cloudflare_task
+    default_route = await default_route_task
+    dns = await dns_task
     return JSONResponse(
         {
             "wlan": {

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -1718,7 +1718,7 @@ class Storage:
             " JOIN races r ON r.id = rs.race_id"
             " WHERE r.start_utc IS NOT NULL"
         )
-        races = await cur.fetchall()
+        races = list(await cur.fetchall())
         for race in races:
             race_id = race["race_id"]
             ts = race["start_utc"]
@@ -1783,7 +1783,7 @@ class Storage:
         cur = await db.execute(
             "SELECT id, name, camera_id, marker_id_a, marker_id_b, tolerance_mm FROM aruco_controls"
         )
-        aruco_rows = await cur.fetchall()
+        aruco_rows = list(await cur.fetchall())
         for ac in aruco_rows:
             # Insert control if it doesn't already exist (e.g., "vang" already seeded)
             await db.execute(
@@ -4365,7 +4365,8 @@ class Storage:
                 " WHERE main_id = ? OR jib_id = ? OR spinnaker_id = ?",
                 (sid, sid, sid),
             )
-            sail["total_sessions"] = (await cur.fetchone())["cnt"]
+            cnt_row = await cur.fetchone()
+            sail["total_sessions"] = cnt_row["cnt"] if cnt_row else 0
 
             # Maneuver counts filtered by point_of_sail, attributed via sail_changes
             if pos == "upwind":
@@ -6290,6 +6291,7 @@ class Storage:
     async def list_boat_settings(self, race_id: int | None) -> list[dict[str, Any]]:
         """Return all boat settings for a race, ordered by timestamp."""
         db = self._read_conn()
+        params: tuple[Any, ...]
         if race_id is None:
             where, params = "race_id IS NULL", ()
         else:
@@ -6308,6 +6310,7 @@ class Storage:
         Uses a window function to pick the most recent entry per parameter.
         """
         db = self._read_conn()
+        params: tuple[Any, ...]
         if race_id is None:
             where, params = "race_id IS NULL", ()
         else:


### PR DESCRIPTION
## Summary

Resolves 113 pre-existing mypy errors across 4 files so the typecheck gate can stop ignoring failures. `uv run mypy src/` now exits clean (0 errors).

## Root cause (the interesting one)

The bulk of the errors (103 of 113) were in `src/helmlog/routes/network.py::api_network_status`, all `union-attr` complaints of the form:

> Item "WlanStatus" of "CloudflareStatus | TailscaleStatus | bool | list[InterfaceInfo] | WlanStatus | DefaultRoute | None" has no attribute "version"

The culprit was a single `asyncio.gather()` call with **seven** awaitables being unpacked into seven named variables. mypy's typeshed stubs for `asyncio.gather` only provide typed overloads up to 6 coroutines; anything beyond that falls back to `gather(*coros, ...) -> Future[list[T]]` where `T` becomes the union of every argument's return type. So `wlan_status`, `interfaces`, `tailscale`, etc. all got typed as the union of all seven return types, and every attribute access downstream was unsafe.

Fix: replaced the gather with individual `asyncio.create_task(...)` calls followed by sequential `await` on each task. This still kicks all probes off concurrently (tasks run on the event loop immediately on creation), while letting mypy keep the precise per-task return type. No functional change; the probes still run in parallel.

## Other fixes

- **`storage.py`** (6 errors):
  - `_migrate_v41_sail_changes` / `_migrate_v55_controls`: `aiosqlite.Cursor.fetchall()` returns `Iterable[Row]` per the stubs, so `len()` rejected it. Wrapped the results in `list(...)`.
  - `list_sails_with_usage`: added a None guard on `await cur.fetchone()` before subscripting `cnt_row["cnt"]`.
  - `list_boat_settings` / `current_boat_settings`: annotated `params: tuple[Any, ...]` so the empty-tuple and single-element initializations unify.

- **`analysis/maneuvers.py`** (3 errors): the function unpacks `for ts_h, hv in hdg:` (making `hv` a `float`) and later reassigns `hv = hdg_by_sec.get(...)` which returns `float | None`. Renamed the lookup variables to `bv_opt` / `hv_opt` so the optional values have their own name.

- **`routes/aruco.py`** (1 error): `ImageFont.truetype()` returns `FreeTypeFont` but the `OSError` fallback `ImageFont.load_default()` returns `ImageFont` — the variable was implicitly typed to the first branch. Added an explicit `font: ImageFont.FreeTypeFont | ImageFont.ImageFont` annotation.

Pre-existing intentional `web.py` errors (documented in CLAUDE.md) were left untouched and are still suppressed by the existing configuration.

## Verification

- `uv run mypy src/` — Success: no issues found in 93 source files
- `uv run pytest` — 1646 passed, 2 skipped
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 171 files already formatted

## Test plan

- [x] mypy clean
- [x] full pytest suite green
- [x] ruff lint + format clean
- [ ] CI typecheck job passes on this branch

Generated with [Claude Code](https://claude.ai/code)