### PR TITLE
session: add TWD to wind card, stack true/apparent by column

### DIFF
--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1140,13 +1140,21 @@ async def api_session_replay(
         tw = true_winds_by_s.get(k)
         tws: float | None = None
         twa: float | None = None
+        twd: float | None = None
         if tw is not None:
             raw_ref = tw.get("reference")
             ref = int(raw_ref) if raw_ref is not None else -1
             tws = float(tw["wind_speed_kts"]) if tw["wind_speed_kts"] is not None else None
             h = hdgs_by_s.get(k)
             heading = float(h["heading_deg"]) if h and h["heading_deg"] is not None else None
-            twa = _polar._compute_twa(float(tw["wind_angle_deg"]), ref, heading)
+            wind_angle = float(tw["wind_angle_deg"])
+            twa = _polar._compute_twa(wind_angle, ref, heading)
+            # TWD is the compass direction the true wind is coming FROM.
+            # ref NORTH: wind_angle is already TWD. ref BOAT: add heading.
+            if ref == _polar._WIND_REF_NORTH:
+                twd = wind_angle % 360
+            elif ref == _polar._WIND_REF_BOAT and heading is not None:
+                twd = (heading + wind_angle) % 360
 
         aw = app_winds_by_s.get(k)
         aws: float | None = None
@@ -1174,6 +1182,7 @@ async def api_session_replay(
                 "hdg": hdg_v,
                 "tws": tws,
                 "twa": twa,
+                "twd": twd,
                 "aws": aws,
                 "awa": awa,
                 "set": set_v,

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6031,10 +6031,16 @@ function _renderHud(utc) {
   };
   setEl('hud-sog', _fmtNum(s && s.sog, 2));
   setEl('hud-stw', _fmtNum(s && s.stw, 2));
+  const _fmtDeg = (v) => {
+    if (v == null || Number.isNaN(v)) return '—';
+    const wrapped = ((Math.round(v) % 360) + 360) % 360;
+    return wrapped + '\u00b0';
+  };
   setEl('hud-tws', _fmtNum(s && s.tws, 1));
-  setEl('hud-twa', _fmtNum(s && s.twa, 0));
+  setEl('hud-twd', _fmtDeg(s && s.twd));
+  setEl('hud-twa', _fmtDeg(s && s.twa));
   setEl('hud-aws', _fmtNum(s && s.aws, 1));
-  setEl('hud-awa', _fmtNum(s && s.awa, 0));
+  setEl('hud-awa', _fmtDeg(s && s.awa));
   setEl('hud-hdg', _fmtNum(s && s.hdg, 0));
   setEl('hud-cog', _fmtNum(s && s.cog, 0));
   setEl('hud-pct', g && g.pct != null ? _fmtPct(g.pct) : '—');
@@ -6403,6 +6409,7 @@ async function _loadReplayData() {
       sog: s.sog,
       tws: s.tws,
       twa: s.twa,
+      twd: s.twd,
       aws: s.aws,
       awa: s.awa,
       hdg: s.hdg,

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -127,11 +127,19 @@
       </div>
       <div class="replay-gauge" data-gauge="wind" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
         <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Wind</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:2px 10px;font-family:monospace">
-          <span><span style="color:var(--text-secondary);font-size:.7rem">TWS</span> <span id="hud-tws" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
-          <span><span style="color:var(--text-secondary);font-size:.7rem">TWA</span> <span id="hud-twa" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
-          <span><span style="color:var(--text-secondary);font-size:.7rem">AWS</span> <span id="hud-aws" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
-          <span><span style="color:var(--text-secondary);font-size:.7rem">AWA</span> <span id="hud-awa" style="font-size:1.05rem;color:var(--text-primary)">—</span></span>
+        <div style="display:grid;grid-template-columns:auto 1fr 1fr;gap:1px 10px;font-family:monospace;align-items:baseline">
+          <span></span>
+          <span style="color:var(--text-secondary);font-size:.65rem;text-transform:uppercase">True</span>
+          <span style="color:var(--text-secondary);font-size:.65rem;text-transform:uppercase">Apparent</span>
+          <span style="color:var(--text-secondary);font-size:.7rem">SPD</span>
+          <span id="hud-tws" style="font-size:1.05rem;color:var(--text-primary)">—</span>
+          <span id="hud-aws" style="font-size:1.05rem;color:var(--text-primary)">—</span>
+          <span style="color:var(--text-secondary);font-size:.7rem">DIR</span>
+          <span id="hud-twd" style="font-size:1.05rem;color:var(--text-primary)">—</span>
+          <span style="font-size:1.05rem;color:var(--text-secondary)">—</span>
+          <span style="color:var(--text-secondary);font-size:.7rem">ANG</span>
+          <span id="hud-twa" style="font-size:1.05rem;color:var(--text-primary)">—</span>
+          <span id="hud-awa" style="font-size:1.05rem;color:var(--text-primary)">—</span>
         </div>
         <canvas id="spark-tws" width="300" height="22" style="width:100%;height:18px;display:block;margin-top:2px"></canvas>
         <canvas id="spark-twa" width="300" height="22" style="width:100%;height:18px;display:block"></canvas>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4015,6 +4015,9 @@ async def test_replay_endpoint_returns_samples_and_grades(storage: Storage) -> N
     assert sample["stw"] == pytest.approx(6.0)
     assert sample["tws"] == pytest.approx(10.0)
     assert sample["twa"] == pytest.approx(45.0)
+    # ref=0 is boat-referenced true wind and we seeded no heading, so TWD
+    # cannot be derived and must surface as None (not NaN or 0).
+    assert sample["twd"] is None
     # 30s / 10s per segment → 3 graded segments (grade is "unknown" because
     # no baseline has been built — we only check shape here).
     assert len(data["grades"]) == 3
@@ -4022,6 +4025,47 @@ async def test_replay_endpoint_returns_samples_and_grades(storage: Storage) -> N
         assert "grade" in g
         assert "t_start" in g
         assert "t_end" in g
+
+
+@pytest.mark.asyncio
+async def test_replay_endpoint_returns_twd_when_heading_present(storage: Storage) -> None:
+    """Boat-referenced true wind + heading → TWD = (heading + wind_angle) mod 360."""
+    from datetime import timedelta
+
+    from helmlog.nmea2000 import (
+        PGN_VESSEL_HEADING,
+        PGN_WIND_DATA,
+        HeadingRecord,
+        WindRecord,
+    )
+
+    start = datetime(2024, 8, 2, 12, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=5)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('TWD', 'E', 1, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    race_id = int((await cur.fetchone())["id"])
+    for i in range(5):
+        ts = start + timedelta(seconds=i)
+        await storage.write(HeadingRecord(PGN_VESSEL_HEADING, 5, ts, 180.0, None, None))
+        # ref=0 (boat-referenced), wind_angle=45 (TWA). Heading 180 → TWD 225.
+        await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, 10.0, 45.0, 0))
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/replay")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    sample = data["samples"][0]
+    assert sample["twd"] == pytest.approx(225.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `/api/sessions/{id}/replay` now emits `twd` per sample (wind compass direction). For ref=NORTH wind rows, `wind_angle_deg` is already TWD; for ref=BOAT, TWD is `(heading + wind_angle) mod 360` and surfaces as `null` when heading is absent.
- Session HUD wind card regrouped into a 3-column grid: row labels (SPD/DIR/ANG) × TRUE/APPARENT. Apparent direction renders as an em-dash (no meaningful compass value). Degrees render with ° and wrap 0–359.
- Added two replay-endpoint tests: `twd is None` when heading is absent, and `twd == 225°` with heading 180° + boat-referenced TWA 45°.

Closes #552

## Test plan

- [x] `uv run pytest tests/test_web.py` — 180 passed
- [x] `uv run ruff check .` / `ruff format --check`
- [x] `uv run mypy src/helmlog/routes/sessions.py`
- [ ] Visual check on a replay with both ref=NORTH and ref=BOAT wind data

Generated with [Claude Code](https://claude.ai/code)