### PR TITLE
session: collapsible layer/gauge rows, current gauge, gauges above map

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -405,6 +405,7 @@ async function loadTrack() {
     attribution: '&copy; OpenStreetMap', maxZoom: 18,
   }).addTo(_map);
   initTrackSizeControls(_map);
+  _restorePersistedSections();
 
   const feature = geojson.features[0];
   const coords = feature.geometry.coordinates;
@@ -1645,14 +1646,33 @@ function _seekVideoToIndex(idx) {
 // ---------------------------------------------------------------------------
 
 const _collapsed = {'boat-settings': true};
+const _PERSISTED_SECTIONS = ['track-layers', 'replay-gauges'];
+const _SECTION_KEY = 'helmlog.session.collapsed.';
 
-function toggleSection(name) {
+function _applySectionState(name, collapsed) {
   const body = document.getElementById(name + '-body');
   const toggle = document.getElementById(name + '-toggle');
   if (!body) return;
-  _collapsed[name] = !_collapsed[name];
-  body.style.display = _collapsed[name] ? 'none' : '';
-  if (toggle) toggle.innerHTML = _collapsed[name] ? '&#9654;' : '&#9660;';
+  _collapsed[name] = collapsed;
+  body.style.display = collapsed ? 'none' : '';
+  if (toggle) toggle.innerHTML = collapsed ? '&#9654;' : '&#9660;';
+}
+
+function toggleSection(name) {
+  const body = document.getElementById(name + '-body');
+  if (!body) return;
+  _applySectionState(name, !_collapsed[name]);
+  if (_PERSISTED_SECTIONS.includes(name)) {
+    try { localStorage.setItem(_SECTION_KEY + name, _collapsed[name] ? '1' : '0'); } catch (e) {}
+  }
+}
+
+function _restorePersistedSections() {
+  for (const name of _PERSISTED_SECTIONS) {
+    let saved = null;
+    try { saved = localStorage.getItem(_SECTION_KEY + name); } catch (e) {}
+    if (saved === '1') _applySectionState(name, true);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1667,6 +1667,36 @@ function toggleSection(name) {
   }
 }
 
+const _LAYER_TOGGLE_KEY = 'helmlog.session.layer.';
+const _PERSISTED_LAYER_TOGGLES = [];
+
+function _persistLayerToggle(id, apply) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  _PERSISTED_LAYER_TOGGLES.push({id, apply});
+  let saved = null;
+  try { saved = localStorage.getItem(_LAYER_TOGGLE_KEY + id); } catch (e) {}
+  if (saved === '1' || saved === '0') {
+    el.checked = saved === '1';
+  }
+  el.addEventListener('change', (e) => {
+    const checked = !!e.target.checked;
+    try { localStorage.setItem(_LAYER_TOGGLE_KEY + id, checked ? '1' : '0'); } catch (err) {}
+    apply(checked);
+  });
+}
+
+// After replay data is loaded, apply the saved state of every persisted layer
+// toggle so overlays like Boat wind / Boat current render on session load
+// instead of waiting for the user to toggle them on.
+function _applyPersistedLayerToggles() {
+  for (const {id, apply} of _PERSISTED_LAYER_TOGGLES) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    try { apply(!!el.checked); } catch (e) {}
+  }
+}
+
 function _restorePersistedSections() {
   for (const name of _PERSISTED_SECTIONS) {
     let saved = null;
@@ -6811,6 +6841,10 @@ async function _loadReplayData() {
     if (!_playClock.positionUtc) _playClock.positionUtc = _replayStart;
     _renderHud(_playClock.positionUtc);
     _updateReplayControls();
+    // Now that samples and the map are in place, re-apply any persisted
+    // layer toggles (boat wind/current, overlays, polar colors, etc.) so
+    // user preferences carry across sessions.
+    _applyPersistedLayerToggles();
     // Samples + replay window are now loaded — redraw the rounding
     // laylines so they respect the race-start filter.
     if (typeof _drawAllLaylines === 'function') _drawAllLaylines();
@@ -6835,43 +6869,22 @@ function _wireReplayControls() {
       _seekTo(new Date(t), 'replay');
     });
   }
-  const toggle = document.getElementById('toggle-polar-grades');
-  if (toggle) toggle.addEventListener('change', (e) => _setGradeViewActive(e.target.checked));
-  const followToggle = document.getElementById('toggle-follow-boat');
-  if (followToggle) followToggle.addEventListener('change', (e) => {
-    _followBoat = !!e.target.checked;
-    // Snap to the current position immediately when enabled so the user
-    // doesn't have to wait for the next tick.
+  const _followBoatApply = (checked) => {
+    _followBoat = !!checked;
     if (_followBoat && _trackData && _playClock.positionUtc) {
       const idx = _indexForUtc(_playClock.positionUtc);
       const latLng = _trackData.latLngs[idx];
       if (latLng && _map) _map.panTo(latLng, {animate: true});
     }
-  });
-  const maneuverToggle = document.getElementById('toggle-maneuver-markers');
-  if (maneuverToggle) maneuverToggle.addEventListener('change', (e) => {
-    _setManeuverMarkersVisible(e.target.checked);
-  });
-  const courseToggle = document.getElementById('toggle-course-overlay');
-  if (courseToggle) courseToggle.addEventListener('change', (e) => {
-    _setCourseOverlayVisible(e.target.checked);
-  });
-  const currentToggle = document.getElementById('toggle-current-overlay');
-  if (currentToggle) currentToggle.addEventListener('change', (e) => {
-    _setCurrentOverlayEnabled(e.target.checked);
-  });
-  const windToggle = document.getElementById('toggle-wind-overlay');
-  if (windToggle) windToggle.addEventListener('change', (e) => {
-    _setWindOverlayEnabled(e.target.checked);
-  });
-  const boatCurrentToggle = document.getElementById('toggle-boat-current');
-  if (boatCurrentToggle) boatCurrentToggle.addEventListener('change', (e) => {
-    _setBoatInstrument('current', e.target.checked);
-  });
-  const boatWindToggle = document.getElementById('toggle-boat-wind');
-  if (boatWindToggle) boatWindToggle.addEventListener('change', (e) => {
-    _setBoatInstrument('wind', e.target.checked);
-  });
+  };
+  _persistLayerToggle('toggle-polar-grades', _setGradeViewActive);
+  _persistLayerToggle('toggle-follow-boat', _followBoatApply);
+  _persistLayerToggle('toggle-maneuver-markers', _setManeuverMarkersVisible);
+  _persistLayerToggle('toggle-course-overlay', _setCourseOverlayVisible);
+  _persistLayerToggle('toggle-current-overlay', _setCurrentOverlayEnabled);
+  _persistLayerToggle('toggle-wind-overlay', _setWindOverlayEnabled);
+  _persistLayerToggle('toggle-boat-current', (checked) => _setBoatInstrument('current', checked));
+  _persistLayerToggle('toggle-boat-wind', (checked) => _setBoatInstrument('wind', checked));
 
   const prevBtn = document.getElementById('replay-prev-event-btn');
   if (prevBtn) prevBtn.addEventListener('click', () => _stepEvent(-1));

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6388,6 +6388,8 @@ function _renderHud(utc) {
   setEl('hud-cog', _fmtNum(s && s.cog, 0));
   setEl('hud-pct', g && g.pct != null ? _fmtPct(g.pct) : '—');
   setEl('hud-delta', g && g.delta != null ? (g.delta >= 0 ? '+' : '') + _fmtNum(g.delta, 2) : '—');
+  setEl('hud-set', s && s.set != null && !Number.isNaN(s.set) ? _fmtDeg(s.set) : '—');
+  setEl('hud-drift', s && s.drift != null && !Number.isNaN(s.drift) ? _fmtNum(s.drift, 2) : '—');
 
   const cursorMs = utc.getTime();
   _drawSparkline('spark-stw', 'stw', cursorMs, 'rgba(120,180,255,0.9)');
@@ -6781,6 +6783,8 @@ async function _loadReplayData() {
     // Show replay UI
     const controls = document.getElementById('replay-controls');
     if (controls) controls.style.display = '';
+    const gaugesWrap = document.getElementById('replay-gauges-wrap');
+    if (gaugesWrap) gaugesWrap.style.display = '';
     const toggleRow = document.getElementById('replay-toggle-row');
     if (toggleRow) toggleRow.style.display = '';
     // Initial HUD render at session start

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -101,6 +101,9 @@
 
 <div id="track-container" class="card" style="display:none">
   <div class="section-title">Track</div>
+  <div id="track-layers-wrap" style="margin-bottom:8px">
+    <div class="section-title" style="margin-top:0;font-size:.72rem;cursor:pointer" onclick="toggleSection('track-layers')">Layers <span id="track-layers-toggle">&#9660;</span></div>
+    <div class="section-body" id="track-layers-body">
   <div id="vakaros-track-toggle" style="display:none;margin-bottom:8px;font-size:.78rem;color:var(--text-secondary)">
     <label style="margin-right:12px"><input type="checkbox" id="toggle-sk-track" checked> SK track</label>
     <label><input type="checkbox" id="toggle-vakaros-track"> Vakaros track</label>
@@ -122,16 +125,12 @@
       <span style="display:inline-block;width:10px;height:10px;background:#888;vertical-align:middle;margin:0 2px 0 8px"></span>unknown
     </span>
   </div>
-  <div id="track-size-row" style="display:flex;gap:4px;align-items:center;margin-bottom:6px;font-size:.72rem;color:var(--text-secondary)">
-    <span style="margin-right:4px">Map size:</span>
-    <button type="button" class="track-size-btn" data-size="s">S</button>
-    <button type="button" class="track-size-btn" data-size="">M</button>
-    <button type="button" class="track-size-btn" data-size="l">L</button>
-    <button type="button" class="track-size-btn" data-size="xl" title="Full height">XL</button>
+    </div>
   </div>
-  <div id="track-map" class="track-map"></div>
-  <div id="replay-controls" style="display:none;margin-top:10px">
-    <div id="replay-gauges" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;margin-bottom:8px">
+  <div id="replay-gauges-wrap" style="display:none;margin-bottom:8px">
+    <div class="section-title" style="margin-top:0;font-size:.72rem;cursor:pointer" onclick="toggleSection('replay-gauges')">Gauges <span id="replay-gauges-toggle">&#9660;</span></div>
+    <div class="section-body" id="replay-gauges-body">
+    <div id="replay-gauges" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px">
       <div class="replay-gauge" data-gauge="speed" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
         <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Speed</div>
         <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
@@ -178,7 +177,25 @@
           <span><span style="color:var(--text-secondary);font-size:.7rem">Δ</span> <span id="hud-delta" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
         </div>
       </div>
+      <div class="replay-gauge" data-gauge="current" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Current</div>
+        <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">SET</span> <span id="hud-set" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">DRIFT</span> <span id="hud-drift" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+        </div>
+      </div>
     </div>
+    </div>
+  </div>
+  <div id="track-size-row" style="display:flex;gap:4px;align-items:center;margin-bottom:6px;font-size:.72rem;color:var(--text-secondary)">
+    <span style="margin-right:4px">Map size:</span>
+    <button type="button" class="track-size-btn" data-size="s">S</button>
+    <button type="button" class="track-size-btn" data-size="">M</button>
+    <button type="button" class="track-size-btn" data-size="l">L</button>
+    <button type="button" class="track-size-btn" data-size="xl" title="Full height">XL</button>
+  </div>
+  <div id="track-map" class="track-map"></div>
+  <div id="replay-controls" style="display:none;margin-top:10px">
     <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
       <button id="replay-prev-event-btn" type="button" title="Previous event ([)" aria-label="Previous event" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;width:30px;height:30px;font-size:.85rem;cursor:pointer">&#9198;</button>
       <button id="replay-play-btn" type="button" aria-label="Play/pause" style="background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;width:34px;height:30px;font-size:1rem;cursor:pointer">&#9654;</button>


### PR DESCRIPTION
## Summary

Follow-ups from #558 on the session detail page:

- **Collapsible layers row** — the track toggle row (SK track, Vakaros track, polar coloring, Keep boat centered, Maneuvers, Marks & lines, Current, Wind, Boat current, Boat wind) is now wrapped in a collapsible "Layers" section so power users can tuck it away once their layers are set.
- **Collapsible gauges row** — the SPEED / WIND / HEADING / POLAR gauge strip is wrapped in a collapsible "Gauges" section for the same reason.
- **Current gauge** — new gauge panel showing set (bearing) and drift (knots) from the same replay samples the dial uses.
- **Gauges above the map** — the gauge strip was moved out of the replay controls block and placed above the track map so the map gets more vertical real estate below. The transport controls (play/scrubber/speed) stay below the map.

Closes #558

## Test plan

- [ ] Load a session with replay samples — layers/gauges sections render collapsed/expanded correctly
- [ ] Current gauge updates as the scrubber moves and matches the dial's set/drift
- [ ] Gauges appear above the map; map size buttons still work
- [ ] Transport controls (play/pause/scrubber/speed) still work below the map

Generated with [Claude Code](https://claude.ai/code)