### PR TITLE
[#462 pt.5] Per-session channel-map override + home-page UI

### DIFF
--- a/src/helmlog/routes/audio_channels.py
+++ b/src/helmlog/routes/audio_channels.py
@@ -110,9 +110,113 @@ async def api_save_audio_channel_map(
     mapping is written and one structured ``voice_consent_ack`` audit entry
     is recorded per position.
     """
-    storage = get_storage(request)
     body = await request.json()
+    await _persist_channel_map(request, _user, body, audio_session_id=None)
+    return Response(status_code=204)
 
+
+# ---------------------------------------------------------------------------
+# Per-session override (#497 / pt.5)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/audio-channels/sessions/{audio_session_id}")
+async def api_get_session_channel_map(
+    request: Request,
+    audio_session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> JSONResponse:
+    """Return the active channel→position map for an audio session.
+
+    Chains override → admin default. Empty dict if neither is set or if
+    the session has no recorded device identity yet.
+    """
+    storage = get_storage(request)
+    row = await storage.get_audio_session_row(audio_session_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="audio session not found")
+    mapping = await storage.get_channel_map_for_audio_session(audio_session_id)
+    return JSONResponse(
+        {
+            "audio_session_id": audio_session_id,
+            "vendor_id": row.get("vendor_id"),
+            "product_id": row.get("product_id"),
+            "serial": row.get("serial"),
+            "usb_port_path": row.get("usb_port_path"),
+            "mapping": mapping,
+        }
+    )
+
+
+@router.post("/api/audio-channels/sessions/{audio_session_id}/override", status_code=204)
+async def api_set_session_override(
+    request: Request,
+    audio_session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> Response:
+    """Persist a per-session override of the admin default channel map.
+
+    Body schema is identical to ``/api/audio-channels/save`` but the
+    ``audio_session_id`` is taken from the URL — the rows are written into
+    the per-session scope of the v63 channel_map table so the admin default
+    is left untouched. Subsequent sessions on the same device revert to the
+    default automatically.
+    """
+    storage = get_storage(request)
+    if await storage.get_audio_session_row(audio_session_id) is None:
+        raise HTTPException(status_code=404, detail="audio session not found")
+    body = await request.json()
+    await _persist_channel_map(request, _user, body, audio_session_id=audio_session_id)
+    return Response(status_code=204)
+
+
+@router.delete("/api/audio-channels/sessions/{audio_session_id}/override", status_code=204)
+async def api_clear_session_override(
+    request: Request,
+    audio_session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> Response:
+    """Clear the per-session override; reverts to the admin default."""
+    storage = get_storage(request)
+    row = await storage.get_audio_session_row(audio_session_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="audio session not found")
+    vendor_id = row.get("vendor_id")
+    product_id = row.get("product_id")
+    if vendor_id is None or product_id is None:
+        # No identity → nothing to clear; treat as no-op success
+        return Response(status_code=204)
+    await storage.set_channel_map(
+        vendor_id=int(vendor_id),
+        product_id=int(product_id),
+        serial=row.get("serial") or "",
+        usb_port_path=row.get("usb_port_path") or "",
+        mapping={},
+        audio_session_id=audio_session_id,
+    )
+    await audit(
+        request,
+        "audio_channel_session_override_cleared",
+        detail=f"audio_session_id={audio_session_id}",
+        user=_user if isinstance(_user, dict) else None,
+    )
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Shared persistence helper
+# ---------------------------------------------------------------------------
+
+
+async def _persist_channel_map(
+    request: Request,
+    user: dict[str, Any] | None,
+    body: dict[str, Any],
+    *,
+    audio_session_id: int | None,
+) -> None:
+    """Validate, consent-gate, and persist a channel map at admin or session scope."""
+    storage = get_storage(request)
     try:
         vendor_id = int(body["vendor_id"])
         product_id = int(body["product_id"])
@@ -126,13 +230,11 @@ async def api_save_audio_channel_map(
     if not mapping_raw:
         raise HTTPException(status_code=400, detail="mapping is empty")
 
-    # Coerce keys to int (JSON object keys are always strings)
     try:
         mapping = {int(k): str(v) for k, v in mapping_raw.items()}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"non-integer channel index: {exc}") from exc
 
-    # Enforce per-position voice biometric consent acknowledgement
     missing = sorted({pos for pos in mapping.values() if pos not in consent_acks})
     if missing:
         raise HTTPException(
@@ -140,15 +242,14 @@ async def api_save_audio_channel_map(
             detail=f"missing consent acknowledgement for: {', '.join(missing)}",
         )
 
-    user_id = _user.get("id") if isinstance(_user, dict) else None
-
-    # Persist the mapping (admin default — audio_session_id=None)
+    user_id = user.get("id") if isinstance(user, dict) else None
     await storage.set_channel_map(
         vendor_id=vendor_id,
         product_id=product_id,
         serial=serial,
         usb_port_path=usb_port_path,
         mapping=mapping,
+        audio_session_id=audio_session_id,
         created_by=user_id if isinstance(user_id, int) else None,
     )
 
@@ -165,14 +266,14 @@ async def api_save_audio_channel_map(
             device=device_identity,
         )
 
+    scope = "default" if audio_session_id is None else f"session={audio_session_id}"
     await audit(
         request,
         "audio_channel_map_saved",
         detail=(
-            f"device={vendor_id:04x}:{product_id:04x} serial={serial} "
-            f"port={usb_port_path} positions={sorted(set(mapping.values()))}"
+            f"scope={scope} device={vendor_id:04x}:{product_id:04x} "
+            f"serial={serial} port={usb_port_path} "
+            f"positions={sorted(set(mapping.values()))}"
         ),
-        user=_user if isinstance(_user, dict) else None,
+        user=user if isinstance(user, dict) else None,
     )
-
-    return Response(status_code=204)

--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -17,7 +17,113 @@ async function loadState() {
     if (!r.ok) { console.error('state fetch failed:', r.status); return; }
     state = await r.json();
     render(state);
+    refreshAudioChannelsCard(state);
   } catch(e) { console.error('state error', e); }
+}
+
+// ---- Multi-channel audio mapping (#462 pt.5) ----
+let _activeAudioSessionId = null;
+let _activeAudioMap = null;
+
+async function refreshAudioChannelsCard(s) {
+  const card = document.getElementById('audio-channels-card');
+  if (!card) return;
+  const aid = (s && s.current_race && s.current_race.audio_session_id) || null;
+  if (!aid) {
+    card.classList.add('hidden');
+    _activeAudioSessionId = null;
+    return;
+  }
+  try {
+    const r = await fetch(`/api/audio-channels/sessions/${aid}`);
+    if (!r.ok) { card.classList.add('hidden'); return; }
+    const body = await r.json();
+    if (!body.vendor_id && !body.product_id) {
+      card.classList.add('hidden');
+      return;
+    }
+    _activeAudioSessionId = aid;
+    _activeAudioMap = body;
+    const summary = document.getElementById('audio-channels-summary');
+    const entries = Object.entries(body.mapping || {}).sort((a, b) => Number(a[0]) - Number(b[0]));
+    summary.textContent = entries.length
+      ? entries.map(([ch, pos]) => `CH${ch}=${pos}`).join('  ')
+      : '(no mapping yet — using device default)';
+    card.classList.remove('hidden');
+  } catch (e) {
+    console.error('audio-channels refresh failed', e);
+    card.classList.add('hidden');
+  }
+}
+
+function openAudioChannelsDialog() {
+  if (!_activeAudioSessionId || !_activeAudioMap) return;
+  const dlg = document.getElementById('audio-channels-dialog');
+  const rows = document.getElementById('audio-channels-rows');
+  rows.innerHTML = '';
+  document.getElementById('audio-channels-err').textContent = '';
+  // Render 4 channel rows by default; preserve existing values from the map
+  for (let i = 0; i < 4; i++) {
+    const pos = (_activeAudioMap.mapping && _activeAudioMap.mapping[String(i)]) || '';
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:8px;align-items:center;margin:4px 0;font-size:.85rem';
+    row.innerHTML = `<span style="width:36px">CH${i}</span>` +
+      `<input type="text" data-ch="${i}" value="${pos}" placeholder="(unmapped)" ` +
+      `style="flex:1;padding:4px 8px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);color:var(--text-primary)">` +
+      `<label style="font-size:.78rem"><input type="checkbox" data-ack="${i}"> consent</label>`;
+    rows.appendChild(row);
+  }
+  dlg.showModal();
+}
+
+async function saveAudioChannelOverride() {
+  if (!_activeAudioSessionId || !_activeAudioMap) return;
+  const errEl = document.getElementById('audio-channels-err');
+  errEl.textContent = '';
+  const mapping = {};
+  const acks = new Set();
+  document.querySelectorAll('#audio-channels-rows input[type=text]').forEach(i => {
+    const v = i.value.trim();
+    if (v) mapping[parseInt(i.dataset.ch, 10)] = v;
+  });
+  document.querySelectorAll('#audio-channels-rows input[type=checkbox]').forEach(c => {
+    if (c.checked) {
+      const pos = mapping[parseInt(c.dataset.ack, 10)];
+      if (pos) acks.add(pos);
+    }
+  });
+  if (!Object.keys(mapping).length) { errEl.textContent = 'Add at least one position.'; return; }
+  const body = {
+    vendor_id: _activeAudioMap.vendor_id,
+    product_id: _activeAudioMap.product_id,
+    serial: _activeAudioMap.serial || '',
+    usb_port_path: _activeAudioMap.usb_port_path || '',
+    mapping,
+    consent_acks: [...acks],
+  };
+  const r = await fetch(
+    `/api/audio-channels/sessions/${_activeAudioSessionId}/override`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+  );
+  if (r.status === 204) {
+    document.getElementById('audio-channels-dialog').close();
+    await loadState();
+  } else {
+    const t = await r.text();
+    errEl.textContent = 'Error: ' + t;
+  }
+}
+
+async function clearAudioChannelOverride() {
+  if (!_activeAudioSessionId) return;
+  const r = await fetch(
+    `/api/audio-channels/sessions/${_activeAudioSessionId}/override`,
+    { method: 'DELETE' }
+  );
+  if (r.status === 204) {
+    document.getElementById('audio-channels-dialog').close();
+    await loadState();
+  }
 }
 
 function render(s) {

--- a/src/helmlog/templates/home.html
+++ b/src/helmlog/templates/home.html
@@ -253,6 +253,30 @@
   <div id="synth-result" style="margin-top:8px;font-size:.85rem;color:var(--warning);display:none"></div>
 </div>
 
+<!-- Multi-channel audio mapping (#462 pt.5) — only visible when an active
+     audio session has a recorded device identity. -->
+<div id="audio-channels-card" class="card hidden">
+  <div class="label">Audio channel mapping</div>
+  <div id="audio-channels-summary" style="font-size:.85rem;color:var(--text-secondary)"></div>
+  <button class="btn-sm" id="audio-channels-edit" style="margin-top:6px" onclick="openAudioChannelsDialog()">Edit for this session…</button>
+</div>
+
+<dialog id="audio-channels-dialog" style="background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:480px;width:90%">
+  <h3 style="margin:0 0 8px 0">Override channel mapping for this session</h3>
+  <div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:10px">
+    The override applies only to this audio session. Per the data licensing
+    policy, voice biometric consent must be acknowledged for every named
+    position before the override can be saved.
+  </div>
+  <div id="audio-channels-rows"></div>
+  <div id="audio-channels-err" style="color:var(--danger);font-size:.8rem;margin-top:6px"></div>
+  <div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">
+    <button class="btn-sm" onclick="document.getElementById('audio-channels-dialog').close()">Cancel</button>
+    <button class="btn-sm btn-save" onclick="clearAudioChannelOverride()">Revert to default</button>
+    <button class="btn-sm btn-save" onclick="saveAudioChannelOverride()">Save override</button>
+  </div>
+</dialog>
+
 <div id="today-summary" class="card hidden" style="text-align:center">
   <div style="font-size:.85rem;color:var(--text-secondary)" id="today-summary-text"></div>
   <a href="/history" style="font-size:.8rem;color:var(--accent);text-decoration:none;margin-top:4px;display:inline-block">View history &rarr;</a>

--- a/tests/test_audio_channels_admin.py
+++ b/tests/test_audio_channels_admin.py
@@ -197,6 +197,162 @@ async def test_save_rejects_empty_mapping(admin_client: httpx.AsyncClient) -> No
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Per-session override (#497 / pt.5)
+# ---------------------------------------------------------------------------
+
+
+async def _make_audio_session(storage: Storage) -> int:
+    from datetime import UTC
+    from datetime import datetime as _dt
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO audio_sessions"
+        " (file_path, device_name, start_utc, sample_rate, channels)"
+        " VALUES (?, ?, ?, ?, ?)",
+        ("/tmp/x.wav", "Lavalier4", _dt.now(UTC).isoformat(), 48000, 4),
+    )
+    await db.commit()
+    sid = cur.lastrowid
+    assert sid is not None
+    await storage.set_audio_session_device(
+        sid,
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+    )
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_get_session_map_falls_back_to_default(
+    admin_client: httpx.AsyncClient, storage: Storage
+) -> None:
+    await storage.set_channel_map(
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+        mapping={0: "helm", 1: "trim"},
+    )
+    sid = await _make_audio_session(storage)
+    resp = await admin_client.get(f"/api/audio-channels/sessions/{sid}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["audio_session_id"] == sid
+    assert body["mapping"] == {"0": "helm", "1": "trim"}
+
+
+@pytest.mark.asyncio
+async def test_session_override_persists_only_for_its_session(
+    admin_client: httpx.AsyncClient, storage: Storage
+) -> None:
+    await storage.set_channel_map(
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+        mapping={0: "helm", 1: "trim"},
+    )
+    sid_a = await _make_audio_session(storage)
+    sid_b = await _make_audio_session(storage)
+
+    resp = await admin_client.post(
+        f"/api/audio-channels/sessions/{sid_a}/override",
+        json={
+            "vendor_id": 0x1234,
+            "product_id": 0x5678,
+            "serial": "ABC",
+            "usb_port_path": "1-1.2",
+            "mapping": {"0": "tactician", "1": "bow"},
+            "consent_acks": ["tactician", "bow"],
+        },
+    )
+    assert resp.status_code == 204
+
+    a = (await admin_client.get(f"/api/audio-channels/sessions/{sid_a}")).json()
+    assert a["mapping"] == {"0": "tactician", "1": "bow"}
+
+    b = (await admin_client.get(f"/api/audio-channels/sessions/{sid_b}")).json()
+    assert b["mapping"] == {"0": "helm", "1": "trim"}
+
+    default = await storage.get_channel_map(
+        vendor_id=0x1234, product_id=0x5678, serial="ABC", usb_port_path="1-1.2"
+    )
+    assert default == {0: "helm", 1: "trim"}
+
+
+@pytest.mark.asyncio
+async def test_session_override_consent_gate(
+    admin_client: httpx.AsyncClient, storage: Storage
+) -> None:
+    sid = await _make_audio_session(storage)
+    resp = await admin_client.post(
+        f"/api/audio-channels/sessions/{sid}/override",
+        json={
+            "vendor_id": 0x1234,
+            "product_id": 0x5678,
+            "serial": "ABC",
+            "usb_port_path": "1-1.2",
+            "mapping": {"0": "helm", "1": "tactician"},
+            "consent_acks": ["helm"],
+        },
+    )
+    assert resp.status_code == 400
+    assert "tactician" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_session_override_clear_reverts_to_default(
+    admin_client: httpx.AsyncClient, storage: Storage
+) -> None:
+    await storage.set_channel_map(
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+        mapping={0: "helm"},
+    )
+    sid = await _make_audio_session(storage)
+    set_resp = await admin_client.post(
+        f"/api/audio-channels/sessions/{sid}/override",
+        json={
+            "vendor_id": 0x1234,
+            "product_id": 0x5678,
+            "serial": "ABC",
+            "usb_port_path": "1-1.2",
+            "mapping": {"0": "bow"},
+            "consent_acks": ["bow"],
+        },
+    )
+    assert set_resp.status_code == 204
+    clear_resp = await admin_client.delete(f"/api/audio-channels/sessions/{sid}/override")
+    assert clear_resp.status_code == 204
+
+    after = (await admin_client.get(f"/api/audio-channels/sessions/{sid}")).json()
+    assert after["mapping"] == {"0": "helm"}
+
+
+@pytest.mark.asyncio
+async def test_session_override_404_for_unknown_session(
+    admin_client: httpx.AsyncClient,
+) -> None:
+    resp = await admin_client.post(
+        "/api/audio-channels/sessions/9999/override",
+        json={
+            "vendor_id": 1,
+            "product_id": 2,
+            "serial": "",
+            "usb_port_path": "x",
+            "mapping": {"0": "helm"},
+            "consent_acks": ["helm"],
+        },
+    )
+    assert resp.status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_save_denied_for_non_admin(viewer_client: httpx.AsyncClient) -> None:
     resp = await viewer_client.post(


### PR DESCRIPTION
## Summary

Part 5 of the multi-channel audio chain (#462). Builds on #496 / #504. PR base = \`feature/462-pt4-admin-ui\` per the epic plan.

- Extracted \`_persist_channel_map\` shared helper from the existing \`/api/audio-channels/save\` handler so admin-default and per-session scopes share validation, consent gating, and audit logging.
- New endpoints (crew role):
  - \`GET    /api/audio-channels/sessions/{id}\` — returns the chained map (override → admin default) plus the device identity stored on the session row
  - \`POST   /api/audio-channels/sessions/{id}/override\` — persists a per-session override into the v63 \`channel_map\` table with \`audio_session_id\` set; same consent gate as the admin save
  - \`DELETE /api/audio-channels/sessions/{id}/override\` — removes the override; subsequent reads fall back to the admin default via \`get_channel_map_for_audio_session\`
- Home page: a new \"Audio channel mapping\" card that appears whenever the active race has an \`audio_session_id\` with a recorded device identity. Shows the current mapping summary and opens a modal with per-channel inputs and a per-position consent checkbox. JS hooks into the existing \`loadState()\` cycle.

Closes #497

## Test plan

- [x] 5 new \`tests/test_audio_channels_admin.py\` tests:
  - \`GET\` falls back to admin default when no override
  - Override on session A is invisible from session B; admin default unchanged
  - Override consent gate (400 when a position lacks ack)
  - \`DELETE\` clears override; subsequent reads see the admin default
  - 404 for unknown session
- [x] \`uv run ruff check .\` clean
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run mypy src/\`: only the 2 pre-existing transcribe errors
- [ ] Full pytest running in background (will report)

## Branching

Branched off \`feature/462-pt4-admin-ui\`; PR base = \`feature/462-pt4-admin-ui\` per the epic plan. Pt.6 (#498) will branch off this branch.

## Notes

- The home-page card is only visible when the active race has both an \`audio_session_id\` and a stored device identity. Without identity (e.g. no USB mic plugged in) the card stays hidden — no user noise.
- I committed and pushed before running the full suite this time, after a parallel session clobbered uncommitted work in pt.4.

🤖 Generated with [Claude Code](https://claude.ai/code)