### PR TITLE
Synced multi-video maneuver comparison page

### DIFF
--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -102,6 +102,33 @@ async def _render_session_page(
 
 
 @router.get(
+    "/session/{session_id:int}/compare",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def maneuver_compare_page(request: Request, session_id: int) -> Response:
+    """Maneuver comparison page — synced multi-video playback (#565)."""
+    storage = get_storage(request)
+    race = await storage.get_race(session_id)
+    if race is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "compare.html",
+        tpl_ctx(
+            request,
+            "/history",
+            session_id=race.id,
+            session_name=race.name,
+            session_slug=race.slug,
+            user_role=user_role,
+        ),
+    )
+
+
+@router.get(
     "/session/{session_id:int}/{slug}",
     response_class=HTMLResponse,
     include_in_schema=False,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1291,6 +1291,35 @@ async def api_session_maneuvers_csv(
     )
 
 
+@router.get("/api/sessions/{session_id}/maneuvers/compare")
+async def api_session_maneuvers_compare(
+    request: Request,
+    session_id: int,
+    ids: str = Query(..., description="Comma-separated maneuver IDs"),
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return enriched maneuver data and video sync info for a set of maneuver IDs.
+
+    Used by the maneuver comparison page to render multiple synced YouTube
+    embeds side-by-side.
+    """
+    storage = get_storage(request)
+    from helmlog.analysis.maneuvers import enrich_session_maneuvers
+
+    try:
+        requested_ids = {int(x.strip()) for x in ids.split(",") if x.strip()}
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="ids must be comma-separated integers") from exc
+
+    if not requested_ids:
+        raise HTTPException(status_code=422, detail="ids must not be empty")
+
+    enriched, video_sync = await enrich_session_maneuvers(storage, session_id)
+    selected = [m for m in enriched if m.get("id") in requested_ids]
+
+    return JSONResponse({"maneuvers": selected, "video_sync": video_sync})
+
+
 @router.post("/api/sessions/{session_id}/detect-maneuvers", status_code=202)
 async def api_detect_maneuvers(
     request: Request,

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -28,15 +28,18 @@ let _ytReady = false;
     _showEmpty();
     return;
   }
-  const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${encodeURIComponent(ids)}`);
+  const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${ids}`);
   if (!resp.ok) {
+    console.error('Compare API error:', resp.status, await resp.text());
     _showEmpty();
     return;
   }
   const data = await resp.json();
+  console.log('Compare API response:', data);
   const maneuvers = data.maneuvers || [];
   const videoSync = data.video_sync;
   if (!maneuvers.length || !videoSync) {
+    console.warn('No maneuvers or no video_sync', {maneuvers: maneuvers.length, videoSync});
     _showEmpty();
     return;
   }
@@ -44,6 +47,7 @@ let _ytReady = false;
   // Filter to maneuvers that have video coverage
   const withVideo = maneuvers.filter(m => m.youtube_url);
   if (!withVideo.length) {
+    console.warn('No maneuvers have youtube_url');
     _showEmpty();
     return;
   }

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -30,16 +30,13 @@ let _ytReady = false;
   }
   const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${ids}`);
   if (!resp.ok) {
-    console.error('Compare API error:', resp.status, await resp.text());
     _showEmpty();
     return;
   }
   const data = await resp.json();
-  console.log('Compare API response:', data);
   const maneuvers = data.maneuvers || [];
   const videoSync = data.video_sync;
   if (!maneuvers.length || !videoSync) {
-    console.warn('No maneuvers or no video_sync', {maneuvers: maneuvers.length, videoSync});
     _showEmpty();
     return;
   }
@@ -47,7 +44,6 @@ let _ytReady = false;
   // Filter to maneuvers that have video coverage
   const withVideo = maneuvers.filter(m => m.youtube_url);
   if (!withVideo.length) {
-    console.warn('No maneuvers have youtube_url');
     _showEmpty();
     return;
   }

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -88,8 +88,6 @@ function _createPendingPlayers() {
 
 function _renderGrid(maneuvers, videoSync) {
   const grid = document.getElementById('compare-grid');
-  const n = maneuvers.length;
-  grid.className = 'compare-grid cols-' + (n <= 1 ? '1' : n <= 2 ? '2' : n <= 4 ? '2' : '3');
 
   for (let i = 0; i < maneuvers.length; i++) {
     const m = maneuvers[i];
@@ -101,17 +99,23 @@ function _renderGrid(maneuvers, videoSync) {
     const typeClass = 'badge-' + (m.type || 'maneuver');
     const dirHint = _directionHint(m);
     const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '';
-    const loss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt loss' : '';
-    const rank = m.rank ? (' <span style="color:' + _rankColor(m.rank) + '">' + m.rank + '</span>') : '';
+    const loss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt dip' : '';
+    const distLoss = m.distance_loss_m != null ? Math.round(m.distance_loss_m) + ' m' : '';
+    const rank = m.rank ? (' <span style="color:' + _rankColor(m.rank) + '">&#9679; ' + m.rank + '</span>') : '';
     const elapsed = _fmtElapsed(m.ts);
+    const bsp = (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '?') + '&#8594;' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '?');
+    const turn = m.turn_angle_deg != null ? Math.abs(Math.round(m.turn_angle_deg)) + '&deg;' : '';
     cell.innerHTML =
       '<div class="yt-wrap" id="' + divId + '"></div>'
       + '<div class="cell-label">'
       + '<b class="' + typeClass + '">' + _esc(m.type || 'maneuver') + '</b>'
       + dirHint + rank
       + ' <span style="font-variant-numeric:tabular-nums">' + elapsed + '</span>'
+      + (turn ? ' &middot; ' + turn : '')
+      + ' &middot; ' + bsp + ' kt'
       + (dur ? ' &middot; ' + dur : '')
       + (loss ? ' &middot; ' + loss : '')
+      + (distLoss ? ' &middot; ' + distLoss : '')
       + '</div>';
     grid.appendChild(cell);
 

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -1,0 +1,253 @@
+/* compare.js — Synced multi-video maneuver comparison (#565)
+ *
+ * Loads maneuver data from the compare API, creates one YouTube IFrame
+ * player per maneuver, and wires them to a common play/pause control.
+ * Each player is cued to [maneuver_ts - preroll] in video time.
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = document.getElementById('app-config').dataset.sessionId;
+let _players = [];   // { player: YT.Player, cueSeconds: number, maneuver: object }
+let _playing = false;
+let _prerollS = 10;
+let _ytReady = false;
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+(async function init() {
+  _loadYouTubeAPI();
+  const ids = new URLSearchParams(window.location.search).get('ids');
+  if (!ids) {
+    _showEmpty();
+    return;
+  }
+  const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${encodeURIComponent(ids)}`);
+  if (!resp.ok) {
+    _showEmpty();
+    return;
+  }
+  const data = await resp.json();
+  const maneuvers = data.maneuvers || [];
+  const videoSync = data.video_sync;
+  if (!maneuvers.length || !videoSync) {
+    _showEmpty();
+    return;
+  }
+
+  // Filter to maneuvers that have video coverage
+  const withVideo = maneuvers.filter(m => m.youtube_url);
+  if (!withVideo.length) {
+    _showEmpty();
+    return;
+  }
+
+  _renderGrid(withVideo, videoSync);
+  document.getElementById('compare-subtitle').textContent =
+    withVideo.length + ' maneuver' + (withVideo.length > 1 ? 's' : '');
+  document.getElementById('compare-controls').style.display = '';
+})();
+
+// ---------------------------------------------------------------------------
+// YouTube IFrame API
+// ---------------------------------------------------------------------------
+
+function _loadYouTubeAPI() {
+  if (window.YT && window.YT.Player) {
+    _ytReady = true;
+    return;
+  }
+  const tag = document.createElement('script');
+  tag.src = 'https://www.youtube.com/iframe_api';
+  document.head.appendChild(tag);
+}
+
+window.onYouTubeIframeAPIReady = function () {
+  _ytReady = true;
+  _createPendingPlayers();
+};
+
+let _pendingPlayers = []; // queued until YT API ready
+
+function _createPendingPlayers() {
+  for (const p of _pendingPlayers) {
+    _createPlayer(p.divId, p.videoId, p.cueSeconds, p.maneuver);
+  }
+  _pendingPlayers = [];
+}
+
+// ---------------------------------------------------------------------------
+// Grid rendering
+// ---------------------------------------------------------------------------
+
+function _renderGrid(maneuvers, videoSync) {
+  const grid = document.getElementById('compare-grid');
+  const n = maneuvers.length;
+  grid.className = 'compare-grid cols-' + (n <= 1 ? '1' : n <= 2 ? '2' : n <= 4 ? '2' : '3');
+
+  for (let i = 0; i < maneuvers.length; i++) {
+    const m = maneuvers[i];
+    const cueSeconds = _maneuverVideoOffset(m, videoSync);
+
+    const cell = document.createElement('div');
+    cell.className = 'compare-cell';
+    const divId = 'yt-compare-' + i;
+    const typeClass = 'badge-' + (m.type || 'maneuver');
+    const dirHint = _directionHint(m);
+    const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '';
+    const loss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt loss' : '';
+    const rank = m.rank ? (' <span style="color:' + _rankColor(m.rank) + '">' + m.rank + '</span>') : '';
+    const elapsed = _fmtElapsed(m.ts);
+    cell.innerHTML =
+      '<div class="yt-wrap" id="' + divId + '"></div>'
+      + '<div class="cell-label">'
+      + '<b class="' + typeClass + '">' + _esc(m.type || 'maneuver') + '</b>'
+      + dirHint + rank
+      + ' <span style="font-variant-numeric:tabular-nums">' + elapsed + '</span>'
+      + (dur ? ' &middot; ' + dur : '')
+      + (loss ? ' &middot; ' + loss : '')
+      + '</div>';
+    grid.appendChild(cell);
+
+    const entry = { divId, videoId: videoSync.video_id, cueSeconds, maneuver: m };
+    if (_ytReady) {
+      _createPlayer(divId, videoSync.video_id, cueSeconds, m);
+    } else {
+      _pendingPlayers.push(entry);
+    }
+  }
+}
+
+function _createPlayer(divId, videoId, cueSeconds, maneuver) {
+  const player = new YT.Player(divId, {
+    width: '100%',
+    height: '100%',
+    videoId: videoId,
+    playerVars: {
+      start: Math.max(0, Math.floor(cueSeconds)),
+      controls: 1,
+      modestbranding: 1,
+      rel: 0,
+    },
+    events: {
+      onReady: function (ev) {
+        ev.target.seekTo(cueSeconds, true);
+        ev.target.pauseVideo();
+        const speed = parseFloat(document.getElementById('speed-select').value) || 1;
+        ev.target.setPlaybackRate(speed);
+      },
+    },
+  });
+  _players.push({ player, cueSeconds, maneuver });
+}
+
+// ---------------------------------------------------------------------------
+// Video sync math
+// ---------------------------------------------------------------------------
+
+function _maneuverVideoOffset(m, videoSync) {
+  // Convert maneuver UTC ts to a video offset in seconds
+  // video_offset = sync_offset_s + (maneuver_utc - sync_utc) in seconds
+  const syncUtc = new Date(videoSync.sync_utc.endsWith('Z') ? videoSync.sync_utc : videoSync.sync_utc + 'Z');
+  const mTs = new Date(m.ts.endsWith('Z') ? m.ts : m.ts + 'Z');
+  const delta = (mTs.getTime() - syncUtc.getTime()) / 1000;
+  return videoSync.sync_offset_s + delta - _prerollS;
+}
+
+// ---------------------------------------------------------------------------
+// Shared controls
+// ---------------------------------------------------------------------------
+
+function togglePlayAll() {
+  if (_playing) {
+    _playing = false;
+    _players.forEach(p => { try { p.player.pauseVideo(); } catch (_e) { /* not ready */ } });
+    document.getElementById('play-all-btn').innerHTML = '&#9654; Play All';
+  } else {
+    _playing = true;
+    _players.forEach(p => { try { p.player.playVideo(); } catch (_e) { /* not ready */ } });
+    document.getElementById('play-all-btn').innerHTML = '&#9646;&#9646; Pause All';
+  }
+}
+
+function seekAllToStart() {
+  _playing = false;
+  document.getElementById('play-all-btn').innerHTML = '&#9654; Play All';
+  _players.forEach(p => {
+    try {
+      p.player.seekTo(p.cueSeconds, true);
+      p.player.pauseVideo();
+    } catch (_e) { /* not ready */ }
+  });
+}
+
+function setAllSpeed(val) {
+  const rate = parseFloat(val) || 1;
+  _players.forEach(p => { try { p.player.setPlaybackRate(rate); } catch (_e) { /* not ready */ } });
+}
+
+function setPreroll(val) {
+  _prerollS = parseInt(val, 10) || 10;
+  // Recalculate cue points — need videoSync which is embedded in the offset calc
+  // For simplicity, just reset all players to the new cue points
+  // We stored the maneuver on each entry, but not videoSync — re-derive from first player's cueSeconds
+  // Actually, the cleanest approach: reload the page with updated preroll
+  // But since we have the maneuver ts and the original cue, just adjust by delta
+  const oldPreroll = _players.length ? (_players[0].maneuver._oldPreroll || 10) : 10;
+  const delta = oldPreroll - _prerollS;
+  _players.forEach(p => {
+    p.cueSeconds += delta;
+    p.maneuver._oldPreroll = _prerollS;
+    try {
+      p.player.seekTo(p.cueSeconds, true);
+      p.player.pauseVideo();
+    } catch (_e) { /* not ready */ }
+  });
+  _playing = false;
+  document.getElementById('play-all-btn').innerHTML = '&#9654; Play All';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function _showEmpty() {
+  document.getElementById('compare-grid').style.display = 'none';
+  document.getElementById('compare-empty').style.display = '';
+}
+
+function _directionHint(m) {
+  if ((m.type === 'tack' || m.type === 'gybe') && m.turn_angle_deg != null) {
+    return m.turn_angle_deg > 0
+      ? ' <span style="color:var(--text-secondary);font-size:.72rem">S&#8594;P</span>'
+      : ' <span style="color:var(--text-secondary);font-size:.72rem">P&#8594;S</span>';
+  }
+  return '';
+}
+
+function _rankColor(rank) {
+  const m = { good: 'var(--success)', bad: 'var(--error)', avg: 'var(--text-secondary)' };
+  return m[rank] || 'var(--text-secondary)';
+}
+
+function _fmtElapsed(iso) {
+  // Simple elapsed from session start — we don't have _session here,
+  // so just show the time portion
+  if (!iso) return '';
+  try {
+    const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z');
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  } catch (_e) { return ''; }
+}
+
+function _esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -3,6 +3,7 @@
  * Loads maneuver data from the compare API, creates one YouTube IFrame
  * player per maneuver, and wires them to a common play/pause control.
  * Each player is cued to [maneuver_ts - preroll] in video time.
+ * The grid auto-sizes so all videos fit in the viewport without scrolling.
  */
 
 'use strict';
@@ -12,7 +13,9 @@
 // ---------------------------------------------------------------------------
 
 const SESSION_ID = document.getElementById('app-config').dataset.sessionId;
-let _players = [];   // { player: YT.Player, cueSeconds: number, maneuver: object }
+let _players = [];   // { player: YT.Player, cueSeconds: number, maneuver: object, idx: number }
+let _allManeuvers = [];  // full set from API (for subtitle updates)
+let _videoSync = null;
 let _playing = false;
 let _prerollS = 10;
 let _ytReady = false;
@@ -24,34 +27,20 @@ let _ytReady = false;
 (async function init() {
   _loadYouTubeAPI();
   const ids = new URLSearchParams(window.location.search).get('ids');
-  if (!ids) {
-    _showEmpty();
-    return;
-  }
+  if (!ids) { _showEmpty(); return; }
   const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${ids}`);
-  if (!resp.ok) {
-    _showEmpty();
-    return;
-  }
+  if (!resp.ok) { _showEmpty(); return; }
   const data = await resp.json();
   const maneuvers = data.maneuvers || [];
-  const videoSync = data.video_sync;
-  if (!maneuvers.length || !videoSync) {
-    _showEmpty();
-    return;
-  }
+  _videoSync = data.video_sync;
+  if (!maneuvers.length || !_videoSync) { _showEmpty(); return; }
 
-  // Filter to maneuvers that have video coverage
-  const withVideo = maneuvers.filter(m => m.youtube_url);
-  if (!withVideo.length) {
-    _showEmpty();
-    return;
-  }
+  _allManeuvers = maneuvers.filter(m => m.youtube_url);
+  if (!_allManeuvers.length) { _showEmpty(); return; }
 
-  _renderGrid(withVideo, videoSync);
-  document.getElementById('compare-subtitle').textContent =
-    withVideo.length + ' maneuver' + (withVideo.length > 1 ? 's' : '');
+  _buildGrid();
   document.getElementById('compare-controls').style.display = '';
+  window.addEventListener('resize', _onResize);
 })();
 
 // ---------------------------------------------------------------------------
@@ -59,10 +48,7 @@ let _ytReady = false;
 // ---------------------------------------------------------------------------
 
 function _loadYouTubeAPI() {
-  if (window.YT && window.YT.Player) {
-    _ytReady = true;
-    return;
-  }
+  if (window.YT && window.YT.Player) { _ytReady = true; return; }
   const tag = document.createElement('script');
   tag.src = 'https://www.youtube.com/iframe_api';
   document.head.appendChild(tag);
@@ -73,62 +59,118 @@ window.onYouTubeIframeAPIReady = function () {
   _createPendingPlayers();
 };
 
-let _pendingPlayers = []; // queued until YT API ready
+let _pendingPlayers = [];
 
 function _createPendingPlayers() {
   for (const p of _pendingPlayers) {
-    _createPlayer(p.divId, p.videoId, p.cueSeconds, p.maneuver);
+    _createPlayer(p.divId, p.videoId, p.cueSeconds, p.maneuver, p.idx);
   }
   _pendingPlayers = [];
 }
 
 // ---------------------------------------------------------------------------
-// Grid rendering
+// Grid layout — fit all cells in the viewport
 // ---------------------------------------------------------------------------
 
-function _renderGrid(maneuvers, videoSync) {
-  const grid = document.getElementById('compare-grid');
+function _gridLayout(n) {
+  // Choose cols x rows so all n items fit with maximum cell size.
+  // Prefer wider-than-tall cells (video is 16:9).
+  if (n <= 1) return { cols: 1, rows: 1 };
+  if (n <= 2) return { cols: 2, rows: 1 };
+  if (n <= 4) return { cols: 2, rows: 2 };
+  if (n <= 6) return { cols: 3, rows: 2 };
+  if (n <= 9) return { cols: 3, rows: 3 };
+  if (n <= 12) return { cols: 4, rows: 3 };
+  if (n <= 16) return { cols: 4, rows: 4 };
+  const cols = Math.ceil(Math.sqrt(n * 16 / 9));
+  return { cols, rows: Math.ceil(n / cols) };
+}
 
-  for (let i = 0; i < maneuvers.length; i++) {
-    const m = maneuvers[i];
+function _buildGrid() {
+  const grid = document.getElementById('compare-grid');
+  grid.innerHTML = '';
+  _players = [];
+  _pendingPlayers = [];
+
+  const n = _allManeuvers.length;
+  if (!n) { _showEmpty(); return; }
+
+  const layout = _gridLayout(n);
+  const headerEl = document.getElementById('compare-header');
+  const headerH = headerEl ? headerEl.offsetHeight + 4 : 40;
+  // Available height = viewport minus header and page padding
+  const availH = window.innerHeight - headerH - 12;
+  const availW = window.innerWidth - 12;
+  const gap = 4;
+  const labelH = 18; // approximate label row height
+  const cellPad = 2; // top+bottom padding inside cell
+
+  const cellW = (availW - gap * (layout.cols - 1)) / layout.cols;
+  const cellH = (availH - gap * (layout.rows - 1)) / layout.rows;
+  const videoH = cellH - labelH - cellPad;
+
+  grid.style.gridTemplateColumns = 'repeat(' + layout.cols + ', 1fr)';
+  grid.style.height = availH + 'px';
+
+  _updateSubtitle();
+
+  for (let i = 0; i < _allManeuvers.length; i++) {
+    const m = _allManeuvers[i];
     const cueSeconds = Math.max(0, (m.video_offset_s || 0) - _prerollS);
+    const divId = 'yt-compare-' + i;
 
     const cell = document.createElement('div');
     cell.className = 'compare-cell';
-    const divId = 'yt-compare-' + i;
+    cell.id = 'compare-cell-' + i;
+    cell.style.maxHeight = cellH + 'px';
+
     const typeClass = 'badge-' + (m.type || 'maneuver');
     const dirHint = _directionHint(m);
     const dur = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '';
     const loss = m.loss_kts != null ? m.loss_kts.toFixed(2) + ' kt dip' : '';
-    const distLoss = m.distance_loss_m != null ? Math.round(m.distance_loss_m) + ' m' : '';
     const rank = m.rank ? (' <span style="color:' + _rankColor(m.rank) + '">&#9679; ' + m.rank + '</span>') : '';
     const elapsed = _fmtElapsed(m.ts);
     const bsp = (m.entry_bsp != null ? m.entry_bsp.toFixed(1) : '?') + '&#8594;' + (m.exit_bsp != null ? m.exit_bsp.toFixed(1) : '?');
     const turn = m.turn_angle_deg != null ? Math.abs(Math.round(m.turn_angle_deg)) + '&deg;' : '';
+
     cell.innerHTML =
-      '<div class="yt-wrap" id="' + divId + '"></div>'
+      '<button class="cell-dismiss" onclick="dismissCell(' + i + ')" title="Remove from comparison">&#10005;</button>'
+      + '<div class="yt-wrap" id="' + divId + '" style="height:' + Math.max(60, videoH) + 'px"></div>'
       + '<div class="cell-label">'
       + '<b class="' + typeClass + '">' + _esc(m.type || 'maneuver') + '</b>'
-      + dirHint + rank
-      + ' <span style="font-variant-numeric:tabular-nums">' + elapsed + '</span>'
+      + dirHint + rank + ' ' + elapsed
       + (turn ? ' &middot; ' + turn : '')
       + ' &middot; ' + bsp + ' kt'
       + (dur ? ' &middot; ' + dur : '')
       + (loss ? ' &middot; ' + loss : '')
-      + (distLoss ? ' &middot; ' + distLoss : '')
       + '</div>';
     grid.appendChild(cell);
 
-    const entry = { divId, videoId: videoSync.video_id, cueSeconds, maneuver: m };
+    const entry = { divId, videoId: _videoSync.video_id, cueSeconds, maneuver: m, idx: i };
     if (_ytReady) {
-      _createPlayer(divId, videoSync.video_id, cueSeconds, m);
+      _createPlayer(divId, _videoSync.video_id, cueSeconds, m, i);
     } else {
       _pendingPlayers.push(entry);
     }
   }
 }
 
-function _createPlayer(divId, videoId, cueSeconds, maneuver) {
+let _resizeTimer = 0;
+function _onResize() {
+  clearTimeout(_resizeTimer);
+  _resizeTimer = setTimeout(_buildGrid, 200);
+}
+
+function _updateSubtitle() {
+  document.getElementById('compare-subtitle').textContent =
+    _allManeuvers.length + ' maneuver' + (_allManeuvers.length !== 1 ? 's' : '');
+}
+
+// ---------------------------------------------------------------------------
+// Player creation
+// ---------------------------------------------------------------------------
+
+function _createPlayer(divId, videoId, cueSeconds, maneuver, idx) {
   const player = new YT.Player(divId, {
     width: '100%',
     height: '100%',
@@ -148,7 +190,29 @@ function _createPlayer(divId, videoId, cueSeconds, maneuver) {
       },
     },
   });
-  _players.push({ player, cueSeconds, maneuver });
+  _players.push({ player, cueSeconds, maneuver, idx });
+}
+
+// ---------------------------------------------------------------------------
+// Dismiss (remove a cell)
+// ---------------------------------------------------------------------------
+
+function dismissCell(idx) {
+  // Destroy the YT player
+  const pi = _players.findIndex(p => p.idx === idx);
+  if (pi !== -1) {
+    try { _players[pi].player.destroy(); } catch (_e) { /* ok */ }
+    _players.splice(pi, 1);
+  }
+  // Remove from data
+  _allManeuvers.splice(idx, 1);
+  if (!_allManeuvers.length) {
+    _showEmpty();
+    document.getElementById('compare-grid').style.display = 'none';
+    return;
+  }
+  // Rebuild the grid with the remaining maneuvers
+  _buildGrid();
 }
 
 // ---------------------------------------------------------------------------
@@ -208,8 +272,8 @@ function _showEmpty() {
 function _directionHint(m) {
   if ((m.type === 'tack' || m.type === 'gybe') && m.turn_angle_deg != null) {
     return m.turn_angle_deg > 0
-      ? ' <span style="color:var(--text-secondary);font-size:.72rem">S&#8594;P</span>'
-      : ' <span style="color:var(--text-secondary);font-size:.72rem">P&#8594;S</span>';
+      ? ' <span style="color:var(--text-secondary);font-size:.68rem">S&#8594;P</span>'
+      : ' <span style="color:var(--text-secondary);font-size:.68rem">P&#8594;S</span>';
   }
   return '';
 }
@@ -220,8 +284,6 @@ function _rankColor(rank) {
 }
 
 function _fmtElapsed(iso) {
-  // Simple elapsed from session start — we don't have _session here,
-  // so just show the time portion
   if (!iso) return '';
   try {
     const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z');

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -91,7 +91,7 @@ function _renderGrid(maneuvers, videoSync) {
 
   for (let i = 0; i < maneuvers.length; i++) {
     const m = maneuvers[i];
-    const cueSeconds = _maneuverVideoOffset(m, videoSync);
+    const cueSeconds = Math.max(0, (m.video_offset_s || 0) - _prerollS);
 
     const cell = document.createElement('div');
     cell.className = 'compare-cell';
@@ -152,19 +152,6 @@ function _createPlayer(divId, videoId, cueSeconds, maneuver) {
 }
 
 // ---------------------------------------------------------------------------
-// Video sync math
-// ---------------------------------------------------------------------------
-
-function _maneuverVideoOffset(m, videoSync) {
-  // Convert maneuver UTC ts to a video offset in seconds
-  // video_offset = sync_offset_s + (maneuver_utc - sync_utc) in seconds
-  const syncUtc = new Date(videoSync.sync_utc.endsWith('Z') ? videoSync.sync_utc : videoSync.sync_utc + 'Z');
-  const mTs = new Date(m.ts.endsWith('Z') ? m.ts : m.ts + 'Z');
-  const delta = (mTs.getTime() - syncUtc.getTime()) / 1000;
-  return videoSync.sync_offset_s + delta - _prerollS;
-}
-
-// ---------------------------------------------------------------------------
 // Shared controls
 // ---------------------------------------------------------------------------
 
@@ -198,16 +185,8 @@ function setAllSpeed(val) {
 
 function setPreroll(val) {
   _prerollS = parseInt(val, 10) || 10;
-  // Recalculate cue points — need videoSync which is embedded in the offset calc
-  // For simplicity, just reset all players to the new cue points
-  // We stored the maneuver on each entry, but not videoSync — re-derive from first player's cueSeconds
-  // Actually, the cleanest approach: reload the page with updated preroll
-  // But since we have the maneuver ts and the original cue, just adjust by delta
-  const oldPreroll = _players.length ? (_players[0].maneuver._oldPreroll || 10) : 10;
-  const delta = oldPreroll - _prerollS;
   _players.forEach(p => {
-    p.cueSeconds += delta;
-    p.maneuver._oldPreroll = _prerollS;
+    p.cueSeconds = Math.max(0, (p.maneuver.video_offset_s || 0) - _prerollS);
     try {
       p.player.seekTo(p.cueSeconds, true);
       p.player.pauseVideo();

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4218,6 +4218,14 @@ function setManeuverSelectAll(mode) {
   renderManeuverCard();
 }
 
+function openManeuverCompare() {
+  const ids = _maneuvers
+    .filter((m, i) => _maneuverSelected.has(_manKey(m, i)) && m.id != null)
+    .map(m => m.id);
+  if (!ids.length) { alert('Select maneuvers to compare.'); return; }
+  window.open('/session/' + SESSION_ID + '/compare?ids=' + ids.join(','), '_blank');
+}
+
 function _maneuverRows() {
   const items = _maneuvers.filter(_matchesManeuverFilter);
   const key = _maneuverSort.key, dir = _maneuverSort.dir;
@@ -4829,11 +4837,14 @@ function renderManeuverCard() {
     : '';
 
   const selCount = _maneuverSelected.size;
+  const hasVideoInSelected = _maneuvers.some(m => _maneuverSelected.has(_manKey(m, _maneuvers.indexOf(m))) && m.youtube_url);
+  const compareBtnStyle = 'font-size:.68rem;padding:1px 6px;border:1px solid ' + (hasVideoInSelected ? 'var(--accent)' : 'var(--border)') + ';background:' + (hasVideoInSelected ? 'var(--accent)' : 'transparent') + ';color:' + (hasVideoInSelected ? 'var(--bg-primary)' : 'var(--text-secondary)') + ';cursor:pointer;border-radius:3px;margin-left:auto';
   const selectBar = '<div style="font-size:.7rem;color:var(--text-secondary);margin:4px 0;display:flex;gap:6px;align-items:center">'
     + '<span>Overlay: ' + selCount + ' selected</span>'
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'all\')">all</button>'
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'none\')">none</button>'
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'filtered\')">match filter</button>'
+    + '<button style="' + compareBtnStyle + '" onclick="openManeuverCompare()" title="Open synced video comparison for selected maneuvers">Compare Videos</button>'
     + '</div>';
 
   body.innerHTML = summary + filterBar + overlayBlock + selectBar

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4220,7 +4220,7 @@ function setManeuverSelectAll(mode) {
 
 function openManeuverCompare() {
   const ids = _maneuvers
-    .filter((m, i) => _maneuverSelected.has(_manKey(m, i)) && m.id != null)
+    .filter((m, i) => _maneuverSelected.has(_manKey(m, i)) && typeof m.id === 'number')
     .map(m => m.id);
   if (!ids.length) { alert('Select maneuvers to compare.'); return; }
   window.open('/session/' + SESSION_ID + '/compare?ids=' + ids.join(','), '_blank');

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4219,8 +4219,11 @@ function setManeuverSelectAll(mode) {
 }
 
 function openManeuverCompare() {
-  const ids = _maneuvers
-    .filter((m, i) => _maneuverSelected.has(_manKey(m, i)) && typeof m.id === 'number')
+  // Use the filtered+sorted rows (respects active filter pills) intersected
+  // with the overlay selection, so the user sees exactly the subset they
+  // expect from the current filter state.
+  const ids = _maneuverRows()
+    .filter(m => _maneuverSelected.has(_manKey(m, _maneuvers.indexOf(m))) && typeof m.id === 'number')
     .map(m => m.id);
   if (!ids.length) { alert('Select maneuvers to compare.'); return; }
   window.open('/session/' + SESSION_ID + '/compare?ids=' + ids.join(','), '_blank');

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Compare Maneuvers — {{ session_name }} — HelmLog{% endblock %}
+
+{% block extra_css %}
+<style>
+.compare-grid{display:grid;gap:12px;margin-top:12px}
+.compare-grid.cols-1{grid-template-columns:1fr}
+.compare-grid.cols-2{grid-template-columns:1fr 1fr}
+.compare-grid.cols-3{grid-template-columns:1fr 1fr 1fr}
+.compare-grid.cols-4{grid-template-columns:1fr 1fr}
+.compare-cell{background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px;overflow:hidden}
+.compare-cell .yt-wrap{aspect-ratio:16/9;border-radius:6px;overflow:hidden;background:#000}
+.compare-cell .cell-label{font-size:.78rem;color:var(--text-secondary);margin-top:6px}
+.compare-cell .cell-label b{color:var(--text-primary)}
+.compare-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:10px 0}
+.compare-controls button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:6px 14px;font-size:.85rem;cursor:pointer}
+.compare-controls button:hover{opacity:.85}
+.compare-controls select{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:.82rem}
+.compare-empty{color:var(--text-secondary);font-size:.85rem;padding:20px 0}
+.back-link{font-size:.82rem;color:var(--text-secondary);text-decoration:none;margin-bottom:8px;display:inline-block}
+.back-link:hover{color:var(--accent)}
+.badge-tack{color:var(--accent)}
+.badge-gybe{color:var(--warning)}
+.badge-rounding{color:var(--success)}
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="app-config"
+  data-session-id="{{ session_id }}"
+  data-session-slug="{{ session_slug or '' }}"
+  style="display:none"></div>
+
+<a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link">&larr; {{ session_name }}</a>
+
+<div class="card">
+  <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px">
+    <div>
+      <div style="font-size:1rem;font-weight:600;color:var(--text-primary)">Compare Maneuvers</div>
+      <div id="compare-subtitle" style="font-size:.78rem;color:var(--text-secondary)"></div>
+    </div>
+    <div class="compare-controls" id="compare-controls" style="display:none">
+      <button id="play-all-btn" type="button" onclick="togglePlayAll()">&#9654; Play All</button>
+      <button type="button" onclick="seekAllToStart()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#9198; Reset</button>
+      <label style="font-size:.78rem;color:var(--text-secondary)">Speed
+        <select id="speed-select" onchange="setAllSpeed(this.value)">
+          <option value="0.25">0.25x</option>
+          <option value="0.5">0.5x</option>
+          <option value="1" selected>1x</option>
+          <option value="1.5">1.5x</option>
+          <option value="2">2x</option>
+        </select>
+      </label>
+      <label style="font-size:.78rem;color:var(--text-secondary)">Pre-roll
+        <select id="preroll-select" onchange="setPreroll(this.value)">
+          <option value="5">5s</option>
+          <option value="10" selected>10s</option>
+          <option value="15">15s</option>
+          <option value="30">30s</option>
+        </select>
+      </label>
+    </div>
+  </div>
+</div>
+
+<div id="compare-grid" class="compare-grid cols-2"></div>
+<div id="compare-empty" class="card compare-empty" style="display:none">
+  No maneuvers selected, or selected maneuvers have no linked video. Return to the session page and select maneuvers with video links, then click Compare.
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/shared.js?v={{ git_sha }}"></script>
+<script src="/static/compare.js?v={{ git_sha }}"></script>
+{% endblock %}

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -3,14 +3,16 @@
 
 {% block extra_css %}
 <style>
-.compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+.page{max-width:100%!important;padding:8px!important}
+footer{display:none}
+.compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:8px}
 @media(max-width:700px){.compare-grid{grid-template-columns:1fr}}
-.compare-cell{background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px;overflow:hidden}
-.compare-cell .yt-wrap{aspect-ratio:16/9;border-radius:6px;overflow:hidden;background:#000}
-.compare-cell .cell-label{font-size:.78rem;color:var(--text-secondary);margin-top:6px}
+.compare-cell{background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:4px;overflow:hidden}
+.compare-cell .yt-wrap{aspect-ratio:16/9;border-radius:4px;overflow:hidden;background:#000}
+.compare-cell .cell-label{font-size:.72rem;color:var(--text-secondary);margin-top:3px;padding:0 2px}
 .compare-cell .cell-label b{color:var(--text-primary)}
-.compare-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:10px 0}
-.compare-controls button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:6px 14px;font-size:.85rem;cursor:pointer}
+.compare-controls{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.compare-controls button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:5px 12px;font-size:.82rem;cursor:pointer}
 .compare-controls button:hover{opacity:.85}
 .compare-controls select{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:.82rem}
 .compare-empty{color:var(--text-secondary);font-size:.85rem;padding:20px 0}
@@ -28,15 +30,12 @@
   data-session-slug="{{ session_slug or '' }}"
   style="display:none"></div>
 
-<a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link">&larr; {{ session_name }}</a>
-
-<div class="card">
-  <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px">
-    <div>
-      <div style="font-size:1rem;font-weight:600;color:var(--text-primary)">Compare Maneuvers</div>
-      <div id="compare-subtitle" style="font-size:.78rem;color:var(--text-secondary)"></div>
-    </div>
-    <div class="compare-controls" id="compare-controls" style="display:none">
+<div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:4px">
+  <a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link" style="margin:0">&larr; {{ session_name }}</a>
+  <span style="font-size:.85rem;font-weight:600;color:var(--text-primary)">Compare</span>
+  <span id="compare-subtitle" style="font-size:.75rem;color:var(--text-secondary)"></span>
+  <span style="flex:1"></span>
+  <div class="compare-controls" id="compare-controls" style="display:none">
       <button id="play-all-btn" type="button" onclick="togglePlayAll()">&#9654; Play All</button>
       <button type="button" onclick="seekAllToStart()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#9198; Reset</button>
       <label style="font-size:.78rem;color:var(--text-secondary)">Speed
@@ -57,10 +56,9 @@
         </select>
       </label>
     </div>
-  </div>
 </div>
 
-<div id="compare-grid" class="compare-grid cols-2"></div>
+<div id="compare-grid" class="compare-grid"></div>
 <div id="compare-empty" class="card compare-empty" style="display:none">
   No maneuvers selected, or selected maneuvers have no linked video. Return to the session page and select maneuvers with video links, then click Compare.
 </div>

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -3,20 +3,23 @@
 
 {% block extra_css %}
 <style>
-.page{max-width:100%!important;padding:8px!important}
-footer{display:none}
-.compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:8px}
-@media(max-width:700px){.compare-grid{grid-template-columns:1fr}}
-.compare-cell{background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:4px;overflow:hidden}
-.compare-cell .yt-wrap{aspect-ratio:16/9;border-radius:4px;overflow:hidden;background:#000}
-.compare-cell .cell-label{font-size:.72rem;color:var(--text-secondary);margin-top:3px;padding:0 2px}
+.page{max-width:100%!important;padding:4px 6px!important}
+footer,.site-nav{display:none}
+.compare-header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:4px;min-height:32px}
+.compare-grid{display:grid;gap:4px;overflow:hidden}
+.compare-cell{position:relative;background:var(--bg-secondary);border:1px solid var(--border);border-radius:4px;overflow:hidden;display:flex;flex-direction:column}
+.compare-cell .yt-wrap{flex:1;min-height:0;border-radius:3px;overflow:hidden;background:#000}
+.compare-cell .yt-wrap iframe{width:100%;height:100%}
+.compare-cell .cell-label{font-size:.68rem;color:var(--text-secondary);padding:2px 4px;line-height:1.3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .compare-cell .cell-label b{color:var(--text-primary)}
+.cell-dismiss{position:absolute;top:4px;right:4px;z-index:10;background:rgba(0,0,0,.6);color:#fff;border:none;border-radius:50%;width:22px;height:22px;font-size:.75rem;cursor:pointer;display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s}
+.compare-cell:hover .cell-dismiss{opacity:1}
 .compare-controls{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-.compare-controls button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:5px 12px;font-size:.82rem;cursor:pointer}
+.compare-controls button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:4px 10px;font-size:.78rem;cursor:pointer}
 .compare-controls button:hover{opacity:.85}
-.compare-controls select{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:4px 8px;font-size:.82rem}
+.compare-controls select{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.78rem}
 .compare-empty{color:var(--text-secondary);font-size:.85rem;padding:20px 0}
-.back-link{font-size:.82rem;color:var(--text-secondary);text-decoration:none;margin-bottom:8px;display:inline-block}
+.back-link{font-size:.78rem;color:var(--text-secondary);text-decoration:none}
 .back-link:hover{color:var(--accent)}
 .badge-tack{color:var(--accent)}
 .badge-gybe{color:var(--warning)}
@@ -30,32 +33,32 @@ footer{display:none}
   data-session-slug="{{ session_slug or '' }}"
   style="display:none"></div>
 
-<div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:4px">
-  <a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link" style="margin:0">&larr; {{ session_name }}</a>
-  <span style="font-size:.85rem;font-weight:600;color:var(--text-primary)">Compare</span>
-  <span id="compare-subtitle" style="font-size:.75rem;color:var(--text-secondary)"></span>
+<div class="compare-header" id="compare-header">
+  <a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link">&larr; {{ session_name }}</a>
+  <span style="font-size:.82rem;font-weight:600;color:var(--text-primary)">Compare</span>
+  <span id="compare-subtitle" style="font-size:.72rem;color:var(--text-secondary)"></span>
   <span style="flex:1"></span>
   <div class="compare-controls" id="compare-controls" style="display:none">
-      <button id="play-all-btn" type="button" onclick="togglePlayAll()">&#9654; Play All</button>
-      <button type="button" onclick="seekAllToStart()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#9198; Reset</button>
-      <label style="font-size:.78rem;color:var(--text-secondary)">Speed
-        <select id="speed-select" onchange="setAllSpeed(this.value)">
-          <option value="0.25">0.25x</option>
-          <option value="0.5">0.5x</option>
-          <option value="1" selected>1x</option>
-          <option value="1.5">1.5x</option>
-          <option value="2">2x</option>
-        </select>
-      </label>
-      <label style="font-size:.78rem;color:var(--text-secondary)">Pre-roll
-        <select id="preroll-select" onchange="setPreroll(this.value)">
-          <option value="5">5s</option>
-          <option value="10" selected>10s</option>
-          <option value="15">15s</option>
-          <option value="30">30s</option>
-        </select>
-      </label>
-    </div>
+    <button id="play-all-btn" type="button" onclick="togglePlayAll()">&#9654; Play All</button>
+    <button type="button" onclick="seekAllToStart()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#9198; Reset</button>
+    <label style="font-size:.75rem;color:var(--text-secondary)">Speed
+      <select id="speed-select" onchange="setAllSpeed(this.value)">
+        <option value="0.25">0.25x</option>
+        <option value="0.5">0.5x</option>
+        <option value="1" selected>1x</option>
+        <option value="1.5">1.5x</option>
+        <option value="2">2x</option>
+      </select>
+    </label>
+    <label style="font-size:.75rem;color:var(--text-secondary)">Pre-roll
+      <select id="preroll-select" onchange="setPreroll(this.value)">
+        <option value="5">5s</option>
+        <option value="10" selected>10s</option>
+        <option value="15">15s</option>
+        <option value="30">30s</option>
+      </select>
+    </label>
+  </div>
 </div>
 
 <div id="compare-grid" class="compare-grid"></div>

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -3,11 +3,8 @@
 
 {% block extra_css %}
 <style>
-.compare-grid{display:grid;gap:12px;margin-top:12px}
-.compare-grid.cols-1{grid-template-columns:1fr}
-.compare-grid.cols-2{grid-template-columns:1fr 1fr}
-.compare-grid.cols-3{grid-template-columns:1fr 1fr 1fr}
-.compare-grid.cols-4{grid-template-columns:1fr 1fr}
+.compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+@media(max-width:700px){.compare-grid{grid-template-columns:1fr}}
 .compare-cell{background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px;overflow:hidden}
 .compare-cell .yt-wrap{aspect-ratio:16/9;border-radius:6px;overflow:hidden;background:#000}
 .compare-cell .cell-label{font-size:.78rem;color:var(--text-secondary);margin-top:6px}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4144,3 +4144,110 @@ async def test_api_state_tolerates_date_only_start_utc(storage: Storage) -> None
     # But it should still appear in today_races with a valid ISO timestamp.
     assert len(data["today_races"]) == 1
     assert "T" in data["today_races"][0]["start_utc"]
+
+
+# ---------------------------------------------------------------------------
+# Maneuver compare
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compare_page_returns_200(storage: Storage) -> None:
+    """GET /session/{id}/compare returns 200 for a valid session."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        resp = await client.get(f"/session/{race_id}/compare")
+    assert resp.status_code == 200
+    assert "Compare Maneuvers" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_compare_page_returns_404_unknown(storage: Storage) -> None:
+    """GET /session/{id}/compare returns 404 for an unknown session."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/session/99999/compare")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_compare_api_returns_maneuvers(storage: Storage) -> None:
+    """GET /api/sessions/{id}/maneuvers/compare returns filtered maneuvers."""
+    from helmlog.maneuver_detector import Maneuver
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+
+    # Seed maneuvers directly via storage
+    m1 = Maneuver(
+        type="tack",
+        ts=datetime(2026, 2, 26, 14, 10, 0, tzinfo=UTC),
+        end_ts=datetime(2026, 2, 26, 14, 10, 8, tzinfo=UTC),
+        duration_sec=8.0,
+        loss_kts=0.5,
+        vmg_loss_kts=None,
+        tws_bin=12,
+        twa_bin=40,
+    )
+    m2 = Maneuver(
+        type="tack",
+        ts=datetime(2026, 2, 26, 14, 15, 0, tzinfo=UTC),
+        end_ts=datetime(2026, 2, 26, 14, 15, 10, tzinfo=UTC),
+        duration_sec=10.0,
+        loss_kts=0.8,
+        vmg_loss_kts=None,
+        tws_bin=12,
+        twa_bin=42,
+    )
+    await storage.write_maneuvers(race_id, [m1, m2])
+
+    # Look up actual IDs
+    maneuvers = await storage.get_session_maneuvers(race_id)
+    id1, id2 = maneuvers[0]["id"], maneuvers[1]["id"]
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/maneuvers/compare?ids={id1},{id2}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "maneuvers" in data
+    assert "video_sync" in data
+    assert len(data["maneuvers"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_compare_api_invalid_ids(storage: Storage) -> None:
+    """GET /api/sessions/{id}/maneuvers/compare returns 422 for invalid ids."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        resp = await client.get(f"/api/sessions/{race_id}/maneuvers/compare?ids=abc")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compare_api_empty_ids(storage: Storage) -> None:
+    """GET /api/sessions/{id}/maneuvers/compare returns 422 for empty ids."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        resp = await client.get(f"/api/sessions/{race_id}/maneuvers/compare?ids=")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Adds a **maneuver comparison page** (`/session/{id}/compare?ids=...`) that displays multiple YouTube embeds in a grid, each cued to a selected maneuver's timestamp
- Shared **Play All / Pause All** control starts and stops all videos simultaneously, with adjustable playback speed (0.25x-2x) and pre-roll (5-30s before maneuver)
- **"Compare Videos" button** added to the maneuvers panel select bar — opens the comparison page in a new tab with the currently selected maneuvers
- New API endpoint `GET /api/sessions/{id}/maneuvers/compare?ids=...` returns enriched maneuver data with video sync metadata

## How it works
1. Select maneuvers in the maneuvers panel using checkboxes (existing selection UI)
2. Click "Compare Videos" — opens a new tab at `/session/{id}/compare?ids=1,2,3`
3. The page fetches enriched maneuver data via the compare API
4. For each maneuver with video coverage, a YouTube IFrame player is created and cued to `maneuver_ts - preroll` in video time
5. Play All starts all players; Reset seeks all back to their cue points

## Test plan
- [x] 5 new tests: page 200/404, API with seeded maneuvers, invalid/empty ids validation
- [x] Full test suite passes (1928 passed)
- [x] Lint (`ruff check`), format (`ruff format`), and type check (`mypy`) clean
- [ ] Visual smoke test on Pi with linked YouTube videos

Closes #565

Generated with [Claude Code](https://claude.ai/code)