### PR TITLE
fix: start line bias sign inversion

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -9054,18 +9054,15 @@ class Storage:
         # Wind-relative line bias.
         # The "square" line is perpendicular to the wind direction (TWD).
         # We measure the line bearing pin→boat against TWD; the offset from
-        # square tells you which end is favoured.
+        # square tells you which end is favoured (more upwind).
         #
-        # Convention here:
-        #   bias_deg = (line_bearing_pin_to_boat - TWD - 90) wrapped to [-90, 90]
-        #     0          → square (no bias)
-        #     positive   → boat end favoured (line tilted toward downwind on
-        #                  the boat side, so the boat end is closer to wind
-        #                  origin... actually depends; see below)
-        #
-        # Sign convention picked so positive == pin favoured, negative ==
-        # committee-boat favoured. Verified by the test fixture: line at 90°
-        # T, TWD 45° → bias = (90 - 45 - 90) = -45 → wrapped → +45 → pin.
+        # Derivation: with line_bearing = B (pin→boat) and wind FROM = TWD,
+        # raw = (B - TWD - 90) wrapped to [-90, 90].
+        #   raw > 0 → pin  end is more upwind → pin  favoured
+        #   raw < 0 → boat end is more upwind → boat favoured
+        # Example: B=80, TWD=0 (wind from N). Pin at origin, boat at bearing
+        # 80° is 0.17d north of pin → boat more upwind → boat favoured.
+        # raw = 80 - 0 - 90 = -10 → boat, matches.
         line_bias_deg: float | None = None
         favored_end: str | None = None
         if line is not None and twd_deg is not None:
@@ -9078,8 +9075,8 @@ class Storage:
                 raw -= 180.0
             elif raw < -90.0:
                 raw += 180.0
-            # Make positive == pin favoured.
-            line_bias_deg = round(-raw, 1)
+            # Positive == boat favoured, negative == pin favoured.
+            line_bias_deg = round(raw, 1)
             if abs(line_bias_deg) < 1.0:
                 favored_end = "square"
             elif line_bias_deg > 0:

--- a/tests/test_vakaros_web.py
+++ b/tests/test_vakaros_web.py
@@ -958,15 +958,13 @@ async def test_vakaros_overlay_race_start_context_includes_polar_pct_and_line_bi
     assert ctx["polar_pct"] == pytest.approx(90.0, abs=0.5)
 
     # Wind-relative line bias.
-    # Line bearing pin → boat = 90° T (due east).
-    # Wind FROM 45° T means wind blows toward 225°.
-    # The "square" line is perpendicular to the wind direction. A line
-    # perpendicular to wind-from-45° has bearings 135° / 315°.
-    # Our line is 90°, which is 45° clockwise of the square (135°)... so
-    # the pin (west end) is favored relative to the boat end.
+    # Line bearing pin → boat = 90° T (pin at west end, boat at east end).
+    # Wind FROM 45° T (NE), so the upwind direction is to the NE. The boat
+    # end (east) projects further along the NE upwind vector than the pin
+    # end (west), so the boat end is more upwind → boat favoured.
     assert ctx["line_bias_deg"] is not None
     assert ctx["favored_end"] in ("pin", "boat", "square")
-    assert ctx["favored_end"] == "pin"  # for this geometry
+    assert ctx["favored_end"] == "boat"  # for this geometry
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The race start context computed `line_bias_deg = -raw`, flipping the sign before the pin/boat label branch. The displayed "favoring X" end was the opposite of the true upwind end.
- Fix: use `raw` directly; the branch mapping (`raw>0 → pin`, `raw<0 → boat`) is correct.
- The existing test was written with the same inverted reasoning and passed despite being wrong — updated the assertion and comment to reflect the real geometry (pin west, boat east, wind FROM NE → boat projects further upwind → boat favoured).

Closes #528

## Test plan
- [x] `uv run pytest tests/test_vakaros_web.py`
- [x] `uv run ruff check` / `ruff format --check`
- [ ] Verify on the reported session that "favoring X" now matches the wind indicator visuals

🤖 Generated with [Claude Code](https://claude.com/claude-code)