### PR TITLE
Mute all button on compare page, muted by default

### DIFF
--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -20,6 +20,7 @@ let _playing = false;
 let _prerollS = 10;
 let _globalNudge = 0;  // seconds, applied to all videos (#568)
 let _ytReady = false;
+let _muted = true; // default muted — multiple simultaneous audio is never useful
 let _trackOverlayVisible = true;
 let _tickInterval = 0; // playback position poll timer
 let _sessionTrack = null; // { coords: [[lng,lat],...], timestamps: [iso,...] }
@@ -247,6 +248,7 @@ function _createPlayer(divId, videoId, cueSeconds, maneuver, idx, nudge) {
       onReady: function (ev) {
         ev.target.seekTo(cueSeconds, true);
         ev.target.pauseVideo();
+        if (_muted) ev.target.mute();
         const speed = parseFloat(document.getElementById('speed-select').value) || 1;
         ev.target.setPlaybackRate(speed);
         // Initial gauge + track dot update for the paused state
@@ -337,6 +339,15 @@ function seekAllToStart() {
 function setAllSpeed(val) {
   const rate = parseFloat(val) || 1;
   _players.forEach(p => { try { p.player.setPlaybackRate(rate); } catch (_e) { /* not ready */ } });
+}
+
+function toggleMuteAll() {
+  _muted = !_muted;
+  _players.forEach(p => {
+    try { _muted ? p.player.mute() : p.player.unMute(); } catch (_e) { /* not ready */ }
+  });
+  const btn = document.getElementById('mute-btn');
+  if (btn) btn.innerHTML = _muted ? '&#128263; Unmute' : '&#128264; Mute';
 }
 
 function setPreroll(val) {

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -53,6 +53,7 @@ footer,.site-nav{display:none}
   <div class="compare-controls" id="compare-controls" style="display:none">
     <button id="play-all-btn" type="button" onclick="togglePlayAll()">&#9654; Play All</button>
     <button type="button" onclick="seekAllToStart()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#9198; Reset</button>
+    <button id="mute-btn" type="button" onclick="toggleMuteAll()" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">&#128263; Unmute</button>
     <label style="font-size:.75rem;color:var(--text-secondary)">Speed
       <select id="speed-select" onchange="setAllSpeed(this.value)">
         <option value="0.25">0.25x</option>


### PR DESCRIPTION
## Summary
- **Mute/unmute toggle** in the compare page header controls
- **Muted by default** on page load — multiple simultaneous audio tracks are never useful
- New players created after dismiss/rebuild inherit the current mute state
- Button label toggles between "Unmute" (when muted) and "Mute" (when unmuted)

## Test plan
- [x] Existing compare tests pass
- [ ] Visual: videos start muted, no audio on Play All
- [ ] Visual: clicking Unmute enables audio on all videos
- [ ] Visual: clicking Mute silences all again
- [ ] Visual: dismissed/rebuilt cells respect current mute state

Closes #578

Generated with [Claude Code](https://claude.ai/code)