### PR TITLE
[#462 pt.3] Per-channel transcription + unified timeline merge

### DIFF
--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -122,6 +122,58 @@ async def _transcribe_one_channel(
         return text, segments
 
 
+async def _transcribe_multi_channel(
+    file_path: str,
+    *,
+    channels: int,
+    channel_map: dict[int, str],
+    model_size: str,
+    transcribe_url: str = "",
+) -> list[dict[str, object]]:
+    """Split a multi-channel WAV and transcribe each channel independently.
+
+    Channel indices are 0-based to match sounddevice / numpy and the v63
+    ``channel_map`` table. ``channel_map[i]`` resolves to the configured
+    position name (e.g. "helm"); unmapped channels fall back to ``CH{i}``.
+
+    Pyannote diarisation is intentionally **skipped** because hardware
+    isolation already ties each channel to a person — running diarisation
+    would be redundant and slow per the issue spec.
+
+    Returns a single list of segments sorted by ``start``, each tagged with
+    ``channel_index``, ``position_name``, and ``speaker`` (= position).
+    """
+    import soundfile as sf
+
+    logger.info("Multi-channel isolation: transcribing {} channels for {}", channels, file_path)
+    data, samplerate = sf.read(file_path)
+
+    all_segments: list[dict[str, object]] = []
+    for i in range(channels):
+        position = channel_map.get(i, f"CH{i}")
+        logger.debug("Transcribing channel {} (position={})", i, position)
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
+            ch_data = data[:, i] if data.ndim > 1 else data
+            sf.write(tmp_path, ch_data, samplerate)
+        try:
+            _text, segments = await _transcribe_one_channel(
+                tmp_path, model_size, diarize=False, transcribe_url=transcribe_url
+            )
+            for seg in segments:
+                seg["channel_index"] = i
+                seg["position_name"] = position
+                seg["speaker"] = position
+            all_segments.extend(segments)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    all_segments.sort(key=lambda x: float(str(x.get("start", 0))))
+    return all_segments
+
+
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
@@ -161,54 +213,38 @@ async def transcribe_session(
     await storage.update_transcript(transcript_id, status="running")
     file_path: str = row["file_path"]
     channels: int = row.get("channels", 1)
-    channel_map: dict[int, str] = row.get("channel_map") or {}
 
     try:
-        # ----- Multi-channel Isolation Mode (#462) -----
+        # ----- Multi-channel Isolation Mode (#462 pt.3) -----
         if channels > 1:
-            import soundfile as sf
-
-            logger.info(
-                "Multi-channel isolation: transcribing {} channels for audio_session_id={}",
-                channels,
-                audio_session_id,
+            # Look up the active channel→position map via the v63/v64 chain:
+            # session identity → channel_map override → admin default. 0-based.
+            channel_map = await storage.get_channel_map_for_audio_session(audio_session_id)
+            all_segments = await _transcribe_multi_channel(
+                file_path,
+                channels=channels,
+                channel_map=channel_map,
+                model_size=model_size,
+                transcribe_url=transcribe_url,
             )
-            all_segments: list[dict[str, object]] = []
-
-            # Read the multi-channel file once
-            data, samplerate = sf.read(file_path)
-
-            for i in range(channels):
-                # Channel indexing in channel_map is 1-based per config
-                pos_name = channel_map.get(i + 1, f"CH{i + 1}")
-                logger.debug("Transcribing channel {} (position={})", i + 1, pos_name)
-
-                # Extract mono channel to temp WAV (faster-whisper/remote worker need a path)
-                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-                    tmp_path = tmp.name
-                    ch_data = data[:, i] if data.ndim > 1 else data
-                    sf.write(tmp_path, ch_data, samplerate)
-
-                try:
-                    # Diarize=False because we have hardware isolation per channel
-                    text, segments = await _transcribe_one_channel(
-                        tmp_path, model_size, diarize=False, transcribe_url=transcribe_url
-                    )
-                    # Tag segments with the position from channel_map
-                    for seg in segments:
-                        seg["channel"] = i + 1
-                        seg["position"] = pos_name
-                        # Use position as speaker for UI compatibility
-                        seg["speaker"] = pos_name
-                    all_segments.extend(segments)
-                finally:
-                    if os.path.exists(tmp_path):
-                        os.unlink(tmp_path)
-
-            # Merge and timestamp-sort
-            all_segments.sort(key=lambda x: float(str(x.get("start", 0))))
             merged_text = " ".join(str(s.get("text", "")).strip() for s in all_segments).strip()
             segments_json_str = json.dumps(all_segments)
+
+            # Relational persistence (#493) — populate transcript_segments so
+            # downstream sub-issues (#496–#499) don't re-parse JSON.
+            relational = [
+                {
+                    "segment_index": idx,
+                    "start_time": float(seg.get("start", 0.0)),  # type: ignore[arg-type]
+                    "end_time": float(seg.get("end", 0.0)),  # type: ignore[arg-type]
+                    "text": str(seg.get("text", "")),
+                    "speaker": seg.get("speaker"),
+                    "channel_index": seg.get("channel_index"),
+                    "position_name": seg.get("position_name"),
+                }
+                for idx, seg in enumerate(all_segments)
+            ]
+            await storage.insert_transcript_segments(transcript_id, relational)
 
             await storage.update_transcript(
                 transcript_id, status="done", text=merged_text, segments_json=segments_json_str

--- a/tests/test_transcribe_multichannel.py
+++ b/tests/test_transcribe_multichannel.py
@@ -1,0 +1,277 @@
+"""Tests for the multi-channel transcribe path (#462 pt.3 / #495).
+
+faster-whisper, pyannote, and the actual WAV split are mocked so the tests
+run on any machine without hardware or models.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a real audio_session + transcript row
+# ---------------------------------------------------------------------------
+
+
+async def _make_session_and_transcript(storage: Storage, *, channels: int) -> tuple[int, int]:
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO audio_sessions"
+        " (file_path, device_name, start_utc, sample_rate, channels)"
+        " VALUES (?, ?, ?, ?, ?)",
+        ("/tmp/x.wav", "Lavalier4", datetime.now(UTC).isoformat(), 48000, channels),
+    )
+    await db.commit()
+    audio_session_id = cur.lastrowid
+    assert audio_session_id is not None
+    transcript_id = await storage.create_transcript_job(audio_session_id, "tiny")
+    return audio_session_id, transcript_id
+
+
+# ---------------------------------------------------------------------------
+# _transcribe_multi_channel — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeMultiChannel:
+    async def test_merges_and_sorts_by_start(self) -> None:
+        from helmlog import transcribe
+
+        # Channel 0 (helm) speaks at t=0 and t=5; channel 1 (trim) at t=2.
+        async def fake_one_channel(
+            tmp_path: str,
+            model_size: str,
+            diarize: bool,
+            *,
+            transcribe_url: str = "",
+        ) -> tuple[str, list[dict[str, object]]]:
+            # Decide what to return based on which call this is. Track via list.
+            calls.append(tmp_path)
+            if len(calls) == 1:
+                return "helm one helm two", [
+                    {"start": 0.0, "end": 1.0, "text": "helm one"},
+                    {"start": 5.0, "end": 6.0, "text": "helm two"},
+                ]
+            return "trim one", [{"start": 2.0, "end": 3.0, "text": "trim one"}]
+
+        calls: list[str] = []
+
+        fake_sf = MagicMock()
+        fake_sf.read.return_value = (MagicMock(ndim=2), 48000)
+
+        with (
+            patch("helmlog.transcribe._transcribe_one_channel", side_effect=fake_one_channel),
+            patch("helmlog.transcribe.tempfile.NamedTemporaryFile") as mock_tmp,
+            patch("os.path.exists", return_value=False),
+            patch.dict("sys.modules", {"soundfile": fake_sf}),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = "/tmp/ch.wav"
+            segments = await transcribe._transcribe_multi_channel(
+                "/tmp/x.wav",
+                channels=2,
+                channel_map={0: "helm", 1: "trim"},
+                model_size="tiny",
+            )
+
+        assert [s["text"] for s in segments] == ["helm one", "trim one", "helm two"]
+        assert [s["channel_index"] for s in segments] == [0, 1, 0]
+        assert [s["position_name"] for s in segments] == ["helm", "trim", "helm"]
+        assert [s["speaker"] for s in segments] == ["helm", "trim", "helm"]
+
+    async def test_falls_back_to_chN_when_position_unmapped(self) -> None:
+        from helmlog import transcribe
+
+        async def fake_one_channel(
+            tmp_path: str, model_size: str, diarize: bool, *, transcribe_url: str = ""
+        ) -> tuple[str, list[dict[str, object]]]:
+            return "x", [{"start": 0.0, "end": 1.0, "text": "x"}]
+
+        fake_sf = MagicMock()
+        fake_sf.read.return_value = (MagicMock(ndim=2), 48000)
+
+        with (
+            patch("helmlog.transcribe._transcribe_one_channel", side_effect=fake_one_channel),
+            patch("helmlog.transcribe.tempfile.NamedTemporaryFile") as mock_tmp,
+            patch("os.path.exists", return_value=False),
+            patch.dict("sys.modules", {"soundfile": fake_sf}),
+        ):
+            mock_tmp.return_value.__enter__.return_value.name = "/tmp/ch.wav"
+            segments = await transcribe._transcribe_multi_channel(
+                "/tmp/x.wav",
+                channels=2,
+                channel_map={0: "helm"},
+                model_size="tiny",
+            )
+
+        positions = [s["position_name"] for s in segments]
+        assert "helm" in positions
+        assert "CH1" in positions
+
+
+# ---------------------------------------------------------------------------
+# Full transcribe_session multi-channel path — relational persistence
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeSessionMultiChannel:
+    async def test_persists_relational_segments(self, storage: Storage) -> None:
+        from helmlog import transcribe
+
+        audio_session_id, transcript_id = await _make_session_and_transcript(storage, channels=2)
+        # Configure a channel map for the device
+        await storage.set_channel_map(
+            vendor_id=0x1234,
+            product_id=0x5678,
+            serial="ABC",
+            usb_port_path="1-1.2",
+            mapping={0: "helm", 1: "trim"},
+        )
+        await storage.set_audio_session_device(
+            audio_session_id,
+            vendor_id=0x1234,
+            product_id=0x5678,
+            serial="ABC",
+            usb_port_path="1-1.2",
+        )
+
+        async def fake_multi(
+            file_path: str,
+            *,
+            channels: int,
+            channel_map: dict[int, str],
+            model_size: str,
+            transcribe_url: str = "",
+        ) -> list[dict[str, object]]:
+            assert channel_map == {0: "helm", 1: "trim"}
+            return [
+                {
+                    "start": 0.0,
+                    "end": 1.0,
+                    "text": "ready about",
+                    "channel_index": 0,
+                    "position_name": "helm",
+                    "speaker": "helm",
+                },
+                {
+                    "start": 1.5,
+                    "end": 2.0,
+                    "text": "trim on",
+                    "channel_index": 1,
+                    "position_name": "trim",
+                    "speaker": "trim",
+                },
+            ]
+
+        with (
+            patch("helmlog.transcribe._transcribe_multi_channel", side_effect=fake_multi),
+            patch("helmlog.transcribe._run_trigger_scan", new=AsyncMock(return_value=None)),
+        ):
+            await transcribe.transcribe_session(
+                storage,
+                audio_session_id,
+                transcript_id,
+                model_size="tiny",
+                diarize=True,
+            )
+
+        # Relational table populated with channel tags
+        rows = await storage.list_transcript_segments(transcript_id)
+        assert len(rows) == 2
+        assert rows[0]["text"] == "ready about"
+        assert rows[0]["channel_index"] == 0
+        assert rows[0]["position_name"] == "helm"
+        assert rows[1]["channel_index"] == 1
+        assert rows[1]["position_name"] == "trim"
+
+        # Transcript JSON column also populated for backward compat
+        t = await storage.get_transcript(audio_session_id)
+        assert t is not None
+        assert t["status"] == "done"
+        assert "ready about" in t["text"]
+        assert "trim on" in t["text"]
+
+    async def test_falls_back_to_empty_map_when_no_device_set(self, storage: Storage) -> None:
+        from helmlog import transcribe
+
+        audio_session_id, transcript_id = await _make_session_and_transcript(storage, channels=2)
+
+        captured: dict[str, object] = {}
+
+        async def fake_multi(
+            file_path: str,
+            *,
+            channels: int,
+            channel_map: dict[int, str],
+            model_size: str,
+            transcribe_url: str = "",
+        ) -> list[dict[str, object]]:
+            captured["channel_map"] = channel_map
+            return []
+
+        with (
+            patch("helmlog.transcribe._transcribe_multi_channel", side_effect=fake_multi),
+            patch("helmlog.transcribe._run_trigger_scan", new=AsyncMock(return_value=None)),
+        ):
+            await transcribe.transcribe_session(
+                storage, audio_session_id, transcript_id, model_size="tiny"
+            )
+
+        assert captured["channel_map"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Single-channel path is unchanged — regression check
+# ---------------------------------------------------------------------------
+
+
+class TestSingleChannelRegression:
+    async def test_single_channel_uses_pyannote_path(self, storage: Storage) -> None:
+        """A 1-channel session should NOT touch _transcribe_multi_channel."""
+        from helmlog import transcribe
+
+        audio_session_id, transcript_id = await _make_session_and_transcript(storage, channels=1)
+
+        multi_called = MagicMock()
+
+        async def fake_multi(*args: object, **kwargs: object) -> list[dict[str, object]]:
+            multi_called()
+            return []
+
+        # Whisper produces a single segment
+        def fake_run_whisper_segments(
+            *, file_path: str, model_size: str
+        ) -> list[tuple[float, float, str]]:
+            return [(0.0, 1.0, "tack")]
+
+        with (
+            patch("helmlog.transcribe._transcribe_multi_channel", side_effect=fake_multi),
+            patch(
+                "helmlog.transcribe._run_whisper_segments",
+                side_effect=fake_run_whisper_segments,
+            ),
+            patch("helmlog.transcribe._pyannote_available", return_value=False),
+            patch("helmlog.transcribe._run_trigger_scan", new=AsyncMock(return_value=None)),
+        ):
+            await transcribe.transcribe_session(
+                storage,
+                audio_session_id,
+                transcript_id,
+                model_size="tiny",
+                diarize=False,
+            )
+
+        multi_called.assert_not_called()
+        t = await storage.get_transcript(audio_session_id)
+        assert t is not None
+        assert t["status"] == "done"
+        assert "tack" in t["text"]


### PR DESCRIPTION
## Summary

Part 3 of the multi-channel audio chain (#462). Builds on #494 / #501. PR base = \`feature/462-pt2-audio\` per the epic plan.

- New \`_transcribe_multi_channel\` helper extracted from \`transcribe_session\`: splits the multi-channel WAV with soundfile, runs faster-whisper once per channel with \`diarize=False\` (hardware isolation makes pyannote redundant per the issue spec), tags each segment with \`channel_index\` + \`position_name\`, and merges into a single timeline sorted by start time.
- Channel indices are **0-based** to match sounddevice/numpy and the v63 \`channel_map\` table; unmapped channels fall back to \`CH{i}\`.
- Channel→position lookup now flows through \`storage.get_channel_map_for_audio_session\` (chained identity → per-session override → admin default from pt.1/pt.2) instead of the legacy per-session JSON blob the prior #462 commit used.
- After merge, the segments are persisted to the relational \`transcript_segments\` table via \`insert_transcript_segments\`, alongside the existing \`segments_json\` column for backward compat. Downstream sub-issues (#496–#499) can read the relational table directly.
- Single-channel path is unchanged — pyannote diarisation still runs when \`HF_TOKEN\` is set. Regression test asserts the multi-channel helper is never called for \`channels=1\`.

Closes #495

## Test plan

- [x] 5 new \`tests/test_transcribe_multichannel.py\` tests:
  - \`_transcribe_multi_channel\` merges and sorts interleaved segments by start time
  - Unmapped channels fall back to \`CH{i}\`
  - \`transcribe_session\` persists relational \`transcript_segments\` rows with channel tags
  - Empty \`channel_map\` when no device identity is set
  - Single-channel regression: multi-channel helper is never invoked
- [x] \`uv run pytest --no-cov\`: **1780 passed**, 2 skipped
- [x] \`uv run ruff check .\` clean
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run mypy src/\`: only the 2 pre-existing errors in \`transcribe.py\` (left from #462 commit), no new errors

## Branching

Branched off \`feature/462-pt2-audio\`; PR base = \`feature/462-pt2-audio\` per the epic plan. Pt.4 (#496) will branch off this branch.

🤖 Generated with [Claude Code](https://claude.ai/code)