### PR TITLE
replay: grading pipeline + playback UI (#464 slice: #465 #468 #469 #470)

### DIFF
--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -8,10 +8,11 @@ this baseline to show whether the boat is over or under-performing.
 from __future__ import annotations
 
 import math
+import os
 from collections import defaultdict
-from dataclasses import dataclass
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
 
@@ -27,6 +28,22 @@ _TWA_BIN_SIZE = 5
 # wind reference values that appear in the winds table
 _WIND_REF_BOAT = 0  # wind_angle_deg IS the TWA (true wind, boat-referenced)
 _WIND_REF_NORTH = 4  # wind_angle_deg is TWD; need heading to derive TWA
+
+# Replay-grading config (#469). All tunable so we can adjust without a
+# schema change. Segment width is read from env so deployments can tweak
+# it without code changes.
+POLAR_SEGMENT_SECONDS: int = int(os.environ.get("POLAR_SEGMENT_SECONDS", "10"))
+
+# pct_target thresholds for the grade decision table.
+GRADE_RED_BELOW: float = 0.90
+GRADE_YELLOW_BELOW: float = 0.97
+GRADE_GREEN_BELOW: float = 1.05  # [0.97, 1.05) → green
+GRADE_SUSPICIOUS_AT: float = 1.20  # ≥ 1.20 → suspicious (likely bad baseline cell)
+
+# Cache invalidation: bumped whenever the polar baseline is rebuilt.
+POLAR_BASELINE_VERSION_KEY: str = "polar_baseline_version"
+
+GradeLabel = Literal["green", "yellow", "red", "suspicious", "unknown"]
 
 # ---------------------------------------------------------------------------
 # Pure helpers (all unit-testable without Storage)
@@ -88,6 +105,9 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
     if not races:
         logger.info("Polar: no completed races found; baseline not built")
         await storage.upsert_polar_baseline([], datetime.now(UTC).isoformat())
+        current = await storage.get_setting(POLAR_BASELINE_VERSION_KEY)
+        next_version = (int(current) if current and current.isdigit() else 0) + 1
+        await storage.set_setting(POLAR_BASELINE_VERSION_KEY, str(next_version))
         return 0
 
     # bin_samples[(tws_bin, twa_bin)] = list of (race_id, bsp_kts)
@@ -170,8 +190,23 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
 
     built_at = datetime.now(UTC).isoformat()
     await storage.upsert_polar_baseline(rows_to_write, built_at)
-    logger.info("Polar baseline built: {} bins from {} races", len(rows_to_write), len(races))
+    # Bump the baseline version so any cached per-segment grades become stale.
+    current = await storage.get_setting(POLAR_BASELINE_VERSION_KEY)
+    next_version = (int(current) if current and current.isdigit() else 0) + 1
+    await storage.set_setting(POLAR_BASELINE_VERSION_KEY, str(next_version))
+    logger.info(
+        "Polar baseline built: {} bins from {} races (baseline_version={})",
+        len(rows_to_write),
+        len(races),
+        next_version,
+    )
     return len(rows_to_write)
+
+
+async def get_polar_baseline_version(storage: Storage) -> int:
+    """Return the current polar baseline version (0 if never built)."""
+    raw = await storage.get_setting(POLAR_BASELINE_VERSION_KEY)
+    return int(raw) if raw and raw.isdigit() else 0
 
 
 # ---------------------------------------------------------------------------
@@ -350,3 +385,248 @@ async def session_polar_comparison(
         twa_bins=twa_bins,
         session_sample_count=total_samples,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-segment grading for race replay (#469)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GradedSegment:
+    """One time-window's worth of polar grading along a session track."""
+
+    segment_index: int
+    t_start: datetime
+    t_end: datetime
+    lat: float | None
+    lon: float | None
+    tws_kts: float | None
+    twa_deg: float | None
+    bsp_kts: float | None
+    target_bsp_kts: float | None
+    pct_target: float | None
+    delta_kts: float | None
+    grade: GradeLabel
+
+    def to_row(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["t_start"] = self.t_start.isoformat()
+        d["t_end"] = self.t_end.isoformat()
+        return d
+
+
+def _grade_from_pct(pct: float | None) -> GradeLabel:
+    """Map pct_target → grade per the decision table."""
+    if pct is None:
+        return "unknown"
+    if pct >= GRADE_SUSPICIOUS_AT:
+        return "suspicious"
+    if pct < GRADE_RED_BELOW:
+        return "red"
+    if pct < GRADE_YELLOW_BELOW:
+        return "yellow"
+    return "green"  # [0.97, 1.20)
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _interp_position(
+    positions: list[dict[str, Any]], t_mid: datetime
+) -> tuple[float | None, float | None]:
+    """Return interpolated (lat, lon) at *t_mid*, or nearest fix within ±2s."""
+    if not positions:
+        return None, None
+    # Find bracketing fixes
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    for p in positions:
+        ts = datetime.fromisoformat(str(p["ts"])).replace(tzinfo=UTC)
+        if ts <= t_mid:
+            before = {**p, "_dt": ts}
+        else:
+            after = {**p, "_dt": ts}
+            break
+    if before is not None and after is not None:
+        span = (after["_dt"] - before["_dt"]).total_seconds()
+        if span <= 0:
+            return float(before["latitude_deg"]), float(before["longitude_deg"])
+        f = (t_mid - before["_dt"]).total_seconds() / span
+        lat = float(before["latitude_deg"]) + f * (
+            float(after["latitude_deg"]) - float(before["latitude_deg"])
+        )
+        lon = float(before["longitude_deg"]) + f * (
+            float(after["longitude_deg"]) - float(before["longitude_deg"])
+        )
+        return lat, lon
+    # Fall back to nearest fix within ±2s
+    candidates = [
+        (abs((datetime.fromisoformat(str(p["ts"])).replace(tzinfo=UTC) - t_mid).total_seconds()), p)
+        for p in positions
+    ]
+    candidates.sort(key=lambda x: x[0])
+    nearest_dt, nearest = candidates[0]
+    if nearest_dt <= 2.0:
+        return float(nearest["latitude_deg"]), float(nearest["longitude_deg"])
+    return None, None
+
+
+async def grade_session_segments(
+    storage: Storage,
+    session_id: int,
+    polar_source: str = "own",
+    segment_seconds: int | None = None,
+) -> list[GradedSegment]:
+    """Return per-segment polar grading for a completed session.
+
+    Segments are fixed-width windows over the session's [start_utc, end_utc]
+    range. Each segment carries averaged conditions, the polar target, and
+    a grade label. Results are cached in ``polar_segment_grades`` and
+    invalidated when the polar baseline is rebuilt.
+    """
+    width = segment_seconds or POLAR_SEGMENT_SECONDS
+    db = storage._conn()
+
+    # Resolve session bounds
+    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    row = await cur.fetchone()
+    if row is None or row["end_utc"] is None:
+        return []  # req 16
+    try:
+        start = datetime.fromisoformat(str(row["start_utc"])).replace(tzinfo=UTC)
+        end = datetime.fromisoformat(str(row["end_utc"])).replace(tzinfo=UTC)
+    except ValueError:
+        return []
+    if end <= start:
+        return []
+
+    baseline_version = await get_polar_baseline_version(storage)
+
+    # Cache hit?
+    cached = await storage.get_polar_segment_grades(session_id, polar_source, baseline_version)
+    if cached is not None:
+        return [
+            GradedSegment(
+                segment_index=int(r["segment_index"]),
+                t_start=datetime.fromisoformat(str(r["t_start"])).replace(tzinfo=UTC),
+                t_end=datetime.fromisoformat(str(r["t_end"])).replace(tzinfo=UTC),
+                lat=r["lat"],
+                lon=r["lon"],
+                tws_kts=r["tws_kts"],
+                twa_deg=r["twa_deg"],
+                bsp_kts=r["bsp_kts"],
+                target_bsp_kts=r["target_bsp_kts"],
+                pct_target=r["pct_target"],
+                delta_kts=r["delta_kts"],
+                grade=r["grade"],
+            )
+            for r in cached
+        ]
+
+    # Load session window data
+    speeds = await storage.query_range("speeds", start, end)
+    winds = await storage.query_range("winds", start, end)
+    headings = await storage.query_range("headings", start, end)
+    positions = await storage.query_range("positions", start, end)
+
+    # Detect un-migrated DB: lookup_polar will raise on missing table.
+    baseline_missing = False
+
+    def _ts_of(rec: dict[str, Any]) -> datetime:
+        return datetime.fromisoformat(str(rec["ts"])).replace(tzinfo=UTC)
+
+    speeds_dt = [(_ts_of(r), r) for r in speeds]
+    winds_dt = [
+        (_ts_of(r), r)
+        for r in winds
+        if int(r.get("reference", -1)) in (_WIND_REF_BOAT, _WIND_REF_NORTH)
+    ]
+    hdg_dt = [(_ts_of(r), r) for r in headings]
+
+    segments: list[GradedSegment] = []
+    grade_hist: dict[str, int] = defaultdict(int)
+
+    n_segments = math.ceil((end - start).total_seconds() / width)
+    for idx in range(n_segments):
+        seg_start = start + timedelta(seconds=idx * width)
+        seg_end = min(end, seg_start + timedelta(seconds=width))
+        t_mid = seg_start + (seg_end - seg_start) / 2
+
+        spd_in = [float(r["speed_kts"]) for ts, r in speeds_dt if seg_start <= ts < seg_end]
+        wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
+        hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
+        pos_in = [r for ts, r in [(_ts_of(r), r) for r in positions] if seg_start <= ts < seg_end]
+
+        lat, lon = _interp_position(positions, t_mid) if positions else (None, None)
+
+        bsp = _mean(spd_in)
+
+        tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
+        # Compute segment TWA from the mean wind angle / mean heading.
+        twa: float | None = None
+        if wind_in:
+            wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
+            ref = int(wind_in[0][1].get("reference", -1))
+            heading_mean = _mean(hdg_in) if ref == _WIND_REF_NORTH else None
+            twa = _compute_twa(wind_angle_mean, ref, heading_mean)
+
+        target: float | None = None
+        pct: float | None = None
+        delta: float | None = None
+        if bsp is not None and tws is not None and twa is not None and not baseline_missing:
+            try:
+                lp = await lookup_polar(storage, tws, twa)
+            except Exception as e:  # un-migrated DB or other table-missing error
+                logger.warning(
+                    "Polar grading: baseline lookup failed for session {}: {}", session_id, e
+                )
+                baseline_missing = True
+                lp = None
+            if lp is not None:
+                target = float(lp["mean_bsp"])
+                pct = bsp / target if target > 0 else None
+                delta = round(bsp - target, 4)
+
+        if bsp is not None and tws is not None and twa is not None:
+            grade = _grade_from_pct(pct)
+        else:
+            grade = "unknown"
+        if lat is None or lon is None:
+            grade = "unknown"
+
+        seg = GradedSegment(
+            segment_index=idx,
+            t_start=seg_start,
+            t_end=seg_end,
+            lat=lat,
+            lon=lon,
+            tws_kts=round(tws, 4) if tws is not None else None,
+            twa_deg=round(twa, 4) if twa is not None else None,
+            bsp_kts=round(bsp, 4) if bsp is not None else None,
+            target_bsp_kts=round(target, 4) if target is not None else None,
+            pct_target=round(pct, 4) if pct is not None else None,
+            delta_kts=delta,
+            grade=grade,
+        )
+        segments.append(seg)
+        grade_hist[grade] += 1
+        # silence unused
+        _ = pos_in
+
+    # Persist cache
+    await storage.upsert_polar_segment_grades(
+        session_id,
+        polar_source,
+        [s.to_row() for s in segments],
+        baseline_version,
+    )
+
+    logger.info(
+        "Polar grading: session={} segments={} grades={}",
+        session_id,
+        len(segments),
+        dict(grade_hist),
+    )
+    return segments

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -319,10 +319,34 @@ async def api_session_track(
     if not positions:
         return JSONResponse({"type": "FeatureCollection", "features": []})
 
-    coords = [[r["longitude_deg"], r["latitude_deg"]] for r in positions]
-    timestamps = [
-        t if "+" in t or t.endswith("Z") else t + "Z" for r in positions if (t := r["ts"])
-    ]
+    # Per-second mean averaging. The SK reader currently records every fix
+    # with source_addr=0 even when Signal K is multiplexing two physical
+    # GPS antennas, so the raw rows zig-zag between antennas (~3m apart).
+    # Bucketing to 1Hz and averaging within the bucket collapses the
+    # zig-zag into a smooth single line midway between the antennas — what
+    # you'd get from a single GPS anyway. Also gives the frontend a
+    # naturally Vakaros-density polyline so its dash style reads cleanly.
+    buckets: dict[str, list[tuple[float, float]]] = {}
+    bucket_order: list[str] = []
+    for r in positions:
+        ts_raw = r["ts"]
+        if not ts_raw:
+            continue
+        key = str(ts_raw)[:19]  # truncate to whole-second precision
+        if key not in buckets:
+            buckets[key] = []
+            bucket_order.append(key)
+        buckets[key].append((float(r["latitude_deg"]), float(r["longitude_deg"])))
+
+    coords: list[list[float]] = []
+    timestamps: list[str] = []
+    for key in bucket_order:
+        rows = buckets[key]
+        avg_lat = sum(p[0] for p in rows) / len(rows)
+        avg_lng = sum(p[1] for p in rows) / len(rows)
+        coords.append([avg_lng, avg_lat])
+        timestamps.append(key + ("" if key.endswith("Z") or "+" in key else "Z"))
+
     feature = {
         "type": "Feature",
         "geometry": {"type": "LineString", "coordinates": coords},

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -740,32 +740,60 @@ async def api_session_replay(
             out[key] = {f: r[f] for f in fields}
         return out
 
+    # Wind table holds both true (ref 0/4) and apparent (ref 2) rows; keep them
+    # separated so the replay HUD can surface TWS/TWA and AWS/AWA independently.
+    async def _wind_series(where: str) -> dict[str, dict[str, Any]]:
+        q = (
+            "SELECT ts, wind_speed_kts, wind_angle_deg, reference FROM winds "
+            f"WHERE ts >= ? AND ts <= ? AND {where} ORDER BY ts"
+        )
+        qcur = await db.execute(q, (start_utc, end_utc))
+        rows = await qcur.fetchall()
+        out: dict[str, dict[str, Any]] = {}
+        for r in rows:
+            key = str(r["ts"])[:19]
+            if key in out:
+                continue
+            out[key] = {
+                "wind_speed_kts": r["wind_speed_kts"],
+                "wind_angle_deg": r["wind_angle_deg"],
+                "reference": r["reference"],
+            }
+        return out
+
     speeds_by_s = await _series("speeds", ["speed_kts"])
-    winds_by_s = await _series("winds", ["wind_speed_kts", "wind_angle_deg", "reference"])
+    true_winds_by_s = await _wind_series("reference IN (0, 4)")
+    app_winds_by_s = await _wind_series("reference = 2")
     hdgs_by_s = await _series("headings", ["heading_deg"])
     cogsog_by_s = await _series("cogsog", ["cog_deg", "sog_kts"])
 
     keys = sorted(
         set(speeds_by_s.keys())
-        | set(winds_by_s.keys())
+        | set(true_winds_by_s.keys())
+        | set(app_winds_by_s.keys())
         | set(hdgs_by_s.keys())
         | set(cogsog_by_s.keys())
     )
 
     samples: list[dict[str, Any]] = []
     for k in keys:
-        w = winds_by_s.get(k)
+        tw = true_winds_by_s.get(k)
         tws: float | None = None
         twa: float | None = None
-        if w is not None:
-            raw_ref = w.get("reference")
+        if tw is not None:
+            raw_ref = tw.get("reference")
             ref = int(raw_ref) if raw_ref is not None else -1
-            tws = float(w["wind_speed_kts"]) if w["wind_speed_kts"] is not None else None
-            # Derive TWA using the same helper the grading pipeline uses so the
-            # HUD value matches the colored-segment value on the map.
+            tws = float(tw["wind_speed_kts"]) if tw["wind_speed_kts"] is not None else None
             h = hdgs_by_s.get(k)
             heading = float(h["heading_deg"]) if h and h["heading_deg"] is not None else None
-            twa = _polar._compute_twa(float(w["wind_angle_deg"]), ref, heading)
+            twa = _polar._compute_twa(float(tw["wind_angle_deg"]), ref, heading)
+
+        aw = app_winds_by_s.get(k)
+        aws: float | None = None
+        awa: float | None = None
+        if aw is not None:
+            aws = float(aw["wind_speed_kts"]) if aw["wind_speed_kts"] is not None else None
+            awa = float(aw["wind_angle_deg"]) if aw["wind_angle_deg"] is not None else None
 
         sp = speeds_by_s.get(k)
         cs = cogsog_by_s.get(k)
@@ -779,6 +807,8 @@ async def api_session_replay(
                 "hdg": float(hd["heading_deg"]) if hd else None,
                 "tws": tws,
                 "twa": twa,
+                "aws": aws,
+                "awa": awa,
             }
         )
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -815,8 +815,14 @@ async def api_session_replay(
     return JSONResponse(
         {
             "session_id": session_id,
-            "start_utc": start_utc + ("" if start_utc.endswith("Z") else "Z"),
-            "end_utc": end_utc + ("" if end_utc.endswith("Z") else "Z"),
+            # Normalize for the JS Date() parser: if the row already carries a
+            # timezone indicator (isoformat on an aware UTC datetime produces
+            # "...+00:00") leave it alone, otherwise append "Z". The previous
+            # unconditional-append produced the invalid "...+00:00Z" that made
+            # new Date() return Invalid Date and silently broke the scrubber,
+            # time label, and YT sync.
+            "start_utc": (start_utc if ("Z" in start_utc or "+" in start_utc) else start_utc + "Z"),
+            "end_utc": end_utc if ("Z" in end_utc or "+" in end_utc) else end_utc + "Z",
             "segment_seconds": _polar.POLAR_SEGMENT_SECONDS,
             "grades": grades_out,
             "samples": samples,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -675,6 +675,125 @@ async def api_session_polar(
     )
 
 
+@router.get("/api/sessions/{session_id}/replay")
+@limiter.limit("30/minute")
+async def api_session_replay(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return the payload the replay UI needs: session bounds, a per-second
+    instrument series for the HUD, and per-segment polar grades (#464/#469).
+
+    The instrument series is downsampled to 1 Hz keyed on the first 19 chars
+    of the ISO timestamp so the frontend can binary-search by cursor position
+    without loading the full raw tables. Fields are nulled out when a given
+    sensor had no reading for that second.
+    """
+    storage = get_storage(request)
+    db = storage._conn()
+    cur = await db.execute("SELECT id, start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    row = await cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Race not found")
+    start_utc = row["start_utc"]
+    end_utc = row["end_utc"] or row["start_utc"]
+
+    # Graded segments (cached) — may be empty if session hasn't ended
+    import helmlog.polar as _polar
+
+    try:
+        graded = await _polar.grade_session_segments(storage, session_id)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("replay: grading failed for session {}: {}", session_id, e)
+        graded = []
+
+    grades_out = [
+        {
+            "i": g.segment_index,
+            "t_start": g.t_start.isoformat(),
+            "t_end": g.t_end.isoformat(),
+            "lat": g.lat,
+            "lon": g.lon,
+            "tws": g.tws_kts,
+            "twa": g.twa_deg,
+            "bsp": g.bsp_kts,
+            "target": g.target_bsp_kts,
+            "pct": g.pct_target,
+            "delta": g.delta_kts,
+            "grade": g.grade,
+        }
+        for g in graded
+    ]
+
+    # Thin instrument series for HUD. 1 Hz dedup by truncated timestamp key.
+    async def _series(table: str, fields: list[str]) -> dict[str, dict[str, Any]]:
+        cols = ", ".join(["ts", *fields])
+        q = f"SELECT {cols} FROM {table} WHERE ts >= ? AND ts <= ? ORDER BY ts"
+        qcur = await db.execute(q, (start_utc, end_utc))
+        rows = await qcur.fetchall()
+        out: dict[str, dict[str, Any]] = {}
+        for r in rows:
+            key = str(r["ts"])[:19]
+            if key in out:
+                continue
+            out[key] = {f: r[f] for f in fields}
+        return out
+
+    speeds_by_s = await _series("speeds", ["speed_kts"])
+    winds_by_s = await _series("winds", ["wind_speed_kts", "wind_angle_deg", "reference"])
+    hdgs_by_s = await _series("headings", ["heading_deg"])
+    cogsog_by_s = await _series("cogsog", ["cog_deg", "sog_kts"])
+
+    keys = sorted(
+        set(speeds_by_s.keys())
+        | set(winds_by_s.keys())
+        | set(hdgs_by_s.keys())
+        | set(cogsog_by_s.keys())
+    )
+
+    samples: list[dict[str, Any]] = []
+    for k in keys:
+        w = winds_by_s.get(k)
+        tws: float | None = None
+        twa: float | None = None
+        if w is not None:
+            raw_ref = w.get("reference")
+            ref = int(raw_ref) if raw_ref is not None else -1
+            tws = float(w["wind_speed_kts"]) if w["wind_speed_kts"] is not None else None
+            # Derive TWA using the same helper the grading pipeline uses so the
+            # HUD value matches the colored-segment value on the map.
+            h = hdgs_by_s.get(k)
+            heading = float(h["heading_deg"]) if h and h["heading_deg"] is not None else None
+            twa = _polar._compute_twa(float(w["wind_angle_deg"]), ref, heading)
+
+        sp = speeds_by_s.get(k)
+        cs = cogsog_by_s.get(k)
+        hd = hdgs_by_s.get(k)
+        samples.append(
+            {
+                "ts": k + "Z",
+                "stw": float(sp["speed_kts"]) if sp else None,
+                "sog": float(cs["sog_kts"]) if cs else None,
+                "cog": float(cs["cog_deg"]) if cs else None,
+                "hdg": float(hd["heading_deg"]) if hd else None,
+                "tws": tws,
+                "twa": twa,
+            }
+        )
+
+    return JSONResponse(
+        {
+            "session_id": session_id,
+            "start_utc": start_utc + ("" if start_utc.endswith("Z") else "Z"),
+            "end_utc": end_utc + ("" if end_utc.endswith("Z") else "Z"),
+            "segment_seconds": _polar.POLAR_SEGMENT_SECONDS,
+            "grades": grades_out,
+            "samples": samples,
+        }
+    )
+
+
 @router.get("/api/sessions/{session_id}/maneuvers")
 async def api_session_maneuvers(
     request: Request,

--- a/src/helmlog/sk_reader.py
+++ b/src/helmlog/sk_reader.py
@@ -47,6 +47,24 @@ _KELVIN_OFFSET: float = 273.15
 SK_SOURCE_ADDR: int = 0  # no CAN source address for SK-originated records
 
 
+def _source_addr_for(src: str | None) -> int:
+    """Stable int hash of a Signal K $source string, fits in a SQLite INTEGER.
+
+    Multiple GPS antennas on a NMEA 2000 bus all publish navigation.position;
+    Signal K forwards each delta with its own $source label
+    (e.g. "n2k.0.130577.0" vs "n2k.1.43.0"). Without preserving that label
+    every SK record collapses to source_addr=0 and the consumers can't tell
+    which antenna an individual fix came from. Hash to a positive int31 so
+    SQLite stores it as a plain integer and tests can compare equality.
+    """
+    if not src:
+        return SK_SOURCE_ADDR
+    h = 0
+    for ch in src:
+        h = (h * 131 + ord(ch)) & 0x7FFFFFFF
+    return h or 1  # avoid colliding with SK_SOURCE_ADDR=0
+
+
 @dataclass
 class SKReaderConfig:
     """Configuration for the Signal K WebSocket reader.
@@ -204,6 +222,20 @@ def process_delta(
         except (ValueError, AttributeError):
             ts = datetime.now(UTC)
 
+        # Per-update Signal K source label (e.g. "n2k.0.130577.0"). Hashed
+        # to an int so position rows from different physical GPS antennas
+        # land on distinct source_addr values rather than all collapsing
+        # to 0. Other record types still use SK_SOURCE_ADDR — the source
+        # ambiguity only mattered for positions in practice. Some Signal K
+        # versions expose the label under "$source", others under
+        # "source.label"; check both.
+        src_label: str | None = update.get("$source")
+        if not src_label:
+            nested = update.get("source")
+            if isinstance(nested, dict):
+                src_label = nested.get("label")
+        update_source_addr = _source_addr_for(src_label)
+
         for entry in update.get("values", []):
             path: str = entry.get("path", "")
             value: Any = entry.get("value")
@@ -220,7 +252,7 @@ def process_delta(
                     records.append(
                         PositionRecord(
                             PGN_POSITION_RAPID,
-                            SK_SOURCE_ADDR,
+                            update_source_addr,
                             ts,
                             float(value["latitude"]),
                             float(value["longitude"]),

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1795,10 +1795,11 @@ function loadAudio() {
   // currently-playing audio: it's distracting to have audio keep going from
   // a new spot just because the user clicked somewhere on the page.
   registerSurface('audio', function(utc) {
-    // Playback independence: if a different player is producing updates,
-    // don't move this player's playhead. Scrubs via replay/map/etc still
-    // seek audio so the preview stays in sync with the cursor.
-    if (_playClock.currentSource === 'video' || _playClock.currentSource === 'mc') return;
+    // NB: setting el.currentTime on a paused audio element is safe — it
+    // doesn't start playback — so unlike the video consumer we don't need
+    // to skip based on currentSource. Seeking a paused audio keeps its
+    // scrubber in lockstep with YT/replay even when the user isn't
+    // listening to it.
     const local = utcToAudioLocal(utc);
     if (local < 0 || (el.duration && local > el.duration)) return;
     const delta = Math.abs(el.currentTime - local);
@@ -2118,9 +2119,9 @@ async function loadMultiChannelAudio() {
   // the mc seek bar and start offset. Skipped while playing (avoid fighting
   // natural playback) and while the user is actively dragging the slider.
   registerSurface('mc', function(utc) {
-    // Playback independence: leave mc alone when a different player drives
-    // the update. Only replay/map/scrub-style sources should move mc.
-    if (_playClock.currentSource === 'video' || _playClock.currentSource === 'audio') return;
+    // Moving _mcStartOffset on a paused mc source doesn't start playback,
+    // so we can safely follow updates from any producer. The _mcIsPlaying
+    // guard below still prevents us from interrupting active playback.
     if (!_mcBuffer) return;
     const anchor = _mcSessionStart();
     if (!anchor) return;

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -659,21 +659,90 @@ function _moveCursorToIndex(idx) {
   if (!_trackData) return;
   const latLng = _trackData.latLngs[idx];
   _trackData.cursor.setLatLng(latLng).addTo(_map);
-  // Read HDG/COG from the replay sample closest to the cursor timestamp.
-  // Falls back to null so the SVG simply hides the missing line instead of
-  // drawing a stale direction.
+  // Read HDG/COG from the replay sample closest to the cursor timestamp,
+  // then smooth across a ±5s window so the icon doesn't twitch with every
+  // 1 Hz sample. Circular mean via sin/cos so values near 0°/360° wrap
+  // cleanly instead of averaging to 180°.
   let hdg = null, cog = null;
   const ts = _trackData.timestamps[idx];
-  if (ts && typeof _binarySearchSample === 'function') {
-    const s = _binarySearchSample(ts.getTime());
-    if (s) { hdg = s.hdg; cog = s.cog; }
+  if (ts) {
+    const windowed = _windowedHeadingCog(ts.getTime(), 5000);
+    hdg = windowed.hdg;
+    cog = windowed.cog;
   }
   const el = _trackData.cursor.getElement();
   if (el) el.innerHTML = _renderBoatCursorSvg(hdg, cog);
-  if (_followBoat && _map) {
-    // animate:false — we may be ticking at 10 Hz, animation would thrash
-    _map.panTo(latLng, {animate: false});
+  if (_followBoat && _map) _maybeFollowPan(latLng);
+}
+
+// Circular-mean smoothing of hdg/cog over a window around ts. Returns
+// {hdg, cog} in degrees [0, 360). Null fields if not enough samples.
+function _windowedHeadingCog(tMs, halfMs) {
+  if (!_replaySamples || !_replaySamples.length) return {hdg: null, cog: null};
+  const lo = tMs - halfMs;
+  const hi = tMs + halfMs;
+  let hdgX = 0, hdgY = 0, hdgN = 0;
+  let cogX = 0, cogY = 0, cogN = 0;
+  // _replaySamples is sorted by ts; linear scan around the cursor is
+  // bounded by the window so this is still O(window) not O(n).
+  const startIdx = _sampleLowerBound(lo);
+  for (let i = startIdx; i < _replaySamples.length; i++) {
+    const s = _replaySamples[i];
+    const t = s.ts.getTime();
+    if (t > hi) break;
+    if (s.hdg != null && !isNaN(s.hdg)) {
+      const r = (s.hdg * Math.PI) / 180;
+      hdgX += Math.cos(r); hdgY += Math.sin(r); hdgN++;
+    }
+    if (s.cog != null && !isNaN(s.cog)) {
+      const r = (s.cog * Math.PI) / 180;
+      cogX += Math.cos(r); cogY += Math.sin(r); cogN++;
+    }
   }
+  const angle = (x, y, n) => {
+    if (!n) return null;
+    const a = (Math.atan2(y / n, x / n) * 180) / Math.PI;
+    return (a + 360) % 360;
+  };
+  return {hdg: angle(hdgX, hdgY, hdgN), cog: angle(cogX, cogY, cogN)};
+}
+
+function _sampleLowerBound(tMs) {
+  if (!_replaySamples || !_replaySamples.length) return 0;
+  let lo = 0, hi = _replaySamples.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (_replaySamples[mid].ts.getTime() < tMs) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+// Soft-viewport follow: only recenter when the boat is within 25% of the
+// nearest map edge, otherwise leave the map alone. Prevents the constant
+// 10 Hz panning that caused the page-wide jitter.
+function _maybeFollowPan(latLng) {
+  if (!_map) return;
+  // latLngs are stored as [lat, lng] arrays; normalize.
+  const lat = Array.isArray(latLng) ? latLng[0] : latLng.lat;
+  const lng = Array.isArray(latLng) ? latLng[1] : latLng.lng;
+  const bounds = _map.getBounds();
+  const ne = bounds.getNorthEast();
+  const sw = bounds.getSouthWest();
+  const latSpan = ne.lat - sw.lat;
+  const lngSpan = ne.lng - sw.lng;
+  const margin = 0.25;
+  const latMargin = latSpan * margin;
+  const lngMargin = lngSpan * margin;
+  const nearEdge =
+    lat < sw.lat + latMargin ||
+    lat > ne.lat - latMargin ||
+    lng < sw.lng + lngMargin ||
+    lng > ne.lng - lngMargin;
+  if (!nearEdge) return;
+  // Use Leaflet's panTo with a short animation so the recenter glides
+  // rather than snapping; duration short enough not to overshoot tick.
+  _map.panTo(latLng, {animate: true, duration: 0.4});
 }
 
 // Render the boat cursor SVG. The hull is a simplified triangle that

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -28,6 +28,7 @@ const _playClock = {
   tickTimer: null,
   tickAnchorUtc: null, // UTC at last tick anchor
   tickAnchorPerf: 0, // performance.now() at last tick anchor
+  speed: 1, // replay speed multiplier (1 / 2 / 4 / 8)
 };
 
 function _clockNowMs() { return performance.now(); }
@@ -64,13 +65,32 @@ function _startPlayTick() {
   _playClock.state = 'playing';
   _playClock.tickTimer = setInterval(() => {
     if (!_playClock.tickAnchorUtc) return;
-    const elapsedMs = _clockNowMs() - _playClock.tickAnchorPerf;
+    const elapsedMs = (_clockNowMs() - _playClock.tickAnchorPerf) * (_playClock.speed || 1);
     const utc = new Date(_playClock.tickAnchorUtc.getTime() + elapsedMs);
     _playClock.positionUtc = utc;
+    // Auto-stop at end of replay window
+    if (_replayEnd && utc.getTime() >= _replayEnd.getTime()) {
+      _playClock.positionUtc = _replayEnd;
+      _stopPlayTick();
+      for (const c of _playClock.consumers) {
+        try { c.render(_replayEnd); } catch (e) { /* swallow */ }
+      }
+      _updateReplayControls();
+      return;
+    }
     for (const c of _playClock.consumers) {
       try { c.render(utc); } catch (e) { /* swallow */ }
     }
+    _updateReplayControls();
   }, 100);
+}
+
+function _setPlaybackSpeed(newSpeed) {
+  if (!newSpeed) return;
+  // Re-anchor so speed change doesn't jump the cursor
+  _playClock.tickAnchorUtc = _playClock.positionUtc;
+  _playClock.tickAnchorPerf = _clockNowMs();
+  _playClock.speed = newSpeed;
 }
 
 function _stopPlayTick() {
@@ -4552,6 +4572,269 @@ function _renderIsolationToggle() {
   // checkbox; nothing to add to the transcript header.
   return '';
 }
+
+// ---------------------------------------------------------------------------
+// Replay controls, HUD, and polar-graded track overlay (#464, #465, #468, #470)
+// ---------------------------------------------------------------------------
+//
+// Extends the existing _playClock (which already drives map/video/audio
+// surfaces) with: a visible scrubber, play/pause, speed selector, keyboard
+// shortcuts, a live instrument HUD, and a polar-grade color overlay that
+// paints the track by % of target. The underlying data comes from
+// /api/sessions/{id}/replay in one fetch.
+
+let _replayStart = null; // Date — session start (for scrubber 0)
+let _replayEnd = null;   // Date — session end (for scrubber max)
+let _replaySamples = null; // [{ts: Date, stw, sog, tws, twa, hdg, cog}]
+let _replayGrades = null;  // [{t_start, t_end, ..., grade}]
+let _gradeSegments = []; // [L.polyline] overlays when polar view is active
+let _gradeViewActive = false;
+
+const _GRADE_COLORS = {
+  red: '#d64545',
+  yellow: '#d6a745',
+  green: '#3db86e',
+  suspicious: '#a855f7',
+  unknown: '#888888',
+};
+
+function _pad2(n) { return String(n).padStart(2, '0'); }
+
+function _fmtClock(deltaMs) {
+  if (deltaMs == null || isNaN(deltaMs)) return '--:--';
+  const totalS = Math.max(0, Math.floor(deltaMs / 1000));
+  const mm = Math.floor(totalS / 60);
+  const ss = totalS % 60;
+  if (mm >= 60) {
+    const hh = Math.floor(mm / 60);
+    return hh + ':' + _pad2(mm % 60) + ':' + _pad2(ss);
+  }
+  return _pad2(mm) + ':' + _pad2(ss);
+}
+
+function _binarySearchSample(tMs) {
+  if (!_replaySamples || !_replaySamples.length) return null;
+  let lo = 0, hi = _replaySamples.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (_replaySamples[mid].ts.getTime() <= tMs) lo = mid;
+    else hi = mid - 1;
+  }
+  return _replaySamples[lo];
+}
+
+function _findGradeAt(tMs) {
+  if (!_replayGrades || !_replayGrades.length) return null;
+  // Grades are segment_index-ordered and time-contiguous; linear scan is fine
+  // at ~360 segments for a 1h session but use binary for safety.
+  let lo = 0, hi = _replayGrades.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (_replayGrades[mid].t_end.getTime() <= tMs) lo = mid + 1;
+    else hi = mid;
+  }
+  const g = _replayGrades[lo];
+  if (!g) return null;
+  if (tMs < g.t_start.getTime()) return null;
+  return g;
+}
+
+function _fmtNum(v, digits) {
+  if (v == null || isNaN(v)) return '—';
+  return Number(v).toFixed(digits);
+}
+
+function _fmtPct(v) {
+  if (v == null || isNaN(v)) return '—';
+  return Math.round(v * 100) + '%';
+}
+
+function _renderHud(utc) {
+  if (!_replaySamples) return;
+  const s = _binarySearchSample(utc.getTime());
+  const g = _findGradeAt(utc.getTime());
+  const setEl = (id, text) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = text;
+  };
+  setEl('hud-sog', _fmtNum(s && s.sog, 2));
+  setEl('hud-stw', _fmtNum(s && s.stw, 2));
+  setEl('hud-tws', _fmtNum(s && s.tws, 1));
+  setEl('hud-twa', _fmtNum(s && s.twa, 0));
+  setEl('hud-hdg', _fmtNum(s && s.hdg, 0));
+  setEl('hud-cog', _fmtNum(s && s.cog, 0));
+  setEl('hud-pct', g && g.pct != null ? _fmtPct(g.pct) : '—');
+  setEl('hud-delta', g && g.delta != null ? (g.delta >= 0 ? '+' : '') + _fmtNum(g.delta, 2) : '—');
+}
+
+function _updateReplayControls() {
+  if (!_replayStart || !_replayEnd) return;
+  const pos = _playClock.positionUtc || _replayStart;
+  const elapsedMs = pos.getTime() - _replayStart.getTime();
+  const durMs = _replayEnd.getTime() - _replayStart.getTime();
+  const timeEl = document.getElementById('replay-time');
+  if (timeEl) timeEl.textContent = _fmtClock(elapsedMs) + ' / ' + _fmtClock(durMs);
+  const scrubber = document.getElementById('replay-scrubber');
+  if (scrubber && document.activeElement !== scrubber) {
+    const frac = durMs > 0 ? Math.min(1, Math.max(0, elapsedMs / durMs)) : 0;
+    scrubber.value = String(Math.round(frac * 1000));
+  }
+  const btn = document.getElementById('replay-play-btn');
+  if (btn) btn.innerHTML = _playClock.state === 'playing' ? '&#10074;&#10074;' : '&#9654;';
+}
+
+function _togglePlayPause() {
+  if (!_replayStart) return;
+  if (_playClock.state === 'playing') {
+    _stopPlayTick();
+  } else {
+    if (!_playClock.positionUtc) _playClock.positionUtc = _replayStart;
+    // If at (or past) the end, restart from the beginning
+    if (_replayEnd && _playClock.positionUtc.getTime() >= _replayEnd.getTime()) {
+      setPosition(_replayStart, {source: 'replay'});
+    }
+    _startPlayTick();
+  }
+  _updateReplayControls();
+}
+
+function _clearGradeSegments() {
+  for (const seg of _gradeSegments) {
+    try { _map.removeLayer(seg); } catch (e) { /* ignore */ }
+  }
+  _gradeSegments = [];
+}
+
+function _drawGradeSegments() {
+  _clearGradeSegments();
+  if (!_map || !_replayGrades || !_trackData) return;
+  // Paint contiguous runs of same-grade segments as individual polylines on
+  // top of the base track. We walk the sample positions and mark each one
+  // with the grade that covers it, then coalesce consecutive same-grade runs.
+  const timestamps = _trackData.timestamps;
+  const latLngs = _trackData.latLngs;
+  if (!timestamps || timestamps.length < 2) return;
+  const gradesAtIdx = new Array(timestamps.length);
+  for (let i = 0; i < timestamps.length; i++) {
+    const g = _findGradeAt(timestamps[i].getTime());
+    gradesAtIdx[i] = g ? g.grade : 'unknown';
+  }
+  let runStart = 0;
+  for (let i = 1; i <= timestamps.length; i++) {
+    if (i === timestamps.length || gradesAtIdx[i] !== gradesAtIdx[runStart]) {
+      const color = _GRADE_COLORS[gradesAtIdx[runStart]] || _GRADE_COLORS.unknown;
+      const slice = latLngs.slice(runStart, i + 1); // include boundary point
+      if (slice.length >= 2) {
+        const line = L.polyline(slice, {color: color, weight: 6, opacity: 0.85}).addTo(_map);
+        _gradeSegments.push(line);
+      }
+      runStart = i;
+    }
+  }
+  // Hide the underlying single-color track while grade overlay is active
+  if (_trackData.line) _trackData.line.setStyle({opacity: 0});
+}
+
+function _setGradeViewActive(active) {
+  _gradeViewActive = !!active;
+  const legend = document.getElementById('polar-legend');
+  if (legend) legend.style.display = _gradeViewActive ? '' : 'none';
+  if (_gradeViewActive) {
+    _drawGradeSegments();
+  } else {
+    _clearGradeSegments();
+    if (_trackData && _trackData.line) _trackData.line.setStyle({opacity: 1});
+  }
+}
+
+async function _loadReplayData() {
+  try {
+    const r = await fetch('/api/sessions/' + SESSION_ID + '/replay');
+    if (!r.ok) return;
+    const data = await r.json();
+    _replayStart = new Date(data.start_utc);
+    _replayEnd = new Date(data.end_utc);
+    _replaySamples = (data.samples || []).map(s => ({
+      ts: new Date(s.ts),
+      stw: s.stw,
+      sog: s.sog,
+      tws: s.tws,
+      twa: s.twa,
+      hdg: s.hdg,
+      cog: s.cog,
+    }));
+    _replayGrades = (data.grades || []).map(g => ({
+      t_start: new Date(g.t_start),
+      t_end: new Date(g.t_end),
+      grade: g.grade,
+      pct: g.pct,
+      delta: g.delta,
+    }));
+    // Register HUD as a clock consumer so it updates on every tick/seek
+    registerSurface('hud', function(utc) { _renderHud(utc); });
+    // Show replay UI
+    const controls = document.getElementById('replay-controls');
+    if (controls) controls.style.display = '';
+    const toggleRow = document.getElementById('replay-toggle-row');
+    if (toggleRow) toggleRow.style.display = '';
+    // Initial HUD render at session start
+    if (!_playClock.positionUtc) _playClock.positionUtc = _replayStart;
+    _renderHud(_playClock.positionUtc);
+    _updateReplayControls();
+  } catch (e) {
+    // Non-fatal: replay is best-effort, the rest of the page still works
+  }
+}
+
+function _wireReplayControls() {
+  const btn = document.getElementById('replay-play-btn');
+  if (btn) btn.addEventListener('click', _togglePlayPause);
+  const speedSel = document.getElementById('replay-speed');
+  if (speedSel) speedSel.addEventListener('change', (e) => {
+    _setPlaybackSpeed(parseFloat(e.target.value) || 1);
+  });
+  const scrubber = document.getElementById('replay-scrubber');
+  if (scrubber) {
+    scrubber.addEventListener('input', (e) => {
+      if (!_replayStart || !_replayEnd) return;
+      const frac = Number(e.target.value) / 1000;
+      const t = _replayStart.getTime() + frac * (_replayEnd.getTime() - _replayStart.getTime());
+      setPosition(new Date(t), {source: 'replay'});
+    });
+  }
+  const toggle = document.getElementById('toggle-polar-grades');
+  if (toggle) toggle.addEventListener('change', (e) => _setGradeViewActive(e.target.checked));
+
+  // Keyboard shortcuts: space toggles play, arrows seek ±5s
+  document.addEventListener('keydown', (e) => {
+    if (!_replayStart) return;
+    const tag = (e.target && e.target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    if (e.code === 'Space') {
+      e.preventDefault();
+      _togglePlayPause();
+    } else if (e.code === 'ArrowRight' || e.code === 'ArrowLeft') {
+      const delta = (e.code === 'ArrowRight' ? 5000 : -5000) * (e.shiftKey ? 6 : 1);
+      const base = _playClock.positionUtc || _replayStart;
+      const next = new Date(Math.min(
+        _replayEnd.getTime(),
+        Math.max(_replayStart.getTime(), base.getTime() + delta)
+      ));
+      setPosition(next, {source: 'replay'});
+      _updateReplayControls();
+    }
+  });
+}
+
+// Hook into init() path without rewriting it: kick off replay load once the
+// DOM is ready, and wire controls immediately. _loadReplayData() waits on
+// the fetch, and the track map is loaded in parallel, so the polar overlay
+// can only be drawn once both are ready — _setGradeViewActive is a no-op
+// until _trackData is populated.
+document.addEventListener('DOMContentLoaded', function() {
+  _wireReplayControls();
+  _loadReplayData();
+});
 
 // ---------------------------------------------------------------------------
 // Go

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -382,13 +382,21 @@ async function loadTrack() {
   const rawTimestamps = feature.properties.timestamps || [];
   const latLngs = coords.map(c => [c[1], c[0]]);
   const timestamps = rawTimestamps.map(t => new Date(t.endsWith('Z') || t.includes('+') ? t : t + 'Z'));
-  const trackColor = cssVar('--accent-strong');
+  // Instrument (SK) track: dashed like the Vakaros overlay but with a
+  // distinct color and a longer dash period, so the two patterns don't
+  // land on top of each other when both tracks are shown. Vakaros uses
+  // '2,4' (dash 2, gap 4, 6px cycle); we use '6,6' (12px cycle). The
+  // different cycle lengths prevent consistent overlap and the different
+  // dash sizes read clearly even where they briefly coincide. Butt caps
+  // keep the dashes sharply rectangular for that "super crisp" look.
+  const trackColor = cssVar('--warning') || '#fbbf24';
   const line = L.polyline(latLngs, {
     color: trackColor,
     weight: 3,
     opacity: 1,
-    lineCap: 'round',
-    lineJoin: 'round',
+    lineCap: 'butt',
+    lineJoin: 'miter',
+    dashArray: '6, 6',
   }).addTo(_map);
 
   const successColor = cssVar('--success');
@@ -576,7 +584,14 @@ async function loadVakarosOverlay() {
   if (data.track && data.track.geometry && data.track.geometry.coordinates.length) {
     const vakLatLngs = data.track.geometry.coordinates.map(c => [c[1], c[0]]);
     vakarosLine = L.polyline(vakLatLngs, {
-      color: vakarosTrackColor, weight: 3, opacity: 0.85, dashArray: '2, 4',
+      color: vakarosTrackColor,
+      weight: 3,
+      opacity: 0.9,
+      lineCap: 'butt',
+      lineJoin: 'miter',
+      // Intentionally kept shorter than the SK track's '6,6' so the two
+      // dash cycles don't align when both overlays are visible.
+      dashArray: '2, 4',
     }).bindPopup('Vakaros track');
     // Reveal the selector now that there's something to toggle.
     const selector = document.getElementById('vakaros-track-toggle');

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -393,9 +393,17 @@ async function loadTrack() {
   L.circleMarker(latLngs[latLngs.length - 1], {radius: 6, color: dangerColor, fillColor: dangerColor, fillOpacity: 1})
     .addTo(_map).bindPopup('Finish');
 
-  const cursor = L.circleMarker([0, 0], {
-    radius: 7, color: warningColor, fillColor: warningColor, fillOpacity: 1, weight: 2,
+  // Boat cursor: divIcon with a rotating SVG so we can show heading (boat
+  // orientation) and COG (a separate indicator line) in one marker. The DOM
+  // is built once and mutated in-place on each tick to avoid re-creating
+  // the Leaflet layer at 10 Hz.
+  const cursorIcon = L.divIcon({
+    className: 'boat-cursor',
+    html: _renderBoatCursorSvg(0, 0),
+    iconSize: [40, 40],
+    iconAnchor: [20, 20],
   });
+  const cursor = L.marker([0, 0], {icon: cursorIcon, interactive: false});
 
   _trackData = {latLngs, timestamps, line, cursor};
 
@@ -649,7 +657,48 @@ function _nearestIndex(latlng) {
 
 function _moveCursorToIndex(idx) {
   if (!_trackData) return;
-  _trackData.cursor.setLatLng(_trackData.latLngs[idx]).addTo(_map);
+  const latLng = _trackData.latLngs[idx];
+  _trackData.cursor.setLatLng(latLng).addTo(_map);
+  // Read HDG/COG from the replay sample closest to the cursor timestamp.
+  // Falls back to null so the SVG simply hides the missing line instead of
+  // drawing a stale direction.
+  let hdg = null, cog = null;
+  const ts = _trackData.timestamps[idx];
+  if (ts && typeof _binarySearchSample === 'function') {
+    const s = _binarySearchSample(ts.getTime());
+    if (s) { hdg = s.hdg; cog = s.cog; }
+  }
+  const el = _trackData.cursor.getElement();
+  if (el) el.innerHTML = _renderBoatCursorSvg(hdg, cog);
+  if (_followBoat && _map) {
+    // animate:false — we may be ticking at 10 Hz, animation would thrash
+    _map.panTo(latLng, {animate: false});
+  }
+}
+
+// Render the boat cursor SVG. The hull is a simplified triangle that
+// rotates with heading so the bow points the way the boat is pointing.
+// A second line extending from the center shows COG, so the offset
+// between heading and COG (leeway, current) is visible at a glance.
+function _renderBoatCursorSvg(hdg, cog) {
+  const hasHdg = hdg != null && !isNaN(hdg);
+  const hasCog = cog != null && !isNaN(cog);
+  const hdgDeg = hasHdg ? hdg : 0;
+  // SVG 0° points up (north) because we use -y for the bow, matching
+  // geographic bearing conventions. viewBox is centered on the anchor.
+  let parts = '<svg width="40" height="40" viewBox="-20 -20 40 40" style="overflow:visible;pointer-events:none">';
+  // COG line (red, slightly longer) — drawn first so it sits under the hull
+  if (hasCog) {
+    parts += '<line x1="0" y1="0" x2="0" y2="-19" stroke="#ef4444" stroke-width="2" stroke-linecap="round" transform="rotate(' + cog + ')"/>';
+  }
+  // Heading line (yellow, stops at bow)
+  if (hasHdg) {
+    parts += '<line x1="0" y1="0" x2="0" y2="-16" stroke="#facc15" stroke-width="2" stroke-linecap="round" transform="rotate(' + hdgDeg + ')"/>';
+  }
+  // Hull — thin triangle, bow at top, stern at bottom, rotated to heading
+  parts += '<polygon points="0,-10 5,7 -5,7" fill="#facc15" stroke="#1f2937" stroke-width="1" stroke-linejoin="round" transform="rotate(' + hdgDeg + ')"/>';
+  parts += '</svg>';
+  return parts;
 }
 
 function _indexForUtc(utcDate) {
@@ -4753,6 +4802,7 @@ let _replaySamples = null; // [{ts: Date, stw, sog, tws, twa, aws, awa, hdg, cog
 let _replayGrades = null;  // [{t_start, t_end, ..., grade}]
 let _gradeSegments = []; // [L.polyline] overlays when polar view is active
 let _gradeViewActive = false;
+let _followBoat = false;  // when true, map re-centers on the boat each tick
 
 const _GRADE_COLORS = {
   red: '#d64545',
@@ -5057,6 +5107,17 @@ function _wireReplayControls() {
   }
   const toggle = document.getElementById('toggle-polar-grades');
   if (toggle) toggle.addEventListener('change', (e) => _setGradeViewActive(e.target.checked));
+  const followToggle = document.getElementById('toggle-follow-boat');
+  if (followToggle) followToggle.addEventListener('change', (e) => {
+    _followBoat = !!e.target.checked;
+    // Snap to the current position immediately when enabled so the user
+    // doesn't have to wait for the next tick.
+    if (_followBoat && _trackData && _playClock.positionUtc) {
+      const idx = _indexForUtc(_playClock.positionUtc);
+      const latLng = _trackData.latLngs[idx];
+      if (latLng && _map) _map.panTo(latLng, {animate: true});
+    }
+  });
 
   // Keyboard shortcuts: space toggles play, arrows seek ±5s
   document.addEventListener('keydown', (e) => {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1794,6 +1794,19 @@ function loadAudio() {
   // A "large jump" (>2 s away) is treated as a user click, so we pause any
   // currently-playing audio: it's distracting to have audio keep going from
   // a new spot just because the user clicked somewhere on the page.
+  // Track the most recently requested local position. Setting currentTime
+  // on a still-loading <audio> element is silently dropped by the browser,
+  // so we re-apply the target on 'loadedmetadata' and 'play' to guarantee
+  // the user's scrub lands when playback actually starts.
+  let _audioTargetLocal = null;
+  const _applyAudioTarget = () => {
+    if (_audioTargetLocal == null) return;
+    if (el.duration && _audioTargetLocal > el.duration) return;
+    if (Math.abs(el.currentTime - _audioTargetLocal) < 0.15) return;
+    try { el.currentTime = _audioTargetLocal; } catch (e) { /* not seekable yet */ }
+  };
+  el.addEventListener('loadedmetadata', _applyAudioTarget);
+
   registerSurface('audio', function(utc) {
     // NB: setting el.currentTime on a paused audio element is safe — it
     // doesn't start playback — so unlike the video consumer we don't need
@@ -1802,6 +1815,7 @@ function loadAudio() {
     // listening to it.
     const local = utcToAudioLocal(utc);
     if (local < 0 || (el.duration && local > el.duration)) return;
+    _audioTargetLocal = local;
     const delta = Math.abs(el.currentTime - local);
     if (delta < 0.15) return; // already there
     if (delta > _LARGE_JUMP_SEC && !el.paused) {
@@ -1828,6 +1842,10 @@ function loadAudio() {
   // replay play button. Fanout via timeupdate is enough to keep the map
   // cursor and gauges tracking while WAV plays on its own.
   el.addEventListener('play', function() {
+    // Re-apply any pending target seek first — if the user scrubbed before
+    // metadata loaded, the original currentTime= assignment may have been
+    // dropped, and we'd otherwise start playback from 0:00.
+    _applyAudioTarget();
     setPosition(audioLocalToUtc(el.currentTime), {source: 'audio'});
   });
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -383,7 +383,13 @@ async function loadTrack() {
   const latLngs = coords.map(c => [c[1], c[0]]);
   const timestamps = rawTimestamps.map(t => new Date(t.endsWith('Z') || t.includes('+') ? t : t + 'Z'));
   const trackColor = cssVar('--accent-strong');
-  const line = L.polyline(latLngs, {color: trackColor, weight: 4}).addTo(_map);
+  const line = L.polyline(latLngs, {
+    color: trackColor,
+    weight: 3,
+    opacity: 1,
+    lineCap: 'round',
+    lineJoin: 'round',
+  }).addTo(_map);
 
   const successColor = cssVar('--success');
   const dangerColor = cssVar('--danger');
@@ -400,8 +406,8 @@ async function loadTrack() {
   const cursorIcon = L.divIcon({
     className: 'boat-cursor',
     html: _renderBoatCursorSvg(0, 0),
-    iconSize: [40, 40],
-    iconAnchor: [20, 20],
+    iconSize: [64, 64],
+    iconAnchor: [32, 32],
   });
   const cursor = L.marker([0, 0], {icon: cursorIcon, interactive: false});
 
@@ -790,19 +796,26 @@ function _renderBoatCursorSvg(hdg, cog) {
   const hasHdg = hdg != null && !isNaN(hdg);
   const hasCog = cog != null && !isNaN(cog);
   const hdgDeg = hasHdg ? hdg : 0;
-  // SVG 0° points up (north) because we use -y for the bow, matching
-  // geographic bearing conventions. viewBox is centered on the anchor.
-  let parts = '<svg width="40" height="40" viewBox="-20 -20 40 40" style="overflow:visible;pointer-events:none">';
-  // COG line (red, slightly longer) — drawn first so it sits under the hull
+  // Larger viewBox so the indicator lines can extend well beyond the hull
+  // and read clearly against the track without being clipped.
+  let parts = '<svg width="64" height="64" viewBox="-32 -32 64 64" style="overflow:visible;pointer-events:none">';
+  // COG line (red) — drawn first so it sits under the hull. Doubled up
+  // with a dark halo stroke so it pops against any map background.
   if (hasCog) {
-    parts += '<line x1="0" y1="0" x2="0" y2="-19" stroke="#ef4444" stroke-width="2" stroke-linecap="round" transform="rotate(' + cog + ')"/>';
+    parts += '<g transform="rotate(' + cog + ')">';
+    parts += '<line x1="0" y1="0" x2="0" y2="-30" stroke="#000" stroke-opacity="0.55" stroke-width="6" stroke-linecap="round"/>';
+    parts += '<line x1="0" y1="0" x2="0" y2="-30" stroke="#ef4444" stroke-width="3.5" stroke-linecap="round"/>';
+    parts += '</g>';
   }
-  // Heading line (yellow, stops at bow)
+  // Heading line (yellow) — same halo treatment.
   if (hasHdg) {
-    parts += '<line x1="0" y1="0" x2="0" y2="-16" stroke="#facc15" stroke-width="2" stroke-linecap="round" transform="rotate(' + hdgDeg + ')"/>';
+    parts += '<g transform="rotate(' + hdgDeg + ')">';
+    parts += '<line x1="0" y1="0" x2="0" y2="-26" stroke="#000" stroke-opacity="0.55" stroke-width="6" stroke-linecap="round"/>';
+    parts += '<line x1="0" y1="0" x2="0" y2="-26" stroke="#facc15" stroke-width="3.5" stroke-linecap="round"/>';
+    parts += '</g>';
   }
   // Hull — thin triangle, bow at top, stern at bottom, rotated to heading
-  parts += '<polygon points="0,-10 5,7 -5,7" fill="#facc15" stroke="#1f2937" stroke-width="1" stroke-linejoin="round" transform="rotate(' + hdgDeg + ')"/>';
+  parts += '<polygon points="0,-11 6,8 -6,8" fill="#facc15" stroke="#1f2937" stroke-width="1.25" stroke-linejoin="round" transform="rotate(' + hdgDeg + ')"/>';
   parts += '</svg>';
   return parts;
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -396,14 +396,12 @@ async function loadTrack() {
   // cursor continues to interpolate against the raw latLngs so the
   // boat position itself isn't lagged by the smoothing.
   const trackColor = cssVar('--warning') || '#fbbf24';
-  // The SK positions table is ~10 Hz, vs Vakaros at 1 Hz — the dense
-  // vertex count is what makes the SK dashes render as chevrons at
-  // zoom. Decimate to ~1 Hz for display (keeps Vakaros-like vertex
-  // density) and match the Vakaros dash style so the two tracks read
-  // the same way. Raw latLngs stay on _trackData.latLngs for the
-  // cursor so playback position isn't decimated.
-  const smoothedLatLngs = _decimateLatLngs(latLngs, timestamps, 1000);
-  const line = L.polyline(smoothedLatLngs, {
+  // The /track endpoint now returns 1 Hz mean-averaged positions (one
+  // row per second across all GPS sources), so we don't need any
+  // frontend smoothing or decimation — the polyline already matches
+  // Vakaros's vertex density. Just style it with the same dash pattern
+  // so the two tracks read the same way.
+  const line = L.polyline(latLngs, {
     color: trackColor,
     weight: 3,
     opacity: 0.9,
@@ -432,7 +430,7 @@ async function loadTrack() {
   });
   const cursor = L.marker([0, 0], {icon: cursorIcon, interactive: false});
 
-  _trackData = {latLngs, displayLatLngs: smoothedLatLngs, timestamps, line, cursor};
+  _trackData = {latLngs, timestamps, line, cursor};
 
   // Map is a consumer: render the cursor at the requested UTC. We use a
   // continuous interpolated position (not the nearest sample index) so the
@@ -689,47 +687,6 @@ function _nearestIndex(latlng) {
     if (d < minDist) { minDist = d; nearIdx = i; }
   }
   return nearIdx;
-}
-
-// Decimate a lat/lng series by timestamp so we keep at most one point
-// per intervalMs. Always keeps the first and last points so the polyline
-// still covers the full extent of the GPS track.
-function _decimateLatLngs(latLngs, timestamps, intervalMs) {
-  if (!latLngs || latLngs.length < 2) return latLngs || [];
-  if (!timestamps || timestamps.length !== latLngs.length) return latLngs;
-  const out = [latLngs[0]];
-  let lastT = timestamps[0].getTime();
-  for (let i = 1; i < latLngs.length - 1; i++) {
-    const t = timestamps[i].getTime();
-    if (t - lastT >= intervalMs) {
-      out.push(latLngs[i]);
-      lastT = t;
-    }
-  }
-  out.push(latLngs[latLngs.length - 1]);
-  return out;
-}
-
-// Centered moving average over lat/lng arrays. half=2 means a 5-point
-// window (i-2..i+2). Leaves the first/last few points progressively less
-// smoothed rather than chopping them off, so the polyline still covers
-// the full extent of the GPS track.
-function _smoothLatLngs(latLngs, half) {
-  if (!latLngs || latLngs.length < 3) return latLngs || [];
-  const out = new Array(latLngs.length);
-  const n = latLngs.length;
-  for (let i = 0; i < n; i++) {
-    const lo = Math.max(0, i - half);
-    const hi = Math.min(n - 1, i + half);
-    let sLat = 0, sLng = 0, c = 0;
-    for (let j = lo; j <= hi; j++) {
-      sLat += latLngs[j][0];
-      sLng += latLngs[j][1];
-      c++;
-    }
-    out[i] = [sLat / c, sLng / c];
-  }
-  return out;
 }
 
 function _moveCursorToIndex(idx) {
@@ -5201,9 +5158,6 @@ function _drawGradeSegments() {
   // top of the base track. We walk the sample positions and mark each one
   // with the grade that covers it, then coalesce consecutive same-grade runs.
   const timestamps = _trackData.timestamps;
-  // Grade overlay walks positions in lockstep with timestamps, so we need
-  // the raw (non-decimated) latLngs — displayLatLngs has been thinned to
-  // 1 Hz for the base polyline and would lose alignment here.
   const latLngs = _trackData.latLngs;
   if (!timestamps || timestamps.length < 2) return;
   const gradesAtIdx = new Array(timestamps.length);

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -396,14 +396,20 @@ async function loadTrack() {
   // cursor continues to interpolate against the raw latLngs so the
   // boat position itself isn't lagged by the smoothing.
   const trackColor = cssVar('--warning') || '#fbbf24';
-  const smoothedLatLngs = _smoothLatLngs(latLngs, 2);
+  // Heavy centered moving average (~15s window at 1 Hz GPS) to kill the
+  // sawtooth produced by 1 Hz sample noise + dash stroking. Combined
+  // with a higher Leaflet smoothFactor to drop near-collinear vertices
+  // during projection so the SVG path is short and the dashes walk
+  // cleanly along gentle curves instead of chevroning at every fix.
+  const smoothedLatLngs = _smoothLatLngs(latLngs, 7);
   const line = L.polyline(smoothedLatLngs, {
     color: trackColor,
     weight: 3,
     opacity: 1,
     lineCap: 'butt',
-    lineJoin: 'miter',
+    lineJoin: 'round',
     dashArray: '6, 6',
+    smoothFactor: 2.0,
   }).addTo(_map);
 
   const successColor = cssVar('--success');

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -783,7 +783,13 @@ function _onVideoReady() {
         currentOffset = _videoSync.player.getCurrentTime();
       }
     } catch (e) { /* swallow */ }
-    if (currentOffset != null && Math.abs(currentOffset - offset) > _LARGE_JUMP_SEC) {
+    const delta = currentOffset != null ? Math.abs(currentOffset - offset) : Infinity;
+    // While the clock tick is driving playback, the render callback fires at
+    // ~10 Hz. Issuing seekTo() on every tick for small deltas (<0.5s) causes
+    // the YouTube embed to stutter — the player is constantly re-buffering
+    // instead of playing. Skip small corrections and let YT run naturally.
+    if (delta < 0.5) return;
+    if (delta > _LARGE_JUMP_SEC) {
       try {
         const state = typeof _videoSync.player.getPlayerState === 'function'
           ? _videoSync.player.getPlayerState() : -1;
@@ -847,7 +853,11 @@ function _onPlayerStateChange(event) {
     _syncTimer = setInterval(_videoTick, 500);
   } else {
     _stopSyncTimer();
-    _videoTick();
+    // Deliberately do NOT call _videoTick() here: every YT state change
+    // (paused, buffering, cued) would otherwise overwrite _playClock.positionUtc
+    // with YT's getCurrentTime(), which during a scrub can still be 0 or an
+    // old offset and snaps the progress bar/cursor backward. _videoTick only
+    // makes sense while YT is actually playing and driving the clock.
   }
 }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -80,10 +80,19 @@ function setPosition(utc, opts) {
   _playClock.tickAnchorUtc = date;
   _playClock.tickAnchorPerf = _clockNowMs();
   const source = (opts && opts.source) || null;
+  // Stash source so individual consumers can decide whether this producer
+  // should drive them. In particular, playback-bearing consumers (video,
+  // audio, mc) use this to avoid seeking one player when a different player
+  // is the one producing updates — e.g. WAV play must not start YT.
+  _playClock.currentSource = source;
   for (const c of _playClock.consumers) {
     if (c.name === source) continue; // don't echo back to producer
     try { c.render(date); } catch (e) { /* never let one surface break others */ }
   }
+  _playClock.currentSource = null;
+  // Keep the replay scrubber + time label in sync with producer events
+  // (YT scrub, WAV scrub) — otherwise only clock-driven ticks update them.
+  try { _updateReplayControls(); } catch (e) { /* not yet wired */ }
 }
 
 function _isEchoEvent() {
@@ -802,6 +811,9 @@ function _onVideoReady() {
   // wherever the user just clicked. Small deltas (playback ticks) don't
   // touch playback state.
   registerSurface('video', function(utc) {
+    // Playback independence: don't seek YT just because another player's
+    // producer fanout reached us. Let WAV/mc play on their own.
+    if (_playClock.currentSource === 'audio' || _playClock.currentSource === 'mc') return;
     if (!_videoSync || !_videoSync.player || !_videoSync.player.seekTo) return;
     const offset = _utcToVideoOffset(utc);
     if (offset === null || offset < 0) return;
@@ -855,12 +867,11 @@ function switchVideo(idx) {
 function _onPlayerStateChange(event) {
   // YT.PlayerState.PLAYING = 1, PAUSED = 2, ENDED = 0, BUFFERING = 3
   if (event.data === 1) {
-    // If the playback clock is paused (user is scrubbing, nothing has been
-    // explicitly played) but the YT embed decided to start on its own — e.g.
-    // because a seekTo resumed playback — clamp it back down immediately so
-    // the video can't escape our paused state. Without this the video keeps
-    // running through every scrub and stepping on the rest of the surfaces.
-    if (_playClock.state !== 'playing') {
+    // If we're inside the echo window from a recent programmatic seek,
+    // clamp YT back to paused — a scrub just drove seekTo() and the embed
+    // is trying to auto-resume out from under us. Outside the echo window
+    // this is a user-initiated play and we leave it alone.
+    if (_isEchoEvent()) {
       try {
         if (typeof _videoSync.player.pauseVideo === 'function') {
           _videoSync.player.pauseVideo();
@@ -869,16 +880,9 @@ function _onPlayerStateChange(event) {
       return;
     }
     _stopSyncTimer();
-    // Treat YT play as a producer: anchor the clock to the current video time
-    if (typeof _videoSync.player.getCurrentTime === 'function') {
-      const utc = _videoOffsetToUtc(_videoSync.player.getCurrentTime());
-      if (utc) {
-        _playClock.positionUtc = utc;
-        // Don't fire echo to video — but other surfaces should follow
-        setPosition(utc, {source: 'video'});
-      }
-    }
-    // Drive a 2 Hz tick from the YT player so map/transcript follow during play
+    // YT plays independently — drive a 2 Hz fanout so the map cursor, gauges,
+    // and track scrubber follow along. Do NOT start the replay clock tick;
+    // replay 'playing' state is reserved for the track replay play button.
     _syncTimer = setInterval(_videoTick, 500);
   } else {
     _stopSyncTimer();
@@ -897,14 +901,14 @@ function _stopSyncTimer() {
 function _videoTick() {
   if (!_videoSync || !_videoSync.player) return;
   if (typeof _videoSync.player.getCurrentTime !== 'function') return;
+  // The replay clock is master when it's playing — let its tick drive the
+  // surfaces instead of YT so the rates don't fight each other.
+  if (_playClock.state === 'playing') return;
   const utc = _videoOffsetToUtc(_videoSync.player.getCurrentTime());
   if (!utc) return;
-  // Treat as a non-seek update: update other surfaces but not the video itself
-  _playClock.positionUtc = utc;
-  for (const c of _playClock.consumers) {
-    if (c.name === 'video') continue;
-    try { c.render(utc); } catch (e) { /* swallow */ }
-  }
+  // Fan out through setPosition so the track scrubber and gauges update too.
+  // source='video' keeps the video consumer itself out of the loop (no echo).
+  setPosition(utc, {source: 'video'});
 }
 
 // Convert video playback seconds → UTC
@@ -1791,6 +1795,10 @@ function loadAudio() {
   // currently-playing audio: it's distracting to have audio keep going from
   // a new spot just because the user clicked somewhere on the page.
   registerSurface('audio', function(utc) {
+    // Playback independence: if a different player is producing updates,
+    // don't move this player's playhead. Scrubs via replay/map/etc still
+    // seek audio so the preview stays in sync with the cursor.
+    if (_playClock.currentSource === 'video' || _playClock.currentSource === 'mc') return;
     const local = utcToAudioLocal(utc);
     if (local < 0 || (el.duration && local > el.duration)) return;
     const delta = Math.abs(el.currentTime - local);
@@ -1814,12 +1822,12 @@ function loadAudio() {
   };
   el.addEventListener('seeked', _fanout);
   el.addEventListener('timeupdate', _fanout);
+  // The WAV player plays independently — it is NOT allowed to drive the
+  // replay clock's 'playing' state. The clock is reserved for the track
+  // replay play button. Fanout via timeupdate is enough to keep the map
+  // cursor and gauges tracking while WAV plays on its own.
   el.addEventListener('play', function() {
     setPosition(audioLocalToUtc(el.currentTime), {source: 'audio'});
-    _startPlayTick();
-  });
-  el.addEventListener('pause', function() {
-    _stopPlayTick();
   });
 }
 
@@ -1992,10 +2000,26 @@ function _mcUpdateProgress() {
   time.textContent = `${fmt(t)} / ${fmt(_mcBuffer.duration)}`;
 }
 
+let _mcFanoutLast = 0;
 function _mcStartProgressTick() {
   _mcStopProgressTick();
   const tick = () => {
     _mcUpdateProgress();
+    // Throttled producer fanout: while mc is playing, push the current
+    // playhead out as a source='mc' update so the map cursor, gauges, and
+    // replay scrubber track along. 150 ms matches the existing audio
+    // fanout cadence.
+    const now = _clockNowMs();
+    if (_mcIsPlaying && now - _mcFanoutLast >= 150) {
+      _mcFanoutLast = now;
+      const anchor = _mcSessionStart();
+      if (anchor) {
+        setPosition(
+          new Date(anchor.getTime() + _mcCurrentTime() * 1000),
+          {source: 'mc'},
+        );
+      }
+    }
     if (_mcIsPlaying) _mcRafHandle = requestAnimationFrame(tick);
   };
   _mcRafHandle = requestAnimationFrame(tick);
@@ -2094,6 +2118,9 @@ async function loadMultiChannelAudio() {
   // the mc seek bar and start offset. Skipped while playing (avoid fighting
   // natural playback) and while the user is actively dragging the slider.
   registerSurface('mc', function(utc) {
+    // Playback independence: leave mc alone when a different player drives
+    // the update. Only replay/map/scrub-style sources should move mc.
+    if (_playClock.currentSource === 'video' || _playClock.currentSource === 'audio') return;
     if (!_mcBuffer) return;
     const anchor = _mcSessionStart();
     if (!anchor) return;
@@ -4883,6 +4910,16 @@ function _togglePlayPause() {
   if (_playClock.state === 'playing') {
     _stopPlayTick();
   } else {
+    // Pause any WAV / multi-channel audio before the clock starts — the
+    // user wants the track replay play button to drive the map/video
+    // preview, not audio. YT is intentionally left running so it keeps
+    // providing a visual preview while the replay scrubs it.
+    try {
+      const aEl = document.getElementById('session-audio')
+        || document.querySelector('#audio-body audio');
+      if (aEl && !aEl.paused) aEl.pause();
+    } catch (e) { /* swallow */ }
+    try { if (typeof _mcIsPlaying !== 'undefined' && _mcIsPlaying) _mcPause(); } catch (e) { /* swallow */ }
     if (!_playClock.positionUtc) _playClock.positionUtc = _replayStart;
     // If at (or past) the end, restart from the beginning
     if (_replayEnd && _playClock.positionUtc.getTime() >= _replayEnd.getTime()) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -820,6 +820,19 @@ function switchVideo(idx) {
 function _onPlayerStateChange(event) {
   // YT.PlayerState.PLAYING = 1, PAUSED = 2, ENDED = 0, BUFFERING = 3
   if (event.data === 1) {
+    // If the playback clock is paused (user is scrubbing, nothing has been
+    // explicitly played) but the YT embed decided to start on its own — e.g.
+    // because a seekTo resumed playback — clamp it back down immediately so
+    // the video can't escape our paused state. Without this the video keeps
+    // running through every scrub and stepping on the rest of the surfaces.
+    if (_playClock.state !== 'playing') {
+      try {
+        if (typeof _videoSync.player.pauseVideo === 'function') {
+          _videoSync.player.pauseVideo();
+        }
+      } catch (e) { /* swallow */ }
+      return;
+    }
     _stopSyncTimer();
     // Treat YT play as a producer: anchor the clock to the current video time
     if (typeof _videoSync.player.getCurrentTime === 'function') {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -389,8 +389,15 @@ async function loadTrack() {
   // different cycle lengths prevent consistent overlap and the different
   // dash sizes read clearly even where they briefly coincide. Butt caps
   // keep the dashes sharply rectangular for that "super crisp" look.
+  //
+  // The polyline is drawn from a moving-average smoothed copy of the
+  // GPS samples. Raw 1 Hz fixes are noisy enough that the line looks
+  // fuzzy when zoomed in (see the user report of a wavy track). The
+  // cursor continues to interpolate against the raw latLngs so the
+  // boat position itself isn't lagged by the smoothing.
   const trackColor = cssVar('--warning') || '#fbbf24';
-  const line = L.polyline(latLngs, {
+  const smoothedLatLngs = _smoothLatLngs(latLngs, 2);
+  const line = L.polyline(smoothedLatLngs, {
     color: trackColor,
     weight: 3,
     opacity: 1,
@@ -419,7 +426,7 @@ async function loadTrack() {
   });
   const cursor = L.marker([0, 0], {icon: cursorIcon, interactive: false});
 
-  _trackData = {latLngs, timestamps, line, cursor};
+  _trackData = {latLngs, displayLatLngs: smoothedLatLngs, timestamps, line, cursor};
 
   // Map is a consumer: render the cursor at the requested UTC. We use a
   // continuous interpolated position (not the nearest sample index) so the
@@ -676,6 +683,28 @@ function _nearestIndex(latlng) {
     if (d < minDist) { minDist = d; nearIdx = i; }
   }
   return nearIdx;
+}
+
+// Centered moving average over lat/lng arrays. half=2 means a 5-point
+// window (i-2..i+2). Leaves the first/last few points progressively less
+// smoothed rather than chopping them off, so the polyline still covers
+// the full extent of the GPS track.
+function _smoothLatLngs(latLngs, half) {
+  if (!latLngs || latLngs.length < 3) return latLngs || [];
+  const out = new Array(latLngs.length);
+  const n = latLngs.length;
+  for (let i = 0; i < n; i++) {
+    const lo = Math.max(0, i - half);
+    const hi = Math.min(n - 1, i + half);
+    let sLat = 0, sLng = 0, c = 0;
+    for (let j = lo; j <= hi; j++) {
+      sLat += latLngs[j][0];
+      sLng += latLngs[j][1];
+      c++;
+    }
+    out[i] = [sLat / c, sLng / c];
+  }
+  return out;
 }
 
 function _moveCursorToIndex(idx) {
@@ -5147,7 +5176,9 @@ function _drawGradeSegments() {
   // top of the base track. We walk the sample positions and mark each one
   // with the grade that covers it, then coalesce consecutive same-grade runs.
   const timestamps = _trackData.timestamps;
-  const latLngs = _trackData.latLngs;
+  // Use the smoothed display path so the colored grade segments inherit
+  // the same crisp line the base polyline uses.
+  const latLngs = _trackData.displayLatLngs || _trackData.latLngs;
   if (!timestamps || timestamps.length < 2) return;
   const gradesAtIdx = new Array(timestamps.length);
   for (let i = 0; i < timestamps.length; i++) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -396,20 +396,20 @@ async function loadTrack() {
   // cursor continues to interpolate against the raw latLngs so the
   // boat position itself isn't lagged by the smoothing.
   const trackColor = cssVar('--warning') || '#fbbf24';
-  // Heavy centered moving average (~15s window at 1 Hz GPS) to kill the
-  // sawtooth produced by 1 Hz sample noise + dash stroking. Combined
-  // with a higher Leaflet smoothFactor to drop near-collinear vertices
-  // during projection so the SVG path is short and the dashes walk
-  // cleanly along gentle curves instead of chevroning at every fix.
-  const smoothedLatLngs = _smoothLatLngs(latLngs, 7);
+  // The SK positions table is ~10 Hz, vs Vakaros at 1 Hz — the dense
+  // vertex count is what makes the SK dashes render as chevrons at
+  // zoom. Decimate to ~1 Hz for display (keeps Vakaros-like vertex
+  // density) and match the Vakaros dash style so the two tracks read
+  // the same way. Raw latLngs stay on _trackData.latLngs for the
+  // cursor so playback position isn't decimated.
+  const smoothedLatLngs = _decimateLatLngs(latLngs, timestamps, 1000);
   const line = L.polyline(smoothedLatLngs, {
     color: trackColor,
     weight: 3,
-    opacity: 1,
+    opacity: 0.9,
     lineCap: 'butt',
-    lineJoin: 'round',
-    dashArray: '6, 6',
-    smoothFactor: 2.0,
+    lineJoin: 'miter',
+    dashArray: '2, 4',
   }).addTo(_map);
 
   const successColor = cssVar('--success');
@@ -689,6 +689,25 @@ function _nearestIndex(latlng) {
     if (d < minDist) { minDist = d; nearIdx = i; }
   }
   return nearIdx;
+}
+
+// Decimate a lat/lng series by timestamp so we keep at most one point
+// per intervalMs. Always keeps the first and last points so the polyline
+// still covers the full extent of the GPS track.
+function _decimateLatLngs(latLngs, timestamps, intervalMs) {
+  if (!latLngs || latLngs.length < 2) return latLngs || [];
+  if (!timestamps || timestamps.length !== latLngs.length) return latLngs;
+  const out = [latLngs[0]];
+  let lastT = timestamps[0].getTime();
+  for (let i = 1; i < latLngs.length - 1; i++) {
+    const t = timestamps[i].getTime();
+    if (t - lastT >= intervalMs) {
+      out.push(latLngs[i]);
+      lastT = t;
+    }
+  }
+  out.push(latLngs[latLngs.length - 1]);
+  return out;
 }
 
 // Centered moving average over lat/lng arrays. half=2 means a 5-point
@@ -5182,9 +5201,10 @@ function _drawGradeSegments() {
   // top of the base track. We walk the sample positions and mark each one
   // with the grade that covers it, then coalesce consecutive same-grade runs.
   const timestamps = _trackData.timestamps;
-  // Use the smoothed display path so the colored grade segments inherit
-  // the same crisp line the base polyline uses.
-  const latLngs = _trackData.displayLatLngs || _trackData.latLngs;
+  // Grade overlay walks positions in lockstep with timestamps, so we need
+  // the raw (non-decimated) latLngs — displayLatLngs has been thinned to
+  // 1 Hz for the base polyline and would lose alignment here.
+  const latLngs = _trackData.latLngs;
   if (!timestamps || timestamps.length < 2) return;
   const gradesAtIdx = new Array(timestamps.length);
   for (let i = 0; i < timestamps.length; i++) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -767,7 +767,36 @@ function _openWatchOnYoutube(ev) {
   return false;
 }
 
+// Watchdog for user scrubs on the YT player itself. The IFrame API doesn't
+// emit a "seeked" event, so we poll getCurrentTime() while the clock is not
+// in playing state and fan out any unexpected jump as a producer event.
+// Disabled during clock-driven playback because fast speeds (2×/4×/8×) would
+// otherwise read as "seeks" on every poll.
+let _ytScrubPollTimer = null;
+let _ytScrubLastOffset = null;
+function _startYtScrubWatch() {
+  if (_ytScrubPollTimer) return;
+  _ytScrubPollTimer = setInterval(() => {
+    if (!_videoSync || !_videoSync.player) return;
+    if (_playClock.state === 'playing') return;
+    if (_isEchoEvent()) return;
+    let cur;
+    try { cur = _videoSync.player.getCurrentTime(); } catch (e) { return; }
+    if (cur == null || isNaN(cur)) return;
+    if (_ytScrubLastOffset == null) { _ytScrubLastOffset = cur; return; }
+    const delta = Math.abs(cur - _ytScrubLastOffset);
+    _ytScrubLastOffset = cur;
+    // Threshold > max natural drift between polls. YT paused shouldn't move
+    // at all, so anything above 0.4s is a user-initiated scrub.
+    if (delta < 0.4) return;
+    const utc = _videoOffsetToUtc(cur);
+    if (!utc) return;
+    setPosition(utc, {source: 'video'});
+  }, 250);
+}
+
 function _onVideoReady() {
+  _startYtScrubWatch();
   // Video is a consumer: seek to the requested UTC if it's within range.
   // Large jumps (>2 s) pause the player so audio doesn't keep playing from
   // wherever the user just clicked. Small deltas (playback ticks) don't
@@ -2061,6 +2090,23 @@ async function loadMultiChannelAudio() {
     console.error('multi-channel audio load failed', e);
     document.getElementById('mc-status').textContent = 'Error: ' + e.message;
   }
+  // Register mc as a clock consumer so scrubs/seeks from other surfaces move
+  // the mc seek bar and start offset. Skipped while playing (avoid fighting
+  // natural playback) and while the user is actively dragging the slider.
+  registerSurface('mc', function(utc) {
+    if (!_mcBuffer) return;
+    const anchor = _mcSessionStart();
+    if (!anchor) return;
+    const seconds = (utc.getTime() - anchor.getTime()) / 1000;
+    if (seconds < 0 || seconds > _mcBuffer.duration) return;
+    if (_mcIsPlaying) return;
+    const seek = document.getElementById('mc-seek');
+    if (seek && document.activeElement === seek) return;
+    const delta = Math.abs((_mcStartOffset || 0) - seconds);
+    if (delta < 0.15) return;
+    _mcStartOffset = seconds;
+    _mcUpdateProgress();
+  });
 }
 
 function _mcTogglePlay() {
@@ -2071,7 +2117,24 @@ function _mcTogglePlay() {
 
 function _mcSeekFromSlider(val) {
   if (!_mcBuffer) return;
-  _mcSeek((Number(val) / 1000) * _mcBuffer.duration);
+  const seconds = (Number(val) / 1000) * _mcBuffer.duration;
+  _mcSeek(seconds);
+  // Producer: fan out to every other surface (map cursor, video, gauges)
+  // so dragging the Web Audio scrubber keeps everything in sync. Skipped
+  // when we can't derive a session-wide UTC anchor.
+  const anchor = _mcSessionStart();
+  if (anchor) setPosition(new Date(anchor.getTime() + seconds * 1000), {source: 'mc'});
+}
+
+// Resolve the session-wide UTC anchor for the multi-channel buffer. The
+// buffer is keyed to _session.audio_start_utc (same reference the transcript
+// highlighter uses), normalized to UTC regardless of how the backend wrote it.
+function _mcSessionStart() {
+  if (!_session || !_session.audio_start_utc) return null;
+  const raw = _session.audio_start_utc;
+  const iso = raw.endsWith('Z') || raw.includes('+') ? raw : raw + 'Z';
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
 }
 
 function _mcToggleSticky(on) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -407,12 +407,14 @@ async function loadTrack() {
 
   _trackData = {latLngs, timestamps, line, cursor};
 
-  // Map is a consumer: render the cursor at the requested UTC
+  // Map is a consumer: render the cursor at the requested UTC. We use a
+  // continuous interpolated position (not the nearest sample index) so the
+  // boat glides along the polyline instead of stepping between fixes — the
+  // stepping was especially visible at 8x replay.
   registerSurface('map', function(utc) {
     if (!_trackData) return;
-    const idx = _indexForUtc(utc);
-    _moveCursorToIndex(idx);
-    _updateBoatSettingsForUtc(_utcForIndex(idx));
+    _moveCursorToUtc(utc);
+    _updateBoatSettingsForUtc(utc);
   });
 
   // Click track → seek the playback clock (which then seeks video, audio, etc.)
@@ -657,22 +659,57 @@ function _nearestIndex(latlng) {
 
 function _moveCursorToIndex(idx) {
   if (!_trackData) return;
-  const latLng = _trackData.latLngs[idx];
-  _trackData.cursor.setLatLng(latLng).addTo(_map);
-  // Read HDG/COG from the replay sample closest to the cursor timestamp,
-  // then smooth across a ±5s window so the icon doesn't twitch with every
-  // 1 Hz sample. Circular mean via sin/cos so values near 0°/360° wrap
-  // cleanly instead of averaging to 180°.
-  let hdg = null, cog = null;
   const ts = _trackData.timestamps[idx];
   if (ts) {
-    const windowed = _windowedHeadingCog(ts.getTime(), 5000);
-    hdg = windowed.hdg;
-    cog = windowed.cog;
+    _moveCursorToUtc(ts);
+  } else {
+    _trackData.cursor.setLatLng(_trackData.latLngs[idx]).addTo(_map);
   }
+}
+
+// Interpolated cursor: finds the two bracketing GPS samples for the
+// requested UTC and lerps lat/lng between them, so the boat glides
+// continuously along the polyline. Rotation is still circular-meaned
+// across a ±5s window to damp HDG/COG noise.
+function _moveCursorToUtc(utc) {
+  if (!_trackData) return;
+  const {latLngs, timestamps} = _trackData;
+  if (!latLngs.length) return;
+  const tMs = utc.getTime();
+  // Bracket the timestamps
+  let hi = _trackLowerBound(tMs);
+  if (hi <= 0) { hi = 1; }
+  if (hi >= timestamps.length) { hi = timestamps.length - 1; }
+  const lo = hi - 1;
+  const t0 = timestamps[lo].getTime();
+  const t1 = timestamps[hi].getTime();
+  let frac = t1 > t0 ? (tMs - t0) / (t1 - t0) : 0;
+  if (frac < 0) frac = 0; else if (frac > 1) frac = 1;
+  const a = latLngs[lo];
+  const b = latLngs[hi];
+  const lat = a[0] + (b[0] - a[0]) * frac;
+  const lng = a[1] + (b[1] - a[1]) * frac;
+  const interp = [lat, lng];
+  _trackData.cursor.setLatLng(interp).addTo(_map);
+
+  const windowed = _windowedHeadingCog(tMs, 5000);
   const el = _trackData.cursor.getElement();
-  if (el) el.innerHTML = _renderBoatCursorSvg(hdg, cog);
-  if (_followBoat && _map) _maybeFollowPan(latLng);
+  if (el) el.innerHTML = _renderBoatCursorSvg(windowed.hdg, windowed.cog);
+  if (_followBoat && _map) _maybeFollowPan(interp);
+}
+
+// Binary search for the first timestamp index where ts >= tMs. Mirrors
+// the replay-sample helper but operates on the track timestamps array.
+function _trackLowerBound(tMs) {
+  const ts = _trackData && _trackData.timestamps;
+  if (!ts || !ts.length) return 0;
+  let lo = 0, hi = ts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (ts[mid].getTime() < tMs) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
 }
 
 // Circular-mean smoothing of hdg/cog over a window around ts. Returns

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -37,6 +37,38 @@ function registerSurface(name, render) {
   _playClock.consumers.push({name, render});
 }
 
+// Stop every active playback surface (replay tick, YT video, HTML audio element,
+// multi-channel Web Audio) so seeks coming from the scrubber/map/keyboard only
+// move the playhead — the PR review caught that they were stepping on each
+// other and stuttering when multiple surfaces kept playing mid-seek.
+function _pauseAllPlayback() {
+  try { _stopPlayTick(); } catch (e) { /* swallow */ }
+  _playClock.state = 'paused';
+  try {
+    if (_videoSync && _videoSync.player && typeof _videoSync.player.getPlayerState === 'function') {
+      const st = _videoSync.player.getPlayerState();
+      if (st === 1 && typeof _videoSync.player.pauseVideo === 'function') {
+        _videoSync.player.pauseVideo();
+      }
+    }
+  } catch (e) { /* swallow */ }
+  try {
+    const aEl = document.getElementById('session-audio')
+      || document.querySelector('#audio-body audio');
+    if (aEl && !aEl.paused) aEl.pause();
+  } catch (e) { /* swallow */ }
+  try { if (typeof _mcIsPlaying !== 'undefined' && _mcIsPlaying) _mcPause(); } catch (e) { /* swallow */ }
+  try { _updateReplayControls(); } catch (e) { /* not yet wired */ }
+}
+
+// Seek helper used by every "click/drag to move the playhead" entry point —
+// scrubber, map click, keyboard arrows, maneuver table, discussion anchors.
+// Guarantees playback is paused first so nothing auto-resumes after the seek.
+function _seekTo(utc, source) {
+  _pauseAllPlayback();
+  setPosition(utc, {source: source || 'seek'});
+}
+
 function setPosition(utc, opts) {
   if (!utc) return;
   const date = utc instanceof Date ? utc : new Date(utc);
@@ -370,7 +402,7 @@ async function loadTrack() {
   line.on('click', function(e) {
     const idx = _nearestIndex(e.latlng);
     const utc = _utcForIndex(idx);
-    if (utc) setPosition(utc, {source: 'map'});
+    if (utc) _seekTo(utc, 'map');
     // Map producer still updates its own cursor immediately
     _moveCursorToIndex(idx);
   });
@@ -3332,7 +3364,7 @@ function highlightManeuver(idx) {
   // Move map cursor to maneuver position
   if (m && _trackData) {
     const ts = new Date(m.ts.endsWith('Z') || m.ts.includes('+') ? m.ts : m.ts + 'Z');
-    setPosition(ts);
+    _seekTo(ts, 'maneuver');
   }
   // Seek the embedded player to the maneuver moment if a video is loaded.
   if (m && _videoSync && _videoSync.player) {
@@ -3953,7 +3985,7 @@ function seekToThreadAnchor(ts) {
   if (!ts) return;
   const utc = new Date(ts.endsWith('Z') || ts.includes('+') ? ts : ts + 'Z');
   if (isNaN(utc.getTime())) return;
-  setPosition(utc);
+  _seekTo(utc, 'thread');
 }
 
 function _checkThreadHash() {
@@ -4585,7 +4617,7 @@ function _renderIsolationToggle() {
 
 let _replayStart = null; // Date — session start (for scrubber 0)
 let _replayEnd = null;   // Date — session end (for scrubber max)
-let _replaySamples = null; // [{ts: Date, stw, sog, tws, twa, hdg, cog}]
+let _replaySamples = null; // [{ts: Date, stw, sog, tws, twa, aws, awa, hdg, cog}]
 let _replayGrades = null;  // [{t_start, t_end, ..., grade}]
 let _gradeSegments = []; // [L.polyline] overlays when polar view is active
 let _gradeViewActive = false;
@@ -4649,6 +4681,71 @@ function _fmtPct(v) {
   return Math.round(v * 100) + '%';
 }
 
+// Lookback window for each gauge's sparkline — enough context to see trend
+// without dominating the card.
+const _SPARK_LOOKBACK_MS = 5 * 60 * 1000;
+
+// Draw a single-channel sparkline into a canvas. `samples` is the full
+// per-second series; we slice it to the lookback window ending at cursorMs
+// and scale y to the slice's own min/max so small movements are still
+// visible. Returns without touching the canvas when the field is absent
+// so missing sensors fall back to a blank strip rather than a garbage line.
+function _drawSparkline(canvasId, field, cursorMs, color) {
+  const c = document.getElementById(canvasId);
+  if (!c || !_replaySamples || !_replaySamples.length) return;
+  const ctx = c.getContext('2d');
+  // Match backing store to displayed size on first draw / on resize so the
+  // line stays crisp without depending on CSS pixels matching width attrs.
+  const cssW = c.clientWidth || c.width;
+  const cssH = c.clientHeight || c.height;
+  if (c.width !== cssW) c.width = cssW;
+  if (c.height !== cssH) c.height = cssH;
+  const w = c.width;
+  const h = c.height;
+  ctx.clearRect(0, 0, w, h);
+
+  const t1 = cursorMs;
+  const t0 = cursorMs - _SPARK_LOOKBACK_MS;
+  // Collect points within [t0, t1] that have a value for this field
+  const pts = [];
+  for (let i = 0; i < _replaySamples.length; i++) {
+    const s = _replaySamples[i];
+    const t = s.ts.getTime();
+    if (t < t0) continue;
+    if (t > t1) break;
+    const v = s[field];
+    if (v == null || isNaN(v)) continue;
+    pts.push([t, v]);
+  }
+  if (pts.length < 2) return;
+
+  let vmin = Infinity, vmax = -Infinity;
+  for (const [, v] of pts) { if (v < vmin) vmin = v; if (v > vmax) vmax = v; }
+  // Pad the range a touch so flat series don't sit on the edges
+  if (vmax - vmin < 1e-6) { vmax = vmin + 1; }
+  const pad = (vmax - vmin) * 0.1;
+  vmin -= pad; vmax += pad;
+
+  const xFor = t => ((t - t0) / (t1 - t0)) * (w - 2) + 1;
+  const yFor = v => h - 1 - ((v - vmin) / (vmax - vmin)) * (h - 2);
+
+  ctx.strokeStyle = color || 'rgba(120,180,255,0.9)';
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.moveTo(xFor(pts[0][0]), yFor(pts[0][1]));
+  for (let i = 1; i < pts.length; i++) {
+    ctx.lineTo(xFor(pts[i][0]), yFor(pts[i][1]));
+  }
+  ctx.stroke();
+
+  // Cursor dot on the most-recent point so it reads as "live"
+  const last = pts[pts.length - 1];
+  ctx.fillStyle = color || 'rgba(120,180,255,0.9)';
+  ctx.beginPath();
+  ctx.arc(xFor(last[0]), yFor(last[1]), 1.8, 0, Math.PI * 2);
+  ctx.fill();
+}
+
 function _renderHud(utc) {
   if (!_replaySamples) return;
   const s = _binarySearchSample(utc.getTime());
@@ -4661,10 +4758,22 @@ function _renderHud(utc) {
   setEl('hud-stw', _fmtNum(s && s.stw, 2));
   setEl('hud-tws', _fmtNum(s && s.tws, 1));
   setEl('hud-twa', _fmtNum(s && s.twa, 0));
+  setEl('hud-aws', _fmtNum(s && s.aws, 1));
+  setEl('hud-awa', _fmtNum(s && s.awa, 0));
   setEl('hud-hdg', _fmtNum(s && s.hdg, 0));
   setEl('hud-cog', _fmtNum(s && s.cog, 0));
   setEl('hud-pct', g && g.pct != null ? _fmtPct(g.pct) : '—');
   setEl('hud-delta', g && g.delta != null ? (g.delta >= 0 ? '+' : '') + _fmtNum(g.delta, 2) : '—');
+
+  const cursorMs = utc.getTime();
+  _drawSparkline('spark-stw', 'stw', cursorMs, 'rgba(120,180,255,0.9)');
+  _drawSparkline('spark-sog', 'sog', cursorMs, 'rgba(120,180,255,0.6)');
+  _drawSparkline('spark-tws', 'tws', cursorMs, 'rgba(100,220,150,0.9)');
+  _drawSparkline('spark-twa', 'twa', cursorMs, 'rgba(100,220,150,0.6)');
+  _drawSparkline('spark-aws', 'aws', cursorMs, 'rgba(220,180,100,0.9)');
+  _drawSparkline('spark-awa', 'awa', cursorMs, 'rgba(220,180,100,0.6)');
+  _drawSparkline('spark-hdg', 'hdg', cursorMs, 'rgba(255,140,140,0.9)');
+  _drawSparkline('spark-cog', 'cog', cursorMs, 'rgba(255,140,140,0.6)');
 }
 
 function _updateReplayControls() {
@@ -4760,6 +4869,8 @@ async function _loadReplayData() {
       sog: s.sog,
       tws: s.tws,
       twa: s.twa,
+      aws: s.aws,
+      awa: s.awa,
       hdg: s.hdg,
       cog: s.cog,
     }));
@@ -4799,7 +4910,7 @@ function _wireReplayControls() {
       if (!_replayStart || !_replayEnd) return;
       const frac = Number(e.target.value) / 1000;
       const t = _replayStart.getTime() + frac * (_replayEnd.getTime() - _replayStart.getTime());
-      setPosition(new Date(t), {source: 'replay'});
+      _seekTo(new Date(t), 'replay');
     });
   }
   const toggle = document.getElementById('toggle-polar-grades');
@@ -4820,7 +4931,7 @@ function _wireReplayControls() {
         _replayEnd.getTime(),
         Math.max(_replayStart.getTime(), base.getTime() + delta)
       ));
-      setPosition(next, {source: 'replay'});
+      _seekTo(next, 'replay');
       _updateReplayControls();
     }
   });

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -134,7 +134,7 @@ _MARK_REFERENCES: frozenset[str] = frozenset(
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 65
+_CURRENT_VERSION: int = 66
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1497,6 +1497,33 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE audio_sessions ADD COLUMN capture_ordinal INTEGER NOT NULL DEFAULT 0;
         CREATE INDEX IF NOT EXISTS idx_audio_sessions_capture_group
             ON audio_sessions(capture_group_id);
+    """,
+    66: """
+        -- Per-segment polar grading cache for race replay (#469).
+        -- One row per (session_id, polar_source, segment_index). Invalidated
+        -- by bumping the polar_baseline_version app_setting in
+        -- build_polar_baseline().
+        CREATE TABLE IF NOT EXISTS polar_segment_grades (
+            session_id        INTEGER NOT NULL,
+            polar_source      TEXT    NOT NULL DEFAULT 'own',
+            segment_index     INTEGER NOT NULL,
+            t_start           TEXT    NOT NULL,
+            t_end             TEXT    NOT NULL,
+            lat               REAL,
+            lon               REAL,
+            tws_kts           REAL,
+            twa_deg           REAL,
+            bsp_kts           REAL,
+            target_bsp_kts    REAL,
+            pct_target        REAL,
+            delta_kts         REAL,
+            grade             TEXT NOT NULL,
+            baseline_version  INTEGER NOT NULL,
+            computed_at       TEXT NOT NULL,
+            PRIMARY KEY (session_id, polar_source, segment_index)
+        );
+        CREATE INDEX IF NOT EXISTS idx_polar_segment_grades_session
+            ON polar_segment_grades(session_id, polar_source);
     """,
 }
 
@@ -4867,6 +4894,74 @@ class Storage:
                     row["session_count"],
                     row["sample_count"],
                     built_at,
+                ),
+            )
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Polar segment grades (#469)
+    # ------------------------------------------------------------------
+
+    async def get_polar_segment_grades(
+        self, session_id: int, polar_source: str, baseline_version: int
+    ) -> list[dict[str, Any]] | None:
+        """Return cached graded segments, or None if cache is missing/stale."""
+        cur = await self._read_conn().execute(
+            "SELECT segment_index, t_start, t_end, lat, lon, tws_kts, twa_deg,"
+            " bsp_kts, target_bsp_kts, pct_target, delta_kts, grade, baseline_version"
+            " FROM polar_segment_grades"
+            " WHERE session_id = ? AND polar_source = ?"
+            " ORDER BY segment_index",
+            (session_id, polar_source),
+        )
+        rows = [dict(r) for r in await cur.fetchall()]
+        if not rows:
+            return None
+        if any(int(r["baseline_version"]) != baseline_version for r in rows):
+            return None
+        return rows
+
+    async def upsert_polar_segment_grades(
+        self,
+        session_id: int,
+        polar_source: str,
+        rows: list[dict[str, Any]],
+        baseline_version: int,
+    ) -> None:
+        """Replace cached segments for *(session_id, polar_source)* in one txn."""
+        from datetime import UTC
+        from datetime import datetime as _datetime
+
+        now = _datetime.now(UTC).isoformat()
+        db = self._conn()
+        await db.execute(
+            "DELETE FROM polar_segment_grades WHERE session_id = ? AND polar_source = ?",
+            (session_id, polar_source),
+        )
+        for r in rows:
+            await db.execute(
+                "INSERT INTO polar_segment_grades"
+                " (session_id, polar_source, segment_index, t_start, t_end, lat, lon,"
+                "  tws_kts, twa_deg, bsp_kts, target_bsp_kts, pct_target, delta_kts,"
+                "  grade, baseline_version, computed_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    session_id,
+                    polar_source,
+                    r["segment_index"],
+                    r["t_start"],
+                    r["t_end"],
+                    r["lat"],
+                    r["lon"],
+                    r["tws_kts"],
+                    r["twa_deg"],
+                    r["bsp_kts"],
+                    r["target_bsp_kts"],
+                    r["pct_target"],
+                    r["delta_kts"],
+                    r["grade"],
+                    baseline_version,
+                    now,
                 ),
             )
         await db.commit()

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -111,15 +111,45 @@
   </div>
   <div id="track-map" class="track-map"></div>
   <div id="replay-controls" style="display:none;margin-top:10px">
-    <div id="replay-hud" style="display:flex;flex-wrap:wrap;gap:6px 14px;font-size:.78rem;color:var(--text-primary);background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:6px 10px;margin-bottom:8px;font-family:monospace">
-      <span><span style="color:var(--text-secondary)">SOG</span> <span id="hud-sog">—</span></span>
-      <span><span style="color:var(--text-secondary)">STW</span> <span id="hud-stw">—</span></span>
-      <span><span style="color:var(--text-secondary)">TWS</span> <span id="hud-tws">—</span></span>
-      <span><span style="color:var(--text-secondary)">TWA</span> <span id="hud-twa">—</span></span>
-      <span><span style="color:var(--text-secondary)">HDG</span> <span id="hud-hdg">—</span></span>
-      <span><span style="color:var(--text-secondary)">COG</span> <span id="hud-cog">—</span></span>
-      <span><span style="color:var(--text-secondary)">Polar</span> <span id="hud-pct">—</span></span>
-      <span><span style="color:var(--text-secondary)">Δ</span> <span id="hud-delta">—</span></span>
+    <div id="replay-gauges" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;margin-bottom:8px">
+      <div class="replay-gauge" data-gauge="speed" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Speed</div>
+        <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">STW</span> <span id="hud-stw" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">SOG</span> <span id="hud-sog" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+        </div>
+        <canvas id="spark-stw" width="300" height="26" style="width:100%;height:22px;display:block;margin-top:2px"></canvas>
+        <canvas id="spark-sog" width="300" height="26" style="width:100%;height:22px;display:block"></canvas>
+      </div>
+      <div class="replay-gauge" data-gauge="wind" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Wind</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:2px 10px;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">TWS</span> <span id="hud-tws" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">TWA</span> <span id="hud-twa" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">AWS</span> <span id="hud-aws" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">AWA</span> <span id="hud-awa" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
+        </div>
+        <canvas id="spark-tws" width="300" height="22" style="width:100%;height:18px;display:block;margin-top:2px"></canvas>
+        <canvas id="spark-twa" width="300" height="22" style="width:100%;height:18px;display:block"></canvas>
+        <canvas id="spark-aws" width="300" height="22" style="width:100%;height:18px;display:block"></canvas>
+        <canvas id="spark-awa" width="300" height="22" style="width:100%;height:18px;display:block"></canvas>
+      </div>
+      <div class="replay-gauge" data-gauge="heading" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Heading</div>
+        <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">HDG</span> <span id="hud-hdg" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">COG</span> <span id="hud-cog" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+        </div>
+        <canvas id="spark-hdg" width="300" height="26" style="width:100%;height:22px;display:block;margin-top:2px"></canvas>
+        <canvas id="spark-cog" width="300" height="26" style="width:100%;height:22px;display:block"></canvas>
+      </div>
+      <div class="replay-gauge" data-gauge="polar" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Polar</div>
+        <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">%</span> <span id="hud-pct" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">Δ</span> <span id="hud-delta" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+        </div>
+      </div>
     </div>
     <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
       <button id="replay-play-btn" type="button" aria-label="Play/pause" style="background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;width:34px;height:30px;font-size:1rem;cursor:pointer">&#9654;</button>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -99,7 +99,40 @@
     <label style="margin-right:12px"><input type="checkbox" id="toggle-sk-track" checked> SK track</label>
     <label><input type="checkbox" id="toggle-vakaros-track"> Vakaros track</label>
   </div>
+  <div id="replay-toggle-row" style="display:none;margin-bottom:8px;font-size:.78rem;color:var(--text-secondary)">
+    <label style="margin-right:12px"><input type="checkbox" id="toggle-polar-grades"> Color track by polar %</label>
+    <span id="polar-legend" style="display:none;margin-left:6px">
+      <span style="display:inline-block;width:10px;height:10px;background:#d64545;vertical-align:middle;margin-right:2px"></span>&lt;90%
+      <span style="display:inline-block;width:10px;height:10px;background:#d6a745;vertical-align:middle;margin:0 2px 0 8px"></span>90–97%
+      <span style="display:inline-block;width:10px;height:10px;background:#3db86e;vertical-align:middle;margin:0 2px 0 8px"></span>97–120%
+      <span style="display:inline-block;width:10px;height:10px;background:#a855f7;vertical-align:middle;margin:0 2px 0 8px"></span>&ge;120% (suspect)
+      <span style="display:inline-block;width:10px;height:10px;background:#888;vertical-align:middle;margin:0 2px 0 8px"></span>unknown
+    </span>
+  </div>
   <div id="track-map" class="track-map"></div>
+  <div id="replay-controls" style="display:none;margin-top:10px">
+    <div id="replay-hud" style="display:flex;flex-wrap:wrap;gap:6px 14px;font-size:.78rem;color:var(--text-primary);background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:6px 10px;margin-bottom:8px;font-family:monospace">
+      <span><span style="color:var(--text-secondary)">SOG</span> <span id="hud-sog">—</span></span>
+      <span><span style="color:var(--text-secondary)">STW</span> <span id="hud-stw">—</span></span>
+      <span><span style="color:var(--text-secondary)">TWS</span> <span id="hud-tws">—</span></span>
+      <span><span style="color:var(--text-secondary)">TWA</span> <span id="hud-twa">—</span></span>
+      <span><span style="color:var(--text-secondary)">HDG</span> <span id="hud-hdg">—</span></span>
+      <span><span style="color:var(--text-secondary)">COG</span> <span id="hud-cog">—</span></span>
+      <span><span style="color:var(--text-secondary)">Polar</span> <span id="hud-pct">—</span></span>
+      <span><span style="color:var(--text-secondary)">Δ</span> <span id="hud-delta">—</span></span>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+      <button id="replay-play-btn" type="button" aria-label="Play/pause" style="background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;width:34px;height:30px;font-size:1rem;cursor:pointer">&#9654;</button>
+      <span id="replay-time" style="font-family:monospace;font-size:.78rem;color:var(--text-secondary);min-width:72px;text-align:center">00:00 / 00:00</span>
+      <input type="range" id="replay-scrubber" min="0" max="1000" value="0" step="1" style="flex:1;min-width:140px">
+      <select id="replay-speed" title="Playback speed" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.78rem">
+        <option value="1">1&times;</option>
+        <option value="2">2&times;</option>
+        <option value="4">4&times;</option>
+        <option value="8">8&times;</option>
+      </select>
+    </div>
+  </div>
   <div id="track-hint" style="font-size:.72rem;color:var(--text-secondary);margin-top:4px"></div>
   <div id="vakaros-line-info" style="display:none;font-size:.78rem;color:var(--text-secondary);margin-top:6px;font-family:monospace"></div>
 </div>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -101,6 +101,7 @@
   </div>
   <div id="replay-toggle-row" style="display:none;margin-bottom:8px;font-size:.78rem;color:var(--text-secondary)">
     <label style="margin-right:12px"><input type="checkbox" id="toggle-polar-grades"> Color track by polar %</label>
+    <label style="margin-right:12px"><input type="checkbox" id="toggle-follow-boat"> Keep boat centered</label>
     <span id="polar-legend" style="display:none;margin-left:6px">
       <span style="display:inline-block;width:10px;height:10px;background:#d64545;vertical-align:middle;margin-right:2px"></span>&lt;90%
       <span style="display:inline-block;width:10px;height:10px;background:#d6a745;vertical-align:middle;margin:0 2px 0 8px"></span>90–97%

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -8,16 +8,25 @@ from typing import TYPE_CHECKING
 import pytest
 
 from helmlog.nmea2000 import (
+    PGN_POSITION_RAPID,
     PGN_SPEED_THROUGH_WATER,
     PGN_WIND_DATA,
+    PositionRecord,
     SpeedRecord,
     WindRecord,
 )
 from helmlog.polar import (
+    GRADE_GREEN_BELOW,
+    GRADE_RED_BELOW,
+    GRADE_SUSPICIOUS_AT,
+    GRADE_YELLOW_BELOW,
     _compute_twa,
+    _grade_from_pct,
     _twa_bin,
     _tws_bin,
     build_polar_baseline,
+    get_polar_baseline_version,
+    grade_session_segments,
     lookup_polar,
     session_polar_comparison,
 )
@@ -337,3 +346,225 @@ async def test_session_polar_tws_and_twa_bins_sorted(storage: Storage) -> None:
     assert 10 in result.tws_bins
     assert 45 in result.twa_bins
     assert 90 in result.twa_bins
+
+
+# ---------------------------------------------------------------------------
+# Per-segment grading (#469)
+# ---------------------------------------------------------------------------
+
+
+class TestGradeFromPct:
+    def test_none_is_unknown(self) -> None:
+        assert _grade_from_pct(None) == "unknown"
+
+    def test_below_red_threshold(self) -> None:
+        assert _grade_from_pct(0.5) == "red"
+        assert _grade_from_pct(GRADE_RED_BELOW - 0.0001) == "red"
+
+    def test_red_threshold_inclusive_yellow(self) -> None:
+        assert _grade_from_pct(GRADE_RED_BELOW) == "yellow"
+
+    def test_yellow_band(self) -> None:
+        assert _grade_from_pct(0.95) == "yellow"
+
+    def test_yellow_threshold_inclusive_green(self) -> None:
+        assert _grade_from_pct(GRADE_YELLOW_BELOW) == "green"
+
+    def test_green_band(self) -> None:
+        assert _grade_from_pct(1.00) == "green"
+
+    def test_green_extends_through_old_top(self) -> None:
+        # 1.05 used to be the green ceiling but now stays green up to 1.20.
+        assert _grade_from_pct(GRADE_GREEN_BELOW) == "green"
+        assert _grade_from_pct(1.10) == "green"
+
+    def test_suspicious_threshold(self) -> None:
+        assert _grade_from_pct(GRADE_SUSPICIOUS_AT) == "suspicious"
+        assert _grade_from_pct(2.0) == "suspicious"
+
+
+async def _seed_session(
+    storage: Storage,
+    *,
+    duration_s: int,
+    bsp: float,
+    tws: float,
+    twa: float,
+    with_positions: bool = True,
+    with_winds: bool = True,
+) -> int:
+    """Create a completed race with 1 Hz instrument data and return its id."""
+    start = datetime(2024, 7, 1, 12, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=duration_s)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('Seg', 'E', 1, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    sid = int((await cur.fetchone())["id"])
+
+    for i in range(duration_s):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, bsp))
+        if with_winds:
+            await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, tws, twa, 0))
+        if with_positions:
+            await storage.write(
+                PositionRecord(PGN_POSITION_RAPID, 5, ts, 37.80 + i * 1e-5, -122.27 + i * 1e-5)
+            )
+    return sid
+
+
+async def _build_baseline_at(storage: Storage, bsp: float, tws: float, twa: float) -> None:
+    for i in range(1, 4):
+        await _make_session(storage, race_num=100 + i, bsp=bsp, tws=tws, twa=twa)
+    await build_polar_baseline(storage)
+
+
+@pytest.mark.asyncio
+async def test_grade_unfinished_session_returns_empty(storage: Storage) -> None:
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc)"
+        " VALUES ('Open', 'E', 1, '2024-07-01', '2024-07-01T12:00:00')"
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    sid = int((await cur.fetchone())["id"])
+    assert await grade_session_segments(storage, sid) == []
+
+
+@pytest.mark.asyncio
+async def test_grade_nonexistent_session(storage: Storage) -> None:
+    assert await grade_session_segments(storage, 9999) == []
+
+
+@pytest.mark.asyncio
+async def test_grade_segment_count_matches_duration(storage: Storage) -> None:
+    """60s session, 10s segments → 6 segments."""
+    sid = await _seed_session(storage, duration_s=60, bsp=6.0, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert len(segs) == 6
+    assert segs[0].segment_index == 0
+    assert segs[-1].segment_index == 5
+
+
+@pytest.mark.asyncio
+async def test_grade_unknown_when_no_baseline(storage: Storage) -> None:
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    # No baseline → target_bsp None → grade unknown
+    assert all(s.grade == "unknown" for s in segs)
+    assert all(s.target_bsp_kts is None for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_green_when_at_target(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.grade == "green" for s in segs)
+    assert all(s.target_bsp_kts == pytest.approx(6.0, rel=1e-3) for s in segs)
+    assert all(s.pct_target == pytest.approx(1.0, rel=1e-3) for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_red_when_far_below_target(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=4.0, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.grade == "red" for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_suspicious_when_far_above_target(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=5.0, tws=10.0, twa=45.0)
+    # 6.5 / 5.0 = 1.30 → suspicious
+    sid = await _seed_session(storage, duration_s=30, bsp=6.5, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.grade == "suspicious" for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_unknown_when_wind_missing(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0, with_winds=False)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.grade == "unknown" for s in segs)
+    assert all(s.tws_kts is None for s in segs)
+    assert all(s.twa_deg is None for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_unknown_when_no_gps(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(
+        storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0, with_positions=False
+    )
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.lat is None and s.lon is None for s in segs)
+    assert all(s.grade == "unknown" for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_position_interpolated(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    # First segment midpoint at +5s → lat ≈ 37.80005
+    assert segs[0].lat is not None
+    assert segs[0].lat == pytest.approx(37.80 + 5e-5, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_grade_cache_hit_does_not_recompute(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    first = await grade_session_segments(storage, sid, segment_seconds=10)
+    # Mutate underlying data; cache should hide it.
+    db = storage._conn()
+    await db.execute("DELETE FROM speeds")
+    await db.commit()
+    second = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert [s.grade for s in second] == [s.grade for s in first]
+
+
+@pytest.mark.asyncio
+async def test_grade_cache_invalidated_on_baseline_rebuild(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    v1 = await get_polar_baseline_version(storage)
+    await grade_session_segments(storage, sid, segment_seconds=10)
+    # Rebuild → version bump → cache stale → recompute reflects new data
+    await build_polar_baseline(storage)
+    v2 = await get_polar_baseline_version(storage)
+    assert v2 == v1 + 1
+    # Clear the speeds and recompute; new run should see the empty data
+    db = storage._conn()
+    await db.execute("DELETE FROM speeds")
+    await db.commit()
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert all(s.bsp_kts is None for s in segs)
+    assert all(s.grade == "unknown" for s in segs)
+
+
+@pytest.mark.asyncio
+async def test_grade_baseline_version_bumped_on_build(storage: Storage) -> None:
+    v0 = await get_polar_baseline_version(storage)
+    assert v0 == 0
+    await build_polar_baseline(storage)
+    assert await get_polar_baseline_version(storage) == v0 + 1
+    await build_polar_baseline(storage)
+    assert await get_polar_baseline_version(storage) == v0 + 2
+
+
+@pytest.mark.asyncio
+async def test_grade_distinct_polar_source_caches_separately(storage: Storage) -> None:
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+    own = await grade_session_segments(storage, sid, polar_source="own", segment_seconds=10)
+    ref = await grade_session_segments(storage, sid, polar_source="reference", segment_seconds=10)
+    assert len(own) == len(ref) == 3

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -94,6 +94,40 @@ class TestPathConversions:
         assert isinstance(rec, PositionRecord)
         assert rec.latitude_deg == pytest.approx(41.79)
         assert rec.longitude_deg == pytest.approx(-71.87)
+        # No $source on the delta — position falls back to the SK constant
+        # so existing rows in the DB stay comparable.
+        assert rec.source_addr == SK_SOURCE_ADDR
+
+    def test_position_distinct_source_addr_per_signalk_source(self) -> None:
+        """Two physical GPS antennas alternating on the bus must end up in
+        rows with different source_addr values, so downstream consumers can
+        deduplicate or filter by source. Regression for the stair-step
+        track artifact found on corvopi-tst1.
+        """
+        buf: dict[str, float] = {}
+        pos = {"latitude": 41.79, "longitude": -71.87}
+
+        def delta_with_source(src: str) -> str:
+            return json.dumps(
+                {
+                    "context": "vessels.self",
+                    "updates": [
+                        {
+                            "$source": src,
+                            "timestamp": _TS,
+                            "values": [{"path": "navigation.position", "value": pos}],
+                        }
+                    ],
+                }
+            )
+
+        rec_a = process_delta(delta_with_source("n2k.0.130577.0"), buf)[0]
+        rec_b = process_delta(delta_with_source("n2k.1.43.0"), buf)[0]
+        assert isinstance(rec_a, PositionRecord)
+        assert isinstance(rec_b, PositionRecord)
+        assert rec_a.source_addr != rec_b.source_addr
+        assert rec_a.source_addr != SK_SOURCE_ADDR
+        assert rec_b.source_addr != SK_SOURCE_ADDR
 
     def test_temperature_kelvin_to_celsius(self) -> None:
         buf: dict[str, float] = {}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3848,3 +3848,80 @@ async def test_v41_migration_creates_sail_changes_table(storage: Storage) -> Non
     )
     row = await cur.fetchone()
     assert row is not None
+
+
+# ---------------------------------------------------------------------------
+# Replay endpoint (#464, #465, #468, #470)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replay_endpoint_unknown_session_returns_404(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions/9999/replay")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_replay_endpoint_returns_samples_and_grades(storage: Storage) -> None:
+    """Seeds a completed race with instrument data, hits /replay, and
+    verifies the payload includes per-second samples, graded segments,
+    and the expected top-level fields.
+    """
+    from datetime import timedelta
+
+    from helmlog.nmea2000 import (
+        PGN_POSITION_RAPID,
+        PGN_SPEED_THROUGH_WATER,
+        PGN_WIND_DATA,
+        PositionRecord,
+        SpeedRecord,
+        WindRecord,
+    )
+
+    start = datetime(2024, 8, 1, 12, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=30)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('Replay', 'E', 1, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    race_id = int((await cur.fetchone())["id"])
+    for i in range(30):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, 6.0))
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, 10.0, 45.0, 0))
+        await storage.write(
+            PositionRecord(PGN_POSITION_RAPID, 5, ts, 37.80 + i * 1e-5, -122.27 + i * 1e-5)
+        )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/replay")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] == race_id
+    assert data["start_utc"].startswith("2024-08-01T12:00:00")
+    assert data["end_utc"].startswith("2024-08-01T12:00:30")
+    assert data["segment_seconds"] == 10
+    assert len(data["samples"]) == 30
+    sample = data["samples"][0]
+    assert sample["stw"] == pytest.approx(6.0)
+    assert sample["tws"] == pytest.approx(10.0)
+    assert sample["twa"] == pytest.approx(45.0)
+    # 30s / 10s per segment → 3 graded segments (grade is "unknown" because
+    # no baseline has been built — we only check shape here).
+    assert len(data["grades"]) == 3
+    for g in data["grades"]:
+        assert "grade" in g
+        assert "t_start" in g
+        assert "t_end" in g


### PR DESCRIPTION
## Summary

First deployable slice of the race-replay epic (#464): a working replay player on the session detail page, fed by a new polar-grading pipeline. Lands #465, #468, #469, and #470 in one PR so it can be deployed to a Pi and smoke-tested end-to-end.

Once this is on a Pi, open any completed race and the Track card now has:
- A play/pause button, scrubber, 1x/2x/4x/8x speed selector, and keyboard shortcuts (space, arrows)
- A live HUD strip showing SOG, STW, TWS, TWA, HDG, COG, polar %, and delta at the cursor
- A "Color track by polar %" toggle that paints the polyline red/yellow/green/suspicious/unknown

### #469 — Polar grading pipeline (High tier)
- New `grade_session_segments()` in `polar.py` that partitions a session into fixed-width windows and grades each window's BSP against the polar baseline
- Schema v66: `polar_segment_grades` cache table keyed by `(session_id, polar_source, segment_index)`
- New `polar_baseline_version` app_setting, bumped inside `build_polar_baseline()` for O(1) cache invalidation
- Grade tiers: **red** (<0.90), **yellow** (<0.97), **green** (<1.20), **suspicious** (≥1.20)
- Tunable segment width via `POLAR_SEGMENT_SECONDS` env (default 10s)
- Robust failure modes per spec: unfinished session, missing wind/GPS, sparse baseline, un-migrated DB all yield `grade="unknown"` without raising
- Position is interpolated to each segment midpoint (or nearest fix within ±2s)

Spec: https://github.com/weaties/helmlog/issues/469#issuecomment-4236271934

### #465 — Replay playback core
- Extends the existing `_playClock` with a speed multiplier and auto-stop at end of session
- Scrubber, play/pause button, speed selector in `session.html`
- Keyboard shortcuts: `space` toggles play, `←/→` seek ±5s, `shift+arrow` jumps 30s
- Piggybacks on the existing `registerSurface`/`setPosition` plumbing, so map, video, audio, and transcript surfaces all stay in sync with the new controls for free

### #468 — Configurable indicator HUD
- Fixed HUD strip above the controls reads the per-second sample series from the replay endpoint
- Registered as a `_playClock` consumer so it updates on every tick and every seek
- Layout picker (floating card / side panel) deferred — v1 ships the fixed strip only

### #470 — Polar view: color gradient track
- "Color track by polar %" toggle redraws the track polyline as a sequence of same-grade runs using the `_GRADE_COLORS` palette
- Base polyline is hidden while the grade view is active so the graded colors are visible
- Other view modes (variable thickness, heatmap regions, ghost ideal boat) are deferred to follow-ups

### Backend glue
- New `GET /api/sessions/{id}/replay` returns session bounds, per-second instrument series (stw/sog/tws/twa/hdg/cog), and cached graded segments in one fetch — the frontend hits this once when the session page loads

## Risk tier

**High** (touches `polar.py` and adds a schema migration). Standard for everything else (`web.py`, templates, JS).

## Test plan

- [x] 22 new unit tests in `tests/test_polar.py` covering: grade decision table boundaries, segment count, missing wind, missing GPS, position interpolation, cache hit behavior, baseline-version bump on rebuild, cache invalidation on rebuild, distinct polar-source caches
- [x] 2 new integration tests in `tests/test_web.py` for the `/replay` endpoint (404 on unknown session; shape + sample values on a seeded race)
- [x] `uv run pytest` — full suite green (1850 passed, 2 skipped)
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] `uv run mypy src/` clean (104 files)
- [ ] **Smoke test on Pi after deploy**: open a recent completed race, scrub the track, confirm HUD updates, toggle "Color track by polar %" and confirm the grades render, try all four speeds, try keyboard shortcuts

## Not in this PR (deferred)

- Event-stepping (#466), A/V sync (#467), overlays (#472–#475), panel expansion (#476), bookmarks (#477), discussions (#478), deep links (#479), export (#480), mobile layout (#481), HUD layout picker, polar source selector (#471), other polar view modes

Closes #465
Closes #468
Closes #469
Closes #470
Part of #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)