### PR TITLE
tests: regression guard for write_audio_session identity persistence

### DIFF
--- a/tests/test_storage_channel_map.py
+++ b/tests/test_storage_channel_map.py
@@ -256,6 +256,82 @@ class TestAudioSessionDeviceIdentity:
         assert row["serial"] == "ABC"
         assert row["usb_port_path"] == "1-1.2"
 
+    async def test_write_audio_session_persists_device_identity(self, storage: Storage) -> None:
+        """write_audio_session must persist vendor/product/serial/usb_port_path.
+
+        Regression guard: prior to the #514 follow-up the INSERT dropped these
+        four columns. The bug was masked in other tests because they seed
+        identity via an explicit set_audio_session_device() call after
+        write_audio_session(). This test deliberately does *not* call
+        set_audio_session_device — it only populates the AudioSession
+        dataclass, then checks the row and the admin-default channel_map
+        lookup chain both resolve.
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        from helmlog.audio import AudioSession as _AudioSession
+
+        await storage.set_channel_map(
+            vendor_id=0x1234,
+            product_id=0x5678,
+            serial="ABC",
+            usb_port_path="1-1.2",
+            mapping={0: "helm", 1: "trim"},
+        )
+
+        session = _AudioSession(
+            file_path="/tmp/siblingA.wav",
+            device_name="Lavalier4",
+            start_utc=_dt.now(UTC),
+            end_utc=None,
+            sample_rate=48000,
+            channels=2,
+            vendor_id=0x1234,
+            product_id=0x5678,
+            serial="ABC",
+            usb_port_path="1-1.2",
+        )
+        session_id = await storage.write_audio_session(session)
+
+        row = await storage.get_audio_session_row(session_id)
+        assert row is not None
+        assert row["vendor_id"] == 0x1234
+        assert row["product_id"] == 0x5678
+        assert row["serial"] == "ABC"
+        assert row["usb_port_path"] == "1-1.2"
+
+        result = await storage.get_channel_map_for_audio_session(session_id)
+        assert result == {0: "helm", 1: "trim"}
+
+    async def test_write_audio_session_null_identity_when_unset(self, storage: Storage) -> None:
+        """Zero / empty identity fields on the dataclass must land as NULL.
+
+        The fix null-coalesces `session.vendor_id or None` so legacy mono /
+        built-in-mic sessions don't pollute the column with 0 / "".
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        from helmlog.audio import AudioSession as _AudioSession
+
+        session = _AudioSession(
+            file_path="/tmp/builtin.wav",
+            device_name="BuiltIn",
+            start_utc=_dt.now(UTC),
+            end_utc=None,
+            sample_rate=48000,
+            channels=1,
+        )
+        session_id = await storage.write_audio_session(session)
+
+        row = await storage.get_audio_session_row(session_id)
+        assert row is not None
+        assert row["vendor_id"] is None
+        assert row["product_id"] is None
+        assert row["serial"] is None
+        assert row["usb_port_path"] is None
+
     async def test_get_channel_map_via_session_device(self, storage: Storage) -> None:
         """Once a session has identity, channel_map lookup chains through it."""
         from datetime import UTC


### PR DESCRIPTION
## Summary

Closes the nightly Claude review HIGH finding against `992662f` (the #514 follow-up): the `write_audio_session` INSERT fix had no targeted regression test, and every pre-existing channel-map test masked the bug by calling `set_audio_session_device()` after the write.

Adds two tests in `TestAudioSessionDeviceIdentity`:

- **`test_write_audio_session_persists_device_identity`** — builds an `AudioSession` dataclass with `vendor_id` / `product_id` / `serial` / `usb_port_path` populated, writes it via `write_audio_session` only (no follow-up `set_audio_session_device` call), then asserts both the row round-trip and the `get_channel_map_for_audio_session` admin-default chain resolve. Verified against a locally reverted INSERT — it fails in the broken state and passes against the fix.
- **`test_write_audio_session_null_identity_when_unset`** — locks in the `session.vendor_id or None` null-coalesce so the zero / empty dataclass defaults (built-in mic / mono fallback path) land as `NULL` instead of `0` / `""`.

Also created the missing `claude-review` repo label, which was the immediate cause of the nightly workflow run failing at the "Open/update failure issue on FAIL" step (`gh issue create --label claude-review` errored out because the label didn't exist).

1828 tests pass (was 1826). Ruff / format clean. No new mypy errors (`tests/test_storage_channel_map.py` still reports the same 50 pre-existing `**dict[str, object]` errors — the new tests deliberately use explicit kwargs to avoid adding to the count).

## Test plan

- [x] `uv run pytest tests/test_storage_channel_map.py` — 18 passed
- [x] `uv run pytest` — 1828 passed, 2 skipped
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run mypy tests/test_storage_channel_map.py` — no new errors
- [x] Manually reverted the `write_audio_session` INSERT to confirm the new persist test fails under the pre-fix code

Generated with [Claude Code](https://claude.ai/code)