### PR TITLE
[#462 pt.1] Schema v63: channel_map + transcript_segments + voice consent audit

### DIFF
--- a/src/helmlog/audio.py
+++ b/src/helmlog/audio.py
@@ -75,6 +75,7 @@ class AudioSession:
     end_utc: datetime | None
     sample_rate: int
     channels: int
+    channel_map: dict[int, str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +154,32 @@ class AudioRecorder:
 
         device_index, device_name = _resolve_device(config.device)
 
+        # Detect channels — if config says 1 but device supports 4 and
+        # AUTO_DETECT is on (or if we just want to be smart), we can upgrade.
+        # For now, we trust config.channels but we'll validate.
+        dev_info = sd.query_devices(device_index, "input")
+        max_ch = int(dev_info["max_input_channels"])
+        requested_ch = config.channels
+
+        if requested_ch > max_ch:
+            logger.warning(
+                "Requested {} channels but device {!r} only supports {}. Falling back to {}.",
+                requested_ch,
+                device_name,
+                max_ch,
+                max_ch,
+            )
+            requested_ch = max_ch
+
+        # Resolve channel map from environment/settings
+        channel_map = None
+        if requested_ch >= 2:
+            channel_map = {}
+            for i in range(1, requested_ch + 1):
+                pos = os.environ.get(f"AUDIO_CH{i}_POS")
+                if pos:
+                    channel_map[i] = pos
+
         # Ensure output directory exists
         Path(config.output_dir).mkdir(parents=True, exist_ok=True)
 
@@ -169,7 +196,7 @@ class AudioRecorder:
             file_path,
             mode="w",
             samplerate=config.sample_rate,
-            channels=config.channels,
+            channels=requested_ch,
             format="WAV",
             subtype="PCM_16",
         )
@@ -191,7 +218,7 @@ class AudioRecorder:
         self._stream = sd.InputStream(
             device=device_index,
             samplerate=config.sample_rate,
-            channels=config.channels,
+            channels=requested_ch,
             dtype="int16",
             callback=self._audio_callback,
         )
@@ -203,7 +230,8 @@ class AudioRecorder:
             start_utc=start_utc,
             end_utc=None,
             sample_rate=config.sample_rate,
-            channels=config.channels,
+            channels=requested_ch,
+            channel_map=channel_map,
         )
 
         logger.debug(
@@ -211,7 +239,7 @@ class AudioRecorder:
             device_name,
             file_path,
             config.sample_rate,
-            config.channels,
+            requested_ch,
         )
         return self._session
 

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -262,6 +262,42 @@ SETTINGS_DEFS: tuple[SettingDef, ...] = (
         default="2",
         help_text="How often to store rudder angle readings (Hz). ESP32 publishes at 10 Hz; default stores at 2 Hz. Live display always shows latest value.",
     ),
+    SettingDef(
+        key="AUDIO_CHANNELS",
+        label="Audio channels",
+        input_type="select",
+        default="1",
+        options=("1", "2", "4"),
+        help_text="Number of channels to record. Use '4' for multi-mic isolation.",
+    ),
+    SettingDef(
+        key="AUDIO_CH1_POS",
+        label="Audio Channel 1 Position",
+        input_type="text",
+        default="helm",
+        help_text="Crew position assigned to audio channel 1.",
+    ),
+    SettingDef(
+        key="AUDIO_CH2_POS",
+        label="Audio Channel 2 Position",
+        input_type="text",
+        default="tactician",
+        help_text="Crew position assigned to audio channel 2.",
+    ),
+    SettingDef(
+        key="AUDIO_CH3_POS",
+        label="Audio Channel 3 Position",
+        input_type="text",
+        default="main",
+        help_text="Crew position assigned to audio channel 3.",
+    ),
+    SettingDef(
+        key="AUDIO_CH4_POS",
+        label="Audio Channel 4 Position",
+        input_type="text",
+        default="pit",
+        help_text="Crew position assigned to audio channel 4.",
+    ),
 )
 
 SETTINGS_BY_KEY: dict[str, SettingDef] = {s.key: s for s in SETTINGS_DEFS}

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1482,7 +1482,8 @@ function _renderDiarizedTranscript(body, t) {
   };
 
   body.innerHTML = ''
-    + '<div style="display:flex;justify-content:flex-end;margin-bottom:6px">'
+    + '<div style="display:flex;justify-content:flex-end;align-items:center;margin-bottom:6px;gap:8px">'
+    + (_session.channels > 1 ? _renderIsolationToggle() : '')
     + '<button id="transcript-follow-btn" type="button" onclick="toggleTranscriptFollow()" '
     + 'style="font-size:.7rem;padding:2px 8px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" '
     + 'title="Auto-scrolling to active segment. Click to pause.">\u25C9 Follow</button>'
@@ -4213,7 +4214,120 @@ function playSegmentAudio(start, end) {
 }
 
 // ---------------------------------------------------------------------------
+// Isolation Mode (Web Audio API)
+// ---------------------------------------------------------------------------
+
+let _isolationMode = false;
+let _audioCtx = null;
+let _audioSource = null;
+let _splitter = null;
+let _merger = null;
+let _gains = [];
+
+function _renderIsolationToggle() {
+  const active = _isolationMode ? 'background:var(--accent);color:white;border-color:var(--accent)' : 'background:transparent;color:var(--text-secondary);border-color:var(--border)';
+  return '<button id="isolation-toggle" type="button" onclick="toggleIsolationMode()" '
+    + 'style="font-size:.7rem;padding:2px 8px;border:1px solid var(--border);cursor:pointer;border-radius:3px;' + active + '" '
+    + 'title="Isolation Mode: solo the active speaker\'s microphone channel during playback.">Isolation</button>';
+}
+
+function toggleIsolationMode() {
+  _isolationMode = !_isolationMode;
+  const btn = document.getElementById('isolation-toggle');
+  if (btn) {
+    if (_isolationMode) {
+      btn.style.background = 'var(--accent)';
+      btn.style.color = 'white';
+      btn.style.borderColor = 'var(--accent)';
+    } else {
+      btn.style.background = 'transparent';
+      btn.style.color = 'var(--text-secondary)';
+      btn.style.borderColor = 'var(--border)';
+    }
+  }
+
+  if (_isolationMode) {
+    _setupAudioIsolation();
+  } else {
+    _resetAudioIsolation();
+  }
+}
+
+function _setupAudioIsolation() {
+  const audio = document.getElementById('session-audio');
+  if (!audio) return;
+
+  if (!_audioCtx) {
+    _audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    _audioSource = _audioCtx.createMediaElementSource(audio);
+
+    const channels = _session.channels || 1;
+    _splitter = _audioCtx.createChannelSplitter(channels);
+    _merger = _audioCtx.createChannelMerger(channels);
+
+    _audioSource.connect(_splitter);
+
+    for (let i = 0; i < channels; i++) {
+      const g = _audioCtx.createGain();
+      _gains.push(g);
+      _splitter.connect(g, i);
+      // Connect each gain node to ALL merger inputs (mono solo) or
+      // to its respective channel (pass-through).
+      // For isolation mode, we'll route the soloed channel to both L/R if stereo.
+      g.connect(_merger, 0, 0);
+      if (channels > 1) g.connect(_merger, 0, 1);
+    }
+    _merger.connect(_audioCtx.destination);
+  }
+
+  if (_audioCtx.state === 'suspended') {
+    _audioCtx.resume();
+  }
+
+  _updateIsolationGains();
+}
+
+function _resetAudioIsolation() {
+  if (!_gains.length) return;
+  _gains.forEach(g => { g.gain.value = 1.0; });
+}
+
+function _updateIsolationGains() {
+  if (!_isolationMode || !_gains.length) return;
+
+  const audio = document.getElementById('session-audio');
+  if (!audio) return;
+
+  const now = audio.currentTime;
+  // Find the segment containing 'now'
+  const activeSeg = (_transcriptBlocks || []).find(b => now >= b.start && now <= b.end);
+
+  if (activeSeg && activeSeg.channel) {
+    const soloIdx = activeSeg.channel - 1;
+    _gains.forEach((g, i) => {
+      // Use setTargetAtTime for smooth transitions
+      g.gain.setTargetAtTime(i === soloIdx ? 1.0 : 0.05, _audioCtx.currentTime, 0.05);
+    });
+  } else {
+    // No active segment, play all channels at low volume or full volume?
+    // Let's go full volume if no one is talking.
+    _gains.forEach(g => {
+      g.gain.setTargetAtTime(1.0, _audioCtx.currentTime, 0.05);
+    });
+  }
+}
+
+// Wire _updateIsolationGains into the audio timeupdate loop
+function _wireIsolationGains() {
+  const audio = document.getElementById('session-audio');
+  if (audio) {
+    audio.addEventListener('timeupdate', _updateIsolationGains);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Go
 // ---------------------------------------------------------------------------
 
 init();
+_wireIsolationGains();

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -132,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 62
+_CURRENT_VERSION: int = 63
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1434,6 +1434,45 @@ _MIGRATIONS: dict[int, str] = {
         -- Multi-channel audio recording and isolation (#462)
         ALTER TABLE audio_sessions ADD COLUMN channel_map TEXT;
     """,
+    63: """
+        -- Multi-channel audio: relational channel_map + per-segment channel
+        -- tagging foundation (#462 pt.1 / #493).
+        CREATE TABLE IF NOT EXISTS channel_map (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            vendor_id        INTEGER NOT NULL,
+            product_id       INTEGER NOT NULL,
+            serial           TEXT    NOT NULL DEFAULT '',
+            usb_port_path    TEXT    NOT NULL,
+            channel_index    INTEGER NOT NULL,
+            position_name    TEXT    NOT NULL,
+            audio_session_id INTEGER REFERENCES audio_sessions(id) ON DELETE CASCADE,
+            created_utc      TEXT    NOT NULL,
+            created_by       INTEGER REFERENCES users(id)
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_map_unique
+            ON channel_map(
+                vendor_id, product_id, serial, usb_port_path,
+                channel_index, IFNULL(audio_session_id, -1)
+            );
+        CREATE INDEX IF NOT EXISTS idx_channel_map_session
+            ON channel_map(audio_session_id);
+
+        CREATE TABLE IF NOT EXISTS transcript_segments (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            transcript_id INTEGER NOT NULL REFERENCES transcripts(id) ON DELETE CASCADE,
+            segment_index INTEGER NOT NULL,
+            start_time    REAL    NOT NULL,
+            end_time      REAL    NOT NULL,
+            text          TEXT    NOT NULL,
+            speaker       TEXT,
+            channel_index INTEGER,
+            position_name TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_transcript_segments_transcript
+            ON transcript_segments(transcript_id);
+        CREATE INDEX IF NOT EXISTS idx_transcript_segments_channel
+            ON transcript_segments(transcript_id, channel_index);
+    """,
 }
 
 # Retention window for retired slugs (#449). Requests for a retired slug 301
@@ -2494,7 +2533,6 @@ class Storage:
         res = dict(row)
         if res.get("channel_map"):
             try:
-                # Convert keys back to int if they were stored as strings (JSON keys must be strings)
                 cmap = json.loads(res["channel_map"])
                 res["channel_map"] = {int(k): v for k, v in cmap.items()}
             except (json.JSONDecodeError, ValueError):
@@ -5235,6 +5273,153 @@ class Storage:
         )
         rows = await cur.fetchall()
         return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Multi-channel audio: channel_map + transcript_segments (#462 pt.1)
+    # ------------------------------------------------------------------
+
+    async def set_channel_map(
+        self,
+        *,
+        vendor_id: int,
+        product_id: int,
+        serial: str,
+        usb_port_path: str,
+        mapping: dict[int, str],
+        audio_session_id: int | None = None,
+        created_by: int | None = None,
+    ) -> None:
+        """Replace the channel→position map for a USB device.
+
+        ``audio_session_id=None`` writes the admin default; passing a session id
+        writes a per-session override that takes precedence over the default
+        when read with the same session id.
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        now = _dt.now(UTC).isoformat()
+        db = self._conn()
+        await db.execute(
+            "DELETE FROM channel_map"
+            " WHERE vendor_id=? AND product_id=? AND serial=? AND usb_port_path=?"
+            " AND IFNULL(audio_session_id, -1) = IFNULL(?, -1)",
+            (vendor_id, product_id, serial, usb_port_path, audio_session_id),
+        )
+        for ch_idx, position in mapping.items():
+            await db.execute(
+                "INSERT INTO channel_map"
+                " (vendor_id, product_id, serial, usb_port_path,"
+                "  channel_index, position_name, audio_session_id,"
+                "  created_utc, created_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    vendor_id,
+                    product_id,
+                    serial,
+                    usb_port_path,
+                    ch_idx,
+                    position,
+                    audio_session_id,
+                    now,
+                    created_by,
+                ),
+            )
+        await db.commit()
+
+    async def get_channel_map(
+        self,
+        *,
+        vendor_id: int,
+        product_id: int,
+        serial: str,
+        usb_port_path: str,
+        audio_session_id: int | None = None,
+    ) -> dict[int, str]:
+        """Return the channel→position map for a device.
+
+        If ``audio_session_id`` is given and a per-session override exists,
+        return it; otherwise fall back to the admin default. Empty dict if
+        neither is set.
+        """
+        db = self._read_conn()
+        if audio_session_id is not None:
+            cur = await db.execute(
+                "SELECT channel_index, position_name FROM channel_map"
+                " WHERE vendor_id=? AND product_id=? AND serial=? AND usb_port_path=?"
+                " AND audio_session_id=?",
+                (vendor_id, product_id, serial, usb_port_path, audio_session_id),
+            )
+            rows = await cur.fetchall()
+            if rows:
+                return {r["channel_index"]: r["position_name"] for r in rows}
+        cur = await db.execute(
+            "SELECT channel_index, position_name FROM channel_map"
+            " WHERE vendor_id=? AND product_id=? AND serial=? AND usb_port_path=?"
+            " AND audio_session_id IS NULL",
+            (vendor_id, product_id, serial, usb_port_path),
+        )
+        return {r["channel_index"]: r["position_name"] for r in await cur.fetchall()}
+
+    async def insert_transcript_segments(
+        self, transcript_id: int, segments: list[dict[str, Any]]
+    ) -> None:
+        """Bulk-insert relational transcript segments with channel tags."""
+        db = self._conn()
+        for seg in segments:
+            await db.execute(
+                "INSERT INTO transcript_segments"
+                " (transcript_id, segment_index, start_time, end_time,"
+                "  text, speaker, channel_index, position_name)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    transcript_id,
+                    seg["segment_index"],
+                    seg["start_time"],
+                    seg["end_time"],
+                    seg["text"],
+                    seg.get("speaker"),
+                    seg.get("channel_index"),
+                    seg.get("position_name"),
+                ),
+            )
+        await db.commit()
+
+    async def list_transcript_segments(self, transcript_id: int) -> list[dict[str, Any]]:
+        """Return relational transcript segments for a transcript, ordered."""
+        cur = await self._read_conn().execute(
+            "SELECT id, transcript_id, segment_index, start_time, end_time,"
+            " text, speaker, channel_index, position_name"
+            " FROM transcript_segments WHERE transcript_id=?"
+            " ORDER BY segment_index",
+            (transcript_id,),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def log_voice_consent_ack(
+        self,
+        *,
+        user_id: int | None,
+        position_name: str,
+        device: dict[str, Any] | None = None,
+    ) -> int:
+        """Record that a user acknowledged voice-biometric consent for a position.
+
+        Writes a structured entry into the existing audit_log under the
+        ``voice_consent_ack`` action so the data licensing review trail covers
+        per-position diarisation. ``device`` may carry vendor/product/serial/
+        port_path so the acknowledgement can be tied to a physical mic.
+        """
+        import json as _json
+
+        payload: dict[str, Any] = {"position": position_name}
+        if device is not None:
+            payload["device"] = device
+        return await self.log_action(
+            "voice_consent_ack",
+            detail=_json.dumps(payload, sort_keys=True),
+            user_id=user_id,
+        )
 
     # ------------------------------------------------------------------
     # Device API keys (#423)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -132,7 +132,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 61
+_CURRENT_VERSION: int = 62
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1430,6 +1430,10 @@ _MIGRATIONS: dict[int, str] = {
         CREATE INDEX IF NOT EXISTS idx_races_regatta ON races(regatta_id);
         CREATE INDEX IF NOT EXISTS idx_races_local_session ON races(local_session_id);
     """,
+    62: """
+        -- Multi-channel audio recording and isolation (#462)
+        ALTER TABLE audio_sessions ADD COLUMN channel_map TEXT;
+    """,
 }
 
 # Retention window for retired slugs (#449). Requests for a retired slug 301
@@ -2446,8 +2450,8 @@ class Storage:
         cur = await db.execute(
             "INSERT INTO audio_sessions"
             " (file_path, device_name, start_utc, end_utc, sample_rate, channels,"
-            "  race_id, session_type, name)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "  race_id, session_type, name, channel_map)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 session.file_path,
                 session.device_name,
@@ -2458,6 +2462,7 @@ class Storage:
                 race_id,
                 session_type,
                 name,
+                json.dumps(session.channel_map) if session.channel_map else None,
             ),
         )
         await db.commit()
@@ -2479,12 +2484,22 @@ class Storage:
         """Return a single audio_sessions row as a dict, or None if not found."""
         cur = await self._read_conn().execute(
             "SELECT id, file_path, device_name, start_utc, end_utc, sample_rate, channels,"
-            " race_id, session_type, name"
+            " race_id, session_type, name, channel_map"
             " FROM audio_sessions WHERE id = ?",
             (session_id,),
         )
         row = await cur.fetchone()
-        return dict(row) if row else None
+        if not row:
+            return None
+        res = dict(row)
+        if res.get("channel_map"):
+            try:
+                # Convert keys back to int if they were stored as strings (JSON keys must be strings)
+                cmap = json.loads(res["channel_map"])
+                res["channel_map"] = {int(k): v for k, v in cmap.items()}
+            except (json.JSONDecodeError, ValueError):
+                pass
+        return res
 
     async def list_audio_sessions(self) -> list[AudioSession]:
         """Return all audio sessions ordered by start_utc descending."""

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -180,16 +180,13 @@ async def transcribe_session(
 
             for i in range(channels):
                 # Channel indexing in channel_map is 1-based per config
-                pos_name = channel_map.get(i + 1, f"CH{i+1}")
+                pos_name = channel_map.get(i + 1, f"CH{i + 1}")
                 logger.debug("Transcribing channel {} (position={})", i + 1, pos_name)
 
                 # Extract mono channel to temp WAV (faster-whisper/remote worker need a path)
                 with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
                     tmp_path = tmp.name
-                    if data.ndim > 1:
-                        ch_data = data[:, i]
-                    else:
-                        ch_data = data  # should not happen if channels > 1
+                    ch_data = data[:, i] if data.ndim > 1 else data
                     sf.write(tmp_path, ch_data, samplerate)
 
                 try:

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -91,6 +92,36 @@ async def _try_remote_transcribe(
         return None
 
 
+async def _transcribe_one_channel(
+    file_path: str,
+    model_size: str,
+    diarize: bool,
+    *,
+    transcribe_url: str = "",
+) -> tuple[str, list[dict[str, object]]]:
+    """Helper: transcribe a single channel (local or remote)."""
+    # 1. Try remote
+    remote = await _try_remote_transcribe(
+        file_path, model_size, diarize, transcribe_url=transcribe_url
+    )
+    if remote is not None:
+        return remote
+
+    # 2. Try local
+    if diarize and _pyannote_available() and bool(os.environ.get("HF_TOKEN")):
+        text, segments_json_str = await asyncio.to_thread(
+            _run_with_diarization, file_path=file_path, model_size=model_size
+        )
+        return text, json.loads(segments_json_str)
+    else:
+        raw_segs = await asyncio.to_thread(
+            _run_whisper_segments, file_path=file_path, model_size=model_size
+        )
+        text = " ".join(t for _, _, t in raw_segs).strip()
+        segments = [{"start": s, "end": e, "text": t} for s, e, t in raw_segs]
+        return text, segments
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -129,9 +160,74 @@ async def transcribe_session(
 
     await storage.update_transcript(transcript_id, status="running")
     file_path: str = row["file_path"]
-    use_diarize = diarize and bool(os.environ.get("HF_TOKEN")) and _pyannote_available()
+    channels: int = row.get("channels", 1)
+    channel_map: dict[int, str] = row.get("channel_map") or {}
 
     try:
+        # ----- Multi-channel Isolation Mode (#462) -----
+        if channels > 1:
+            import soundfile as sf
+
+            logger.info(
+                "Multi-channel isolation: transcribing {} channels for audio_session_id={}",
+                channels,
+                audio_session_id,
+            )
+            all_segments: list[dict[str, object]] = []
+
+            # Read the multi-channel file once
+            data, samplerate = sf.read(file_path)
+
+            for i in range(channels):
+                # Channel indexing in channel_map is 1-based per config
+                pos_name = channel_map.get(i + 1, f"CH{i+1}")
+                logger.debug("Transcribing channel {} (position={})", i + 1, pos_name)
+
+                # Extract mono channel to temp WAV (faster-whisper/remote worker need a path)
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                    tmp_path = tmp.name
+                    if data.ndim > 1:
+                        ch_data = data[:, i]
+                    else:
+                        ch_data = data  # should not happen if channels > 1
+                    sf.write(tmp_path, ch_data, samplerate)
+
+                try:
+                    # Diarize=False because we have hardware isolation per channel
+                    text, segments = await _transcribe_one_channel(
+                        tmp_path, model_size, diarize=False, transcribe_url=transcribe_url
+                    )
+                    # Tag segments with the position from channel_map
+                    for seg in segments:
+                        seg["channel"] = i + 1
+                        seg["position"] = pos_name
+                        # Use position as speaker for UI compatibility
+                        seg["speaker"] = pos_name
+                    all_segments.extend(segments)
+                finally:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+
+            # Merge and timestamp-sort
+            all_segments.sort(key=lambda x: float(str(x.get("start", 0))))
+            merged_text = " ".join(str(s.get("text", "")).strip() for s in all_segments).strip()
+            segments_json_str = json.dumps(all_segments)
+
+            await storage.update_transcript(
+                transcript_id, status="done", text=merged_text, segments_json=segments_json_str
+            )
+            logger.info(
+                "Multi-channel transcription done: audio_session_id={} channels={} segments={}",
+                audio_session_id,
+                channels,
+                len(all_segments),
+            )
+            await _run_trigger_scan(storage, audio_session_id, row, all_segments)
+            return
+
+        # ----- Single-channel mode (Existing logic) -----
+        use_diarize = diarize and bool(os.environ.get("HF_TOKEN")) and _pyannote_available()
+
         # ----- Remote offload (preferred when TRANSCRIBE_URL is set) -----
         remote = await _try_remote_transcribe(
             file_path, model_size, diarize, transcribe_url=transcribe_url

--- a/tests/test_results_migration.py
+++ b/tests/test_results_migration.py
@@ -8,13 +8,13 @@ from helmlog.storage import _CURRENT_VERSION, Storage
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_61(storage: Storage) -> None:
-    assert _CURRENT_VERSION == 61
+async def test_schema_version_at_least_61(storage: Storage) -> None:
+    assert _CURRENT_VERSION >= 61
     db = storage._conn()
     async with db.execute("SELECT MAX(version) FROM schema_version") as cur:
         row = await cur.fetchone()
     assert row is not None
-    assert row[0] == 61
+    assert row[0] >= 61
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_channel_map.py
+++ b/tests/test_storage_channel_map.py
@@ -1,0 +1,233 @@
+"""Tests for v63 multi-channel audio schema (#493 / #462 pt.1).
+
+Pure storage layer: channel_map CRUD, transcript_segments per-channel rows,
+and voice-consent acknowledgement audit entries.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Schema presence
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaV63:
+    async def test_schema_at_v63_or_higher(self, storage: Storage) -> None:
+        db = storage._conn()
+        cur = await db.execute("SELECT MAX(version) FROM schema_version")
+        row = await cur.fetchone()
+        assert row is not None and row[0] is not None
+        assert row[0] >= 63
+
+    async def test_channel_map_table_exists(self, storage: Storage) -> None:
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='channel_map'"
+        )
+        assert await cur.fetchone() is not None
+
+    async def test_transcript_segments_table_exists(self, storage: Storage) -> None:
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='transcript_segments'"
+        )
+        assert await cur.fetchone() is not None
+
+    async def test_transcript_segments_has_channel_columns(self, storage: Storage) -> None:
+        db = storage._conn()
+        cur = await db.execute("PRAGMA table_info(transcript_segments)")
+        cols = {row[1] for row in await cur.fetchall()}
+        assert "channel_index" in cols
+        assert "position_name" in cols
+        assert "transcript_id" in cols
+        assert "start_time" in cols
+        assert "end_time" in cols
+        assert "text" in cols
+
+
+# ---------------------------------------------------------------------------
+# channel_map CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestChannelMap:
+    DEVICE = {
+        "vendor_id": 0x1234,
+        "product_id": 0x5678,
+        "serial": "ABC123",
+        "usb_port_path": "1-1.2",
+    }
+
+    async def test_set_and_get_default_map(self, storage: Storage) -> None:
+        await storage.set_channel_map(
+            **self.DEVICE,
+            mapping={0: "helm", 1: "tactician", 2: "trim", 3: "bow"},
+        )
+        result = await storage.get_channel_map(**self.DEVICE)
+        assert result == {0: "helm", 1: "tactician", 2: "trim", 3: "bow"}
+
+    async def test_get_returns_empty_when_unset(self, storage: Storage) -> None:
+        result = await storage.get_channel_map(**self.DEVICE)
+        assert result == {}
+
+    async def test_set_replaces_existing_default(self, storage: Storage) -> None:
+        await storage.set_channel_map(**self.DEVICE, mapping={0: "helm", 1: "trim"})
+        await storage.set_channel_map(**self.DEVICE, mapping={0: "tactician", 1: "bow"})
+        result = await storage.get_channel_map(**self.DEVICE)
+        assert result == {0: "tactician", 1: "bow"}
+
+    async def test_session_override_falls_back_to_default(self, storage: Storage) -> None:
+        # Need a real audio session for FK
+        session_id = await self._make_audio_session(storage)
+        await storage.set_channel_map(**self.DEVICE, mapping={0: "helm", 1: "bow"})
+        # No override yet → fallback to default
+        result = await storage.get_channel_map(**self.DEVICE, audio_session_id=session_id)
+        assert result == {0: "helm", 1: "bow"}
+
+    async def test_session_override_takes_precedence(self, storage: Storage) -> None:
+        session_id = await self._make_audio_session(storage)
+        await storage.set_channel_map(**self.DEVICE, mapping={0: "helm", 1: "bow"})
+        await storage.set_channel_map(
+            **self.DEVICE,
+            mapping={0: "tactician", 1: "trim"},
+            audio_session_id=session_id,
+        )
+        # Default unchanged
+        assert await storage.get_channel_map(**self.DEVICE) == {0: "helm", 1: "bow"}
+        # Override visible for that session
+        assert await storage.get_channel_map(**self.DEVICE, audio_session_id=session_id) == {
+            0: "tactician",
+            1: "trim",
+        }
+
+    async def test_devices_with_different_ports_are_independent(self, storage: Storage) -> None:
+        await storage.set_channel_map(**self.DEVICE, mapping={0: "helm"})
+        other = {**self.DEVICE, "usb_port_path": "1-1.3"}
+        await storage.set_channel_map(**other, mapping={0: "bow"})
+        assert await storage.get_channel_map(**self.DEVICE) == {0: "helm"}
+        assert await storage.get_channel_map(**other) == {0: "bow"}
+
+    @staticmethod
+    async def _make_audio_session(storage: Storage) -> int:
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        db = storage._conn()
+        cur = await db.execute(
+            "INSERT INTO audio_sessions"
+            " (file_path, device_name, start_utc, sample_rate, channels)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("/tmp/x.wav", "TestMic", _dt.now(UTC).isoformat(), 48000, 4),
+        )
+        await db.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# transcript_segments round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptSegments:
+    async def test_insert_and_list_segments(self, storage: Storage) -> None:
+        transcript_id = await self._make_transcript(storage)
+        segments = [
+            {
+                "segment_index": 0,
+                "start_time": 0.0,
+                "end_time": 1.5,
+                "text": "ready about",
+                "speaker": "helm",
+                "channel_index": 0,
+                "position_name": "helm",
+            },
+            {
+                "segment_index": 1,
+                "start_time": 1.5,
+                "end_time": 2.0,
+                "text": "trim on",
+                "speaker": "trim",
+                "channel_index": 2,
+                "position_name": "trim",
+            },
+        ]
+        await storage.insert_transcript_segments(transcript_id, segments)
+        rows = await storage.list_transcript_segments(transcript_id)
+        assert len(rows) == 2
+        assert rows[0]["text"] == "ready about"
+        assert rows[0]["channel_index"] == 0
+        assert rows[0]["position_name"] == "helm"
+        assert rows[1]["channel_index"] == 2
+        assert rows[1]["position_name"] == "trim"
+
+    async def test_segments_cascade_with_transcript(self, storage: Storage) -> None:
+        transcript_id = await self._make_transcript(storage)
+        await storage.insert_transcript_segments(
+            transcript_id,
+            [
+                {
+                    "segment_index": 0,
+                    "start_time": 0.0,
+                    "end_time": 1.0,
+                    "text": "x",
+                    "speaker": None,
+                    "channel_index": 0,
+                    "position_name": "helm",
+                }
+            ],
+        )
+        db = storage._conn()
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute("DELETE FROM transcripts WHERE id = ?", (transcript_id,))
+        await db.commit()
+        rows = await storage.list_transcript_segments(transcript_id)
+        assert rows == []
+
+    @staticmethod
+    async def _make_transcript(storage: Storage) -> int:
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        db = storage._conn()
+        cur = await db.execute(
+            "INSERT INTO audio_sessions"
+            " (file_path, device_name, start_utc, sample_rate, channels)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("/tmp/x.wav", "TestMic", _dt.now(UTC).isoformat(), 48000, 4),
+        )
+        await db.commit()
+        audio_session_id = cur.lastrowid
+        return await storage.create_transcript_job(audio_session_id, "tiny")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Voice-biometric consent acknowledgement audit
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceConsentAudit:
+    async def test_log_voice_consent_writes_audit_entry(self, storage: Storage) -> None:
+        await storage.log_voice_consent_ack(
+            user_id=None,
+            position_name="helm",
+            device={
+                "vendor_id": 0x1234,
+                "product_id": 0x5678,
+                "serial": "ABC123",
+                "usb_port_path": "1-1.2",
+            },
+        )
+        entries = await storage.list_audit_log(limit=10)
+        assert any(e["action"] == "voice_consent_ack" for e in entries)
+        entry = next(e for e in entries if e["action"] == "voice_consent_ack")
+        assert "helm" in (entry["detail"] or "")

--- a/uv.lock
+++ b/uv.lock
@@ -1182,16 +1182,16 @@ requires-dist = [
     { name = "google-auth-httplib2", specifier = ">=0.3.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "influxdb-client", specifier = ">=1.44.0" },
+    { name = "influxdb-client", specifier = ">=1.50.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "opencv-contrib-python-headless", specifier = ">=4.8.0" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "psutil", specifier = ">=7.2.2" },
-    { name = "pyannote-audio", specifier = ">=1.1" },
+    { name = "pyannote-audio", specifier = ">=4.0.4" },
     { name = "python-can", specifier = ">=4.4.2" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "selectolax", specifier = ">=0.4.7" },
     { name = "shapely", specifier = ">=2.1.2" },
@@ -1209,7 +1209,7 @@ dev = [
     { name = "mypy", specifier = ">=1.11.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-env", specifier = ">=1.5.0" },
     { name = "ruff", specifier = ">=0.7.0" },
 ]
@@ -2844,16 +2844,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Part 1 of the multi-channel audio chain (#462). **Pure storage layer — no audio/UI touched.**

Note: schema is at v62 on `main` (not v58 as the issue describes), so this introduces v63 instead of v59. Same content, just renumbered.

- New table `channel_map` keyed on `(vendor_id, product_id, serial, usb_port_path, channel_index, IFNULL(audio_session_id, -1))` so admin defaults and per-session overrides coexist for the same device
- New table `transcript_segments` with `channel_index` / `position_name` columns — populated by pt.3
- Storage helpers: `set_channel_map`, `get_channel_map` (per-session override falls back to admin default), `insert_transcript_segments`, `list_transcript_segments`
- `log_voice_consent_ack` writes a structured `voice_consent_ack` entry into the existing `audit_log` — no new audit table, per the issue scope
- Drive-by lint fixes from the prior #462 commit (E501 in storage.py, SIM108 in transcribe.py)

Closes #493

## Test plan

- [x] `uv run pytest tests/test_storage_channel_map.py` — 13 new tests pass (channel_map CRUD, override fallback, port-path independence, segment round-trip, segment FK cascade, consent audit)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — no new errors (2 pre-existing in transcribe.py from prior #462 commit, untouched)
- [x] Full suite: 1754 passed. Pre-existing failures untouched: 4 in `tests/test_audio.py` (mock returns list, code expects dict — broken on `main` since #462 commit) and 1 in `tests/test_results_migration.py` which hard-coded `_CURRENT_VERSION == 61`; relaxed to `>= 61` so future bumps don't break it.

## Branching

This PR targets `main` directly per the issue text. The downstream sub-issues (#494–#499) per the epic comment will branch off this branch as it lands.

🤖 Generated with [Claude Code](https://claude.ai/code)