### PR TITLE
session: resizable track map (S/M/L/XL)

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -364,6 +364,34 @@ function renderHeader() {
 // Track map
 // ---------------------------------------------------------------------------
 
+const TRACK_SIZE_KEY = 'helmlog.session.trackMapSize';
+const TRACK_SIZES = ['s', '', 'l', 'xl'];
+
+function applyTrackSize(size, map) {
+  const el = document.getElementById('track-map');
+  if (!el) return;
+  TRACK_SIZES.forEach(s => { if (s) el.classList.remove('size-' + s); });
+  if (size) el.classList.add('size-' + size);
+  document.querySelectorAll('.track-size-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.size === size);
+  });
+  if (map) setTimeout(() => map.invalidateSize(), 160);
+}
+
+function initTrackSizeControls(map) {
+  let saved = '';
+  try { saved = localStorage.getItem(TRACK_SIZE_KEY) || ''; } catch (e) {}
+  if (!TRACK_SIZES.includes(saved)) saved = '';
+  applyTrackSize(saved, null);
+  document.querySelectorAll('.track-size-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const size = btn.dataset.size;
+      applyTrackSize(size, map);
+      try { localStorage.setItem(TRACK_SIZE_KEY, size); } catch (e) {}
+    });
+  });
+}
+
 async function loadTrack() {
   const r = await fetch('/api/sessions/' + SESSION_ID + '/track');
   const geojson = await r.json();
@@ -376,6 +404,7 @@ async function loadTrack() {
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; OpenStreetMap', maxZoom: 18,
   }).addTo(_map);
+  initTrackSizeControls(_map);
 
   const feature = geojson.features[0];
   const coords = feature.geometry.coordinates;

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -5,7 +5,13 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
 <style>
 .field{background:var(--bg-input);border:1px solid var(--accent-strong);border-radius:6px;color:var(--text-primary)}
-.track-map{height:350px;border-radius:8px}
+.track-map{height:350px;border-radius:8px;transition:height .15s ease}
+.track-map.size-s{height:280px}
+.track-map.size-m{height:450px}
+.track-map.size-l{height:650px}
+.track-map.size-xl{height:calc(100vh - 160px);min-height:500px}
+.track-size-btn{background:var(--bg-input);color:var(--text-secondary);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:.72rem;cursor:pointer;min-height:26px}
+.track-size-btn.active{background:var(--accent-strong);color:var(--bg-primary);border-color:var(--accent-strong)}
 .section{margin-top:16px}
 .section-title{font-size:.82rem;text-transform:uppercase;letter-spacing:.07em;color:var(--text-secondary);margin-bottom:6px;cursor:pointer;user-select:none}
 .section-title:hover{color:var(--accent)}
@@ -115,6 +121,13 @@
       <span style="display:inline-block;width:10px;height:10px;background:#a855f7;vertical-align:middle;margin:0 2px 0 8px"></span>&ge;120% (suspect)
       <span style="display:inline-block;width:10px;height:10px;background:#888;vertical-align:middle;margin:0 2px 0 8px"></span>unknown
     </span>
+  </div>
+  <div id="track-size-row" style="display:flex;gap:4px;align-items:center;margin-bottom:6px;font-size:.72rem;color:var(--text-secondary)">
+    <span style="margin-right:4px">Map size:</span>
+    <button type="button" class="track-size-btn" data-size="s">S</button>
+    <button type="button" class="track-size-btn" data-size="">M</button>
+    <button type="button" class="track-size-btn" data-size="l">L</button>
+    <button type="button" class="track-size-btn" data-size="xl" title="Full height">XL</button>
   </div>
   <div id="track-map" class="track-map"></div>
   <div id="replay-controls" style="display:none;margin-top:10px">


### PR DESCRIPTION
## Summary
- Adds a size picker above the track map on the session page with four presets: S (280px), M (350px, default), L (650px), XL (nearly full viewport height).
- Choice is persisted in localStorage, so laptops stay on L/XL while phones stay on S/M.
- After resize, Leaflet's \`invalidateSize()\` is called so tiles refill without re-fitting the viewport (keeps current pan/zoom).

Starts simple per the issue discussion — inline expand only. Full-screen overlay, dedicated page, and pop-out window remain open follow-ups on #476 / #464.

Closes #476

## Test plan
- [ ] Open a session on a laptop, click L/XL, confirm map grows and tiles fill in.
- [ ] Reload — size choice is remembered.
- [ ] Click S on a phone-width viewport, confirm map shrinks and page remains usable.
- [ ] Switch sizes while replay is playing, confirm the boat cursor and overlays stay aligned.

Generated with [Claude Code](https://claude.ai/code)