### PR TITLE
[#509 chunk 3] Sibling playback — session detail + merged transcript + multi-source Web Audio

### DIFF
--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -207,7 +207,10 @@ async def api_get_transcript(
 ) -> JSONResponse:
     """Poll transcription status and retrieve the transcript text when done.
 
-    Applies speaker anonymization map if present (#197).
+    Applies speaker anonymization map if present (#197). When the target
+    session is part of a sibling capture group (#509), the segments array
+    is a merged, time-sorted union of every sibling's transcript so the
+    UI sees one continuous timeline across all receivers.
     """
     storage = get_storage(request)
     import json as _json
@@ -215,9 +218,31 @@ async def api_get_transcript(
     t = await storage.get_transcript_with_anon(session_id)
     if t is None:
         raise HTTPException(status_code=404, detail="No transcript job found for this session")
-    if t.get("segments_json"):
+
+    # Sibling merge: if this session has a capture_group_id, union the
+    # segments from every sibling's transcript into a single sorted array.
+    row = await storage.get_audio_session_row(session_id)
+    group_id = row.get("capture_group_id") if row else None
+    if group_id:
+        merged: list[dict[str, Any]] = []
+        siblings = await storage.list_capture_group_siblings(str(group_id))
+        for sr in siblings:
+            st = await storage.get_transcript_with_anon(int(sr["id"]))
+            if st is None:
+                continue
+            sj = st.get("segments_json")
+            if not sj:
+                continue
+            try:
+                segs = _json.loads(sj)
+            except (_json.JSONDecodeError, TypeError):
+                continue
+            merged.extend(segs)
+        merged.sort(key=lambda s: float(s.get("start", 0.0)))
+        t["segments"] = merged
+    elif t.get("segments_json"):
         t["segments"] = _json.loads(t["segments_json"])
-    del t["segments_json"]
+    t.pop("segments_json", None)
     # Remove internal anon map from response
     t.pop("speaker_anon_map", None)
     # Expose speaker_map for UI (crew labels, auto-match info)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -401,13 +401,34 @@ async def api_session_detail(
     end_utc = datetime.fromisoformat(row["end_utc"]) if row["end_utc"] else None
     duration_s = (end_utc - start_utc).total_seconds() if end_utc else None
 
-    # Check for audio
+    # Check for audio — prefer the primary sibling (ordinal 0) so
+    # single-session callers keep the scalar audio_session_id.
     acur = await db.execute(
-        "SELECT id, start_utc, channels FROM audio_sessions"
-        " WHERE race_id = ? AND session_type IN ('race','practice')",
+        "SELECT id, start_utc, channels, capture_group_id, capture_ordinal"
+        " FROM audio_sessions"
+        " WHERE race_id = ? AND session_type IN ('race','practice')"
+        " ORDER BY capture_ordinal ASC, id ASC",
         (session_id,),
     )
     arow = await acur.fetchone()
+
+    # Sibling-card block (#509): when the primary row is part of a capture
+    # group, surface all siblings so session.js can drive N-source Web
+    # Audio playback and show a merged transcript.
+    audio_siblings: list[dict[str, Any]] = []
+    if arow and arow["capture_group_id"]:
+        group_rows = await storage.list_capture_group_siblings(str(arow["capture_group_id"]))
+        for sr in group_rows:
+            cmap = await storage.get_channel_map_for_audio_session(int(sr["id"]))
+            position_name = cmap.get(0, f"sib{sr['capture_ordinal']}")
+            audio_siblings.append(
+                {
+                    "audio_session_id": int(sr["id"]),
+                    "ordinal": int(sr["capture_ordinal"]),
+                    "position_name": position_name,
+                    "stream_url": f"/api/audio/{int(sr['id'])}/stream",
+                }
+            )
 
     # Check for wind field params (synthesized sessions)
     wf_cur = await db.execute(
@@ -434,7 +455,10 @@ async def api_session_detail(
             "audio_start_utc": (
                 datetime.fromisoformat(arow["start_utc"]).isoformat() if arow else None
             ),
-            "audio_channels": arow["channels"] if arow else None,
+            "audio_channels": (
+                len(audio_siblings) if audio_siblings else (arow["channels"] if arow else None)
+            ),
+            "audio_siblings": audio_siblings,
             "peer_fingerprint": row["peer_fingerprint"],
             "has_wind_field": has_wind_field,
             "shared_name": row["shared_name"],

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1732,9 +1732,9 @@ function loadAudio() {
 // ---------------------------------------------------------------------------
 
 let _mcCtx = null;
-let _mcBuffer = null;
-let _mcSource = null;
-let _mcSplitter = null;
+let _mcBuffer = null;          // primary duration/time reference
+let _mcSource = null;          // single-file multi-channel source
+let _mcSplitter = null;        // used only in single-file multi-channel path
 let _mcMerger = null;
 let _mcGains = [];
 let _mcStartTime = 0;        // AudioContext.currentTime when playback started
@@ -1742,6 +1742,12 @@ let _mcStartOffset = 0;       // buffer offset (seconds) when playback started
 let _mcIsPlaying = false;
 let _mcIsolatedChannel = null;
 let _mcIsolationTimer = null;
+// Sibling-card capture (#509): N mono buffers played in parallel, one
+// BufferSource per receiver. Sync is sample-accurate because all sources
+// share the same AudioContext clock via a single start(when, offset).
+let _mcSiblings = false;
+let _mcBuffers = [];
+let _mcSources = [];
 let _mcSticky = false;
 let _mcRafHandle = null;
 
@@ -1774,6 +1780,39 @@ function _mcClearTimer() {
 }
 
 function _mcRebuildSource(offsetSeconds) {
+  // Sibling-card mode: rebuild N BufferSources in parallel, started at the
+  // same AudioContext time so all receivers stay sample-aligned (#509).
+  if (_mcSiblings) {
+    _mcSources.forEach(s => {
+      try { s.stop(); } catch (e) { /* not started */ }
+      try { s.disconnect(); } catch (e) { /* swallow */ }
+    });
+    _mcSources = [];
+    const when = _mcCtx.currentTime + 0.02;  // small lead so start() is atomic
+    _mcBuffers.forEach((buf, i) => {
+      const src = _mcCtx.createBufferSource();
+      src.buffer = buf;
+      src.connect(_mcGains[i]);
+      if (i === 0) {
+        src.onended = () => {
+          if (!_mcSources.length) return;
+          if (_mcCurrentTime() >= _mcBuffer.duration - 0.05) {
+            _mcIsPlaying = false;
+            _mcStartOffset = 0;
+            _mcUpdateButtons();
+          }
+        };
+      }
+      src.start(when, offsetSeconds);
+      _mcSources.push(src);
+    });
+    _mcStartTime = when;
+    _mcStartOffset = offsetSeconds;
+    _mcIsPlaying = true;
+    _mcUpdateButtons();
+    return;
+  }
+
   // AudioBufferSourceNode is single-use: every play/seek requires a fresh one.
   if (_mcSource) {
     try { _mcSource.stop(); } catch (e) { /* not started */ }
@@ -1806,7 +1845,16 @@ function _mcPlay() {
 }
 
 function _mcPause() {
-  if (!_mcSource || !_mcIsPlaying) return;
+  if (!_mcIsPlaying) return;
+  if (_mcSiblings) {
+    _mcStartOffset = _mcCurrentTime();
+    _mcSources.forEach(s => { try { s.stop(); } catch (e) { /* swallow */ } });
+    _mcIsPlaying = false;
+    _mcUpdateButtons();
+    _mcStopProgressTick();
+    return;
+  }
+  if (!_mcSource) return;
   _mcStartOffset = _mcCurrentTime();
   try { _mcSource.stop(); } catch (e) { /* already stopped */ }
   _mcIsPlaying = false;
@@ -1879,6 +1927,39 @@ async function loadMultiChannelAudio() {
       return;
     }
     _mcCtx = new Ctx();
+
+    // Sibling-card capture (#509): N mono WAVs, one BufferSource per
+    // receiver, routed through per-source gains to a common mono merger.
+    const siblings = _session && _session.audio_siblings;
+    if (siblings && siblings.length > 1) {
+      _mcSiblings = true;
+      const decoded = await Promise.all(siblings.map(async s => {
+        const r = await fetch(s.stream_url);
+        if (!r.ok) throw new Error('audio fetch failed: ' + r.status);
+        const ab = await r.arrayBuffer();
+        return await _mcCtx.decodeAudioData(ab);
+      }));
+      _mcBuffers = decoded;
+      // Primary buffer = the longest sibling, so the seek bar covers the
+      // whole recording even if one card's stream ended a few ms early.
+      let longest = decoded[0];
+      for (const b of decoded) { if (b.duration > longest.duration) longest = b; }
+      _mcBuffer = longest;
+      _mcMerger = _mcCtx.createChannelMerger(1);
+      _mcGains = decoded.map(() => {
+        const g = _mcCtx.createGain();
+        g.gain.value = 1;
+        g.connect(_mcMerger, 0, 0);
+        return g;
+      });
+      _mcMerger.connect(_mcCtx.destination);
+      const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`).join(', ');
+      document.getElementById('mc-status').textContent =
+        `${siblings.length} receivers (${labels}) — click a transcript segment to isolate that mic.`;
+      _mcUpdateProgress();
+      return;
+    }
+
     const r = await fetch('/api/audio/' + _session.audio_session_id + '/stream');
     if (!r.ok) throw new Error('audio fetch failed: ' + r.status);
     const buf = await r.arrayBuffer();

--- a/tests/test_sibling_playback_api.py
+++ b/tests/test_sibling_playback_api.py
@@ -1,0 +1,301 @@
+"""Sibling-card playback API (#509 chunk 3).
+
+Verifies:
+- ``GET /api/sessions/{id}`` includes an ``audio_siblings`` block when the
+  race's audio is a sibling capture, with stream URLs and position names
+  in ordinal order; ``audio_channels`` reflects the sibling count so the
+  session.js pt.6 multi-channel gate trips.
+- ``GET /api/audio/{id}/transcript`` returns a merged, time-sorted
+  ``segments`` array combining every sibling's transcript when the
+  target belongs to a capture group.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.audio import AudioSession
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+_START_UTC = datetime(2026, 4, 12, 16, 30, 0, tzinfo=UTC)
+_END_UTC = datetime(2026, 4, 12, 16, 30, 30, tzinfo=UTC)
+
+
+async def _seed_race_with_sibling_audio(storage: Storage, tmp_path: Path) -> tuple[int, int, int]:
+    """Create a race + two mono sibling audio sessions. Returns ids."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races"
+        " (name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Test Race",
+            "Tuesday Night",
+            1,
+            _START_UTC.date().isoformat(),
+            "race",
+            _START_UTC.isoformat(),
+            _END_UTC.isoformat(),
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+
+    wav_a = tmp_path / "sib0.wav"
+    wav_b = tmp_path / "sib1.wav"
+    wav_a.write_bytes(b"RIFF0000WAVEfmt ")
+    wav_b.write_bytes(b"RIFF0000WAVEfmt ")
+
+    def _sess(path: Path, ordinal: int, serial: str) -> AudioSession:
+        return AudioSession(
+            file_path=str(path),
+            device_name=f"Jieli {ordinal}",
+            start_utc=_START_UTC,
+            end_utc=_END_UTC,
+            sample_rate=48000,
+            channels=1,
+            vendor_id=0x3634,
+            product_id=0x4155,
+            serial=serial,
+            usb_port_path=f"1-{ordinal + 1}",
+            capture_group_id="grp-xyz",
+            capture_ordinal=ordinal,
+        )
+
+    primary_id = await storage.write_audio_session(
+        _sess(wav_a, 0, "AAA"), race_id=race_id, session_type="race", name="Test Race"
+    )
+    secondary_id = await storage.write_audio_session(
+        _sess(wav_b, 1, "BBB"), race_id=race_id, session_type="race", name="Test Race"
+    )
+    await storage.set_audio_session_device(
+        primary_id, vendor_id=0x3634, product_id=0x4155, serial="AAA", usb_port_path="1-1"
+    )
+    await storage.set_audio_session_device(
+        secondary_id,
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="BBB",
+        usb_port_path="1-2",
+    )
+    await storage.set_channel_map(
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="AAA",
+        usb_port_path="1-1",
+        mapping={0: "Helm pair"},
+        audio_session_id=primary_id,
+    )
+    await storage.set_channel_map(
+        vendor_id=0x3634,
+        product_id=0x4155,
+        serial="BBB",
+        usb_port_path="1-2",
+        mapping={0: "Bow pair"},
+        audio_session_id=secondary_id,
+    )
+    return race_id, primary_id, secondary_id
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions/{id} — audio_siblings block
+# ---------------------------------------------------------------------------
+
+
+async def test_session_detail_returns_sibling_audio_group(storage: Storage, tmp_path: Path) -> None:
+    race_id, primary_id, secondary_id = await _seed_race_with_sibling_audio(storage, tmp_path)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/detail")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["has_audio"] is True
+    # Primary is ordinal 0 so session.js keeps the scalar audio_session_id.
+    assert data["audio_session_id"] == primary_id
+    # Exposed sibling count so the pt.6 multi-channel gate trips.
+    assert data["audio_channels"] == 2
+    # New sibling block.
+    siblings = data["audio_siblings"]
+    assert len(siblings) == 2
+    assert [s["ordinal"] for s in siblings] == [0, 1]
+    assert [s["audio_session_id"] for s in siblings] == [primary_id, secondary_id]
+    assert siblings[0]["position_name"] == "Helm pair"
+    assert siblings[1]["position_name"] == "Bow pair"
+    assert siblings[0]["stream_url"] == f"/api/audio/{primary_id}/stream"
+    assert siblings[1]["stream_url"] == f"/api/audio/{secondary_id}/stream"
+
+
+async def test_session_detail_single_session_no_sibling_block(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Non-sibling races get the legacy shape (no audio_siblings key or empty list)."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "Legacy Race",
+            "Tuesday Night",
+            2,
+            _START_UTC.date().isoformat(),
+            "race",
+            _START_UTC.isoformat(),
+            _END_UTC.isoformat(),
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+
+    wav = tmp_path / "legacy.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    await storage.write_audio_session(
+        AudioSession(
+            file_path=str(wav),
+            device_name="Built-in",
+            start_utc=_START_UTC,
+            end_utc=_END_UTC,
+            sample_rate=48000,
+            channels=1,
+        ),
+        race_id=race_id,
+        session_type="race",
+        name="Legacy Race",
+    )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/detail")
+    data = resp.json()
+    assert data["has_audio"] is True
+    assert data["audio_channels"] == 1
+    assert data.get("audio_siblings") in (None, [])
+
+
+# ---------------------------------------------------------------------------
+# /api/audio/{id}/transcript — sibling merge
+# ---------------------------------------------------------------------------
+
+
+async def test_transcript_endpoint_merges_sibling_segments(
+    storage: Storage, tmp_path: Path
+) -> None:
+    _, primary_id, secondary_id = await _seed_race_with_sibling_audio(storage, tmp_path)
+
+    # Primary (ordinal 0, helm pair) — two segments
+    t0 = await storage.create_transcript_job(primary_id, "base")
+    await storage.update_transcript(
+        t0,
+        status="done",
+        text="helm one helm two",
+        segments_json=json.dumps(
+            [
+                {
+                    "start": 0.0,
+                    "end": 1.0,
+                    "text": "helm one",
+                    "channel_index": 0,
+                    "position_name": "Helm pair",
+                    "speaker": "Helm pair",
+                },
+                {
+                    "start": 5.0,
+                    "end": 6.0,
+                    "text": "helm two",
+                    "channel_index": 0,
+                    "position_name": "Helm pair",
+                    "speaker": "Helm pair",
+                },
+            ]
+        ),
+    )
+    # Secondary (ordinal 1, bow pair) — one segment that should sort in the middle
+    t1 = await storage.create_transcript_job(secondary_id, "base")
+    await storage.update_transcript(
+        t1,
+        status="done",
+        text="bow one",
+        segments_json=json.dumps(
+            [
+                {
+                    "start": 2.5,
+                    "end": 3.5,
+                    "text": "bow one",
+                    "channel_index": 1,
+                    "position_name": "Bow pair",
+                    "speaker": "Bow pair",
+                },
+            ]
+        ),
+    )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/audio/{primary_id}/transcript")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "done"
+    # Merged across siblings, sorted by start_time.
+    assert [s["text"] for s in data["segments"]] == [
+        "helm one",
+        "bow one",
+        "helm two",
+    ]
+    assert [s["channel_index"] for s in data["segments"]] == [0, 1, 0]
+
+
+async def test_transcript_endpoint_sibling_single_completed(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Only one sibling done yet — we still return its segments."""
+    _, primary_id, secondary_id = await _seed_race_with_sibling_audio(storage, tmp_path)
+    t0 = await storage.create_transcript_job(primary_id, "base")
+    await storage.update_transcript(
+        t0,
+        status="done",
+        text="only helm",
+        segments_json=json.dumps(
+            [
+                {
+                    "start": 0.0,
+                    "end": 1.0,
+                    "text": "only helm",
+                    "channel_index": 0,
+                    "position_name": "Helm pair",
+                    "speaker": "Helm pair",
+                }
+            ]
+        ),
+    )
+    # Secondary: pending, no segments yet
+    await storage.create_transcript_job(secondary_id, "base")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/audio/{primary_id}/transcript")
+    data = resp.json()
+    assert len(data["segments"]) == 1
+    assert data["segments"][0]["text"] == "only helm"


### PR DESCRIPTION
## Summary

Third chunk of the sibling-card capture stopgap. Stacked on #511 (chunk 2 — per-sibling ASR). Chunk 4 (deletion dispatch) still to come.

## What's in this chunk

### Backend

**\`GET /api/sessions/{id}/detail\`** — when the race's audio is a sibling capture:
- order by \`capture_ordinal\` so the primary (ordinal 0) wins \`audio_session_id\`
- set \`audio_channels = len(siblings)\` so the existing pt.6 multi-channel gate trips
- emit a new \`audio_siblings\` block: \`[{audio_session_id, ordinal, position_name, stream_url}, …]\`
- \`position_name\` resolved per sibling via \`get_channel_map_for_audio_session\`

**\`GET /api/audio/{id}/transcript\`** — when the target has a \`capture_group_id\`:
- union \`segments_json\` from every sibling's transcript
- sort by \`start_time\`
- pending siblings are skipped so one sibling still transcribing doesn't block display of the others

Legacy single-session callers get the exact same shape as before.

### Frontend — \`session.js\`

**\`loadMultiChannelAudio()\`** new sibling branch:
- fetches each sibling's \`stream_url\` in parallel (\`Promise.all\`)
- decodes each \`ArrayBuffer\` into its own \`AudioBuffer\`
- builds \`N × GainNode → ChannelMerger(1) → destination\` — no \`ChannelSplitter\` because each buffer is already mono
- primary buffer reference (\`_mcBuffer\`) = longest sibling, so the seek bar covers the whole recording even if one card's stream ended a few ms early

**\`_mcRebuildSource()\`** sibling-mode path:
- rebuilds all N \`BufferSource\` nodes on every play/seek (they're single-use)
- starts them with \`src.start(when, offsetSeconds)\` using a shared \`when = currentTime + 0.02\` lead — sample-accurate sync between receivers because all sources share the \`AudioContext\` clock
- only the first source's \`onended\` fires end-of-buffer state transitions

**\`_mcPause()\`** stops every \`BufferSource\` in sibling mode.

**\`_mcSetIsolation()\`** and **\`_mcOnSegmentClick()\`** need no changes — the existing gain-array iteration already maps one-to-one with siblings, and chunk 2 tagged \`transcript_segments\` with \`channel_index = capture_ordinal\` so segment clicks route to the correct gain.

## Test plan

- [x] 4 new tests in \`tests/test_sibling_playback_api.py\`:
  - session detail exposes \`audio_siblings\` block with stream URLs, position names, ordinal order
  - non-sibling race still returns legacy shape (no \`audio_siblings\` or empty)
  - transcript endpoint returns merged time-sorted segments across siblings (3 segments: 0→1s, 2.5→3.5s, 5→6s from two siblings, interleaved correctly)
  - partial group: only the completed sibling's segments are returned when the other is still pending
- [x] \`uv run pytest\` — 1821 passed, 2 skipped
- [x] \`uv run ruff check . && uv run ruff format --check .\` clean
- [x] \`uv run mypy src/helmlog/routes/sessions.py src/helmlog/routes/audio.py\` clean

### ⚠️ Browser smoke test — NOT DONE

JS changes always need a real-browser check per CLAUDE.md, and I can't drive a browser from this agent loop. Before merge, on a real sibling session (or after enabling \`AUDIO_CAPTURE_MODE=sibling\` on corvopi-tst1 with the two Jieli receivers):

- [ ] Mixed playback audible for both siblings (you should hear every speaker regardless of which receiver they're paired with)
- [ ] Seek bar works across the full recording duration
- [ ] Clicking a transcript segment isolates the correct sibling's audio for the segment duration, then resumes mixed
- [ ] Sticky toggle + "All channels" button behave the same as the pt.6 multi-channel path
- [ ] Legacy single-session session still plays via \`<audio>\` element (regression check — pt.6 non-sibling multi-channel path also still works)

## Still to come

- **Chunk 4** — per-sibling deletion dispatch (\`DELETE /api/audio/{id}\` on a sibling-backed session needs to route through a group-aware helper so the data-licensing deletion right applies cleanly to the whole group or a single sibling)

Related: #509, #510, #511

🤖 Generated with [Claude Code](https://claude.ai/code)