### PR TITLE
docs: Sprint 8 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,131 @@
 # Release Notes
 
+## Sprint 8 — Race Replay, Multi-Channel Audio & Results Import (2026-04-14)
+
+Full race-replay UI with polar-graded track and event stepping, multi-channel
+audio recording with per-position mic isolation and parallel sibling-card
+capture, Clubspot/STYC race-results import with session linking, and polar
+analysis overhauls.
+
+### Race replay ([#464](https://github.com/weaties/helmlog/issues/464), [#516](https://github.com/weaties/helmlog/pull/516), [#521](https://github.com/weaties/helmlog/pull/521))
+- **Playback core** ([#465](https://github.com/weaties/helmlog/issues/465),
+  [#468](https://github.com/weaties/helmlog/issues/468)) — play/pause/speed
+  scrubber with pause-on-seek, gauge cards with sparklines, and a unified
+  clock that fans seeks out from YouTube and multi-channel audio scrubbers
+  back to the map cursor and replay controls
+- **Polar-graded track** ([#469](https://github.com/weaties/helmlog/issues/469),
+  [#470](https://github.com/weaties/helmlog/issues/470)) — per-segment grading
+  pipeline drives the polyline color by polar %; SK track averaged per second
+  with source address captured per fix, decimated to match Vakaros vertex
+  density, and smoothed for display
+- **Boat cursor** — rotating boat icon interpolated between GPS fixes with
+  smoothed rotation, a follow-boat toggle, and crisper HDG/COG indicators
+- **Maneuver markers & event stepping** ([#475](https://github.com/weaties/helmlog/issues/475),
+  [#466](https://github.com/weaties/helmlog/issues/466)) — clickable markers
+  on track, keyboard-driven event navigation, and reclassification of
+  large-turn tacks/gybes as roundings
+- **Laylines & course overlay** ([#473](https://github.com/weaties/helmlog/issues/473))
+  — layline kind split by mark, anchored to roundings, wind-frame math fixed,
+  type-aware scaling with leeward cap, start-line laylines with 120s grace
+  window, and Vakaros race-gun honored as effective start
+- **Derived current overlay** ([#523](https://github.com/weaties/helmlog/issues/523),
+  [#538](https://github.com/weaties/helmlog/pull/538)) — phase 1: derive and
+  render current vectors on the replay map
+- **Cross-surface playback** — media players made independent, audio target
+  re-applied on play/loadedmetadata, YouTube clamped to clock state so
+  pause-on-seek sticks, throttled YT seekTo
+
+### Multi-channel audio & sibling capture ([#462](https://github.com/weaties/helmlog/issues/462), [#509](https://github.com/weaties/helmlog/issues/509))
+- **Schema & consent** ([#493](https://github.com/weaties/helmlog/issues/493))
+  — v63 channel_map + transcript_segments + voice biometric consent audit
+- **Hardware discovery & capture** ([#494](https://github.com/weaties/helmlog/issues/494))
+  — pyudev USB device detection and multi-channel recording in `audio.py`
+- **Per-channel transcription** ([#495](https://github.com/weaties/helmlog/issues/495))
+  — per-channel ASR with unified time-sorted segment merge
+- **Channel mapping UI** ([#496](https://github.com/weaties/helmlog/issues/496),
+  [#497](https://github.com/weaties/helmlog/issues/497)) — admin channel-map
+  page, voice consent acknowledgement flow, and per-session overrides from
+  the home page
+- **Mixed playback + isolation** ([#498](https://github.com/weaties/helmlog/issues/498))
+  — Web Audio mixed playback with segment-click channel isolation
+- **Export & deletion** ([#499](https://github.com/weaties/helmlog/issues/499))
+  — multi-channel WAV export preserves all channels; atomic per-channel
+  deletion satisfies data-licensing right-to-erasure
+- **Sibling-card parallel capture** ([#509](https://github.com/weaties/helmlog/issues/509))
+  — `AudioRecorderGroup` opens one mono USB receiver per sibling with a
+  shared `capture_group_id`; transcription fans out across siblings and
+  merges into one time-sorted transcript; session page plays every sibling
+  via multi-source Web Audio
+- **Per-receiver native players** ([#525](https://github.com/weaties/helmlog/issues/525),
+  [#540](https://github.com/weaties/helmlog/pull/540)) — stacked native
+  `<audio controls>` below the mixed player, one per receiver, with per-row
+  download; starting one pauses the mix and any other playing sibling
+- **Capture hotfixes** — PortAudio re-init on Linux detection, pyudev sound
+  subsystem filtered to `card*`, `AudioRecorderGroup` accepted alongside
+  `AudioRecorder` on the web layer, and graceful race-start audio failure
+
+### Race results import ([#459](https://github.com/weaties/helmlog/issues/459), [#460](https://github.com/weaties/helmlog/pull/460))
+- **Clubspot provider & importer** — schema v59 with provider protocol, idempotent Clubspot importer, and bundled test fixtures
+- **STYC HTML provider** — STYC results import with place dedup and a `series.htm` fallback ([#526](https://github.com/weaties/helmlog/issues/526))
+- **Admin Race Results page** — browse imported regattas, trigger imports, link imported races to local sessions
+- **Auto-discover** ([#524](https://github.com/weaties/helmlog/pull/524),
+  [#526](https://github.com/weaties/helmlog/issues/526)) — Clubspot regatta
+  name + classes and STYC series/races discovered from a single URL
+- **Session linking** ([#520](https://github.com/weaties/helmlog/issues/520))
+  — auto-link imported races to local sessions on import, pair by order,
+  match by stored date column, `/rematch` endpoint + admin button, session
+  page picker to link results manually
+- **History & session page polish** — imported races hidden from session
+  history listing, session page shows linked fleet results, source links on
+  the results page, class ID validation
+
+### Polar analysis ([#534](https://github.com/weaties/helmlog/issues/534), [#536](https://github.com/weaties/helmlog/issues/536))
+- **Full-circle polar diagram** — port/stbd split with panel split by
+  point-of-sail and tack; upwind and downwind curves stay disconnected
+- **Panel filters** — position, tack, TWS range, delta, and race phase
+- **Click-to-highlight** — polar diagram dot click highlights matching replay
+  segments via enriched grade mapping carrying bsp + target
+- **Baseline race window** ([#536](https://github.com/weaties/helmlog/issues/536),
+  [#537](https://github.com/weaties/helmlog/pull/537)) — exclude pre-start
+  from polar baseline
+
+### Maneuvers UI ([#531](https://github.com/weaties/helmlog/pull/531))
+- **Filter pills** — stackable type/tack/rank/post-start filters on the
+  maneuvers card, overlay respects them, and the enriched payload is cached
+  per session
+- **Tracks & markers** — smoother maneuver tracks with speed-recovery
+  markers, tack direction labels corrected, track ticks, and optional
+  Vakaros overlay with SK/Vakaros source toggles and row→overlay highlight
+
+### Backup & reporting ([#518](https://github.com/weaties/helmlog/issues/518), [#519](https://github.com/weaties/helmlog/pull/519))
+- **SSH preflight, safety gate, and email reports** — backup script now
+  pre-checks the SSH target, refuses to clobber, and mails a summary on
+  completion
+
+### CI & test hygiene
+- **Nightly review + bisect** ([#514](https://github.com/weaties/helmlog/pull/514),
+  [#515](https://github.com/weaties/helmlog/pull/515)) — replace per-PR
+  Claude review with a nightly-on-main job that bisects regressions, plus
+  follow-up storage/CI fixes
+- **write_audio_session identity regression guard** ([#517](https://github.com/weaties/helmlog/pull/517))
+
+### Bug fixes
+- **Start-line bias sign** ([#529](https://github.com/weaties/helmlog/pull/529))
+  — pin→boat bias sign inversion fixed
+- **Imported races break /api/state** ([#532](https://github.com/weaties/helmlog/issues/532),
+  [#533](https://github.com/weaties/helmlog/pull/533)) — naive/missing
+  start_utc on imported rows no longer 500s the home endpoint; v68/v69
+  migrations backfill existing rows
+- **Ghost "open" imported races** ([#541](https://github.com/weaties/helmlog/issues/541),
+  [#542](https://github.com/weaties/helmlog/pull/542)) — importer now writes
+  `end_utc = start_utc` at insert time so imported rows never get picked up
+  by `get_current_race`; the dead `start_utc LIKE '%T%'` filter removed
+
+### Dependencies
+- **ruff** → `>=0.15.10`, **python-dotenv** → `>=1.2.2`,
+  **pytest-cov** → `>=7.1.0`, **influxdb-client** → `>=1.50.0`,
+  **pyannote-audio** → `>=4.0.4`, **actions/github-script** → v9
+
 ## Sprint 7 — Vakaros Ingest, Maneuver Analysis & Diarized Playback (2026-04-11)
 
 Vakaros VKX watched-folder ingest with rich start-line overlays, a new

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,13 @@
 # Release Notes
 
-## Sprint 8 — Race Replay, Multi-Channel Audio & Results Import (2026-04-14)
+## Sprint 8 — Race Replay, Multi-Channel Audio, Results Import & Session Page Overhaul (2026-04-15)
 
 Full race-replay UI with polar-graded track and event stepping, multi-channel
 audio recording with per-position mic isolation and parallel sibling-card
-capture, Clubspot/STYC race-results import with session linking, and polar
-analysis overhauls.
+capture, Clubspot/STYC race-results import with session linking, polar
+analysis overhauls, debrief audio on the session page, a rebuilt history row
+summary, and a session page with wind overlay, resizable track map, and
+collapsible gauge layers.
 
 ### Race replay ([#464](https://github.com/weaties/helmlog/issues/464), [#516](https://github.com/weaties/helmlog/pull/516), [#521](https://github.com/weaties/helmlog/pull/521))
 - **Playback core** ([#465](https://github.com/weaties/helmlog/issues/465),
@@ -120,6 +122,44 @@ analysis overhauls.
   [#542](https://github.com/weaties/helmlog/pull/542)) — importer now writes
   `end_utc = start_utc` at insert time so imported rows never get picked up
   by `get_current_race`; the dead `start_utc LIKE '%T%'` filter removed
+- **Backup rsync partial-transfer** ([#544](https://github.com/weaties/helmlog/issues/544),
+  [#545](https://github.com/weaties/helmlog/pull/545)) — treat rsync rc=23/24
+  as warning instead of failure in backup reporting
+- **Clubspot multi-race linking** ([#551](https://github.com/weaties/helmlog/pull/551))
+  — fix session linking for multi-race days; admin rematch can force-relink
+  existing rows
+
+### Debrief audio on session page ([#546](https://github.com/weaties/helmlog/issues/546), [#547](https://github.com/weaties/helmlog/pull/547))
+- **Surface debrief audio + transcript** — attached debrief audio and its
+  transcript now render on the session page alongside the race audio
+- **Click-to-seek** — clicking a debrief transcript segment seeks the debrief
+  audio player
+- **Consolidated layout** — race transcript lives under the race audio player,
+  debrief renders as a collapsible subsection below it
+- **History cleanup** — attached debriefs hidden from the default history
+  list so they don't double-count as sessions
+
+### History row overhaul ([#549](https://github.com/weaties/helmlog/pull/549))
+- **Race-first filter** — default history filter is Race; debrief filter
+  removed (debriefs now live attached to their race)
+- **Per-row race summary** — each row shows thumbnail, wind, and top-3 fleet
+  result (preferring imported `race_results`, always surfacing the own boat)
+- **Simpler rows** — inline actions, exports, audio player, and pills
+  stripped from list rows; initial load triggers on page render
+
+### Session page: wind overlay, resizable map, collapsible gauges
+- **Wind card with TWD** ([#553](https://github.com/weaties/helmlog/pull/553))
+  — TWD added to wind card with true/apparent stacked by column
+- **Wind overlay on track** ([#555](https://github.com/weaties/helmlog/pull/555))
+  — TWD/TWS met wind barbs drawn along the track with zoom-adaptive cadence
+  and hover tooltips
+- **Current overlay polish** ([#557](https://github.com/weaties/helmlog/pull/557))
+  — zoom-adaptive cadence and lighter strokes for the derived current overlay
+- **Resizable track map** ([#559](https://github.com/weaties/helmlog/pull/559))
+  — S/M/L/XL size presets for the session track map
+- **Collapsible layer/gauge rows** ([#560](https://github.com/weaties/helmlog/pull/560))
+  — layer and gauge rows collapse, a current gauge was added, and gauges
+  moved above the map
 
 ### Dependencies
 - **ruff** → `>=0.15.10`, **python-dotenv** → `>=1.2.2`,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -161,6 +161,15 @@ collapsible gauge layers.
   — layer and gauge rows collapse, a current gauge was added, and gauges
   moved above the map
 
+### Discussion threads
+- **Shareable deep links** ([#561](https://github.com/weaties/helmlog/issues/561))
+  — query-param anchors (`?thread=<id>&comment=<id>`) that survive Slack and
+  other unfurls, copy-link buttons on threads and comments, flash-highlight on
+  arrival, and auth redirects that preserve the query string so a signed-out
+  recipient lands on the login wall and returns to the exact thread after
+  signing in; scroll pins the thread header to the top unless a linked reply
+  would fall below the fold, in which case the reply is centered
+
 ### Dependencies
 - **ruff** → `>=0.15.10`, **python-dotenv** → `>=1.2.2`,
   **pytest-cov** → `>=7.1.0`, **influxdb-client** → `>=1.50.0`,


### PR DESCRIPTION
## Summary
- Drafts the Sprint 8 entry in `RELEASES.md` in preparation for promoting `main` → `stage`.
- Covers commits since `stage/2026-04-11T23.47.32Z`.
- Updated 2026-04-15 to include debrief-on-session, history overhaul, and session-page wind/map/gauges work merged after the initial draft.

## Sections
- **Race replay** (#464, #516, #521) — playback core, polar-graded track, boat cursor, maneuver markers, laylines, derived current overlay (#538), cross-surface playback
- **Multi-channel audio & sibling capture** (#462 parts 1–7, #509, #525/#540) — schema + consent, pyudev capture, per-channel ASR, channel-map UI, mixed playback + isolation, multi-channel export + atomic deletion, sibling-card parallel capture, per-receiver native players, hotfixes
- **Race results import** (#459, #460, #520, #524, #526) — Clubspot + STYC providers, admin page, auto-discover, session linking
- **Polar analysis** (#534, #536, #537) — full-circle diagram, panel filters, click-to-highlight, baseline race window
- **Maneuvers UI** (#531) — filter pills, smoother tracks, Vakaros overlay
- **Backup** (#518, #519, #544, #545) — SSH preflight, safety gate, email reports, rsync partial-transfer warn
- **CI** (#514, #515, #517) — nightly review + bisect
- **Bug fixes** (#529, #532/#533, #541/#542, #551) — start-line bias sign, imported race start_utc, ghost imported races, clubspot multi-race linking
- **Debrief audio on session page** (#546/#547) — surface audio + transcript, click-to-seek, collapsible layout, hide attached debriefs from history list
- **History row overhaul** (#549) — race-first filter, per-row summary with thumbnail/wind/top-3, simpler rows
- **Session page: wind overlay, resizable map, collapsible gauges** (#553, #555, #557, #559, #560)
- **Dependencies** — ruff, python-dotenv, pytest-cov, influxdb-client, pyannote-audio, actions/github-script

## Test plan
- [ ] Review the new section and tweak wording/grouping as needed
- [ ] Confirm every PR/issue link resolves
- [ ] After merge, the \`promote.yml\` workflow should accept \`main → stage\` since this adds a new \`##\` heading

Generated with [Claude Code](https://claude.ai/code)