### PR TITLE
P→S / S→P direction filter pills on maneuvers panel

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4155,6 +4155,7 @@ let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distan
 let _maneuverFilter = new Set();
 const _MANEUVER_TYPE_PILLS = ['tack', 'gybe', 'rounding'];
 const _MANEUVER_RANK_PILLS = ['good', 'bad'];
+const _MANEUVER_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
 const _MANEUVER_TIME_PILLS = ['post-start'];
 let _maneuverOverlay = false; // toggle for all-tacks-overlaid diagram
 let _maneuverShowSK = true; // toggle SK-derived tracks in the overlay
@@ -4256,6 +4257,10 @@ function setManeuverFilter(f) {
   } else if (_maneuverFilter.has(f)) {
     _maneuverFilter.delete(f);
   } else {
+    // Direction pills are mutually exclusive
+    if (_MANEUVER_DIR_PILLS.includes(f)) {
+      _MANEUVER_DIR_PILLS.forEach(d => _maneuverFilter.delete(d));
+    }
     _maneuverFilter.add(f);
   }
   renderManeuverCard();
@@ -4654,6 +4659,14 @@ function _matchesManeuverFilter(m) {
   if (activeTypes.length && !activeTypes.includes(m.type)) return false;
   const activeRanks = _MANEUVER_RANK_PILLS.filter(p => _maneuverFilter.has(p));
   if (activeRanks.length && !activeRanks.includes(m.rank)) return false;
+  // Direction filter: P→S = negative turn_angle_deg, S→P = positive
+  const activeDir = _MANEUVER_DIR_PILLS.filter(p => _maneuverFilter.has(p));
+  if (activeDir.length) {
+    if (m.turn_angle_deg == null) return false;
+    const isPS = m.turn_angle_deg < 0;  // P→S = negative
+    if (activeDir.includes('P\u2192S') && !isPS) return false;
+    if (activeDir.includes('S\u2192P') && isPS) return false;
+  }
   if (_maneuverFilter.has('post-start')) {
     const startMs = _raceStartMs();
     if (startMs != null) {
@@ -4771,7 +4784,7 @@ function renderManeuverCard() {
     + '<a href="/api/sessions/' + SESSION_ID + '/maneuvers.csv" download style="color:var(--accent);text-decoration:none">CSV &#8595;</a>'
     + '</div>';
 
-  const filters = ['all', 'tack', 'gybe', 'rounding', 'good', 'bad'];
+  const filters = ['all', 'tack', 'gybe', 'rounding', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
   if (_raceStartMs() != null) filters.push('post-start');
   const filterBar = '<div style="display:flex;gap:4px;margin-bottom:6px;flex-wrap:wrap">'
     + filters.map(f => {


### PR DESCRIPTION
## Summary
- Adds **P→S** and **S→P** filter pills to the maneuvers panel filter bar
- One click isolates all port-to-starboard (or starboard-to-port) maneuvers
- Direction pills are **mutually exclusive** — selecting one deactivates the other
- Combines with existing filters via AND (e.g., `tack` + `P→S` + `post-start` = only post-start port-to-starboard tacks)
- Works for both tacks and gybes
- Direction derived from `turn_angle_deg` sign (negative = P→S, positive = S→P) — no backend changes

## Test plan
- [x] All 185 web tests pass
- [ ] Visual: P→S and S→P pills appear in the filter bar
- [ ] Visual: clicking P→S shows only P→S maneuvers, clicking again deselects
- [ ] Visual: clicking S→P while P→S is active switches to S→P only
- [ ] Visual: combines correctly with tack/gybe/good/bad/post-start filters
- [ ] Visual: Compare Videos with direction filter sends only matching maneuvers

Closes #576

Generated with [Claude Code](https://claude.ai/code)