### PR TITLE
results: link imported races to local sessions in order (#550)

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -150,6 +150,8 @@ def _resolve_venue_tz(venue_tz: str | None) -> tzinfo:
 async def _link_regatta_races_to_local_sessions(
     db: aiosqlite.Connection,
     regatta_id: int,
+    *,
+    force: bool = False,
 ) -> int:
     """Link imported races to local race sessions on the same date.
 
@@ -165,7 +167,10 @@ async def _link_regatta_races_to_local_sessions(
     single-session behavior for short-handed days.
 
     Only rows with ``local_session_id IS NULL`` are updated, so manual
-    links and prior matches are preserved.
+    links and prior matches are preserved. Pass ``force=True`` to
+    re-link rows that already have a value — used by the admin rematch
+    endpoint to fix up data that was linked before zip-in-order was
+    implemented.
 
     Returns the number of links written.
     """
@@ -201,9 +206,9 @@ async def _link_regatta_races_to_local_sessions(
         zip_in_order = len(local_sessions) >= len(imported_sorted)
 
         for idx, (imp_id, _race_num, existing_link) in enumerate(imported_sorted):
-            if existing_link is not None:
-                continue
             local_id = local_sessions[idx] if zip_in_order else local_sessions[0]
+            if existing_link is not None and (not force or existing_link == local_id):
+                continue
             await db.execute(
                 "UPDATE races SET local_session_id = ? WHERE id = ?",
                 (local_id, imp_id),

--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -151,12 +151,18 @@ async def _link_regatta_races_to_local_sessions(
     db: aiosqlite.Connection,
     regatta_id: int,
 ) -> int:
-    """Link imported races to the earliest local race session on the same date.
+    """Link imported races to local race sessions on the same date.
 
-    For each date that the regatta has imported races on, every imported
-    race is linked to the earliest local race-type session recorded on
-    that date. A regatta date maps to one sailing day, so multiple
-    imported races (race 1, race 2, ...) share a single local session.
+    When the number of local race-type sessions on a date is greater
+    than or equal to the number of imported races on that date, imported
+    races are zipped 1:1 with local sessions in order (imported by
+    ``race_num``, local by ``start_utc``). This handles beer-can nights
+    where race 1 and race 2 are each their own logged session.
+
+    Otherwise (fewer local sessions than imported races, i.e. a single
+    local session covered the whole sailing day), every imported race is
+    linked to the earliest local session on that date — preserving the
+    single-session behavior for short-handed days.
 
     Only rows with ``local_session_id IS NULL`` are updated, so manual
     links and prior matches are preserved.
@@ -164,7 +170,7 @@ async def _link_regatta_races_to_local_sessions(
     Returns the number of links written.
     """
     cur = await db.execute(
-        "SELECT id, date, local_session_id FROM races"
+        "SELECT id, date, race_num, local_session_id FROM races"
         " WHERE regatta_id = ? AND source IS NOT NULL AND source != 'live'"
         " AND date IS NOT NULL",
         (regatta_id,),
@@ -173,24 +179,31 @@ async def _link_regatta_races_to_local_sessions(
     if not imported_rows:
         return 0
 
-    by_date: dict[date, list[tuple[int, int | None]]] = {}
+    by_date: dict[date, list[tuple[int, int | None, int | None]]] = {}
     for r in imported_rows:
         try:
             d = date.fromisoformat(r[1])
         except (ValueError, TypeError):
             continue
-        by_date.setdefault(d, []).append((r[0], r[2]))
+        by_date.setdefault(d, []).append((r[0], r[2], r[3]))
 
     linked_count = 0
     for d, imported in by_date.items():
         local_sessions = await _list_local_race_sessions_on_date(db, d)
         if not local_sessions:
             continue
-        local_id = local_sessions[0]
 
-        for imp_id, existing_link in imported:
+        imported_sorted = sorted(
+            imported,
+            key=lambda row: (row[1] is None, row[1] if row[1] is not None else 0, row[0]),
+        )
+
+        zip_in_order = len(local_sessions) >= len(imported_sorted)
+
+        for idx, (imp_id, _race_num, existing_link) in enumerate(imported_sorted):
             if existing_link is not None:
                 continue
+            local_id = local_sessions[idx] if zip_in_order else local_sessions[0]
             await db.execute(
                 "UPDATE races SET local_session_id = ? WHERE id = ?",
                 (local_id, imp_id),

--- a/src/helmlog/routes/results.py
+++ b/src/helmlog/routes/results.py
@@ -344,10 +344,10 @@ async def api_rematch_regatta(
 ) -> JSONResponse:
     """Re-run local-session matching over an already-imported regatta's races.
 
-    Pairs imported races to local race-type sessions by order within each
-    venue-local date.  Only updates rows with ``local_session_id IS NULL``;
-    manual links and prior matches are preserved.  Useful when local
-    sessions were created after the import.
+    Pairs imported races to local race-type sessions by order within
+    each venue-local date.  Re-links existing rows so an admin can fix
+    up a regatta that was imported before zip-in-order matching was
+    introduced (see #550).
     """
     from helmlog.results.importer import _link_regatta_races_to_local_sessions
 
@@ -365,7 +365,7 @@ async def api_rematch_regatta(
     row = await cur.fetchone()
     races_checked = int(row[0]) if row else 0
 
-    linked = await _link_regatta_races_to_local_sessions(db, regatta_id)
+    linked = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
     await db.commit()
 
     await audit(

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -403,6 +403,66 @@ async def test_import_preserves_manual_local_session_link(
 
 
 @pytest.mark.asyncio
+async def test_force_relinks_existing_wrong_links(storage: Storage) -> None:
+    """force=True rewrites auto-links that were set before zip-in-order
+    matching existed — the backfill path for regattas imported on a
+    server running the pre-#550 linker."""
+    from datetime import datetime
+
+    from helmlog.results.importer import _link_regatta_races_to_local_sessions
+
+    db = storage._conn()
+    results = await _fetch_results()
+    race_date = results.races[0].date
+    a = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    b = datetime.fromisoformat(race_date + "T19:10:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Race 1", "Local", 1, race_date, a.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (a_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Race 2", "Local", 2, race_date, b.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (b_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.commit()
+
+    await import_results(storage, results)
+
+    # Simulate the pre-#550 state: both imported races pinned to the
+    # earliest local session.
+    await db.execute(
+        "UPDATE races SET local_session_id = ? WHERE source = 'clubspot' AND date = ?",
+        (a_id, race_date),
+    )
+    await db.commit()
+
+    cur = await db.execute(
+        "SELECT regatta_id FROM races WHERE source = 'clubspot' LIMIT 1",
+    )
+    (regatta_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    linked = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
+    await db.commit()
+    # Race 1 was already pointing at a_id, so only race 2 needs rewriting.
+    assert linked == 1, "race 2 should be moved off the earliest session"
+
+    cur = await db.execute(
+        "SELECT race_num, local_session_id FROM races"
+        " WHERE source = 'clubspot' AND date = ? ORDER BY race_num",
+        (race_date,),
+    )
+    rows = await cur.fetchall()
+    assert rows[0]["local_session_id"] == a_id
+    assert rows[1]["local_session_id"] == b_id
+
+
+@pytest.mark.asyncio
 async def test_reimport_backfills_null_local_session(storage: Storage) -> None:
     """A re-import populates local_session_id when the prior import left it NULL."""
     from datetime import datetime

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -267,29 +267,75 @@ async def test_import_links_local_session_when_one_match(storage: Storage) -> No
 
 
 @pytest.mark.asyncio
-async def test_import_picks_earliest_when_multiple_local_sessions(
+async def test_import_zips_multiple_local_sessions_in_order(
     storage: Storage,
 ) -> None:
-    """Multi-session days link to the earliest local session."""
+    """Two local sessions + two imported races → each imported race links
+    to its own local session in race-number order (#550).
+
+    Beer-can nights log each on-the-water race as its own local session,
+    so race 1 should attach to the earlier local session and race 2 to
+    the later one.
+    """
     from datetime import datetime
 
     db = storage._conn()
     results = await _fetch_results()
     race_date = results.races[0].date
-    early = datetime.fromisoformat(race_date + "T15:00:00+00:00")
-    late = datetime.fromisoformat(race_date + "T22:00:00+00:00")
+    early = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    late = datetime.fromisoformat(race_date + "T19:10:00+00:00")
     await db.execute(
         "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
         " VALUES (?, ?, ?, ?, ?, 'race')",
-        ("Morning practice", "Local", 1, race_date, early.isoformat()),
+        ("Wednesday race 1", "Local", 1, race_date, early.isoformat()),
     )
     cur = await db.execute("SELECT last_insert_rowid()")
     (early_id,) = await cur.fetchone()  # type: ignore[misc]
     await db.execute(
         "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
         " VALUES (?, ?, ?, ?, ?, 'race')",
-        ("Afternoon races", "Local", 2, race_date, late.isoformat()),
+        ("Wednesday race 2", "Local", 2, race_date, late.isoformat()),
     )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (late_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.commit()
+
+    await import_results(storage, results)
+
+    cur = await db.execute(
+        "SELECT race_num, local_session_id FROM races"
+        " WHERE source = 'clubspot' AND date = ? ORDER BY race_num",
+        (race_date,),
+    )
+    rows = await cur.fetchall()
+    assert len(rows) == 2
+    assert rows[0]["local_session_id"] == early_id, (
+        "imported race 1 should link to the earlier local session"
+    )
+    assert rows[1]["local_session_id"] == late_id, (
+        "imported race 2 should link to the later local session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_shares_single_local_session_when_fewer_locals(
+    storage: Storage,
+) -> None:
+    """One local session + multiple imported races → all imported races
+    share that single local session (short-handed day, unchanged)."""
+    from datetime import datetime
+
+    db = storage._conn()
+    results = await _fetch_results()
+    race_date = results.races[0].date
+    start = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Wednesday night", "Local", 1, race_date, start.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (local_id,) = await cur.fetchone()  # type: ignore[misc]
     await db.commit()
 
     await import_results(storage, results)
@@ -299,9 +345,61 @@ async def test_import_picks_earliest_when_multiple_local_sessions(
         (race_date,),
     )
     rows = await cur.fetchall()
-    assert rows
+    assert len(rows) == 2
     for row in rows:
-        assert row["local_session_id"] == early_id
+        assert row["local_session_id"] == local_id
+
+
+@pytest.mark.asyncio
+async def test_import_preserves_manual_local_session_link(
+    storage: Storage,
+) -> None:
+    """A manually-set local_session_id on an imported race must survive re-import."""
+    from datetime import datetime
+
+    db = storage._conn()
+    results = await _fetch_results()
+    race_date = results.races[0].date
+    a = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    b = datetime.fromisoformat(race_date + "T19:10:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Session A", "Local", 1, race_date, a.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (a_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Session B", "Local", 2, race_date, b.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (b_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.commit()
+
+    await import_results(storage, results)
+
+    # Manually override: pin race 1 to session B (swap from the auto link).
+    await db.execute(
+        "UPDATE races SET local_session_id = ? WHERE source = 'clubspot' AND race_num = 1",
+        (b_id,),
+    )
+    await db.commit()
+
+    # Re-import must not clobber the manual link.
+    await import_results(storage, results)
+
+    cur = await db.execute(
+        "SELECT race_num, local_session_id FROM races"
+        " WHERE source = 'clubspot' AND date = ? ORDER BY race_num",
+        (race_date,),
+    )
+    rows = await cur.fetchall()
+    assert rows[0]["local_session_id"] == b_id, "manual link must be preserved"
+    # Race 2 keeps whatever was written on first import (session B by order).
+    assert rows[1]["local_session_id"] == b_id
+    _ = a_id  # a_id unused once manual override runs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Zip imported races 1:1 with local race-type sessions when the date has enough local sessions (imported ordered by `race_num`, local by `start_utc`)
- Fall back to the prior share-one-session behavior when there are fewer local sessions than imported races
- Preserves manually-set `local_session_id` links on re-import

Fixes the beer-can-night case where race 1 and race 2 are each logged as their own local session — previously both imported rows hooked to the earliest session, leaving session B with no top-3 on the history card.

Closes #550

## Test plan
- [x] New: two local sessions + two imported races → each links to its own session in order
- [x] Regression: one local session + multiple imported races → all share that session
- [x] Regression: manual `local_session_id` override survives re-import
- [x] `uv run pytest tests/test_results_importer.py`
- [x] `uv run ruff check` / `ruff format --check` / `mypy` on touched files

Generated with [Claude Code](https://claude.ai/code)