### PR TITLE
feat: derived current overlay on replay map (phase 1 of #523)

### DIFF
--- a/src/helmlog/current.py
+++ b/src/helmlog/current.py
@@ -1,0 +1,44 @@
+"""Water current derivation from boat velocity vectors.
+
+The boat's velocity through the water (STW, HDG) and over the ground
+(SOG, COG) differ by the water current acting on the hull. Subtracting
+the two vectors yields the current the boat experienced at that moment.
+
+Convention: "set" is the compass direction the current is flowing *toward*
+(oceanographic), degrees 0..360 with 0=N, 90=E. "drift" is current speed
+in knots.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def _polar_to_ne(speed: float, compass_deg: float) -> tuple[float, float]:
+    rad = math.radians(compass_deg)
+    return (speed * math.cos(rad), speed * math.sin(rad))
+
+
+def compute_set_drift(
+    sog: float | None,
+    cog: float | None,
+    stw: float | None,
+    hdg: float | None,
+) -> tuple[float, float] | None:
+    """Return (set_deg, drift_kts) or None if any input is missing.
+
+    set_deg is the direction the current flows *toward*, 0..360.
+    When drift is effectively zero, set_deg is reported as 0.0.
+    """
+    if sog is None or cog is None or stw is None or hdg is None:
+        return None
+
+    n_g, e_g = _polar_to_ne(sog, cog)
+    n_w, e_w = _polar_to_ne(stw, hdg)
+    n_c, e_c = n_g - n_w, e_g - e_w
+
+    drift = math.hypot(n_c, e_c)
+    if drift < 1e-9:
+        return (0.0, 0.0)
+    set_deg = math.degrees(math.atan2(e_c, n_c)) % 360.0
+    return (set_deg, drift)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse, Response
 from loguru import logger
 
 from helmlog.auth import require_auth, require_developer
+from helmlog.current import compute_set_drift
 from helmlog.routes._helpers import audit, get_storage, limiter
 
 router = APIRouter()
@@ -955,17 +956,26 @@ async def api_session_replay(
         sp = speeds_by_s.get(k)
         cs = cogsog_by_s.get(k)
         hd = hdgs_by_s.get(k)
+        stw_v = float(sp["speed_kts"]) if sp else None
+        sog_v = float(cs["sog_kts"]) if cs else None
+        cog_v = float(cs["cog_deg"]) if cs else None
+        hdg_v = float(hd["heading_deg"]) if hd else None
+        sd = compute_set_drift(sog=sog_v, cog=cog_v, stw=stw_v, hdg=hdg_v)
+        set_v: float | None = sd[0] if sd is not None else None
+        drift_v: float | None = sd[1] if sd is not None else None
         samples.append(
             {
                 "ts": k + "Z",
-                "stw": float(sp["speed_kts"]) if sp else None,
-                "sog": float(cs["sog_kts"]) if cs else None,
-                "cog": float(cs["cog_deg"]) if cs else None,
-                "hdg": float(hd["heading_deg"]) if hd else None,
+                "stw": stw_v,
+                "sog": sog_v,
+                "cog": cog_v,
+                "hdg": hdg_v,
                 "tws": tws,
                 "twa": twa,
                 "aws": aws,
                 "awa": awa,
+                "set": set_v,
+                "drift": drift_v,
             }
         )
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -440,6 +440,7 @@ async function loadTrack() {
     if (!_trackData) return;
     _moveCursorToUtc(utc);
     _updateBoatSettingsForUtc(utc);
+    _updateBoatCurrentMarker(utc);
   });
 
   // Click track → seek the playback clock (which then seeks video, audio, etc.)
@@ -832,6 +833,151 @@ function _maybeFollowPan(latLng) {
   // Use Leaflet's panTo with a short animation so the recenter glides
   // rather than snapping; duration short enough not to overshoot tick.
   _map.panTo(latLng, {animate: true, duration: 0.4});
+}
+
+// -----------------------------------------------------------------------
+// Current overlay (#523). Toggleable layer showing derived water current
+// (set/drift) from the boat's own track. Phase 1 renders arrows along the
+// sailed track and a live boat-adjacent indicator during replay. The
+// extrapolated field beyond the sailed area is deferred to a follow-up.
+// -----------------------------------------------------------------------
+
+let _currentLayer = null;         // L.LayerGroup for along-track arrows
+let _currentBoatMarker = null;    // L.marker for boat-adjacent indicator
+let _currentEnabled = false;
+let _currentOverlayBuilt = false;
+
+function _renderCurrentArrowSvg(setDeg, driftKts, color) {
+  // Length in px scales with drift, clamped for readability. 1 kt -> 18 px,
+  // capped at ~44 px so heavy current doesn't swamp the map.
+  const len = Math.min(44, Math.max(10, 8 + driftKts * 18));
+  const tail = Math.max(0, len - 6);
+  const c = color || '#2563eb';
+  // Compass rotation: set_deg is the direction the current flows *toward*
+  // (0=N, 90=E). SVG x-axis points east so rotate by (setDeg - 90).
+  const rot = setDeg - 90;
+  const w = len + 4;
+  return (
+    '<svg width="' + w + '" height="12" viewBox="-2 -6 ' + w + ' 12" ' +
+    'style="overflow:visible;pointer-events:none;transform:rotate(' + rot + 'deg);transform-origin:0 0">' +
+    '<line x1="0" y1="0" x2="' + tail + '" y2="0" stroke="#000" stroke-opacity="0.5" stroke-width="4" stroke-linecap="round"/>' +
+    '<line x1="0" y1="0" x2="' + tail + '" y2="0" stroke="' + c + '" stroke-width="2.2" stroke-linecap="round"/>' +
+    '<polygon points="' + len + ',0 ' + tail + ',-4 ' + tail + ',4" fill="' + c + '" stroke="#000" stroke-opacity="0.5" stroke-width="0.5"/>' +
+    '</svg>'
+  );
+}
+
+function _currentArrowDivIcon(setDeg, driftKts, color) {
+  return L.divIcon({
+    className: 'current-arrow',
+    html: _renderCurrentArrowSvg(setDeg, driftKts, color),
+    iconSize: [0, 0],
+    iconAnchor: [0, 0],
+  });
+}
+
+// Locate the track position for a given UTC by bracketing the track
+// timestamps (same bracket-and-lerp approach as _moveCursorToUtc).
+function _trackLatLngAtUtc(tMs) {
+  if (!_trackData) return null;
+  const {latLngs, timestamps} = _trackData;
+  if (!latLngs.length) return null;
+  let hi = _trackLowerBound(tMs);
+  if (hi <= 0) hi = 1;
+  if (hi >= timestamps.length) hi = timestamps.length - 1;
+  const lo = hi - 1;
+  const t0 = timestamps[lo].getTime();
+  const t1 = timestamps[hi].getTime();
+  let frac = t1 > t0 ? (tMs - t0) / (t1 - t0) : 0;
+  if (frac < 0) frac = 0; else if (frac > 1) frac = 1;
+  const a = latLngs[lo];
+  const b = latLngs[hi];
+  return [a[0] + (b[0] - a[0]) * frac, a[1] + (b[1] - a[1]) * frac];
+}
+
+// Circular-mean of set/drift across a ±halfMs window. Used both for
+// along-track thinning (damp noise) and the live boat-adjacent indicator.
+function _windowedSetDrift(tMs, halfMs) {
+  if (!_replaySamples || !_replaySamples.length) return null;
+  const lo = tMs - halfMs;
+  const hi = tMs + halfMs;
+  let x = 0, y = 0, n = 0;
+  const startIdx = _sampleLowerBound(lo);
+  for (let i = startIdx; i < _replaySamples.length; i++) {
+    const s = _replaySamples[i];
+    const t = s.ts.getTime();
+    if (t > hi) break;
+    if (s.set == null || s.drift == null) continue;
+    if (isNaN(s.set) || isNaN(s.drift)) continue;
+    // Vector mean: average the (set, drift) vectors in N/E components.
+    const r = (s.set * Math.PI) / 180;
+    x += s.drift * Math.cos(r);
+    y += s.drift * Math.sin(r);
+    n++;
+  }
+  if (!n) return null;
+  x /= n; y /= n;
+  const drift = Math.hypot(x, y);
+  if (drift < 1e-6) return {set: 0, drift: 0};
+  const setDeg = ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+  return {set: setDeg, drift: drift};
+}
+
+function _rebuildCurrentOverlay() {
+  if (!_map || !_trackData || !_replaySamples || !_replaySamples.length) return;
+  if (_currentLayer) { _map.removeLayer(_currentLayer); _currentLayer = null; }
+  _currentLayer = L.layerGroup();
+
+  // Sample every ~20 seconds along the track and use a ±10s window mean
+  // to damp sample-to-sample noise (STW + HDG are both noisy at 1 Hz).
+  const stepMs = 20000;
+  const halfMs = 10000;
+  const t0 = _trackData.timestamps[0].getTime();
+  const tEnd = _trackData.timestamps[_trackData.timestamps.length - 1].getTime();
+  for (let t = t0; t <= tEnd; t += stepMs) {
+    const sd = _windowedSetDrift(t, halfMs);
+    if (!sd || sd.drift < 0.08) continue; // noise floor
+    const pos = _trackLatLngAtUtc(t);
+    if (!pos) continue;
+    const marker = L.marker(pos, {
+      icon: _currentArrowDivIcon(sd.set, sd.drift, '#2563eb'),
+      interactive: false,
+      keyboard: false,
+    });
+    _currentLayer.addLayer(marker);
+  }
+
+  if (_currentEnabled) _currentLayer.addTo(_map);
+  _currentOverlayBuilt = true;
+}
+
+function _updateBoatCurrentMarker(utc) {
+  if (!_currentEnabled || !_map || !_trackData) return;
+  const tMs = utc.getTime();
+  const sd = _windowedSetDrift(tMs, 15000);
+  const pos = _trackLatLngAtUtc(tMs);
+  if (!pos || !sd || sd.drift < 0.05) {
+    if (_currentBoatMarker) { _map.removeLayer(_currentBoatMarker); _currentBoatMarker = null; }
+    return;
+  }
+  const icon = _currentArrowDivIcon(sd.set, sd.drift, '#f59e0b');
+  if (!_currentBoatMarker) {
+    _currentBoatMarker = L.marker(pos, {icon: icon, interactive: false, keyboard: false}).addTo(_map);
+  } else {
+    _currentBoatMarker.setLatLng(pos);
+    _currentBoatMarker.setIcon(icon);
+  }
+}
+
+function _setCurrentOverlayEnabled(on) {
+  _currentEnabled = !!on;
+  if (_currentEnabled) {
+    if (!_currentOverlayBuilt) _rebuildCurrentOverlay();
+    if (_currentLayer && _map) _currentLayer.addTo(_map);
+  } else {
+    if (_currentLayer && _map) _map.removeLayer(_currentLayer);
+    if (_currentBoatMarker && _map) { _map.removeLayer(_currentBoatMarker); _currentBoatMarker = null; }
+  }
 }
 
 // Render the boat cursor SVG. The hull is a simplified triangle that
@@ -6116,7 +6262,10 @@ async function _loadReplayData() {
       awa: s.awa,
       hdg: s.hdg,
       cog: s.cog,
+      set: s.set,
+      drift: s.drift,
     }));
+    if (typeof _rebuildCurrentOverlay === 'function') _rebuildCurrentOverlay();
     _replayGrades = (data.grades || []).map(g => ({
       i: g.i,
       t_start: new Date(g.t_start),
@@ -6186,6 +6335,13 @@ function _wireReplayControls() {
   const courseToggle = document.getElementById('toggle-course-overlay');
   if (courseToggle) courseToggle.addEventListener('change', (e) => {
     _setCourseOverlayVisible(e.target.checked);
+  });
+  const currentToggle = document.getElementById('toggle-current-overlay');
+  if (currentToggle) currentToggle.addEventListener('change', (e) => {
+    _setCurrentOverlayEnabled(e.target.checked);
+    if (e.target.checked && _playClock && _playClock.positionUtc) {
+      _updateBoatCurrentMarker(_playClock.positionUtc);
+    }
   });
 
   const prevBtn = document.getElementById('replay-prev-event-btn');

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -104,6 +104,7 @@
     <label style="margin-right:12px"><input type="checkbox" id="toggle-follow-boat"> Keep boat centered</label>
     <label style="margin-right:12px"><input type="checkbox" id="toggle-maneuver-markers" checked> Maneuvers</label>
     <label style="margin-right:12px"><input type="checkbox" id="toggle-course-overlay" checked> Marks &amp; lines</label>
+    <label style="margin-right:12px"><input type="checkbox" id="toggle-current-overlay"> Current</label>
     <span id="polar-legend" style="display:none;margin-left:6px">
       <span style="display:inline-block;width:10px;height:10px;background:#d64545;vertical-align:middle;margin-right:2px"></span>&lt;90%
       <span style="display:inline-block;width:10px;height:10px;background:#d6a745;vertical-align:middle;margin:0 2px 0 8px"></span>90–97%

--- a/tests/test_current.py
+++ b/tests/test_current.py
@@ -1,0 +1,64 @@
+"""Tests for derived water current (set/drift) from boat velocity vectors.
+
+Convention: "set" is the compass direction the current is flowing *toward*
+(oceanographic), degrees 0..360 with 0=N, 90=E. "drift" is current speed in knots.
+
+Derivation:
+    v_ground = (SOG, COG)  # boat velocity over ground
+    v_water  = (STW, HDG)  # boat velocity through water
+    current  = v_ground - v_water
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from helmlog.current import compute_set_drift
+
+
+def _approx(a: float, b: float, tol: float = 1e-6) -> bool:
+    return abs(a - b) <= tol
+
+
+class TestComputeSetDrift:
+    def test_no_current_when_ground_matches_water(self) -> None:
+        set_deg, drift_kts = compute_set_drift(sog=5.0, cog=0.0, stw=5.0, hdg=0.0)
+        assert drift_kts == pytest.approx(0.0, abs=1e-9)
+        # Set direction is undefined when drift is zero; implementation returns 0.0.
+        assert set_deg == 0.0
+
+    def test_pure_eastward_push_on_northbound_boat(self) -> None:
+        # Boat steering 5 kt due north through water, but made good 5 kt
+        # due east over ground. Water pushed the boat east and south equally:
+        # current = (5,0) ground - (0,5) water = (5,-5). Toward SE, mag √50.
+        set_deg, drift_kts = compute_set_drift(sog=5.0, cog=90.0, stw=5.0, hdg=0.0)
+        assert drift_kts == pytest.approx(math.sqrt(50), rel=1e-6)
+        assert set_deg == pytest.approx(135.0, abs=1e-6)
+
+    def test_head_current_slows_boat(self) -> None:
+        # Boat steering north at 5 kt water, only making 3 kt COG due north.
+        # Current = (0,3)-(0,5) = (0,-2). Toward south, 2 kt.
+        set_deg, drift_kts = compute_set_drift(sog=3.0, cog=0.0, stw=5.0, hdg=0.0)
+        assert drift_kts == pytest.approx(2.0, abs=1e-9)
+        assert set_deg == pytest.approx(180.0, abs=1e-6)
+
+    def test_drifting_with_stw_zero(self) -> None:
+        # Sails down, STW=0, but making 1 kt south over ground.
+        set_deg, drift_kts = compute_set_drift(sog=1.0, cog=180.0, stw=0.0, hdg=0.0)
+        assert drift_kts == pytest.approx(1.0, abs=1e-9)
+        assert set_deg == pytest.approx(180.0, abs=1e-6)
+
+    def test_wraps_to_360_range(self) -> None:
+        # Boat steering east through water, pushed slightly north.
+        # water = (5,0) (east component, north component)... using math convention
+        # with compass angles, we trust the function to wrap [0, 360).
+        set_deg, _ = compute_set_drift(sog=5.05, cog=85.0, stw=5.0, hdg=90.0)
+        assert 0.0 <= set_deg < 360.0
+
+    def test_returns_none_for_missing_inputs(self) -> None:
+        assert compute_set_drift(sog=None, cog=0.0, stw=5.0, hdg=0.0) is None
+        assert compute_set_drift(sog=5.0, cog=None, stw=5.0, hdg=0.0) is None
+        assert compute_set_drift(sog=5.0, cog=0.0, stw=None, hdg=0.0) is None
+        assert compute_set_drift(sog=5.0, cog=0.0, stw=5.0, hdg=None) is None


### PR DESCRIPTION
## Summary

Phase 1 of #523 — a toggleable water-current overlay on the session replay map.

- **`src/helmlog/current.py`** — pure vector-subtraction of boat-through-water (STW, HDG) from boat-over-ground (SOG, COG). Returns (set°, drift kts) where *set* is the direction the current flows toward (oceanographic convention). 6 unit tests cover the cardinal cases + missing inputs.
- **Replay route** — each per-second sample now carries `set` / `drift` fields derived via `compute_set_drift`. No schema change, works on historical sessions immediately.
- **session.js / session.html** — new "Current" checkbox next to the other replay toggles. Builds a Leaflet layer of along-track arrows (~20 s spacing, ±10 s vector-mean smoothing to damp 1 Hz STW/HDG noise) and a live amber boat-adjacent arrow that tracks the replay cursor. Arrows are SVG divIcons so length stays readable at any zoom; length is proportional to drift, rotation encodes set.

## Scope & deferred work

Ships 4 of the 5 acceptance criteria from #523:
- [x] Toggle control on the replay map
- [x] Vectors rendered along the sailed track from observed data
- [x] Direction + speed both visually encoded and legible
- [x] Boat-adjacent current indicator updates during replay
- [ ] **Extrapolated field beyond the track** — deferred

Extrapolation is deferred deliberately: the value of an interpolated field depends on the quality of the underlying derivation, and this PR lets us eyeball the along-track arrows against lived experience on a few real sessions first. Follow-up PRs will cover (a) a `current_observations` table for season-long aggregation, (b) NOAA CO-OPS comparison, and (c) the learned prediction model that motivated the original issue.

## Test plan
- [x] `uv run pytest tests/test_current.py` — 6 passing
- [x] Full suite: 1877 passed, 2 skipped (no regressions)
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/` clean (0 issues across 105 files)
- [ ] Visual smoke test on a real session once deployed — toggle Current, verify along-track arrows appear, scrub the replay and watch the amber boat-adjacent arrow rotate

Closes partial #523 — remains open for the extrapolation + prediction phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)