### PR TITLE
fix: imported race rows must not become ghost sessions

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -280,22 +280,26 @@ async def _upsert_race(
     if row:
         return row[0]  # type: ignore[no-any-return]
 
-    # #532: Write a real ISO-8601 UTC timestamp into start_utc rather than the
-    # bare race date. The column is NOT NULL so we can't write NULL; midnight
-    # UTC of the race date is a harmless placeholder that parses cleanly via
-    # _parse_utc and is filtered out of get_current_race(). If the source
-    # payload ever carries a real scheduled start, substitute it here.
-    start_utc_iso = f"{race.date}T00:00:00+00:00"
+    # Imported races have no real start/stop timestamps — they're just
+    # result rows pinned to a date. Write midnight UTC of race.date for both
+    # start_utc and end_utc so (a) the NOT NULL start_utc column is
+    # satisfied and (b) get_current_race() never picks them up as open
+    # sessions. The previous attempt (#532) left end_utc NULL and relied on
+    # a `start_utc LIKE '%T%'` filter, which matched the placeholder and
+    # promoted imported rows to "current", producing ghost sessions on the
+    # home page.
+    placeholder_iso = f"{race.date}T00:00:00+00:00"
     cur = await db.execute(
-        "INSERT INTO races (name, event, race_num, date, start_utc, "
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, "
         "session_type, regatta_id, source, source_id) "
-        "VALUES (?, ?, ?, ?, ?, 'race', ?, ?, ?)",
+        "VALUES (?, ?, ?, ?, ?, ?, 'race', ?, ?, ?)",
         (
             f"{race.name} - {race.class_name}" if race.class_name else race.name,
             race.class_name,
             race.race_number,
             race.date,
-            start_utc_iso,
+            placeholder_iso,
+            placeholder_iso,
             regatta_id,
             source,
             race.source_id,

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -3311,15 +3311,16 @@ class Storage:
     async def get_current_race(self) -> Race | None:
         """Return the most recent race with no end_utc, or None.
 
-        Excludes rows whose ``start_utc`` is empty or date-only — those are
-        imported results placeholders (#532), not genuinely open sessions,
-        and reporting one as "current" would surface a stale race on the UI.
+        Imported race-result rows set ``end_utc`` at insert time so they
+        never appear here — see ``results/importer.py``. Earlier code
+        (#532) tried to filter them via ``start_utc LIKE '%T%'``, but the
+        placeholder ISO string matched that pattern, producing ghost "open"
+        races on the home page for every imported row.
         """
         db = self._read_conn()
         cur = await db.execute(
             f"SELECT {self._RACE_COLS}"
             " FROM races WHERE end_utc IS NULL"
-            "   AND start_utc IS NOT NULL AND start_utc LIKE '%T%'"
             " ORDER BY start_utc DESC LIMIT 1"
         )
         row = await cur.fetchone()

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -97,6 +97,23 @@ async def test_import_races_have_full_iso_start_utc(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_imported_races_are_closed_and_not_current(storage: Storage) -> None:
+    """Imported race rows must have end_utc set at insert time so they are
+    never returned by ``get_current_race``. Otherwise every imported row
+    shows up as an open session on the home page with a runaway timer."""
+    results = await _fetch_results()
+    await import_results(storage, results)
+    db = storage._conn()
+    async with db.execute("SELECT start_utc, end_utc FROM races WHERE source = 'clubspot'") as cur:
+        rows = await cur.fetchall()
+    assert rows, "expected imported races"
+    for row in rows:
+        assert row["end_utc"] is not None, "imported race missing end_utc"
+        assert row["end_utc"] == row["start_utc"]
+    assert await storage.get_current_race() is None
+
+
+@pytest.mark.asyncio
 async def test_import_creates_boats(storage: Storage) -> None:
     results = await _fetch_results()
     await import_results(storage, results)

--- a/tests/test_storage_start_utc_parse.py
+++ b/tests/test_storage_start_utc_parse.py
@@ -131,19 +131,20 @@ class TestMigrationV67Backfill:
 
 
 class TestGetCurrentRace:
-    """get_current_race must not return a race with a date-only start_utc."""
+    """get_current_race must only return genuinely open recording sessions."""
 
     @pytest.mark.asyncio
-    async def test_skips_date_only_start_utc(self, storage: Storage) -> None:
-        """Imported results rows (date-only start_utc, no end_utc) should not
-        be reported as the 'current' race — they are not actually running."""
+    async def test_skips_imported_race_with_end_utc(self, storage: Storage) -> None:
+        """Imported results rows carry end_utc at insert time so they are
+        never returned by get_current_race. Without this guarantee every
+        imported row would show up as an open session on the home page."""
         db = storage._conn()
         await db.execute(
             "INSERT INTO races"
             " (name, event, race_num, date, start_utc, end_utc, session_type)"
             " VALUES"
             " ('Imported Race', 'Flying Sails', 1, '2026-04-13',"
-            "  '2026-04-13', NULL, 'race')"
+            "  '2026-04-13T00:00:00+00:00', '2026-04-13T00:00:00+00:00', 'race')"
         )
         await db.commit()
 


### PR DESCRIPTION
## Summary
- Race-results importer now writes `end_utc = start_utc` at insert time so imported rows are never classified as an open recording session.
- `Storage.get_current_race()` drops its dead `start_utc LIKE '%T%'` filter — that filter was supposed to skip imported placeholders but the importer's synthesized ISO string contained `T`, so every imported row slipped through and showed up as the \"current\" race.
- Regression tests added in `tests/test_results_importer.py` and `tests/test_storage_start_utc_parse.py`.

Closes #541

## Background

On corvopi-live, importing Ballard Cup results left four rows with `end_utc=NULL`. The home page happily picked one as the current race and displayed a 49-hour runaway counter. Clicking **END Race** ended rows one at a time, but the next imported row immediately promoted to current, so from the user's perspective nothing happened.

## Unsticking an already-affected Pi

```sql
UPDATE races SET end_utc = start_utc
 WHERE end_utc IS NULL AND source IS NOT NULL;
```

(corvopi-live was unstuck manually before this PR.)

## Test plan
- [x] `uv run pytest tests/test_results_importer.py tests/test_races.py tests/test_storage.py tests/test_storage_start_utc_parse.py -q` — 174 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/helmlog/results/importer.py src/helmlog/storage.py` — clean
- [ ] Deploy to a Pi, import race results, confirm home page stays on the real current race (or idle) rather than promoting an imported row.

Generated with [Claude Code](https://claude.ai/code)