### PR TITLE
Split polar panel by point-of-sail and tack (#534)

### DIFF
--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -45,6 +45,12 @@ POLAR_BASELINE_VERSION_KEY: str = "polar_baseline_version"
 
 GradeLabel = Literal["green", "yellow", "red", "suspicious", "unknown"]
 
+PointOfSail = Literal["upwind", "downwind"]
+Tack = Literal["port", "starboard"]
+
+# Upwind/downwind cutoff (#534). TWAs strictly below this are upwind.
+UPWIND_CUTOFF_DEG: float = 90.0
+
 # ---------------------------------------------------------------------------
 # Pure helpers (all unit-testable without Storage)
 # ---------------------------------------------------------------------------
@@ -81,6 +87,33 @@ def _compute_twa(
         twa_raw = (wind_angle_deg - heading_deg + 360) % 360
         return twa_raw if twa_raw <= 180 else 360 - twa_raw
     return None  # apparent wind or unknown reference
+
+
+def _compute_twa_with_tack(
+    wind_angle_deg: float,
+    reference: int,
+    heading_deg: float | None,
+) -> tuple[float, Tack] | None:
+    """Return (abs_twa, tack) or None.
+
+    Positive signed TWA (wind from the starboard side) → starboard tack.
+    """
+    if reference == _WIND_REF_BOAT:
+        signed = wind_angle_deg % 360
+    elif reference == _WIND_REF_NORTH:
+        if heading_deg is None:
+            return None
+        signed = (wind_angle_deg - heading_deg) % 360
+    else:
+        return None
+    if signed > 180:
+        signed -= 360  # now in (-180, 180]
+    tack: Tack = "starboard" if signed >= 0 else "port"
+    return abs(signed), tack
+
+
+def _point_of_sail(abs_twa_deg: float) -> PointOfSail:
+    return "upwind" if abs_twa_deg < UPWIND_CUTOFF_DEG else "downwind"
 
 
 # ---------------------------------------------------------------------------
@@ -242,10 +275,17 @@ async def lookup_polar(
 
 @dataclass
 class PolarCell:
-    """One (TWS, TWA) cell with baseline and session data."""
+    """One (TWS, TWA, point-of-sail, tack) cell with baseline and session data.
+
+    The baseline is symmetric across port/starboard (keyed on abs TWA), but
+    the session cell carries its own point-of-sail and tack so the panel can
+    show asymmetries without rebuilding the baseline (#534).
+    """
 
     tws_bin: int
     twa_bin: int
+    point_of_sail: PointOfSail
+    tack: Tack
     baseline_mean_bsp: float | None
     baseline_p90_bsp: float | None
     session_mean_bsp: float | None
@@ -304,8 +344,9 @@ async def session_polar_comparison(
             continue
         tw_by_s.setdefault(str(w["ts"])[:19], w)
 
-    # Bin session samples
-    bin_samples: dict[tuple[int, int], list[float]] = defaultdict(list)
+    # Bin session samples by (tws, twa, point_of_sail, tack)
+    SplitKey = tuple[int, int, PointOfSail, Tack]
+    bin_samples: dict[SplitKey, list[float]] = defaultdict(list)
     for sk, spd_row in spd_by_s.items():
         wind_row = tw_by_s.get(sk)
         if wind_row is None:
@@ -319,63 +360,55 @@ async def session_polar_comparison(
         hdg_row = hdg_by_s.get(sk)
         heading = float(hdg_row["heading_deg"]) if hdg_row else None
 
-        twa = _compute_twa(wind_angle, ref, heading)
-        if twa is None:
+        twa_tack = _compute_twa_with_tack(wind_angle, ref, heading)
+        if twa_tack is None:
             continue
+        twa, tack = twa_tack
 
         tb = _tws_bin(tws_kts)
         ab = _twa_bin(twa)
-        bin_samples[(tb, ab)].append(bsp_kts)
+        pos = _point_of_sail(twa)
+        bin_samples[(tb, ab, pos, tack)].append(bsp_kts)
 
-    # Load full baseline
+    # Load full baseline (symmetric, no min_sessions gate — #534)
     baseline: dict[tuple[int, int], dict[str, Any]] = {}
     try:
-        bcur = await db.execute(
-            "SELECT tws_bin, twa_bin, mean_bsp, p90_bsp"
-            " FROM polar_baseline WHERE session_count >= 3"
-        )
+        bcur = await db.execute("SELECT tws_bin, twa_bin, mean_bsp, p90_bsp FROM polar_baseline")
         for br in await bcur.fetchall():
             baseline[(int(br["tws_bin"]), int(br["twa_bin"]))] = dict(br)
     except Exception:
         pass  # no baseline table on un-migrated DB
 
-    # Merge session + baseline into cells
-    all_keys = set(bin_samples.keys()) | set(baseline.keys())
     cells: list[PolarCell] = []
     total_samples = 0
 
-    for key in all_keys:
-        tws_b, twa_b = key
-        samples = bin_samples.get(key, [])
-        bl = baseline.get(key)
+    for key, samples in bin_samples.items():
+        tws_b, twa_b, pos, tack = key
+        bl = baseline.get((tws_b, twa_b))
 
-        session_mean = round(sum(samples) / len(samples), 4) if samples else None
+        session_mean = round(sum(samples) / len(samples), 4)
         bl_mean = float(bl["mean_bsp"]) if bl else None
         bl_p90 = float(bl["p90_bsp"]) if bl else None
-        delta = (
-            round(session_mean - bl_mean, 4)
-            if session_mean is not None and bl_mean is not None
-            else None
-        )
+        delta = round(session_mean - bl_mean, 4) if bl_mean is not None else None
 
         n = len(samples)
         total_samples += n
 
-        # Only include cells where the session has data
-        if n > 0:
-            cells.append(
-                PolarCell(
-                    tws_bin=tws_b,
-                    twa_bin=twa_b,
-                    baseline_mean_bsp=bl_mean,
-                    baseline_p90_bsp=bl_p90,
-                    session_mean_bsp=session_mean,
-                    session_sample_count=n,
-                    delta=delta,
-                )
+        cells.append(
+            PolarCell(
+                tws_bin=tws_b,
+                twa_bin=twa_b,
+                point_of_sail=pos,
+                tack=tack,
+                baseline_mean_bsp=bl_mean,
+                baseline_p90_bsp=bl_p90,
+                session_mean_bsp=session_mean,
+                session_sample_count=n,
+                delta=delta,
             )
+        )
 
-    cells.sort(key=lambda c: (c.tws_bin, c.twa_bin))
+    cells.sort(key=lambda c: (c.tws_bin, c.point_of_sail, c.tack, c.twa_bin))
     tws_bins = sorted({c.tws_bin for c in cells})
     twa_bins = sorted({c.twa_bin for c in cells})
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -739,6 +739,8 @@ async def api_session_polar(
                 {
                     "tws": c.tws_bin,
                     "twa": c.twa_bin,
+                    "point_of_sail": c.point_of_sail,
+                    "tack": c.tack,
                     "baseline_mean": c.baseline_mean_bsp,
                     "baseline_p90": c.baseline_p90_bsp,
                     "session_mean": c.session_mean_bsp,
@@ -813,23 +815,64 @@ async def api_session_replay(
         logger.warning("replay: grading failed for session {}: {}", session_id, e)
         graded = []
 
-    grades_out = [
-        {
-            "i": g.segment_index,
-            "t_start": g.t_start.isoformat(),
-            "t_end": g.t_end.isoformat(),
-            "lat": g.lat,
-            "lon": g.lon,
-            "tws": g.tws_kts,
-            "twa": g.twa_deg,
-            "bsp": g.bsp_kts,
-            "target": g.target_bsp_kts,
-            "pct": g.pct_target,
-            "delta": g.delta_kts,
-            "grade": g.grade,
-        }
-        for g in graded
-    ]
+    # Enrich each grade with tack + point_of_sail (#534). Cached grades carry
+    # only unsigned TWA, so we re-derive tack from raw wind records for each
+    # segment window. Cheap: winds/headings queries are already cached below.
+    tack_winds = await storage.query_range(
+        "winds",
+        datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC),
+        datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC),
+    )
+    tack_winds = [w for w in tack_winds if int(w.get("reference", -1)) in (0, 4)]
+    tack_hdgs = await storage.query_range(
+        "headings",
+        datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC),
+        datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC),
+    )
+    hdg_by_key: dict[str, float] = {}
+    for hrec in tack_hdgs:
+        hdg_by_key.setdefault(str(hrec["ts"])[:19], float(hrec["heading_deg"]))
+
+    def _seg_tack_pos(g: _polar.GradedSegment) -> tuple[str | None, str | None]:
+        votes: dict[str, int] = {"port": 0, "starboard": 0}
+        for w in tack_winds:
+            ts = datetime.fromisoformat(str(w["ts"])).replace(tzinfo=UTC)
+            if not (g.t_start <= ts < g.t_end):
+                continue
+            ref = int(w.get("reference", -1))
+            heading = hdg_by_key.get(str(w["ts"])[:19]) if ref == 4 else None
+            result = _polar._compute_twa_with_tack(float(w["wind_angle_deg"]), ref, heading)
+            if result is None:
+                continue
+            _, tack = result
+            votes[tack] += 1
+        if votes["port"] == 0 and votes["starboard"] == 0:
+            return None, None
+        tack = "starboard" if votes["starboard"] >= votes["port"] else "port"
+        pos = _polar._point_of_sail(g.twa_deg) if g.twa_deg is not None else None
+        return tack, pos
+
+    grades_out = []
+    for g in graded:
+        tack, pos = _seg_tack_pos(g)
+        grades_out.append(
+            {
+                "i": g.segment_index,
+                "t_start": g.t_start.isoformat(),
+                "t_end": g.t_end.isoformat(),
+                "lat": g.lat,
+                "lon": g.lon,
+                "tws": g.tws_kts,
+                "twa": g.twa_deg,
+                "bsp": g.bsp_kts,
+                "target": g.target_bsp_kts,
+                "pct": g.pct_target,
+                "delta": g.delta_kts,
+                "grade": g.grade,
+                "tack": tack,
+                "point_of_sail": pos,
+            }
+        )
 
     # Thin instrument series for HUD. 1 Hz dedup by truncated timestamp key.
     async def _series(table: str, fields: list[str]) -> dict[str, dict[str, Any]]:

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -816,45 +816,54 @@ async def api_session_replay(
         graded = []
 
     # Enrich each grade with tack + point_of_sail (#534). Cached grades carry
-    # only unsigned TWA, so we re-derive tack from raw wind records for each
-    # segment window. Cheap: winds/headings queries are already cached below.
-    tack_winds = await storage.query_range(
-        "winds",
-        datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC),
-        datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC),
-    )
-    tack_winds = [w for w in tack_winds if int(w.get("reference", -1)) in (0, 4)]
-    tack_hdgs = await storage.query_range(
-        "headings",
-        datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC),
-        datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC),
-    )
+    # only unsigned TWA, so we re-derive tack from raw wind records. Parse
+    # once, then sweep segments with a single pointer — O(n + m), not O(n*m).
+    start_dt = datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC)
+    end_dt = datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC)
+    tack_winds_raw = await storage.query_range("winds", start_dt, end_dt)
+    tack_hdgs_raw = await storage.query_range("headings", start_dt, end_dt)
+
     hdg_by_key: dict[str, float] = {}
-    for hrec in tack_hdgs:
+    for hrec in tack_hdgs_raw:
         hdg_by_key.setdefault(str(hrec["ts"])[:19], float(hrec["heading_deg"]))
 
-    def _seg_tack_pos(g: _polar.GradedSegment) -> tuple[str | None, str | None]:
-        votes: dict[str, int] = {"port": 0, "starboard": 0}
-        for w in tack_winds:
-            ts = datetime.fromisoformat(str(w["ts"])).replace(tzinfo=UTC)
-            if not (g.t_start <= ts < g.t_end):
-                continue
-            ref = int(w.get("reference", -1))
-            heading = hdg_by_key.get(str(w["ts"])[:19]) if ref == 4 else None
-            result = _polar._compute_twa_with_tack(float(w["wind_angle_deg"]), ref, heading)
-            if result is None:
-                continue
-            _, tack = result
-            votes[tack] += 1
-        if votes["port"] == 0 and votes["starboard"] == 0:
-            return None, None
-        tack = "starboard" if votes["starboard"] >= votes["port"] else "port"
-        pos = _polar._point_of_sail(g.twa_deg) if g.twa_deg is not None else None
-        return tack, pos
+    wind_tacks: list[tuple[datetime, str]] = []
+    for w in tack_winds_raw:
+        ref = int(w.get("reference", -1))
+        if ref not in (0, 4):
+            continue
+        heading = hdg_by_key.get(str(w["ts"])[:19]) if ref == 4 else None
+        result = _polar._compute_twa_with_tack(float(w["wind_angle_deg"]), ref, heading)
+        if result is None:
+            continue
+        _, tk = result
+        wind_tacks.append((datetime.fromisoformat(str(w["ts"])).replace(tzinfo=UTC), tk))
+    wind_tacks.sort(key=lambda x: x[0])
+
+    grades_sorted = sorted(graded, key=lambda g: g.t_start)
+    tacks_by_segment: dict[int, str | None] = {}
+    wi = 0
+    for g in grades_sorted:
+        port = 0
+        stbd = 0
+        while wi < len(wind_tacks) and wind_tacks[wi][0] < g.t_start:
+            wi += 1
+        j = wi
+        while j < len(wind_tacks) and wind_tacks[j][0] < g.t_end:
+            if wind_tacks[j][1] == "port":
+                port += 1
+            else:
+                stbd += 1
+            j += 1
+        if port == 0 and stbd == 0:
+            tacks_by_segment[g.segment_index] = None
+        else:
+            tacks_by_segment[g.segment_index] = "starboard" if stbd >= port else "port"
 
     grades_out = []
     for g in graded:
-        tack, pos = _seg_tack_pos(g)
+        tack = tacks_by_segment.get(g.segment_index)
+        pos = _polar._point_of_sail(g.twa_deg) if g.twa_deg is not None else None
         grades_out.append(
             {
                 "i": g.segment_index,

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2878,7 +2878,8 @@ async function runAbCompare() {
 // Polar Performance
 // ---------------------------------------------------------------------------
 
-let _polarData = null;
+let _polarData = null;       // full-session cells from /api/sessions/:id/polar
+let _polarDataRaw = null;    // untouched API response (for reset)
 
 async function loadPolar() {
   try {
@@ -2887,6 +2888,7 @@ async function loadPolar() {
     const data = await r.json();
     if (!data.cells || !data.cells.length) return;
 
+    _polarDataRaw = data;
     _polarData = data;
     document.getElementById('polar-card').style.display = '';
     renderPolarDiagram();
@@ -3232,6 +3234,117 @@ function highlightPolarCellSegments(twsBin, pointOfSail, tack, twaBin) {
       : 'No matching segments for ' + label;
   }
   _setPolarHighlightSegments(matching);
+}
+
+// Polar filters (#534). All client-side — no API calls.
+function _readPolarFilters() {
+  const el = id => document.getElementById(id);
+  return {
+    pos: el('pf-pos') ? el('pf-pos').value : 'all',
+    tack: el('pf-tack') ? el('pf-tack').value : 'all',
+    twsMin: el('pf-tws-min') ? parseFloat(el('pf-tws-min').value) : 0,
+    twsMax: el('pf-tws-max') ? parseFloat(el('pf-tws-max').value) : 40,
+    delta: el('pf-delta') ? el('pf-delta').value : 'all',
+    phase: el('pf-phase') ? el('pf-phase').value : 'all',
+  };
+}
+
+function _rebuildCellsFromGrades(grades) {
+  // Re-aggregate segments into (tws, twa, pos, tack) cells. Used when a
+  // time-window filter (race phase) restricts which segments count.
+  // Target BSP is constant per (tws, twa) since the baseline is symmetric,
+  // so we just reuse the first non-null target seen in the bucket.
+  const buckets = {};
+  for (const g of grades) {
+    if (g.tws == null || g.twa == null || g.tack == null || g.point_of_sail == null) continue;
+    const tws = Math.floor(g.tws);
+    const twa = Math.floor(g.twa / 5) * 5;
+    const key = tws + '|' + twa + '|' + g.point_of_sail + '|' + g.tack;
+    let b = buckets[key];
+    if (!b) {
+      b = {
+        tws: tws, twa: twa, point_of_sail: g.point_of_sail, tack: g.tack,
+        bspSum: 0, bspCount: 0, target: null,
+      };
+      buckets[key] = b;
+    }
+    if (g.bsp != null) { b.bspSum += g.bsp; b.bspCount += 1; }
+    if (b.target == null && g.target != null) b.target = g.target;
+  }
+  const cells = [];
+  for (const b of Object.values(buckets)) {
+    const session_mean = b.bspCount ? b.bspSum / b.bspCount : null;
+    const delta = (session_mean != null && b.target != null)
+      ? Math.round((session_mean - b.target) * 10000) / 10000 : null;
+    cells.push({
+      tws: b.tws, twa: b.twa,
+      point_of_sail: b.point_of_sail, tack: b.tack,
+      baseline_mean: b.target, baseline_p90: null,
+      session_mean: session_mean != null ? Math.round(session_mean * 10000) / 10000 : null,
+      samples: b.bspCount,
+      delta: delta,
+    });
+  }
+  cells.sort((a, b) => a.tws - b.tws || a.twa - b.twa);
+  return cells;
+}
+
+function _applyPolarFilters() {
+  if (!_polarDataRaw) return;
+  const f = _readPolarFilters();
+
+  // 1. Decide the cell source: raw API cells or re-aggregate from replay grades
+  //    when a race-phase filter is active.
+  let cells;
+  if (f.phase !== 'all'
+      && typeof _replayGrades !== 'undefined' && _replayGrades && _replayGrades.length) {
+    const gun = (typeof _raceGun !== 'undefined' && _raceGun) ? _raceGun : _replayStart;
+    const finish = _replayEnd;
+    const subset = _replayGrades.filter(g => {
+      const t = g.t_start.getTime();
+      if (f.phase === 'prestart') return t < gun.getTime();
+      if (f.phase === 'racing') return t >= gun.getTime() && t <= finish.getTime();
+      if (f.phase === 'postfinish') return t > finish.getTime();
+      return true;
+    });
+    cells = _rebuildCellsFromGrades(subset);
+  } else {
+    cells = _polarDataRaw.cells.slice();
+  }
+
+  // 2. Apply client-side hides.
+  cells = cells.filter(c => {
+    if (f.pos !== 'all' && c.point_of_sail !== f.pos) return false;
+    if (f.tack !== 'all' && c.tack !== f.tack) return false;
+    if (c.tws < f.twsMin || c.tws > f.twsMax) return false;
+    if (f.delta === 'faster' && !(c.delta != null && c.delta > 0)) return false;
+    if (f.delta === 'slower' && !(c.delta != null && c.delta < 0)) return false;
+    if (f.delta === 'big' && !(c.delta != null && Math.abs(c.delta) >= 0.5)) return false;
+    return true;
+  });
+
+  _polarData = Object.assign({}, _polarDataRaw, {
+    cells: cells,
+    tws_bins: Array.from(new Set(cells.map(c => c.tws))).sort((a, b) => a - b),
+    twa_bins: Array.from(new Set(cells.map(c => c.twa))).sort((a, b) => a - b),
+    session_sample_count: cells.reduce((s, c) => s + (c.samples || 0), 0),
+  });
+  _polarSelectedCells.clear();
+  renderPolarDiagram();
+  renderPolarHeatmap();
+}
+
+function _onPolarFiltersChanged() { _applyPolarFilters(); }
+
+function _resetPolarFilters() {
+  const set = (id, v) => { const el = document.getElementById(id); if (el) el.value = v; };
+  set('pf-pos', 'all');
+  set('pf-tack', 'all');
+  set('pf-tws-min', '0');
+  set('pf-tws-max', '40');
+  set('pf-delta', 'all');
+  set('pf-phase', 'all');
+  _applyPolarFilters();
 }
 
 // Dot click-selection state for the polar diagram.

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -3046,16 +3046,23 @@ function renderPolarDiagram() {
     ctx.strokeStyle = color;
     ctx.lineWidth = 2;
     ctx.globalAlpha = 0.7;
+    // Split upwind (<90°) from downwind (≥90°) so the baseline curve
+    // doesn't cross the beam line — a boat never sails that shape.
+    const upwind = pts.filter(p => p.twa < 90);
+    const downwind = pts.filter(p => p.twa >= 90);
     for (const side of [1, -1]) {
-      ctx.beginPath();
-      for (let i = 0; i < pts.length; i++) {
-        const rad = pts[i].twa * Math.PI / 180;
-        const r = pts[i].baseline_mean * scale;
-        const x = cx + side * r * Math.sin(rad);
-        const y = cy - r * Math.cos(rad);
-        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      for (const leg of [upwind, downwind]) {
+        if (leg.length < 2) continue;
+        ctx.beginPath();
+        for (let i = 0; i < leg.length; i++) {
+          const rad = leg[i].twa * Math.PI / 180;
+          const r = leg[i].baseline_mean * scale;
+          const x = cx + side * r * Math.sin(rad);
+          const y = cy - r * Math.cos(rad);
+          if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+        }
+        ctx.stroke();
       }
-      ctx.stroke();
     }
     ctx.globalAlpha = 1;
   }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -3059,6 +3059,7 @@ function renderPolarDiagram() {
   }
 
   // Session points, placed on the side that matches the cell's tack.
+  _polarDotHitboxes = [];
   for (const c of _polarData.cells) {
     if (c.session_mean == null) continue;
     const side = c.tack === 'port' ? -1 : 1;
@@ -3078,7 +3079,18 @@ function renderPolarDiagram() {
     ctx.strokeStyle = cssVar('--bg-primary');
     ctx.lineWidth = 1;
     ctx.stroke();
+
+    _polarDotHitboxes.push({x: x, y: y, r: dotSize, cell: c});
+
+    if (_polarSelectedCells.has(_polarCellKey(c))) {
+      ctx.beginPath();
+      ctx.arc(x, y, dotSize + 4, 0, 2 * Math.PI);
+      ctx.strokeStyle = '#facc15';
+      ctx.lineWidth = 2.5;
+      ctx.stroke();
+    }
   }
+  _bindPolarCanvasHandler();
 
   const legend = document.getElementById('polar-legend');
   if (legend && drawnTws.length) {
@@ -3147,7 +3159,7 @@ function _polarSubgridHtml(title, cells, twaBins, twsRange) {
         + '\nP90: ' + (c.baseline_p90 != null ? c.baseline_p90.toFixed(2) : 'n/a')
         + '\nSamples: ' + c.samples
         + (c.delta != null ? '\n\nClick to highlight matching replay segments' : '');
-      const onclick = 'highlightPolarCellSegments(' + tws + ",'" + c.point_of_sail + "','" + c.tack + "')";
+      const onclick = 'highlightPolarCellSegments(' + tws + ",'" + c.point_of_sail + "','" + c.tack + "'," + twa + ')';
       const cursor = c.delta != null ? 'pointer' : 'default';
       html += '<td style="padding:2px 4px;background:' + bg + ';border:1px solid var(--bg-input);'
         + 'color:' + textColor + ';text-align:center;cursor:' + cursor + '" title="' + ttl + '"'
@@ -3190,9 +3202,11 @@ function renderPolarHeatmap() {
   container.innerHTML = html;
 }
 
-// Highlight all graded replay segments that match a (tws_bin, point_of_sail,
-// tack) polar cell. Called from the heatmap cell click handler (#534).
-function highlightPolarCellSegments(twsBin, pointOfSail, tack) {
+// Highlight all graded replay segments that match a polar cell (#534).
+// twaBin is optional: when omitted, matches all TWA bins in that TWS/pos/tack
+// (heatmap row/col click); when provided, restricts to a single cell (diagram
+// dot click).
+function highlightPolarCellSegments(twsBin, pointOfSail, tack, twaBin) {
   const grades = (typeof _replayGrades !== 'undefined' && _replayGrades) ? _replayGrades : null;
   const st = document.getElementById('polar-highlight-status');
   if (!grades || !grades.length) {
@@ -3201,14 +3215,92 @@ function highlightPolarCellSegments(twsBin, pointOfSail, tack) {
   }
   const matching = grades.filter(g => {
     if (g.tws == null || g.tack == null || g.point_of_sail == null) return false;
-    return Math.floor(g.tws) === twsBin
-      && g.point_of_sail === pointOfSail
-      && g.tack === tack;
+    if (Math.floor(g.tws) !== twsBin) return false;
+    if (g.point_of_sail !== pointOfSail) return false;
+    if (g.tack !== tack) return false;
+    if (twaBin != null) {
+      if (g.twa == null) return false;
+      if (Math.floor(g.twa / 5) * 5 !== twaBin) return false;
+    }
+    return true;
   });
+  const label = twsBin + ' kt / ' + pointOfSail + ' / ' + tack
+    + (twaBin != null ? ' / TWA ' + twaBin + '\u00b0' : '');
   if (st) {
     st.textContent = matching.length
-      ? matching.length + ' segments highlighted (' + twsBin + ' kt / ' + pointOfSail + ' / ' + tack + ')'
-      : 'No matching segments in replay';
+      ? matching.length + ' segments highlighted (' + label + ')'
+      : 'No matching segments for ' + label;
+  }
+  _setPolarHighlightSegments(matching);
+}
+
+// Dot click-selection state for the polar diagram.
+let _polarDotHitboxes = [];  // [{x, y, r, cell}]
+let _polarSelectedCells = new Set(); // keys "tws|twa|pos|tack"
+let _polarCanvasHandlerBound = false;
+
+function _polarCellKey(c) {
+  return c.tws + '|' + c.twa + '|' + c.point_of_sail + '|' + c.tack;
+}
+
+function _bindPolarCanvasHandler() {
+  if (_polarCanvasHandlerBound) return;
+  const canvas = document.getElementById('polar-canvas');
+  if (!canvas) return;
+  canvas.addEventListener('click', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+    let best = null;
+    let bestDist = Infinity;
+    for (const hb of _polarDotHitboxes) {
+      const dx = x - hb.x;
+      const dy = y - hb.y;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d <= hb.r + 4 && d < bestDist) { best = hb; bestDist = d; }
+    }
+    if (!best) {
+      if (!e.shiftKey) {
+        _polarSelectedCells.clear();
+        _applyPolarDotSelection();
+      }
+      return;
+    }
+    const key = _polarCellKey(best.cell);
+    if (e.shiftKey) {
+      if (_polarSelectedCells.has(key)) _polarSelectedCells.delete(key);
+      else _polarSelectedCells.add(key);
+    } else {
+      _polarSelectedCells.clear();
+      _polarSelectedCells.add(key);
+    }
+    _applyPolarDotSelection();
+  });
+  _polarCanvasHandlerBound = true;
+}
+
+function _applyPolarDotSelection() {
+  renderPolarDiagram();  // redraws rings around selected dots
+  const grades = (typeof _replayGrades !== 'undefined' && _replayGrades) ? _replayGrades : null;
+  const st = document.getElementById('polar-highlight-status');
+  if (!grades) return;
+  if (!_polarSelectedCells.size) {
+    if (st) st.textContent = '';
+    _setPolarHighlightSegments([]);
+    return;
+  }
+  const matching = grades.filter(g => {
+    if (g.tws == null || g.tack == null || g.point_of_sail == null || g.twa == null) return false;
+    const tws = Math.floor(g.tws);
+    const twa = Math.floor(g.twa / 5) * 5;
+    const key = tws + '|' + twa + '|' + g.point_of_sail + '|' + g.tack;
+    return _polarSelectedCells.has(key);
+  });
+  if (st) {
+    st.textContent = _polarSelectedCells.size + ' cell(s) selected \u2014 '
+      + matching.length + ' segments highlighted';
   }
   _setPolarHighlightSegments(matching);
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2958,12 +2958,14 @@ function renderPolarDiagram() {
   if (!canvas || !_polarData) return;
   const ctx = canvas.getContext('2d');
   const W = canvas.width, H = canvas.height;
-  const cx = W / 2, cy = 30;
-  const maxRadius = H - 50;
+  // Full-circle layout: starboard on the right (positive x), port mirrored
+  // on the left (negative x) — lets the diagram show port/starboard asymmetry
+  // alongside the heatmap split (#534).
+  const cx = W / 2, cy = H / 2;
+  const maxRadius = Math.min(cx, cy) - 30;
 
   ctx.clearRect(0, 0, W, H);
 
-  // Determine BSP range for scaling
   let maxBsp = 0;
   for (const c of _polarData.cells) {
     if (c.session_mean != null) maxBsp = Math.max(maxBsp, c.session_mean);
@@ -2974,7 +2976,6 @@ function renderPolarDiagram() {
   if (maxBsp < 4) maxBsp = 4;
   const scale = maxRadius / maxBsp;
 
-  // Draw concentric BSP circles
   const polarBorder = cssVar('--border');
   const polarTextSec = cssVar('--text-secondary');
   ctx.strokeStyle = polarBorder;
@@ -2985,40 +2986,57 @@ function renderPolarDiagram() {
   for (let bsp = 1; bsp <= maxBsp; bsp++) {
     const r = bsp * scale;
     ctx.beginPath();
-    ctx.arc(cx, cy, r, 0, Math.PI);
+    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
     ctx.stroke();
     ctx.fillText(bsp + '', cx + r + 3, cy + 4);
   }
 
-  // Draw radial TWA lines
+  // Radial TWA lines on both sides.
   ctx.strokeStyle = polarBorder;
-  for (let deg = 0; deg <= 180; deg += 30) {
-    const rad = deg * Math.PI / 180;
-    const x2 = cx + maxBsp * scale * Math.sin(rad);
-    const y2 = cy + maxBsp * scale * Math.cos(rad);
-    ctx.beginPath();
-    ctx.moveTo(cx, cy);
-    ctx.lineTo(x2, y2);
-    ctx.stroke();
-    // Label
-    const lx = cx + (maxBsp * scale + 14) * Math.sin(rad);
-    const ly = cy + (maxBsp * scale + 14) * Math.cos(rad);
-    ctx.fillText(deg + '\u00b0', lx - 10, ly + 4);
+  for (const side of [1, -1]) {
+    for (let deg = 0; deg <= 180; deg += 30) {
+      const rad = deg * Math.PI / 180;
+      const x2 = cx + side * maxBsp * scale * Math.sin(rad);
+      const y2 = cy - maxBsp * scale * Math.cos(rad);
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(x2, y2);
+      ctx.stroke();
+      const lx = cx + side * (maxBsp * scale + 14) * Math.sin(rad);
+      const ly = cy - (maxBsp * scale + 14) * Math.cos(rad);
+      ctx.fillText(deg + '\u00b0', lx - 10, ly + 4);
+    }
   }
+  // Horizontal upwind/downwind divider at TWA = 90°.
+  ctx.setLineDash([6, 4]);
+  ctx.strokeStyle = polarTextSec;
+  ctx.beginPath();
+  ctx.moveTo(cx - maxBsp * scale, cy);
+  ctx.lineTo(cx + maxBsp * scale, cy);
+  ctx.stroke();
   ctx.setLineDash([]);
+  ctx.fillStyle = polarTextSec;
+  ctx.fillText('PORT', cx - maxBsp * scale - 4, cy - maxBsp * scale - 6);
+  ctx.fillText('STBD', cx + maxBsp * scale - 26, cy - maxBsp * scale - 6);
 
-  // Group baseline cells by TWS
+  // Baseline curves — symmetric, so draw mirrored on both sides.
   const baselineByTws = {};
   for (const c of _polarData.cells) {
     if (c.baseline_mean == null) continue;
     if (!baselineByTws[c.tws]) baselineByTws[c.tws] = [];
     baselineByTws[c.tws].push(c);
   }
-
-  // Draw baseline curves
+  // Dedup baseline points per TWS so mirrored draws don't double up.
   const drawnTws = [];
   for (const tws of Object.keys(baselineByTws).map(Number).sort((a, b) => a - b)) {
-    const pts = baselineByTws[tws].sort((a, b) => a.twa - b.twa);
+    const seen = {};
+    const uniq = [];
+    for (const p of baselineByTws[tws]) {
+      if (seen[p.twa]) continue;
+      seen[p.twa] = true;
+      uniq.push(p);
+    }
+    const pts = uniq.sort((a, b) => a.twa - b.twa);
     if (pts.length < 2) continue;
     const color = _twsColor(tws);
     drawnTws.push({tws, color});
@@ -3026,25 +3044,28 @@ function renderPolarDiagram() {
     ctx.strokeStyle = color;
     ctx.lineWidth = 2;
     ctx.globalAlpha = 0.7;
-    ctx.beginPath();
-    for (let i = 0; i < pts.length; i++) {
-      const rad = pts[i].twa * Math.PI / 180;
-      const r = pts[i].baseline_mean * scale;
-      const x = cx + r * Math.sin(rad);
-      const y = cy + r * Math.cos(rad);
-      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    for (const side of [1, -1]) {
+      ctx.beginPath();
+      for (let i = 0; i < pts.length; i++) {
+        const rad = pts[i].twa * Math.PI / 180;
+        const r = pts[i].baseline_mean * scale;
+        const x = cx + side * r * Math.sin(rad);
+        const y = cy - r * Math.cos(rad);
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
     }
-    ctx.stroke();
     ctx.globalAlpha = 1;
   }
 
-  // Draw session points
+  // Session points, placed on the side that matches the cell's tack.
   for (const c of _polarData.cells) {
     if (c.session_mean == null) continue;
+    const side = c.tack === 'port' ? -1 : 1;
     const rad = c.twa * Math.PI / 180;
     const r = c.session_mean * scale;
-    const x = cx + r * Math.sin(rad);
-    const y = cy + r * Math.cos(rad);
+    const x = cx + side * r * Math.sin(rad);
+    const y = cy - r * Math.cos(rad);
 
     const dotColor = c.delta == null ? cssVar('--text-muted')
       : c.delta >= 0 ? cssVar('--success') : cssVar('--danger');
@@ -3059,14 +3080,13 @@ function renderPolarDiagram() {
     ctx.stroke();
   }
 
-  // Legend
   const legend = document.getElementById('polar-legend');
   if (legend && drawnTws.length) {
     legend.innerHTML = 'Baseline curves: '
       + drawnTws.map(d =>
         '<span style="color:' + d.color + '">\u25cf ' + d.tws + ' kt</span>'
       ).join(' &nbsp; ')
-      + ' &nbsp; Session: '
+      + ' &nbsp; Session (left = port, right = stbd): '
       + '<span style="color:var(--success)">\u25cf faster</span> '
       + '<span style="color:var(--danger)">\u25cf slower</span> '
       + '<span style="color:var(--text-muted)">\u25cf no baseline</span>';

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -3091,29 +3091,26 @@ function _deltaColor(delta) {
   }
 }
 
-function renderPolarHeatmap() {
-  const container = document.getElementById('polar-heatmap');
-  if (!container || !_polarData) return;
+// Max TWS bin to always show in the heatmap (even when session has no data
+// there) so the wind range up to 20 kt is always visible (#534).
+const POLAR_HEATMAP_MAX_TWS = 20;
 
-  const data = _polarData;
+function _polarSubgridHtml(title, cells, twaBins, twsRange) {
   const cellMap = {};
-  for (const c of data.cells) {
-    cellMap[c.tws + ',' + c.twa] = c;
-  }
+  for (const c of cells) cellMap[c.tws + ',' + c.twa] = c;
 
-  let html = '<table style="border-collapse:collapse;font-size:.72rem;width:100%">';
-
-  // Header row: TWA labels
+  let html = '<div class="polar-subgrid"><h4 style="margin:.5rem 0 .25rem;font-size:.78rem;'
+    + 'color:var(--text-secondary);font-weight:600">' + title + '</h4>';
+  html += '<table style="border-collapse:collapse;font-size:.72rem;width:100%">';
   html += '<tr><th style="padding:2px 4px;color:var(--text-secondary);text-align:right;font-weight:normal">TWS\\TWA</th>';
-  for (const twa of data.twa_bins) {
+  for (const twa of twaBins) {
     html += '<th style="padding:2px 4px;color:var(--text-secondary);font-weight:normal;min-width:36px">' + twa + '\u00b0</th>';
   }
   html += '</tr>';
 
-  // One row per TWS
-  for (const tws of data.tws_bins) {
+  for (const tws of twsRange) {
     html += '<tr><td style="padding:2px 4px;color:var(--text-secondary);text-align:right;white-space:nowrap">' + tws + ' kt</td>';
-    for (const twa of data.twa_bins) {
+    for (const twa of twaBins) {
       const c = cellMap[tws + ',' + twa];
       if (!c) {
         html += '<td style="padding:2px 4px;background:var(--bg-secondary);border:1px solid var(--bg-input)"></td>';
@@ -3124,19 +3121,110 @@ function renderPolarHeatmap() {
       const text = c.delta != null
         ? (c.delta >= 0 ? '+' : '') + c.delta.toFixed(2)
         : c.session_mean != null ? c.session_mean.toFixed(1) : '';
-      const title = 'TWS=' + tws + ' TWA=' + twa + '\u00b0'
+      const ttl = 'TWS=' + tws + ' TWA=' + twa + '\u00b0 (' + c.point_of_sail + '/' + c.tack + ')'
         + '\nSession BSP: ' + (c.session_mean != null ? c.session_mean.toFixed(2) : 'n/a')
         + '\nBaseline: ' + (c.baseline_mean != null ? c.baseline_mean.toFixed(2) : 'n/a')
         + '\nP90: ' + (c.baseline_p90 != null ? c.baseline_p90.toFixed(2) : 'n/a')
-        + '\nSamples: ' + c.samples;
+        + '\nSamples: ' + c.samples
+        + (c.delta != null ? '\n\nClick to highlight matching replay segments' : '');
+      const onclick = 'highlightPolarCellSegments(' + tws + ",'" + c.point_of_sail + "','" + c.tack + "')";
+      const cursor = c.delta != null ? 'pointer' : 'default';
       html += '<td style="padding:2px 4px;background:' + bg + ';border:1px solid var(--bg-input);'
-        + 'color:' + textColor + ';text-align:center;cursor:default" title="' + title + '">'
-        + text + '</td>';
+        + 'color:' + textColor + ';text-align:center;cursor:' + cursor + '" title="' + ttl + '"'
+        + ' onclick="' + onclick + '">' + text + '</td>';
     }
     html += '</tr>';
   }
-  html += '</table>';
+  html += '</table></div>';
+  return html;
+}
+
+function renderPolarHeatmap() {
+  const container = document.getElementById('polar-heatmap');
+  if (!container || !_polarData) return;
+
+  const data = _polarData;
+  const split = { 'upwind-starboard': [], 'upwind-port': [], 'downwind-starboard': [], 'downwind-port': [] };
+  let maxTws = 0;
+  for (const c of data.cells) {
+    const key = c.point_of_sail + '-' + c.tack;
+    if (split[key]) split[key].push(c);
+    if (c.tws > maxTws) maxTws = c.tws;
+  }
+
+  const topTws = Math.max(POLAR_HEATMAP_MAX_TWS, maxTws);
+  const twsRange = [];
+  for (let t = 0; t <= topTws; t++) twsRange.push(t);
+
+  const upwindTwa = [];
+  for (let a = 0; a < 90; a += 5) upwindTwa.push(a);
+  const downwindTwa = [];
+  for (let a = 90; a <= 180; a += 5) downwindTwa.push(a);
+
+  let html = '<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">';
+  html += _polarSubgridHtml('Upwind \u2014 Starboard tack', split['upwind-starboard'], upwindTwa, twsRange);
+  html += _polarSubgridHtml('Upwind \u2014 Port tack', split['upwind-port'], upwindTwa, twsRange);
+  html += _polarSubgridHtml('Downwind \u2014 Starboard tack', split['downwind-starboard'], downwindTwa, twsRange);
+  html += _polarSubgridHtml('Downwind \u2014 Port tack', split['downwind-port'], downwindTwa, twsRange);
+  html += '</div>';
   container.innerHTML = html;
+}
+
+// Highlight all graded replay segments that match a (tws_bin, point_of_sail,
+// tack) polar cell. Called from the heatmap cell click handler (#534).
+function highlightPolarCellSegments(twsBin, pointOfSail, tack) {
+  const grades = (typeof _replayGrades !== 'undefined' && _replayGrades) ? _replayGrades : null;
+  const st = document.getElementById('polar-highlight-status');
+  if (!grades || !grades.length) {
+    if (st) st.textContent = 'Replay not loaded \u2014 highlight unavailable';
+    return;
+  }
+  const matching = grades.filter(g => {
+    if (g.tws == null || g.tack == null || g.point_of_sail == null) return false;
+    return Math.floor(g.tws) === twsBin
+      && g.point_of_sail === pointOfSail
+      && g.tack === tack;
+  });
+  if (st) {
+    st.textContent = matching.length
+      ? matching.length + ' segments highlighted (' + twsBin + ' kt / ' + pointOfSail + ' / ' + tack + ')'
+      : 'No matching segments in replay';
+  }
+  _setPolarHighlightSegments(matching);
+}
+
+// Bright overlay polylines for segments matching a clicked polar cell.
+// Drawn on top of the base track; cleared on next call.
+let _polarHighlightLayers = [];
+
+function _clearPolarHighlight() {
+  for (const l of _polarHighlightLayers) {
+    try { _map && _map.removeLayer(l); } catch (e) { /* ignore */ }
+  }
+  _polarHighlightLayers = [];
+}
+
+function _setPolarHighlightSegments(grades) {
+  _clearPolarHighlight();
+  if (!_map || !_trackData || !_trackData.timestamps || !_trackData.latLngs) return;
+  if (!grades || !grades.length) return;
+  const timestamps = _trackData.timestamps;
+  const latLngs = _trackData.latLngs;
+  for (const g of grades) {
+    const tStart = g.t_start.getTime();
+    const tEnd = g.t_end.getTime();
+    const slice = [];
+    for (let i = 0; i < timestamps.length; i++) {
+      const t = timestamps[i].getTime();
+      if (t >= tStart && t <= tEnd) slice.push(latLngs[i]);
+    }
+    if (slice.length >= 2) {
+      const line = L.polyline(slice, {
+        color: '#facc15', weight: 8, opacity: 0.95,
+      }).addTo(_map);
+      _polarHighlightLayers.push(line);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -5798,11 +5886,16 @@ async function _loadReplayData() {
       cog: s.cog,
     }));
     _replayGrades = (data.grades || []).map(g => ({
+      i: g.i,
       t_start: new Date(g.t_start),
       t_end: new Date(g.t_end),
       grade: g.grade,
       pct: g.pct,
       delta: g.delta,
+      tws: g.tws,
+      twa: g.twa,
+      tack: g.tack,
+      point_of_sail: g.point_of_sail,
     }));
     // Register HUD as a clock consumer so it updates on every tick/seek
     registerSurface('hud', function(utc) { _renderHud(utc); });

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6119,6 +6119,8 @@ async function _loadReplayData() {
       delta: g.delta,
       tws: g.tws,
       twa: g.twa,
+      bsp: g.bsp,
+      target: g.target,
       tack: g.tack,
       point_of_sail: g.point_of_sail,
     }));

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -203,7 +203,8 @@
     </div>
     <div id="polar-heatmap-view" style="display:none">
       <div id="polar-heatmap" style="overflow-x:auto"></div>
-      <div style="font-size:.72rem;color:var(--text-secondary);margin-top:6px;text-align:center">Green = faster than baseline &middot; Red = slower &middot; Gray = no baseline</div>
+      <div style="font-size:.72rem;color:var(--text-secondary);margin-top:6px;text-align:center">Green = faster than baseline &middot; Red = slower &middot; Gray = no baseline &middot; Click a cell to highlight matching replay segments</div>
+      <div id="polar-highlight-status" style="font-size:.72rem;color:var(--accent);margin-top:4px;text-align:center"></div>
     </div>
     <div id="polar-summary" style="font-size:.78rem;color:var(--text-secondary);margin-top:8px;text-align:center"></div>
   </div>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -197,6 +197,45 @@
       <button class="filter-btn active" id="polar-tab-diagram" onclick="setPolarView('diagram')">Polar Diagram</button>
       <button class="filter-btn" id="polar-tab-heatmap" onclick="setPolarView('heatmap')">Heatmap</button>
     </div>
+    <div id="polar-filters" style="display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;margin-bottom:8px;font-size:.72rem;color:var(--text-secondary)">
+      <label>Point of sail
+        <select id="pf-pos" onchange="_onPolarFiltersChanged()">
+          <option value="all">All</option>
+          <option value="upwind">Upwind</option>
+          <option value="downwind">Downwind</option>
+        </select>
+      </label>
+      <label>Tack
+        <select id="pf-tack" onchange="_onPolarFiltersChanged()">
+          <option value="all">All</option>
+          <option value="port">Port</option>
+          <option value="starboard">Starboard</option>
+        </select>
+      </label>
+      <label>TWS
+        <input id="pf-tws-min" type="number" min="0" max="40" value="0" style="width:3.5em" onchange="_onPolarFiltersChanged()">
+        &ndash;
+        <input id="pf-tws-max" type="number" min="0" max="40" value="40" style="width:3.5em" onchange="_onPolarFiltersChanged()">
+        kt
+      </label>
+      <label>Performance
+        <select id="pf-delta" onchange="_onPolarFiltersChanged()">
+          <option value="all">All</option>
+          <option value="faster">Faster than baseline</option>
+          <option value="slower">Slower than baseline</option>
+          <option value="big">|&Delta;| &ge; 0.5 kt</option>
+        </select>
+      </label>
+      <label>Race phase
+        <select id="pf-phase" onchange="_onPolarFiltersChanged()">
+          <option value="all">Full session</option>
+          <option value="prestart">Pre-start</option>
+          <option value="racing">Racing</option>
+          <option value="postfinish">Post-finish</option>
+        </select>
+      </label>
+      <button class="filter-btn" onclick="_resetPolarFilters()" style="padding:2px 8px">Reset</button>
+    </div>
     <div id="polar-diagram-view">
       <canvas id="polar-canvas" width="600" height="600" style="width:100%;max-width:600px;display:block;margin:0 auto"></canvas>
       <div id="polar-legend" style="font-size:.72rem;color:var(--text-secondary);margin-top:6px;text-align:center"></div>

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -349,6 +349,117 @@ async def test_session_polar_tws_and_twa_bins_sorted(storage: Storage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Session polar splits (#534) — point-of-sail × tack
+# ---------------------------------------------------------------------------
+
+
+async def _make_session_split(
+    storage: Storage,
+    race_num: int,
+    bsp: float,
+    tws: float,
+    wind_angle: float,  # ref=0 boat-relative, signed
+) -> int:
+    start = _BASE_TS + timedelta(hours=race_num)
+    end = start + timedelta(seconds=10)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES (?, 'SplitEvt', ?, ?, ?, ?)",
+        (
+            f"Split-R{race_num}",
+            race_num,
+            start.date().isoformat(),
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    await db.commit()
+    for i in range(10):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, bsp))
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, tws, wind_angle, 0))
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    row = await cur.fetchone()
+    return int(row["id"])
+
+
+@pytest.mark.asyncio
+async def test_split_starboard_upwind(storage: Storage) -> None:
+    sid = await _make_session_split(storage, 30, bsp=6.0, tws=10.0, wind_angle=45.0)
+    result = await session_polar_comparison(storage, sid)
+    assert result is not None
+    assert len(result.cells) == 1
+    c = result.cells[0]
+    assert c.tack == "starboard"
+    assert c.point_of_sail == "upwind"
+    assert c.twa_bin == 45
+
+
+@pytest.mark.asyncio
+async def test_split_port_downwind(storage: Storage) -> None:
+    sid = await _make_session_split(storage, 31, bsp=5.0, tws=12.0, wind_angle=-140.0)
+    result = await session_polar_comparison(storage, sid)
+    assert result is not None
+    assert len(result.cells) == 1
+    c = result.cells[0]
+    assert c.tack == "port"
+    assert c.point_of_sail == "downwind"
+    # abs(140) → bin 140
+    assert c.twa_bin == 140
+
+
+@pytest.mark.asyncio
+async def test_split_same_twa_bin_different_tacks(storage: Storage) -> None:
+    """Port and starboard at the same angle produce two distinct cells."""
+    start = _BASE_TS + timedelta(hours=32)
+    end = start + timedelta(seconds=20)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('Both', 'E', 32, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    for i in range(10):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, 6.0))
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, 10.0, 45.0, 0))
+    for i in range(10, 20):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, 5.8))
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, 10.0, -45.0, 0))
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    row = await cur.fetchone()
+    result = await session_polar_comparison(storage, int(row["id"]))
+    assert result is not None
+    assert len(result.cells) == 2
+    by_tack = {c.tack: c for c in result.cells}
+    assert set(by_tack) == {"port", "starboard"}
+    assert by_tack["starboard"].session_mean_bsp == pytest.approx(6.0, rel=1e-3)
+    assert by_tack["port"].session_mean_bsp == pytest.approx(5.8, rel=1e-3)
+    assert all(c.twa_bin == 45 for c in result.cells)
+    assert all(c.point_of_sail == "upwind" for c in result.cells)
+
+
+@pytest.mark.asyncio
+async def test_split_shares_symmetric_baseline(storage: Storage) -> None:
+    """Baseline is still keyed on abs(TWA); both tacks read the same target."""
+    for i in range(1, 4):
+        await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)
+    await build_polar_baseline(storage)
+
+    sid = await _make_session_split(storage, 33, bsp=6.5, tws=10.0, wind_angle=-45.0)
+    result = await session_polar_comparison(storage, sid)
+    assert result is not None
+    assert len(result.cells) == 1
+    c = result.cells[0]
+    assert c.tack == "port"
+    assert c.baseline_mean_bsp == pytest.approx(6.0, rel=1e-3)
+    assert c.delta == pytest.approx(0.5, rel=1e-2)
+
+
+# ---------------------------------------------------------------------------
 # Per-segment grading (#469)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Session polar comparison now bins by `(tws, twa, point_of_sail, tack)`. Baseline stays symmetric (no migration); the split is session-view only, per the design decision on #534.
- Heatmap renders four tables (upwind × port/stb, downwind × port/stb), always showing the TWS range up to 20 kt.
- Clicking a flagged cell highlights matching replay segments as a bright overlay on the track map — no navigation, per option (C).
- `/api/sessions/{id}/replay` enriches each graded segment with `tack` and `point_of_sail` derived from the raw wind records in that segment's window.
- Drops the `session_count >= 3` gate on the session-view baseline lookup so sparse cells still show a target (decision from #534 comment thread).

Closes #534

## Test plan

- [x] `uv run pytest` — 1907 passed
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy src/helmlog/polar.py src/helmlog/routes/sessions.py`
- [ ] Visual check on a real session: four heatmap tables render, TWS range goes to 20, cell click highlights track segments. (I cannot exercise the browser UI from here — please spot-check on corvopi-tst1 after deploy.)

🤖 Generated with [Claude Code](https://claude.ai/code)