### PR TITLE
[#462 pt.7] Multi-channel WAV export + atomic per-channel deletion

### DIFF
--- a/src/helmlog/export.py
+++ b/src/helmlog/export.py
@@ -441,6 +441,48 @@ async def export_json(
 
 
 # ---------------------------------------------------------------------------
+# WAV export — multi-channel preservation (#462 pt.7 / #499)
+# ---------------------------------------------------------------------------
+
+
+async def export_wav(
+    storage: Storage,
+    audio_session_id: int,
+    output_path: str | Path,
+) -> int:
+    """Export a session's recorded WAV verbatim, preserving all channels.
+
+    Audio files on disk are already written as multi-channel PCM by
+    ``audio.py``; this export path must never downmix or flatten them, so
+    external tools can keep per-position isolation.
+
+    Returns the channel count of the exported file.
+    """
+    import shutil
+
+    import soundfile as sf
+
+    row = await storage.get_audio_session_row(audio_session_id)
+    if row is None:
+        raise ValueError(f"audio session {audio_session_id} not found")
+    src = Path(row["file_path"])
+    if not src.exists():
+        raise FileNotFoundError(f"source WAV missing: {src}")
+
+    dst = Path(output_path)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+    info = sf.info(str(dst))
+    expected = int(row["channels"] or 0)
+    if expected and info.channels != expected:
+        dst.unlink(missing_ok=True)
+        raise RuntimeError(f"exported WAV channel count {info.channels} != expected {expected}")
+    logger.info("WAV export: session={} channels={} → {}", audio_session_id, info.channels, dst)
+    return int(info.channels)
+
+
+# ---------------------------------------------------------------------------
 # Dispatch by extension
 # ---------------------------------------------------------------------------
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7,10 +7,12 @@ all logged data.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import aiosqlite
@@ -6056,6 +6058,125 @@ class Storage:
         await db.commit()
         logger.info("Audio session {} deleted", audio_session_id)
         return file_path
+
+    # ------------------------------------------------------------------
+    # Per-channel audio deletion (#462 pt.7 / #499)
+    # ------------------------------------------------------------------
+
+    async def delete_audio_channel(
+        self,
+        audio_session_id: int,
+        *,
+        channel_index: int,
+        user_id: int | None = None,
+        reason: str | None = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        """Atomically delete one channel's audio + transcript + channel_map.
+
+        Executes the per-channel data-licensing deletion right for a single
+        position in a multi-channel recording:
+
+        * Zero out ``channel_index`` in the WAV on disk (preserves channel
+          count so remaining channels keep their indices).
+        * Delete all ``transcript_segments`` rows tagged with that channel
+          for this session's transcript(s).
+        * Delete the matching ``channel_map`` row(s) for this session.
+        * Write an ``audio_channel_delete`` audit log entry.
+
+        The WAV rewrite is staged via a sibling ``.tmpNNN`` file and swapped
+        with ``os.replace`` only after all DB mutations succeed; any failure
+        rolls back the DB and leaves the original WAV untouched.
+        """
+        import os
+        import tempfile
+
+        import soundfile as sf
+
+        row = await self.get_audio_session_row(audio_session_id)
+        if row is None:
+            raise ValueError(f"audio session {audio_session_id} not found")
+        channels = int(row.get("channels") or 0)
+        if channel_index < 0 or channel_index >= channels:
+            raise ValueError(
+                f"channel_index {channel_index} out of range for {channels}-channel session"
+            )
+        wav_path = Path(row["file_path"])
+        if not wav_path.exists():
+            raise FileNotFoundError(f"audio file missing: {wav_path}")
+
+        # Stage the zeroed WAV into a sibling tmp file. soundfile preserves
+        # samplerate/subtype via sf.info.
+        data, sr = sf.read(str(wav_path), always_2d=True)
+        info = sf.info(str(wav_path))
+        if data.shape[1] != channels:
+            raise RuntimeError(f"WAV channel count {data.shape[1]} != DB channels {channels}")
+        data[:, channel_index] = 0
+
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=wav_path.name + ".", suffix=".tmp", dir=str(wav_path.parent)
+        )
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            sf.write(str(tmp_path), data, sr, format=info.format, subtype=info.subtype)
+
+            db = self._conn()
+            try:
+                await db.execute(
+                    "DELETE FROM transcript_segments"
+                    " WHERE channel_index = ?"
+                    "   AND transcript_id IN"
+                    "       (SELECT id FROM transcripts WHERE audio_session_id = ?)",
+                    (channel_index, audio_session_id),
+                )
+                await db.execute(
+                    "DELETE FROM channel_map WHERE audio_session_id = ? AND channel_index = ?",
+                    (audio_session_id, channel_index),
+                )
+                detail = json.dumps(
+                    {
+                        "audio_session_id": audio_session_id,
+                        "channel_index": channel_index,
+                        "position_name": (
+                            await self._channel_position_name(audio_session_id, channel_index)
+                        ),
+                        "reason": reason,
+                    }
+                )
+                await self.log_action(
+                    "audio_channel_delete",
+                    detail=detail,
+                    user_id=user_id,
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                )
+                os.replace(str(tmp_path), str(wav_path))
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        except Exception:
+            if tmp_path.exists():
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink()
+            raise
+        logger.info(
+            "Audio channel deleted: session={} channel={}",
+            audio_session_id,
+            channel_index,
+        )
+
+    async def _channel_position_name(self, audio_session_id: int, channel_index: int) -> str | None:
+        """Look up the stored position name for a channel (may be None)."""
+        cur = await self._read_conn().execute(
+            "SELECT position_name FROM channel_map"
+            " WHERE audio_session_id = ? AND channel_index = ?",
+            (audio_session_id, channel_index),
+        )
+        r = await cur.fetchone()
+        return r["position_name"] if r else None
 
     # ------------------------------------------------------------------
     # Photo cleanup on note deletion (#205)

--- a/tests/test_channel_deletion.py
+++ b/tests/test_channel_deletion.py
@@ -1,0 +1,197 @@
+"""Per-channel atomic deletion (#462 pt.7 / #499).
+
+Exercise the full data-licensing deletion right for a single position in a
+multi-channel recording: zero the channel in the WAV, drop its transcript
+segments, drop its channel_map row, and write an audit entry — all atomic.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from helmlog.audio import AudioSession
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+
+
+def _write_four_channel_wav(path: Path, *, sample_rate: int = 48000, seconds: float = 0.25) -> None:
+    n = int(sample_rate * seconds)
+    t = np.arange(n, dtype=np.float32) / sample_rate
+    data = np.stack(
+        [
+            0.5 * np.sin(2 * np.pi * 220.0 * t),
+            0.5 * np.sin(2 * np.pi * 330.0 * t),
+            0.5 * np.sin(2 * np.pi * 440.0 * t),
+            0.5 * np.sin(2 * np.pi * 550.0 * t),
+        ],
+        axis=1,
+    ).astype(np.float32)
+    sf.write(str(path), data, sample_rate, subtype="PCM_16")
+
+
+async def _seed_multichannel(storage: Storage, wav_path: Path) -> tuple[int, int]:
+    """Write audio session, device identity, channel_map, transcript, and
+    4 segments (one per channel). Return (audio_session_id, transcript_id)."""
+    session = AudioSession(
+        file_path=str(wav_path),
+        device_name="Gordik 4ch",
+        start_utc=datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC),
+        end_utc=datetime(2024, 6, 15, 12, 0, 1, tzinfo=UTC),
+        sample_rate=48000,
+        channels=4,
+    )
+    audio_session_id = await storage.write_audio_session(session)
+    await storage.set_audio_session_device(
+        audio_session_id,
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+    )
+    await storage.set_channel_map(
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="ABC",
+        usb_port_path="1-1.2",
+        mapping={0: "helm", 1: "tactician", 2: "trim", 3: "bow"},
+        audio_session_id=audio_session_id,
+    )
+    transcript_id = await storage.create_transcript_job(audio_session_id, model="tiny.en")
+    segments = [
+        {
+            "segment_index": i,
+            "start_time": float(i) * 0.05,
+            "end_time": float(i) * 0.05 + 0.04,
+            "text": f"channel {i} test",
+            "speaker": pos,
+            "channel_index": i,
+            "position_name": pos,
+        }
+        for i, pos in enumerate(["helm", "tactician", "trim", "bow"])
+    ]
+    await storage.insert_transcript_segments(transcript_id, segments)
+    return audio_session_id, transcript_id
+
+
+@pytest.mark.asyncio
+async def test_delete_audio_channel_zeros_and_cascades(tmp_path: Path, storage: Storage) -> None:
+    wav = tmp_path / "rec.wav"
+    _write_four_channel_wav(wav)
+    audio_session_id, transcript_id = await _seed_multichannel(storage, wav)
+
+    original, _ = sf.read(str(wav), dtype="float32", always_2d=True)
+    assert original.shape[1] == 4
+
+    await storage.delete_audio_channel(
+        audio_session_id,
+        channel_index=1,
+        user_id=None,
+        reason="crew member deletion request",
+    )
+
+    # WAV: still 4 channels, channel 1 is silent, others untouched.
+    after, sr = sf.read(str(wav), dtype="float32", always_2d=True)
+    assert after.shape == original.shape
+    assert sr == 48000
+    np.testing.assert_array_equal(after[:, 1], np.zeros_like(after[:, 1]))
+    for ch in (0, 2, 3):
+        np.testing.assert_allclose(after[:, ch], original[:, ch], atol=1e-3)
+
+    # transcript_segments: channel 1 gone, others remain
+    remaining = await storage.list_transcript_segments(transcript_id)
+    indexes = sorted(s["channel_index"] for s in remaining)
+    assert indexes == [0, 2, 3]
+
+    # channel_map: channel 1 row gone, others remain
+    cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
+    assert 1 not in cmap
+    assert set(cmap.keys()) == {0, 2, 3}
+
+    # Audit log
+    entries = await storage.list_audit_log(limit=5)
+    assert any(
+        e["action"] == "audio_channel_delete"
+        and f'"audio_session_id": {audio_session_id}' in (e["detail"] or "")
+        and '"channel_index": 1' in (e["detail"] or "")
+        for e in entries
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_audio_channel_rolls_back_on_missing_file(
+    tmp_path: Path, storage: Storage
+) -> None:
+    wav = tmp_path / "rec.wav"
+    _write_four_channel_wav(wav)
+    audio_session_id, transcript_id = await _seed_multichannel(storage, wav)
+
+    wav.unlink()  # simulate missing file
+
+    with pytest.raises(FileNotFoundError):
+        await storage.delete_audio_channel(audio_session_id, channel_index=2, user_id=None)
+
+    # DB state must be untouched
+    remaining = await storage.list_transcript_segments(transcript_id)
+    assert sorted(s["channel_index"] for s in remaining) == [0, 1, 2, 3]
+    cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
+    assert set(cmap.keys()) == {0, 1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_delete_audio_channel_rolls_back_on_db_error(
+    tmp_path: Path, storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wav = tmp_path / "rec.wav"
+    _write_four_channel_wav(wav)
+    audio_session_id, transcript_id = await _seed_multichannel(storage, wav)
+    original, _ = sf.read(str(wav), dtype="float32", always_2d=True)
+
+    # Force the audit insert (last DB step) to raise.
+    real_log = storage.log_action
+
+    async def boom(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("audit log exploded")
+
+    monkeypatch.setattr(storage, "log_action", boom)
+
+    with pytest.raises(RuntimeError, match="audit log exploded"):
+        await storage.delete_audio_channel(audio_session_id, channel_index=0, user_id=None)
+
+    # WAV unchanged
+    after, _ = sf.read(str(wav), dtype="float32", always_2d=True)
+    np.testing.assert_array_equal(after, original)
+
+    # DB state unchanged
+    remaining = await storage.list_transcript_segments(transcript_id)
+    assert sorted(s["channel_index"] for s in remaining) == [0, 1, 2, 3]
+    cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
+    assert set(cmap.keys()) == {0, 1, 2, 3}
+
+    # No stray tmp files
+    strays = list(tmp_path.glob("*.tmp*"))
+    assert strays == []
+    _ = real_log  # keep ref
+
+
+@pytest.mark.asyncio
+async def test_delete_audio_channel_rejects_out_of_range(tmp_path: Path, storage: Storage) -> None:
+    wav = tmp_path / "rec.wav"
+    _write_four_channel_wav(wav)
+    audio_session_id, _ = await _seed_multichannel(storage, wav)
+
+    with pytest.raises(ValueError):
+        await storage.delete_audio_channel(audio_session_id, channel_index=9, user_id=None)
+
+
+@pytest.mark.asyncio
+async def test_delete_audio_channel_unknown_session(tmp_path: Path, storage: Storage) -> None:
+    with pytest.raises(ValueError):
+        await storage.delete_audio_channel(99999, channel_index=0, user_id=None)

--- a/tests/test_export_wav.py
+++ b/tests/test_export_wav.py
@@ -1,0 +1,84 @@
+"""WAV export preserves all channels (#462 pt.7 / #499)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from helmlog.audio import AudioSession
+from helmlog.export import export_wav
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+
+
+def _write_four_channel_wav(path: Path, *, sample_rate: int = 48000, seconds: float = 0.5) -> None:
+    n = int(sample_rate * seconds)
+    t = np.arange(n, dtype=np.float32) / sample_rate
+    data = np.stack(
+        [
+            np.sin(2 * np.pi * 220.0 * t),
+            np.sin(2 * np.pi * 330.0 * t),
+            np.sin(2 * np.pi * 440.0 * t),
+            np.sin(2 * np.pi * 550.0 * t),
+        ],
+        axis=1,
+    ).astype(np.float32)
+    sf.write(str(path), data, sample_rate, subtype="PCM_16")
+
+
+async def _seed_session(storage: Storage, file_path: Path, channels: int = 4) -> int:
+    session = AudioSession(
+        file_path=str(file_path),
+        device_name="TestDev",
+        start_utc=datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC),
+        end_utc=datetime(2024, 6, 15, 12, 0, 1, tzinfo=UTC),
+        sample_rate=48000,
+        channels=channels,
+    )
+    return await storage.write_audio_session(session)
+
+
+@pytest.mark.asyncio
+async def test_export_wav_preserves_all_four_channels(tmp_path: Path, storage: Storage) -> None:
+    src = tmp_path / "recording.wav"
+    _write_four_channel_wav(src)
+    audio_session_id = await _seed_session(storage, src)
+
+    dst = tmp_path / "export.wav"
+    await export_wav(storage, audio_session_id, dst)
+
+    assert dst.exists()
+    info = sf.info(str(dst))
+    assert info.channels == 4
+    assert info.samplerate == 48000
+
+    orig, _ = sf.read(str(src), dtype="float32", always_2d=True)
+    out, _ = sf.read(str(dst), dtype="float32", always_2d=True)
+    assert orig.shape == out.shape
+    np.testing.assert_array_equal(orig, out)
+
+
+@pytest.mark.asyncio
+async def test_export_wav_missing_session_raises(tmp_path: Path, storage: Storage) -> None:
+    dst = tmp_path / "nope.wav"
+    with pytest.raises(ValueError):
+        await export_wav(storage, 9999, dst)
+    assert not dst.exists()
+
+
+@pytest.mark.asyncio
+async def test_export_wav_missing_source_file_raises(tmp_path: Path, storage: Storage) -> None:
+    ghost = tmp_path / "ghost.wav"
+    audio_session_id = await _seed_session(storage, ghost)
+
+    dst = tmp_path / "out.wav"
+    with pytest.raises(FileNotFoundError):
+        await export_wav(storage, audio_session_id, dst)
+    assert not dst.exists()


### PR DESCRIPTION
## Summary

Part 7 (final) of the multi-channel audio chain for #462. Builds on #507 (pt.6). PR base = \`feature/462-pt6-playback\` per the epic plan. Merging this closes the epic.

### \`export_wav\`

New \`export.py:export_wav(storage, audio_session_id, output_path)\`. Verbatim file copy of the recorded multi-channel WAV; asserts \`soundfile\` sees the same channel count the DB has. No flattening/downmix — external tools keep per-position isolation. CSV/GPX/JSON exports unchanged.

### \`Storage.delete_audio_channel\` — atomic per-channel deletion

Executes the per-position data-licensing deletion right for one channel in a multi-channel recording:

1. Stage zeroed WAV in a sibling \`<name>.<rand>.tmp\` file (original untouched).
2. Open DB transaction:
   - \`DELETE FROM transcript_segments WHERE channel_index=? AND transcript_id IN (…audio_session…)\`
   - \`DELETE FROM channel_map WHERE audio_session_id=? AND channel_index=?\`
   - \`log_action('audio_channel_delete', detail={audio_session_id, channel_index, position_name, reason}, user_id, …)\`
   - \`os.replace(tmp, original)\` — atomic FS swap
   - \`commit()\`
3. Any failure ⇒ \`rollback()\` + \`tmp.unlink()\`; original WAV + DB rows remain intact.

Zeroing (rather than dropping) preserves channel indices so the remaining speakers keep their \`channel_index → position_name\` mapping stable.

### Data licensing

Per-channel deletion satisfies the deletion/anonymization right for PII audio in \`docs/data-licensing.md\`: a single speaker can be removed without affecting other speakers on the same recording, with a full audit trail.

Closes #499

## Test plan

- [x] \`uv run pytest tests/test_export_wav.py tests/test_channel_deletion.py\` — 8 new tests pass
- [x] Full \`uv run pytest\` — 1799 passed, 2 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run mypy src/helmlog/storage.py src/helmlog/export.py\` clean
- Rollback paths covered:
  - [x] Missing source WAV ⇒ \`FileNotFoundError\`, DB untouched
  - [x] Audit-log failure mid-transaction ⇒ WAV untouched, all DB rows preserved, no stray tmp files
  - [x] Out-of-range \`channel_index\` ⇒ \`ValueError\`
  - [x] Unknown \`audio_session_id\` ⇒ \`ValueError\`

## Branching

Stacked on \`feature/462-pt6-playback\` (PR #507). Not mergeable until pt.6 lands; when pt.6 merges to \`main\`, rebase-retarget this to \`main\`.

🤖 Generated with [Claude Code](https://claude.ai/code)