### PR TITLE
[#509 chunk 1] Sibling-card parallel capture + capture_group_id migration

### DIFF
--- a/src/helmlog/audio.py
+++ b/src/helmlog/audio.py
@@ -83,6 +83,11 @@ class AudioSession:
     product_id: int = 0
     serial: str = ""
     usb_port_path: str = ""
+    # Sibling-card capture (#509). When multiple mono USB receivers are
+    # recorded in parallel, every sibling shares a ``capture_group_id`` and
+    # gets its own ordinal (0..N-1). None / 0 = legacy single-device session.
+    capture_group_id: str | None = None
+    capture_ordinal: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -323,6 +328,202 @@ class AudioRecorder:
                 continue
             except Exception as exc:
                 logger.error("Audio writer thread error: {}", exc)
+
+
+# ---------------------------------------------------------------------------
+# AudioRecorderGroup — sibling-card parallel capture (#509)
+# ---------------------------------------------------------------------------
+
+
+class AudioRecorderGroup:
+    """Record from N USB capture devices in parallel, one WAV per card.
+
+    Stopgap for hardware that presents each wireless receiver as a
+    mono-only USB device (#509). Each sibling recorder writes its own
+    WAV file; all siblings from one start/stop cycle share a single
+    ``capture_group_id`` UUID and an ordinal within the group.
+
+    Usage::
+
+        from helmlog.usb_audio import detect_all_capture_devices
+
+        group = AudioRecorderGroup()
+        sessions = await group.start(
+            config,
+            devices=detect_all_capture_devices(min_channels=1),
+            name=race.name,
+        )
+        # … write every session to storage; all share capture_group_id …
+        completed = await group.stop()
+
+    On failure during ``start()``, any siblings that already opened are
+    best-effort stopped before the exception propagates, so we never
+    leak USB streams.
+    """
+
+    def __init__(self) -> None:
+        self._recorders: list[AudioRecorder] = []
+        self._sessions: list[AudioSession] = []
+
+    @property
+    def is_recording(self) -> bool:
+        return bool(self._recorders)
+
+    async def start(
+        self,
+        config: AudioConfig,
+        *,
+        devices: list[Any],  # list[DetectedDevice]; loose to avoid import
+        name: str | None = None,
+    ) -> list[AudioSession]:
+        """Open one sibling recorder per device and return their sessions."""
+        import uuid
+
+        if not devices:
+            raise AudioDeviceNotFoundError(
+                "AudioRecorderGroup.start(): no capture devices provided"
+            )
+
+        group_id = uuid.uuid4().hex
+        sessions: list[AudioSession] = []
+        recorders: list[AudioRecorder] = []
+        try:
+            for ordinal, device in enumerate(devices):
+                sibling_name: str | None = None
+                if name is not None:
+                    sibling_name = f"{name}-sib{ordinal}"
+                recorder = AudioRecorder()
+                session = await recorder.start(config, name=sibling_name, detected=device)
+                session.capture_group_id = group_id
+                session.capture_ordinal = ordinal
+                recorders.append(recorder)
+                sessions.append(session)
+        except Exception:
+            for r in recorders:
+                try:
+                    await r.stop()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("sibling cleanup on start failure: {}", exc)
+            raise
+
+        self._recorders = recorders
+        self._sessions = sessions
+        logger.debug(
+            "AudioRecorderGroup started: group={} siblings={}",
+            group_id,
+            len(sessions),
+        )
+        return sessions
+
+    async def stop(self) -> list[AudioSession]:
+        """Stop every sibling and return the completed sessions in ordinal order."""
+        if not self._recorders:
+            raise RuntimeError("AudioRecorderGroup.stop() called before start()")
+        completed: list[AudioSession] = []
+        errors: list[BaseException] = []
+        for r, staged in zip(self._recorders, self._sessions, strict=True):
+            try:
+                done = await r.stop()
+                done.capture_group_id = staged.capture_group_id
+                done.capture_ordinal = staged.capture_ordinal
+                completed.append(done)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("sibling stop failed ordinal={}: {}", staged.capture_ordinal, exc)
+                errors.append(exc)
+        self._recorders = []
+        self._sessions = []
+        if errors:
+            raise RuntimeError(
+                f"AudioRecorderGroup.stop(): {len(errors)} sibling(s) failed — first: {errors[0]!r}"
+            )
+        return completed
+
+
+# ---------------------------------------------------------------------------
+# Unified start/stop helpers that handle both AudioRecorder and
+# AudioRecorderGroup so route handlers can stay oblivious (#509).
+# ---------------------------------------------------------------------------
+
+
+async def capture_start(
+    recorder: AudioRecorder | AudioRecorderGroup,
+    config: AudioConfig,
+    storage: Any,  # noqa: ANN401 — Storage; loose to avoid import cycle
+    *,
+    name: str | None,
+    race_id: int | None,
+    session_type: str,
+) -> int:
+    """Start an audio capture and persist every resulting session.
+
+    Works transparently whether the recorder is a single-device
+    ``AudioRecorder`` or a sibling-card ``AudioRecorderGroup``. Returns
+    the *primary* session id (ordinal 0) so the caller can keep tracking
+    the capture with a single scalar in ``session_state``.
+    """
+    if isinstance(recorder, AudioRecorderGroup):
+        from helmlog.usb_audio import detect_all_capture_devices
+
+        devices = detect_all_capture_devices(min_channels=1)
+        sessions = await recorder.start(config, devices=devices, name=name)
+    else:
+        sessions = [await recorder.start(config, name=name)]
+
+    primary_id: int | None = None
+    for s in sessions:
+        sid = await storage.write_audio_session(
+            s, race_id=race_id, session_type=session_type, name=name
+        )
+        if primary_id is None:
+            primary_id = sid
+    assert primary_id is not None
+    return primary_id
+
+
+async def capture_stop(
+    recorder: AudioRecorder | AudioRecorderGroup,
+    storage: Any,  # noqa: ANN401 — Storage
+    *,
+    primary_session_id: int,
+) -> AudioSession:
+    """Stop the active capture and persist end_utc for every sibling.
+
+    In single-device mode only ``primary_session_id`` is updated. In
+    sibling mode the recorder's completed sessions carry their
+    ``capture_group_id`` and ordinals; we resolve the corresponding
+    audio_sessions row ids by querying ``list_capture_group_siblings``.
+    Returns the primary completed ``AudioSession``.
+    """
+    if isinstance(recorder, AudioRecorderGroup):
+        completed = await recorder.stop()
+        if not completed:
+            raise RuntimeError("capture_stop(): group returned no sessions")
+        primary = completed[0]
+        assert primary.end_utc is not None
+        group_id = primary.capture_group_id
+        if group_id is None:
+            # Defensive: sibling recorder somehow forgot the group id.
+            await storage.update_audio_session_end(primary_session_id, primary.end_utc)
+            return primary
+        rows = await storage.list_capture_group_siblings(group_id)
+        by_ordinal = {r["capture_ordinal"]: r["id"] for r in rows}
+        for s in completed:
+            sid = by_ordinal.get(s.capture_ordinal)
+            if sid is None:
+                logger.warning(
+                    "capture_stop(): no row for group={} ordinal={}",
+                    group_id,
+                    s.capture_ordinal,
+                )
+                continue
+            assert s.end_utc is not None
+            await storage.update_audio_session_end(sid, s.end_utc)
+        return primary
+
+    completed_single = await recorder.stop()
+    assert completed_single.end_utc is not None
+    await storage.update_audio_session_end(primary_session_id, completed_single.end_utc)
+    return completed_single
 
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -397,10 +397,16 @@ async def _run() -> None:
     for row in await storage.list_settings():
         os.environ.setdefault(row["key"], row["value"])
 
-    from helmlog.audio import AudioConfig, AudioRecorder
+    from helmlog.audio import AudioConfig, AudioRecorder, AudioRecorderGroup
 
     audio_config = AudioConfig()
-    recorder = AudioRecorder()
+    _capture_mode = os.environ.get("AUDIO_CAPTURE_MODE", "single").lower()
+    recorder: AudioRecorder | AudioRecorderGroup
+    if _capture_mode == "sibling":
+        logger.info("Audio capture mode: sibling (parallel USB cards, #509)")
+        recorder = AudioRecorderGroup()
+    else:
+        recorder = AudioRecorder()
 
     # Seed cameras table from env var on first run, then load from DB
     cameras_str = os.environ.get("CAMERAS", "")

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -167,15 +167,16 @@ async def _do_scheduled_start(app: FastAPI, event: str, session_type: str) -> No
 
         # Start audio if request.app.state.recorder is available
         if app.state.recorder is not None and app.state.audio_config is not None:
-            from helmlog.audio import AudioDeviceNotFoundError
+            from helmlog.audio import AudioDeviceNotFoundError, capture_start
 
             try:
-                session = await app.state.recorder.start(app.state.audio_config, name=race.name)
-                ss.audio_session_id = await storage.write_audio_session(
-                    session,
+                ss.audio_session_id = await capture_start(
+                    app.state.recorder,
+                    app.state.audio_config,
+                    storage,
+                    name=race.name,
                     race_id=race.id,
                     session_type=session_type,
-                    name=race.name,
                 )
             except AudioDeviceNotFoundError as exc:
                 logger.warning("Audio unavailable for scheduled race {}: {}", name, exc)
@@ -337,9 +338,13 @@ async def api_start_race(
 
     # Auto-stop any active debrief before starting a new session
     if ss.debrief_audio_session_id is not None:
-        completed = await request.app.state.recorder.stop()
-        assert completed.end_utc is not None
-        await storage.update_audio_session_end(ss.debrief_audio_session_id, completed.end_utc)
+        from helmlog.audio import capture_stop
+
+        await capture_stop(
+            request.app.state.recorder,
+            storage,
+            primary_session_id=ss.debrief_audio_session_id,
+        )
         logger.info("Debrief auto-stopped to start new {}", session_type)
         ss.debrief_audio_session_id = None
         ss.debrief_race_id = None
@@ -373,19 +378,18 @@ async def api_start_race(
         logger.warning("Failed to auto-apply sail defaults for race {}: {}", race.name, exc)
 
     if request.app.state.recorder is not None and request.app.state.audio_config is not None:
-        from helmlog.audio import AudioDeviceNotFoundError
+        from helmlog.audio import AudioDeviceNotFoundError, capture_start
 
         try:
-            session = await request.app.state.recorder.start(
-                request.app.state.audio_config, name=race.name
-            )
-            ss.audio_session_id = await storage.write_audio_session(
-                session,
+            ss.audio_session_id = await capture_start(
+                request.app.state.recorder,
+                request.app.state.audio_config,
+                storage,
+                name=race.name,
                 race_id=race.id,
                 session_type=session_type,
-                name=race.name,
             )
-            logger.info("Audio recording started: {}", session.file_path)
+            logger.info("Audio recording started for race {}", race.name)
         except AudioDeviceNotFoundError as exc:
             logger.warning("Audio unavailable for race {}: {}", race.name, exc)
 
@@ -485,9 +489,13 @@ async def api_end_race(
     asyncio.ensure_future(_auto_detect_maneuvers(race_id))
 
     if request.app.state.recorder is not None and ss.audio_session_id is not None:
-        completed = await request.app.state.recorder.stop()
-        assert completed.end_utc is not None
-        await storage.update_audio_session_end(ss.audio_session_id, completed.end_utc)
+        from helmlog.audio import capture_stop
+
+        completed = await capture_stop(
+            request.app.state.recorder,
+            storage,
+            primary_session_id=ss.audio_session_id,
+        )
         logger.info("Audio recording saved: {}", completed.file_path)
         ss.audio_session_id = None
 
@@ -511,38 +519,43 @@ async def api_start_debrief(
     if row is None:
         raise HTTPException(status_code=404, detail="Race not found")
 
+    from helmlog.audio import capture_start, capture_stop
+
     # Defensive: if the race is still in progress, auto-end it first
     if row["end_utc"] is None:
         now_end = datetime.now(UTC)
         await storage.end_race(race_id, now_end)
         if ss.audio_session_id is not None:
-            completed = await request.app.state.recorder.stop()
-            assert completed.end_utc is not None
-            await storage.update_audio_session_end(ss.audio_session_id, completed.end_utc)
+            await capture_stop(
+                request.app.state.recorder,
+                storage,
+                primary_session_id=ss.audio_session_id,
+            )
             ss.audio_session_id = None
         logger.info("Race {} auto-ended to start debrief", race_id)
 
     if ss.debrief_audio_session_id is not None:
-        completed = await request.app.state.recorder.stop()
-        assert completed.end_utc is not None
-        await storage.update_audio_session_end(ss.debrief_audio_session_id, completed.end_utc)
+        await capture_stop(
+            request.app.state.recorder,
+            storage,
+            primary_session_id=ss.debrief_audio_session_id,
+        )
         ss.debrief_audio_session_id = None
 
     debrief_name = f"{row['name']}-debrief"
     now = datetime.now(UTC)
-    session = await request.app.state.recorder.start(
-        request.app.state.audio_config, name=debrief_name
-    )
-    ss.debrief_audio_session_id = await storage.write_audio_session(
-        session,
+    ss.debrief_audio_session_id = await capture_start(
+        request.app.state.recorder,
+        request.app.state.audio_config,
+        storage,
+        name=debrief_name,
         race_id=race_id,
         session_type="debrief",
-        name=debrief_name,
     )
     ss.debrief_race_id = race_id
     ss.debrief_race_name = row["name"]
     ss.debrief_start_utc = now
-    logger.info("Debrief recording started: {}", session.file_path)
+    logger.info("Debrief recording started for {}", debrief_name)
 
     await audit(request, "debrief.start", detail=row["name"], user=_user)
     return JSONResponse(
@@ -562,9 +575,13 @@ async def api_stop_debrief(
     if ss.debrief_audio_session_id is None:
         raise HTTPException(status_code=409, detail="No debrief in progress")
 
-    completed = await request.app.state.recorder.stop()
-    assert completed.end_utc is not None
-    await storage.update_audio_session_end(ss.debrief_audio_session_id, completed.end_utc)
+    from helmlog.audio import capture_stop
+
+    completed = await capture_stop(
+        request.app.state.recorder,
+        storage,
+        primary_session_id=ss.debrief_audio_session_id,
+    )
     logger.info("Debrief recording saved: {}", completed.file_path)
 
     await audit(request, "debrief.stop", user=_user)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -134,7 +134,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 64
+_CURRENT_VERSION: int = 65
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1485,6 +1485,19 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE audio_sessions ADD COLUMN serial TEXT;
         ALTER TABLE audio_sessions ADD COLUMN usb_port_path TEXT;
     """,
+    65: """
+        -- Sibling-card capture stopgap (#509 / #462 follow-up): when two or
+        -- more mono USB receivers are used in parallel (e.g. the Jieli
+        -- 4-mic wireless sets that mix all transmitters to mono before USB),
+        -- each card produces its own mono WAV and its own audio_sessions
+        -- row. All siblings from one start/stop cycle share a
+        -- ``capture_group_id`` UUID and each carries its ordinal within the
+        -- group. NULL capture_group_id = legacy single-device session.
+        ALTER TABLE audio_sessions ADD COLUMN capture_group_id TEXT;
+        ALTER TABLE audio_sessions ADD COLUMN capture_ordinal INTEGER NOT NULL DEFAULT 0;
+        CREATE INDEX IF NOT EXISTS idx_audio_sessions_capture_group
+            ON audio_sessions(capture_group_id);
+    """,
 }
 
 # Retention window for retired slugs (#449). Requests for a retired slug 301
@@ -2501,8 +2514,9 @@ class Storage:
         cur = await db.execute(
             "INSERT INTO audio_sessions"
             " (file_path, device_name, start_utc, end_utc, sample_rate, channels,"
-            "  race_id, session_type, name, channel_map)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "  race_id, session_type, name, channel_map,"
+            "  capture_group_id, capture_ordinal)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 session.file_path,
                 session.device_name,
@@ -2514,6 +2528,8 @@ class Storage:
                 session_type,
                 name,
                 json.dumps(session.channel_map) if session.channel_map else None,
+                session.capture_group_id,
+                session.capture_ordinal,
             ),
         )
         await db.commit()
@@ -2577,7 +2593,8 @@ class Storage:
         cur = await self._read_conn().execute(
             "SELECT id, file_path, device_name, start_utc, end_utc, sample_rate, channels,"
             " race_id, session_type, name, channel_map,"
-            " vendor_id, product_id, serial, usb_port_path"
+            " vendor_id, product_id, serial, usb_port_path,"
+            " capture_group_id, capture_ordinal"
             " FROM audio_sessions WHERE id = ?",
             (session_id,),
         )
@@ -2592,6 +2609,25 @@ class Storage:
             except (json.JSONDecodeError, ValueError):
                 pass
         return res
+
+    async def list_capture_group_siblings(self, capture_group_id: str) -> list[dict[str, Any]]:
+        """Return all audio_sessions rows sharing a capture_group_id, in ordinal order.
+
+        Used by the sibling-card playback path (#509) to discover every WAV
+        that belongs to a single start/stop cycle across multiple mono USB
+        receivers. Returns an empty list if the group is unknown.
+        """
+        cur = await self._read_conn().execute(
+            "SELECT id, file_path, device_name, start_utc, end_utc, sample_rate, channels,"
+            " race_id, session_type, name, channel_map,"
+            " vendor_id, product_id, serial, usb_port_path,"
+            " capture_group_id, capture_ordinal"
+            " FROM audio_sessions WHERE capture_group_id = ?"
+            " ORDER BY capture_ordinal ASC",
+            (capture_group_id,),
+        )
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
 
     async def list_audio_sessions(self) -> list[AudioSession]:
         """Return all audio sessions ordered by start_utc descending."""

--- a/src/helmlog/usb_audio.py
+++ b/src/helmlog/usb_audio.py
@@ -168,6 +168,78 @@ def detect_via_pyudev(*, min_channels: int) -> DetectedDevice | None:
 # ---------------------------------------------------------------------------
 
 
+def detect_all_capture_devices(*, min_channels: int = 1) -> list[DetectedDevice]:
+    """Enumerate every USB audio input device that meets ``min_channels``.
+
+    Used by the sibling-card capture path (#509) when a single physical
+    USB receiver exposes only a mono PCM stream and we need to open
+    multiple cards in parallel.
+
+    On Linux each entry is enriched with a pyudev identity tuple in
+    enumeration order (best-effort — if pyudev lists fewer USB sound
+    devices than sounddevice sees, the extras get blank identity and the
+    sibling path records them anyway with an unstable channel-map key).
+
+    On darwin the identity tuple is always blank because PortAudio does
+    not expose USB vendor/product/serial.
+    """
+    import sounddevice as sd
+
+    sd_devices = sd.query_devices()
+    sd_inputs: list[tuple[int, dict[str, object]]] = [
+        (idx, dev)
+        for idx, dev in enumerate(sd_devices)
+        if int(dev["max_input_channels"]) >= min_channels
+    ]
+    if not sd_inputs:
+        return []
+
+    udev_entries: list[tuple[int, int, str, str]] = []
+    if _is_linux():
+        try:
+            import pyudev
+
+            context = pyudev.Context()
+            try:
+                usb_iter = context.list_devices(subsystem="sound", ID_BUS="usb")
+            except TypeError:
+                usb_iter = context.list_devices(subsystem="sound")
+            for udev in usb_iter:
+                vendor = udev.get("ID_VENDOR_ID", None)
+                product = udev.get("ID_MODEL_ID", None)
+                if not vendor or not product:
+                    continue
+                udev_entries.append(
+                    (
+                        _parse_hex(vendor),
+                        _parse_hex(product),
+                        udev.get("ID_SERIAL_SHORT", "") or "",
+                        str(getattr(udev, "sys_name", "") or ""),
+                    )
+                )
+        except Exception as exc:  # pragma: no cover - libudev missing
+            logger.warning("pyudev enumeration failed, identities blank: {}", exc)
+
+    result: list[DetectedDevice] = []
+    for pos, (sd_idx, sd_dev) in enumerate(sd_inputs):
+        if pos < len(udev_entries):
+            vid, pid, serial, port = udev_entries[pos]
+        else:
+            vid, pid, serial, port = 0, 0, "", ""
+        result.append(
+            DetectedDevice(
+                vendor_id=vid,
+                product_id=pid,
+                serial=serial,
+                usb_port_path=port,
+                max_channels=int(sd_dev["max_input_channels"]),  # type: ignore[call-overload]
+                sounddevice_index=sd_idx,
+                name=str(sd_dev["name"]),
+            )
+        )
+    return result
+
+
 def detect_multi_channel_device(*, min_channels: int = 4) -> DetectedDevice | None:
     """Detect a multi-channel USB audio input device.
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -15,8 +15,10 @@ from helmlog.audio import (
     AudioConfig,
     AudioDeviceNotFoundError,
     AudioRecorder,
+    AudioRecorderGroup,
     _resolve_device,
 )
+from helmlog.usb_audio import DetectedDevice
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -384,3 +386,171 @@ def test_start_with_custom_name(tmp_path: Path) -> None:
 
     assert session.file_path.endswith("20260226-BallardCup-1.wav")
     assert "audio_" not in session.file_path
+
+
+# ---------------------------------------------------------------------------
+# AudioRecorderGroup — sibling-card capture (#509)
+# ---------------------------------------------------------------------------
+
+
+_FAKE_SIBLING_SD_DEVICES = [
+    {
+        "name": "USB Composite Device: Audio (hw:2,0)",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+        "default_samplerate": 48000.0,
+    },
+    {
+        "name": "USB Composite Device: Audio (hw:3,0)",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+        "default_samplerate": 48000.0,
+    },
+]
+
+
+def _detected(idx: int, serial: str) -> DetectedDevice:
+    return DetectedDevice(
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial=serial,
+        usb_port_path=f"1-{idx + 1}",
+        max_channels=1,
+        sounddevice_index=idx,
+        name=f"USB Composite Device: Audio (hw:{idx + 2},0)",
+    )
+
+
+def test_audio_recorder_group_start_opens_n_siblings(tmp_path: Path) -> None:
+    """Start() with 2 devices opens 2 InputStreams + 2 SoundFiles, one per card."""
+    import asyncio
+
+    mock_streams = [MagicMock(), MagicMock()]
+    mock_soundfiles = [MagicMock(), MagicMock()]
+    stream_iter = iter(mock_streams)
+    sf_iter = iter(mock_soundfiles)
+
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_SIBLING_SD_DEVICES),
+        patch("sounddevice.InputStream", side_effect=lambda **kw: next(stream_iter)),
+        patch("soundfile.SoundFile", side_effect=lambda *a, **kw: next(sf_iter)),
+    ):
+        config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+        group = AudioRecorderGroup()
+        devices = [_detected(0, "AAA"), _detected(1, "BBB")]
+        sessions = asyncio.run(
+            group.start(config, devices=devices, name="20260412-multichannel-P1")
+        )
+
+    assert len(sessions) == 2
+    # Distinct filenames so the two recorders don't collide.
+    assert sessions[0].file_path != sessions[1].file_path
+    assert sessions[0].file_path.endswith("-sib0.wav")
+    assert sessions[1].file_path.endswith("-sib1.wav")
+
+    # Shared capture_group_id, distinct ordinals.
+    assert sessions[0].capture_group_id == sessions[1].capture_group_id
+    assert sessions[0].capture_group_id is not None
+    assert sessions[0].capture_ordinal == 0
+    assert sessions[1].capture_ordinal == 1
+
+    # Per-sibling USB identity carried through.
+    assert sessions[0].serial == "AAA"
+    assert sessions[1].serial == "BBB"
+    assert sessions[0].channels == 1
+    assert sessions[1].channels == 1
+
+    # Both streams were started.
+    assert mock_streams[0].start.called
+    assert mock_streams[1].start.called
+    assert group.is_recording
+
+
+def test_audio_recorder_group_stop_stops_all_siblings(tmp_path: Path) -> None:
+    """Stop() closes every sibling's stream and SoundFile, preserves group metadata."""
+    import asyncio
+
+    mock_streams = [MagicMock(), MagicMock()]
+    mock_soundfiles = [MagicMock(), MagicMock()]
+    stream_iter = iter(mock_streams)
+    sf_iter = iter(mock_soundfiles)
+
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_SIBLING_SD_DEVICES),
+        patch("sounddevice.InputStream", side_effect=lambda **kw: next(stream_iter)),
+        patch("soundfile.SoundFile", side_effect=lambda *a, **kw: next(sf_iter)),
+    ):
+        config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+        group = AudioRecorderGroup()
+        asyncio.run(
+            group.start(
+                config,
+                devices=[_detected(0, "AAA"), _detected(1, "BBB")],
+                name="20260412-race",
+            )
+        )
+        completed = asyncio.run(group.stop())
+
+    assert len(completed) == 2
+    assert not group.is_recording
+    # Group metadata preserved through stop().
+    assert completed[0].capture_group_id == completed[1].capture_group_id
+    assert completed[0].capture_ordinal == 0
+    assert completed[1].capture_ordinal == 1
+    # end_utc set on every sibling.
+    for s in completed:
+        assert s.end_utc is not None
+    # Both streams + files closed.
+    for m in mock_streams:
+        assert m.stop.called
+        assert m.close.called
+    for m in mock_soundfiles:
+        assert m.close.called
+
+
+def test_audio_recorder_group_start_rejects_empty_device_list(tmp_path: Path) -> None:
+    import asyncio
+
+    config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+    group = AudioRecorderGroup()
+    with pytest.raises(AudioDeviceNotFoundError):
+        asyncio.run(group.start(config, devices=[], name="x"))
+
+
+def test_audio_recorder_group_start_cleans_up_on_sibling_failure(tmp_path: Path) -> None:
+    """If the second sibling fails to open, the first must be stopped cleanly."""
+    import asyncio
+
+    mock_first_stream = MagicMock()
+    mock_first_sf = MagicMock()
+
+    def input_stream_side_effect(**_kwargs: object) -> MagicMock:
+        if input_stream_side_effect.calls == 0:
+            input_stream_side_effect.calls += 1
+            return mock_first_stream
+        raise RuntimeError("device busy")
+
+    input_stream_side_effect.calls = 0  # type: ignore[attr-defined]
+
+    sf_iter = iter([mock_first_sf, MagicMock()])
+
+    with (
+        patch("sounddevice.query_devices", return_value=_FAKE_SIBLING_SD_DEVICES),
+        patch("sounddevice.InputStream", side_effect=input_stream_side_effect),
+        patch("soundfile.SoundFile", side_effect=lambda *a, **kw: next(sf_iter)),
+    ):
+        config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+        group = AudioRecorderGroup()
+        with pytest.raises(RuntimeError, match="device busy"):
+            asyncio.run(
+                group.start(
+                    config,
+                    devices=[_detected(0, "AAA"), _detected(1, "BBB")],
+                    name="x",
+                )
+            )
+
+    # First sibling was cleaned up even though start() raised.
+    assert mock_first_stream.stop.called
+    assert mock_first_stream.close.called
+    assert not group.is_recording

--- a/tests/test_capture_groups.py
+++ b/tests/test_capture_groups.py
@@ -1,0 +1,241 @@
+"""Sibling-card capture storage path (#509 / #462 follow-up)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.audio import AudioSession
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+def _sess(
+    file_path: str,
+    *,
+    capture_group_id: str | None,
+    ordinal: int,
+    device_name: str = "Jieli card",
+) -> AudioSession:
+    return AudioSession(
+        file_path=file_path,
+        device_name=device_name,
+        start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+        end_utc=datetime(2026, 4, 12, 16, 30, 30, tzinfo=UTC),
+        sample_rate=48000,
+        channels=1,
+        capture_group_id=capture_group_id,
+        capture_ordinal=ordinal,
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_group_roundtrip(storage: Storage) -> None:
+    a = await storage.write_audio_session(
+        _sess("/tmp/a.wav", capture_group_id="grp-abc", ordinal=0)
+    )
+    b = await storage.write_audio_session(
+        _sess("/tmp/b.wav", capture_group_id="grp-abc", ordinal=1, device_name="Jieli card 2")
+    )
+    # Unrelated legacy session must not be returned.
+    await storage.write_audio_session(
+        _sess("/tmp/c.wav", capture_group_id=None, ordinal=0, device_name="built-in")
+    )
+
+    siblings = await storage.list_capture_group_siblings("grp-abc")
+    assert [s["id"] for s in siblings] == [a, b]
+    assert [s["capture_ordinal"] for s in siblings] == [0, 1]
+    assert all(s["capture_group_id"] == "grp-abc" for s in siblings)
+    assert [s["file_path"] for s in siblings] == ["/tmp/a.wav", "/tmp/b.wav"]
+
+
+@pytest.mark.asyncio
+async def test_capture_group_unknown_returns_empty(storage: Storage) -> None:
+    assert await storage.list_capture_group_siblings("nope") == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_has_null_group(storage: Storage) -> None:
+    sid = await storage.write_audio_session(
+        _sess("/tmp/legacy.wav", capture_group_id=None, ordinal=0)
+    )
+    row = await storage.get_audio_session_row(sid)
+    assert row is not None
+    assert row["capture_group_id"] is None
+    assert row["capture_ordinal"] == 0
+
+
+# ---------------------------------------------------------------------------
+# capture_start / capture_stop helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeSingleRecorder:
+    """Quacks like AudioRecorder.start()/stop() for capture_start/stop tests."""
+
+    def __init__(self, file_path: str) -> None:
+        self._file_path = file_path
+        self._started = False
+
+    async def start(self, config: object, *, name: str | None = None) -> AudioSession:
+        self._started = True
+        return AudioSession(
+            file_path=self._file_path,
+            device_name="Fake",
+            start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+            end_utc=None,
+            sample_rate=48000,
+            channels=1,
+        )
+
+    async def stop(self) -> AudioSession:
+        self._started = False
+        return AudioSession(
+            file_path=self._file_path,
+            device_name="Fake",
+            start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+            end_utc=datetime(2026, 4, 12, 16, 30, 30, tzinfo=UTC),
+            sample_rate=48000,
+            channels=1,
+        )
+
+
+class _FakeGroupRecorder:
+    """Quacks like AudioRecorderGroup for sibling-mode helper tests."""
+
+    def __init__(self, paths: list[str]) -> None:
+        self._paths = paths
+        self._group_id = "grp-fake"
+
+    async def start(
+        self, config: object, *, devices: list[object], name: str | None = None
+    ) -> list[AudioSession]:
+        sessions = []
+        for ordinal, _dev in enumerate(self._paths):
+            sessions.append(
+                AudioSession(
+                    file_path=self._paths[ordinal],
+                    device_name=f"Fake card {ordinal}",
+                    start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+                    end_utc=None,
+                    sample_rate=48000,
+                    channels=1,
+                    capture_group_id=self._group_id,
+                    capture_ordinal=ordinal,
+                )
+            )
+        return sessions
+
+    async def stop(self) -> list[AudioSession]:
+        return [
+            AudioSession(
+                file_path=p,
+                device_name=f"Fake card {i}",
+                start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+                end_utc=datetime(2026, 4, 12, 16, 30, 30, tzinfo=UTC),
+                sample_rate=48000,
+                channels=1,
+                capture_group_id=self._group_id,
+                capture_ordinal=i,
+            )
+            for i, p in enumerate(self._paths)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_capture_start_single_mode_persists_one_row(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from helmlog.audio import AudioConfig, AudioRecorder, capture_start
+
+    rec = _FakeSingleRecorder("/tmp/single.wav")
+    # Bypass isinstance check so we can use the duck-typed fake.
+    monkeypatch.setattr(
+        "helmlog.audio.AudioRecorderGroup",
+        type("Never", (), {}),
+        raising=True,
+    )
+
+    # Re-import to pick up monkeypatched class reference used by capture_start
+    # We'll just call capture_start directly which uses isinstance — since
+    # _FakeSingleRecorder is not an AudioRecorderGroup, it takes the single path.
+    _ = AudioRecorder  # keep import
+
+    sid = await capture_start(
+        rec,  # type: ignore[arg-type]
+        AudioConfig(device=None, sample_rate=48000, channels=1, output_dir="/tmp"),
+        storage,
+        name="test-race",
+        race_id=None,
+        session_type="race",
+    )
+    row = await storage.get_audio_session_row(sid)
+    assert row is not None
+    assert row["file_path"] == "/tmp/single.wav"
+    assert row["capture_group_id"] is None
+    assert row["capture_ordinal"] == 0
+
+
+@pytest.mark.asyncio
+async def test_capture_start_and_stop_sibling_mode_roundtrip(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from helmlog.audio import (
+        AudioConfig,
+        capture_start,
+        capture_stop,
+    )
+
+    paths = ["/tmp/sib0.wav", "/tmp/sib1.wav"]
+    fake = _FakeGroupRecorder(paths)
+    # Make the isinstance check in capture_start/stop treat our fake as a group.
+    monkeypatch.setattr(
+        "helmlog.audio.AudioRecorderGroup",
+        _FakeGroupRecorder,
+        raising=True,
+    )
+    # Stub detect_all_capture_devices so capture_start doesn't hit real sounddevice.
+    monkeypatch.setattr(
+        "helmlog.usb_audio.detect_all_capture_devices",
+        lambda *, min_channels=1: [object(), object()],
+    )
+
+    primary_id = await capture_start(
+        fake,  # type: ignore[arg-type]
+        AudioConfig(device=None, sample_rate=48000, channels=1, output_dir="/tmp"),
+        storage,
+        name="sibling-race",
+        race_id=None,
+        session_type="race",
+    )
+
+    # Two rows exist, same capture_group_id, ordinals 0 and 1.
+    row0 = await storage.get_audio_session_row(primary_id)
+    assert row0 is not None
+    group_id = row0["capture_group_id"]
+    assert group_id == "grp-fake"
+    assert row0["capture_ordinal"] == 0
+
+    siblings = await storage.list_capture_group_siblings(group_id)
+    assert len(siblings) == 2
+    assert [s["file_path"] for s in siblings] == paths
+    # Only the primary's id is the one returned; second sibling has a different id.
+    assert siblings[0]["id"] == primary_id
+    assert siblings[1]["id"] != primary_id
+
+    # end_utc must be NULL before stop.
+    for s in siblings:
+        assert s["end_utc"] is None
+
+    await capture_stop(
+        fake,  # type: ignore[arg-type]
+        storage,
+        primary_session_id=primary_id,
+    )
+
+    siblings_after = await storage.list_capture_group_siblings(group_id)
+    for s in siblings_after:
+        assert s["end_utc"] is not None

--- a/tests/test_usb_audio.py
+++ b/tests/test_usb_audio.py
@@ -14,6 +14,7 @@ import pytest
 
 from helmlog.usb_audio import (
     DetectedDevice,
+    detect_all_capture_devices,
     detect_multi_channel_device,
     detect_via_sounddevice,
 )
@@ -175,6 +176,93 @@ def test_detect_multi_channel_device_returns_none_when_nothing_found() -> None:
     ):
         result = detect_multi_channel_device(min_channels=4)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Sibling-card enumeration (#509)
+# ---------------------------------------------------------------------------
+
+
+_FAKE_SD_TWO_MONO = [
+    {"name": "Built-in", "max_input_channels": 0, "max_output_channels": 2},
+    {
+        "name": "USB Composite Device: Audio (hw:2,0)",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+    },
+    {
+        "name": "USB Composite Device: Audio (hw:3,0)",
+        "max_input_channels": 1,
+        "max_output_channels": 0,
+    },
+]
+
+
+def test_detect_all_capture_devices_darwin_returns_all_inputs() -> None:
+    """darwin path: every input-capable device meeting min_channels is returned."""
+    with (
+        patch("helmlog.usb_audio._is_linux", return_value=False),
+        patch("sounddevice.query_devices", return_value=_FAKE_SD_TWO_MONO),
+    ):
+        result = detect_all_capture_devices(min_channels=1)
+    assert len(result) == 2
+    assert all(d.max_channels == 1 for d in result)
+    assert [d.sounddevice_index for d in result] == [1, 2]
+    assert all(d.vendor_id == 0 and d.serial == "" for d in result)
+
+
+def test_detect_all_capture_devices_filters_by_min_channels() -> None:
+    with (
+        patch("helmlog.usb_audio._is_linux", return_value=False),
+        patch("sounddevice.query_devices", return_value=_FAKE_SD_TWO_MONO),
+    ):
+        result = detect_all_capture_devices(min_channels=2)
+    assert result == []
+
+
+def test_detect_all_capture_devices_linux_enriches_with_pyudev() -> None:
+    """Linux path: each sounddevice input is paired with a pyudev entry in order."""
+    fake_a = _fake_udev_device(vendor="3634", product="4155", serial="AAA", devpath="1-1")
+    fake_b = _fake_udev_device(vendor="3634", product="4155", serial="BBB", devpath="1-2")
+    fake_context = MagicMock()
+    fake_context.list_devices.return_value = [fake_a, fake_b]
+    fake_pyudev = MagicMock()
+    fake_pyudev.Context.return_value = fake_context
+
+    with (
+        patch.dict(sys.modules, {"pyudev": fake_pyudev}),
+        patch("sounddevice.query_devices", return_value=_FAKE_SD_TWO_MONO),
+        patch("helmlog.usb_audio._is_linux", return_value=True),
+    ):
+        result = detect_all_capture_devices(min_channels=1)
+
+    assert len(result) == 2
+    assert [d.serial for d in result] == ["AAA", "BBB"]
+    assert [d.vendor_id for d in result] == [0x3634, 0x3634]
+    assert [d.product_id for d in result] == [0x4155, 0x4155]
+    assert [d.usb_port_path for d in result] == ["1-1", "1-2"]
+    assert [d.sounddevice_index for d in result] == [1, 2]
+
+
+def test_detect_all_capture_devices_linux_fewer_pyudev_entries_than_sd() -> None:
+    """If pyudev sees fewer USB sound devices than sounddevice lists, extras
+    get blank identity so the sibling path still records (best-effort)."""
+    fake = _fake_udev_device(vendor="3634", product="4155", serial="ONLY", devpath="1-1")
+    fake_context = MagicMock()
+    fake_context.list_devices.return_value = [fake]
+    fake_pyudev = MagicMock()
+    fake_pyudev.Context.return_value = fake_context
+
+    with (
+        patch.dict(sys.modules, {"pyudev": fake_pyudev}),
+        patch("sounddevice.query_devices", return_value=_FAKE_SD_TWO_MONO),
+        patch("helmlog.usb_audio._is_linux", return_value=True),
+    ):
+        result = detect_all_capture_devices(min_channels=1)
+    assert len(result) == 2
+    assert result[0].serial == "ONLY"
+    assert result[1].serial == ""
+    assert result[1].vendor_id == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

First chunk of the sibling-card capture stopgap from #509. Recording path only — transcription, playback, and deletion dispatch follow in chunks 2–4.

Branched off \`feature/462-pt7-export-deletion\` so it inherits the full pt.1–pt.7 schema (channel_map, transcript_segments, per-channel deletion). Will rebase to \`main\` once the upstream epic merges.

## What's in this chunk

- **v65 migration:** \`capture_group_id TEXT\` + \`capture_ordinal INTEGER NOT NULL DEFAULT 0\` on \`audio_sessions\`, plus \`idx_audio_sessions_capture_group\`. Legacy rows get NULL/0 — no data migration.
- **\`AudioSession\` dataclass** gains \`capture_group_id\` / \`capture_ordinal\`. \`write_audio_session()\`, \`get_audio_session_row()\`, new \`list_capture_group_siblings()\`.
- **\`usb_audio.detect_all_capture_devices(min_channels=1)\`** — enumerates every input-capable sounddevice entry, pairs each with a pyudev USB identity in order on Linux. Stopgap-friendly: handles the 2× Jieli mono case where each card is a separate USB device.
- **\`AudioRecorderGroup\`** — wraps N \`AudioRecorder\` instances in parallel, stamps one \`capture_group_id\` UUID + ordinal onto every sibling session. Best-effort cleanup of siblings that opened before a start() failure so USB streams don't leak. \`stop()\` flushes every sibling even if one fails.
- **\`capture_start()\` / \`capture_stop()\` helpers** in \`audio.py\` — route handlers stay oblivious to single vs sibling mode. \`capture_stop()\` resolves sibling row ids via \`list_capture_group_siblings\` and updates \`end_utc\` on every row.
- **\`main.py\`:** \`AUDIO_CAPTURE_MODE=sibling\` (default \`single\`) picks the group recorder.
- **\`routes/races.py\`:** all 4 start + 5 stop call sites (scheduled, race, debrief, auto-stop) now go through the helpers. Switching modes is one env var.

## What's NOT in this chunk

- Per-sibling ASR + transcript merge (chunk 2)
- \`/api/sessions/{id}\` sibling response + session.js multi-source Web Audio playback (chunk 3)
- Per-sibling deletion dispatch (chunk 4)

With \`AUDIO_CAPTURE_MODE=sibling\` and two mono receivers, this chunk produces two \`audio_sessions\` rows sharing a \`capture_group_id\` and two WAV files on disk. Playback still falls through the legacy single-file path until chunk 3 lands — which is fine for a gated feature flag.

Related: #509, #462

## Test plan

- [x] 12 new tests: migration + sibling storage roundtrip (5), \`detect_all_capture_devices\` (4), \`AudioRecorderGroup\` lifecycle + cleanup (4)
- [x] \`uv run pytest\` — 1812 passed, 2 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\`
- [x] \`uv run mypy src/helmlog/audio.py src/helmlog/storage.py src/helmlog/usb_audio.py src/helmlog/main.py src/helmlog/routes/races.py\` clean
- Manual on \`corvopi-tst1\` still gated on real-hardware smoke (this chunk alone won't change user-visible behavior until chunks 2–4 land or until \`AUDIO_CAPTURE_MODE=sibling\` is set)

🤖 Generated with [Claude Code](https://claude.ai/code)