### PR TITLE
Watch on YouTube link on each compare page video cell

### DIFF
--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -213,6 +213,7 @@ function _buildGrid() {
       + ' &middot; ' + bsp + ' kt'
       + (dur ? ' &middot; ' + dur : '')
       + (loss ? ' &middot; ' + loss : '')
+      + (m.youtube_url ? ' <a href="' + _esc(m.youtube_url) + '" target="_blank" rel="noopener" title="Watch on YouTube" style="color:var(--text-secondary);text-decoration:none;font-size:.72rem" onclick="event.stopPropagation()">&#9654;YT</a>' : '')
       + '<span class="nudge-controls">'
       + '<button onclick="event.stopPropagation();nudgeVideo(' + i + ',-0.5)" title="-0.5s">&#9664;</button>'
       + '<span class="nudge-value" id="nudge-val-' + i + '">' + nudgeDisplay + '</span>'


### PR DESCRIPTION
## Summary
- Adds a small **▶YT** link in each cell's label bar on the compare page
- Opens the YouTube video at the maneuver's timestamp in a new tab
- Uses the existing `youtube_url` deep-link from the enriched maneuver data
- One line change

## Test plan
- [x] Existing compare tests pass
- [ ] Visual: ▶YT link appears in each cell label
- [ ] Visual: clicking opens YouTube at the correct timestamp in a new tab

Closes #582

Generated with [Claude Code](https://claude.ai/code)