### PR TITLE
[#509 chunk 2] Per-sibling ASR tagging + transcribe endpoint fan-out

### DIFF
--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
@@ -17,9 +17,28 @@ import helmlog.web as _web_mod
 from helmlog.auth import require_auth
 from helmlog.routes._helpers import audit, get_storage, limiter
 
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
 _web_mod.asyncio = asyncio  # type: ignore[attr-defined]
 
 router = APIRouter()
+
+
+async def _resolve_transcription_targets(storage: Storage, row: dict[str, Any]) -> list[int]:
+    """Return every audio_session_id that should be transcribed for this request.
+
+    Single-device sessions return ``[row["id"]]``. Sibling-card captures
+    (#509) return every member of the ``capture_group_id`` in ordinal
+    order so fan-out transcribes the whole group in one click.
+    """
+    group_id = row.get("capture_group_id")
+    if not group_id:
+        return [int(row["id"])]
+    siblings = await storage.list_capture_group_siblings(str(group_id))
+    if not siblings:
+        return [int(row["id"])]
+    return [int(s["id"]) for s in siblings]
 
 
 @router.get("/api/audio/{session_id}/download")
@@ -79,12 +98,6 @@ async def api_transcribe(
     if row is None:
         raise HTTPException(status_code=404, detail="Audio session not found")
     model = os.environ.get("WHISPER_MODEL", "base")
-    try:
-        transcript_id = await storage.create_transcript_job(session_id, model)
-    except ValueError:
-        raise HTTPException(  # noqa: B904
-            status_code=409, detail="Transcript job already exists for this session"
-        )
 
     from helmlog.storage import get_effective_setting
     from helmlog.transcribe import transcribe_session
@@ -94,18 +107,45 @@ async def api_transcribe(
     # the worker has its own HF_TOKEN and decides locally.  Only gate on
     # the Pi's HF_TOKEN when running the local fallback path.
     diarize = True if t_url else bool(os.environ.get("HF_TOKEN"))
-    asyncio.create_task(
-        transcribe_session(
-            storage,
-            session_id,
-            transcript_id,
-            model_size=model,
-            diarize=diarize,
-            transcribe_url=t_url,
+
+    # Sibling-card capture (#509): fan out to every sibling in the group so
+    # the merged transcript covers every receiver, not just the one the UI
+    # happened to click on. Non-sibling sessions take the single-row path.
+    targets = await _resolve_transcription_targets(storage, row)
+    jobs: list[int] = []
+    try:
+        for tgt in targets:
+            jobs.append(await storage.create_transcript_job(tgt, model))
+    except ValueError:
+        # Roll back any sibling jobs we already created so the group state is
+        # consistent (all pending or none pending).
+        for _created, t in zip(jobs, targets, strict=False):
+            await storage.delete_transcript(t)
+        raise HTTPException(  # noqa: B904
+            status_code=409, detail="Transcript job already exists for this session"
         )
-    )
+
+    for tgt, tid in zip(targets, jobs, strict=True):
+        asyncio.create_task(
+            transcribe_session(
+                storage,
+                tgt,
+                tid,
+                model_size=model,
+                diarize=diarize,
+                transcribe_url=t_url,
+            )
+        )
     await audit(request, "transcribe.start", detail=str(session_id), user=_user)
-    return JSONResponse({"status": "accepted", "transcript_id": transcript_id}, status_code=202)
+    primary_transcript_id = jobs[0] if jobs else None
+    return JSONResponse(
+        {
+            "status": "accepted",
+            "transcript_id": primary_transcript_id,
+            "sibling_count": len(jobs),
+        },
+        status_code=202,
+    )
 
 
 @router.post("/api/audio/{session_id}/retranscribe", status_code=202)
@@ -124,11 +164,14 @@ async def api_retranscribe(
     row = await storage.get_audio_session_row(session_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Audio session not found")
-    # Delete the existing transcript (and any linked extraction runs)
-    await storage.delete_transcript(session_id)
-    # Create a new job
+
+    # Fan out to siblings (#509): delete + recreate jobs for every member.
+    targets = await _resolve_transcription_targets(storage, row)
+    for tgt in targets:
+        await storage.delete_transcript(tgt)
+
     model = os.environ.get("WHISPER_MODEL", "base")
-    transcript_id = await storage.create_transcript_job(session_id, model)
+    jobs = [await storage.create_transcript_job(tgt, model) for tgt in targets]
 
     from helmlog.storage import get_effective_setting
     from helmlog.transcribe import transcribe_session
@@ -138,18 +181,22 @@ async def api_retranscribe(
     # the worker has its own HF_TOKEN and decides locally.  Only gate on
     # the Pi's HF_TOKEN when running the local fallback path.
     diarize = True if t_url else bool(os.environ.get("HF_TOKEN"))
-    asyncio.create_task(
-        transcribe_session(
-            storage,
-            session_id,
-            transcript_id,
-            model_size=model,
-            diarize=diarize,
-            transcribe_url=t_url,
+    for tgt, tid in zip(targets, jobs, strict=True):
+        asyncio.create_task(
+            transcribe_session(
+                storage,
+                tgt,
+                tid,
+                model_size=model,
+                diarize=diarize,
+                transcribe_url=t_url,
+            )
         )
-    )
     await audit(request, "transcribe.retranscribe", detail=str(session_id), user=_user)
-    return JSONResponse({"status": "accepted", "transcript_id": transcript_id}, status_code=202)
+    return JSONResponse(
+        {"status": "accepted", "transcript_id": jobs[0], "sibling_count": len(jobs)},
+        status_code=202,
+    )
 
 
 @router.get("/api/audio/{session_id}/transcript")

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -179,6 +179,42 @@ async def _transcribe_multi_channel(
 # ---------------------------------------------------------------------------
 
 
+async def _persist_sibling_segments(
+    storage: Storage,
+    transcript_id: int,
+    segments: list[dict[str, object]],
+    *,
+    ordinal: int,
+    position_name: str,
+) -> None:
+    """Tag mono-sibling segments with channel_index/position and persist relationally.
+
+    Sibling-card captures (#509) skip the multi-channel split because each
+    WAV is already a single-channel file — but the downstream merge (chunk 3)
+    needs the same ``channel_index``/``position_name``/``speaker`` tags that
+    pt.4's multi-channel path provides, so we annotate and bulk-insert here.
+    """
+    if not segments:
+        return
+    for seg in segments:
+        seg["channel_index"] = ordinal
+        seg["position_name"] = position_name
+        seg["speaker"] = position_name
+    relational = [
+        {
+            "segment_index": idx,
+            "start_time": float(seg.get("start", 0.0)),  # type: ignore[arg-type]
+            "end_time": float(seg.get("end", 0.0)),  # type: ignore[arg-type]
+            "text": str(seg.get("text", "")),
+            "speaker": position_name,
+            "channel_index": ordinal,
+            "position_name": position_name,
+        }
+        for idx, seg in enumerate(segments)
+    ]
+    await storage.insert_transcript_segments(transcript_id, relational)
+
+
 async def transcribe_session(
     storage: Storage,
     audio_session_id: int,
@@ -214,6 +250,16 @@ async def transcribe_session(
     file_path: str = row["file_path"]
     channels: int = row.get("channels", 1)
 
+    # Sibling-card capture (#509): when the session is one of N parallel
+    # mono USB cards, tag its segments with the ordinal + configured
+    # position_name so the downstream merge can stitch them back together.
+    sibling_tag: tuple[int, str] | None = None
+    if row.get("capture_group_id") and channels == 1:
+        cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
+        position = cmap.get(0, f"sib{row.get('capture_ordinal', 0)}")
+        sibling_tag = (int(row.get("capture_ordinal") or 0), position)
+
+    segments_json_str: str | None = None
     try:
         # ----- Multi-channel Isolation Mode (#462 pt.3) -----
         if channels > 1:
@@ -267,6 +313,14 @@ async def transcribe_session(
         )
         if remote is not None:
             text, segments = remote
+            if sibling_tag is not None:
+                await _persist_sibling_segments(
+                    storage,
+                    transcript_id,
+                    segments,
+                    ordinal=sibling_tag[0],
+                    position_name=sibling_tag[1],
+                )
             segments_json_str = json.dumps(segments) if segments else None
             await storage.update_transcript(
                 transcript_id, status="done", text=text, segments_json=segments_json_str
@@ -313,6 +367,22 @@ async def transcribe_session(
                 "Transcription done: audio_session_id={} chars={}",
                 audio_session_id,
                 len(text),
+            )
+
+        # Sibling-card annotation (#509): local single-channel paths reach here
+        # with a plain segments list; tag and persist before trigger scan.
+        if sibling_tag is not None:
+            await _persist_sibling_segments(
+                storage,
+                transcript_id,
+                segments,
+                ordinal=sibling_tag[0],
+                position_name=sibling_tag[1],
+            )
+            # Rewrite segments_json so GET /api/audio/{id}/transcript sees the tags
+            segments_json_str = json.dumps(segments) if segments else None
+            await storage.update_transcript(
+                transcript_id, status="done", segments_json=segments_json_str
             )
 
         # Auto-scan for trigger keywords and create tagged notes

--- a/tests/test_transcribe_siblings.py
+++ b/tests/test_transcribe_siblings.py
@@ -1,0 +1,234 @@
+"""Sibling-card transcription (#509 chunk 2).
+
+Verifies that when an audio_sessions row carries a ``capture_group_id``,
+``transcribe_session`` runs the single-channel whisper path, tags each
+segment with the sibling's ``capture_ordinal`` + configured position
+name, and that the HTTP transcribe/retranscribe endpoints fan out to
+every sibling in the group.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from helmlog.audio import AudioSession
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_sibling_pair(storage: Storage, tmp_path: Path) -> tuple[int, int, str]:
+    """Seed two mono sibling audio_sessions sharing a capture_group_id.
+
+    Returns ``(primary_id, secondary_id, capture_group_id)``. Both rows
+    have a matching ``channel_map`` entry mapping channel 0 to a
+    position, so the sibling tag lookup resolves.
+    """
+    group_id = "grp-test"
+    wav_a = tmp_path / "sib0.wav"
+    wav_b = tmp_path / "sib1.wav"
+    wav_a.write_bytes(b"RIFF0000WAVEfmt ")
+    wav_b.write_bytes(b"RIFF0000WAVEfmt ")
+
+    def _sess(path: Path, ordinal: int, serial: str) -> AudioSession:
+        return AudioSession(
+            file_path=str(path),
+            device_name=f"Jieli card {ordinal}",
+            start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+            end_utc=datetime(2026, 4, 12, 16, 30, 30, tzinfo=UTC),
+            sample_rate=48000,
+            channels=1,
+            vendor_id=0x3634,
+            product_id=0x4155,
+            serial=serial,
+            usb_port_path=f"1-{ordinal + 1}",
+            capture_group_id=group_id,
+            capture_ordinal=ordinal,
+        )
+
+    primary_id = await storage.write_audio_session(_sess(wav_a, 0, "AAA"))
+    secondary_id = await storage.write_audio_session(_sess(wav_b, 1, "BBB"))
+    # Match the session-override write path used by the admin UI.
+    await storage.set_audio_session_device(
+        primary_id, vendor_id=0x3634, product_id=0x4155, serial="AAA", usb_port_path="1-1"
+    )
+    await storage.set_audio_session_device(
+        secondary_id,
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="BBB",
+        usb_port_path="1-2",
+    )
+    await storage.set_channel_map(
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="AAA",
+        usb_port_path="1-1",
+        mapping={0: "Helm pair"},
+        audio_session_id=primary_id,
+    )
+    await storage.set_channel_map(
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="BBB",
+        usb_port_path="1-2",
+        mapping={0: "Bow pair"},
+        audio_session_id=secondary_id,
+    )
+    return primary_id, secondary_id, group_id
+
+
+# ---------------------------------------------------------------------------
+# transcribe_session() — sibling tag + relational persistence
+# ---------------------------------------------------------------------------
+
+
+async def test_transcribe_session_tags_sibling_segments(storage: Storage, tmp_path: Path) -> None:
+    """A mono sibling gets channel_index=capture_ordinal and position from channel_map."""
+    primary_id, secondary_id, _ = await _make_sibling_pair(storage, tmp_path)
+    transcript_id = await storage.create_transcript_job(secondary_id, "base")
+
+    fake_segs = [(0.0, 1.5, "bowman ready"), (2.0, 3.0, "jib in")]
+    with patch("helmlog.transcribe._run_whisper_segments", return_value=fake_segs):
+        from helmlog.transcribe import transcribe_session
+
+        await transcribe_session(storage, secondary_id, transcript_id, model_size="base")
+
+    rows = await storage.list_transcript_segments(transcript_id)
+    assert len(rows) == 2
+    assert [r["text"] for r in rows] == ["bowman ready", "jib in"]
+    # Ordinal 1 → virtual channel index 1.
+    assert all(r["channel_index"] == 1 for r in rows)
+    assert all(r["position_name"] == "Bow pair" for r in rows)
+    assert all(r["speaker"] == "Bow pair" for r in rows)
+
+
+async def test_transcribe_session_sibling_falls_back_to_sibN_when_unmapped(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """No channel_map entry → fall back to sib{ordinal} label."""
+    wav = tmp_path / "loose.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    session = AudioSession(
+        file_path=str(wav),
+        device_name="Loose card",
+        start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+        end_utc=datetime(2026, 4, 12, 16, 30, 10, tzinfo=UTC),
+        sample_rate=48000,
+        channels=1,
+        capture_group_id="grp-loose",
+        capture_ordinal=3,
+    )
+    sid = await storage.write_audio_session(session)
+    tid = await storage.create_transcript_job(sid, "base")
+    with patch("helmlog.transcribe._run_whisper_segments", return_value=[(0.0, 1.0, "hi")]):
+        from helmlog.transcribe import transcribe_session
+
+        await transcribe_session(storage, sid, tid, model_size="base")
+    rows = await storage.list_transcript_segments(tid)
+    assert rows[0]["position_name"] == "sib3"
+    assert rows[0]["channel_index"] == 3
+
+
+# ---------------------------------------------------------------------------
+# POST /api/audio/{id}/transcribe — sibling fan-out
+# ---------------------------------------------------------------------------
+
+
+async def test_transcribe_endpoint_fans_out_to_all_siblings(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Hitting /transcribe on one sibling creates jobs for every member."""
+    primary_id, secondary_id, _ = await _make_sibling_pair(storage, tmp_path)
+    app = create_app(storage)
+
+    with patch("helmlog.web.asyncio.create_task") as mock_create_task:
+        mock_create_task.return_value = AsyncMock()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/audio/{primary_id}/transcribe")
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["status"] == "accepted"
+    assert data["sibling_count"] == 2
+    # Two transcribe_session coroutines should have been enqueued.
+    assert mock_create_task.call_count == 2
+
+    # Both siblings have a transcripts row now.
+    primary_trans = await storage.get_transcript(primary_id)
+    secondary_trans = await storage.get_transcript(secondary_id)
+    assert primary_trans is not None
+    assert secondary_trans is not None
+
+
+async def test_transcribe_endpoint_single_session_unchanged(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Non-sibling sessions still return a single-job response."""
+    wav = tmp_path / "solo.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    session = AudioSession(
+        file_path=str(wav),
+        device_name="Built-in",
+        start_utc=datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC),
+        end_utc=datetime(2026, 4, 12, 16, 30, 10, tzinfo=UTC),
+        sample_rate=48000,
+        channels=1,
+    )
+    sid = await storage.write_audio_session(session)
+    app = create_app(storage)
+    with patch("helmlog.web.asyncio.create_task") as mock_create_task:
+        mock_create_task.return_value = AsyncMock()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/audio/{sid}/transcribe")
+    assert resp.status_code == 202
+    assert resp.json()["sibling_count"] == 1
+    assert mock_create_task.call_count == 1
+
+
+async def test_retranscribe_endpoint_fans_out_to_all_siblings(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Retranscribe deletes all sibling transcripts and relaunches jobs for each."""
+    primary_id, secondary_id, _ = await _make_sibling_pair(storage, tmp_path)
+    # Seed an existing transcript job on both siblings.
+    t1 = await storage.create_transcript_job(primary_id, "base")
+    t2 = await storage.create_transcript_job(secondary_id, "base")
+
+    app = create_app(storage)
+    with patch("helmlog.web.asyncio.create_task") as mock_create_task:
+        mock_create_task.return_value = AsyncMock()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(f"/api/audio/{secondary_id}/retranscribe")
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["sibling_count"] == 2
+    # New jobs were created — ids should differ from the old ones.
+    primary_trans = await storage.get_transcript(primary_id)
+    secondary_trans = await storage.get_transcript(secondary_id)
+    assert primary_trans is not None
+    assert secondary_trans is not None
+    assert primary_trans["id"] not in {t1, t2}
+    assert secondary_trans["id"] not in {t1, t2}
+    assert mock_create_task.call_count == 2


### PR DESCRIPTION
## Summary

Chunk 2 of the sibling-card capture stopgap. Builds on #510 (chunk 1, recording path). Chunk 3 (playback UI) and chunk 4 (deletion dispatch) still to come.

Stacked on \`feature/462-sibling-capture\` — merge #510 first, then rebase-retarget this to \`main\`.

## What's in this chunk

### \`transcribe_session()\` sibling-aware tagging

Sibling rows (\`capture_group_id\` set, \`channels=1\`) run the existing single-channel whisper path unchanged. After ASR completes, a new \`_persist_sibling_segments()\` helper tags each segment with:

- \`channel_index = capture_ordinal\` — each sibling becomes a distinct virtual channel in the merged view (chunk 3)
- \`position_name\` — looked up via \`get_channel_map_for_audio_session()\`, falls back to \`sib{ordinal}\` when unmapped
- \`speaker = position_name\` — so the existing pt.6 diarized renderer groups correctly

Segments are bulk-inserted into \`transcript_segments\` so the downstream merge sees the same row shape pt.4's multi-channel path produces. The segments_json blob is also rewritten with the tags so the legacy GET response still works.

### Endpoint fan-out

POST \`/api/audio/{id}/transcribe\` and \`/retranscribe\` now detect sibling membership and transcribe the entire capture group in one click:

- New \`_resolve_transcription_targets()\` helper — returns \`[session_id]\` for single-device, or every sibling id in ordinal order for a group.
- Transcribe: creates jobs for every target; on 409 conflict rolls back any partial jobs so group state stays consistent.
- Retranscribe: deletes all sibling transcripts, creates fresh jobs, launches all tasks.
- Response now includes \`sibling_count\` so the UI can show progress across siblings in chunk 3.

### Minor

- Explicit \`segments_json_str: str | None\` annotation in \`transcribe_session()\` — the sibling branch re-writes it after the local path and mypy was narrowing the initial multi-channel assignment too aggressively.

## Test plan

- [x] 5 new tests in \`tests/test_transcribe_siblings.py\`:
  - sibling segments get \`channel_index = capture_ordinal\` + correct position_name from channel_map
  - unmapped sibling falls back to \`sib{ordinal}\`
  - POST /transcribe fans out to both siblings (sibling_count=2, 2 create_task calls)
  - single-session path unchanged (sibling_count=1, 1 create_task call)
  - POST /retranscribe deletes old transcripts and creates fresh jobs for every sibling
- [x] \`uv run pytest\` — 1817 passed, 2 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run mypy src/helmlog/transcribe.py src/helmlog/routes/audio.py\` clean

## Still to come

- **Chunk 3** — \`/api/sessions/{id}\` sibling response + session.js multi-source Web Audio playback with segment isolation
- **Chunk 4** — per-sibling deletion dispatch (delete an entire sibling file + its transcript when exercising the data-licensing right)

Related: #509, #510

🤖 Generated with [Claude Code](https://claude.ai/code)