### PR TITLE
feat: cross-session maneuver browser + wind-range filter (#584)

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -762,3 +762,46 @@ async def enrich_session_maneuvers(
         {"maneuvers": enriched, "video_sync": video_sync},
     )
     return enriched, video_sync
+
+
+async def enrich_maneuvers_for_ids(
+    storage: Storage, pairs: list[tuple[int, int]]
+) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any] | None]]:
+    """Cross-session version of :func:`enrich_session_maneuvers` (#584).
+
+    Takes a list of ``(session_id, maneuver_id)`` pairs and returns the
+    enriched maneuver payloads across sessions, plus a mapping
+    ``{session_id: video_sync}`` keyed by session. Each returned maneuver
+    has ``session_id``, ``session_name``, ``session_slug``, and
+    ``session_start_utc`` injected so the compare UI can label cells when
+    mixing sessions.
+
+    The underlying per-session enrichment is cached, so repeat calls for
+    the same session only pay the enrichment cost once.
+    """
+    if not pairs:
+        return [], {}
+
+    by_session: dict[int, set[int]] = {}
+    for sid, mid in pairs:
+        by_session.setdefault(sid, set()).add(mid)
+
+    out: list[dict[str, Any]] = []
+    video_sync_by_session: dict[int, dict[str, Any] | None] = {}
+
+    for session_id, wanted_ids in by_session.items():
+        race = await storage.get_race(session_id)
+        if race is None:
+            continue
+        enriched, video_sync = await enrich_session_maneuvers(storage, session_id)
+        video_sync_by_session[session_id] = video_sync
+        for m in enriched:
+            if m.get("id") in wanted_ids:
+                tagged = dict(m)
+                tagged["session_id"] = session_id
+                tagged["session_name"] = race.name
+                tagged["session_slug"] = race.slug or ""
+                tagged["session_start_utc"] = race.start_utc.isoformat() if race.start_utc else None
+                out.append(tagged)
+
+    return out, video_sync_by_session

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -128,6 +128,46 @@ async def maneuver_compare_page(request: Request, session_id: int) -> Response:
     )
 
 
+@router.get("/compare", response_class=HTMLResponse, include_in_schema=False)
+async def cross_session_compare_page(request: Request) -> Response:
+    """Cross-session maneuver compare page (#584).
+
+    Unlike ``/session/{id}/compare`` this has no session context in the URL
+    — the ``ids`` query param carries ``<session_id>:<maneuver_id>`` pairs
+    and the page fetches everything it needs from
+    ``/api/maneuvers/compare``.
+    """
+    get_storage(request)
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "compare.html",
+        tpl_ctx(
+            request,
+            "/maneuvers",
+            session_id=None,
+            session_name="",
+            session_slug="",
+            user_role=user_role,
+            cross_session=True,
+        ),
+    )
+
+
+@router.get("/maneuvers", response_class=HTMLResponse, include_in_schema=False)
+async def maneuvers_browser_page(request: Request) -> Response:
+    """Cross-session maneuver browser (#584)."""
+    get_storage(request)
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "maneuvers.html",
+        tpl_ctx(request, "/maneuvers", user_role=user_role),
+    )
+
+
 @router.get(
     "/session/{session_id:int}/{slug}",
     response_class=HTMLResponse,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1393,9 +1393,11 @@ async def api_maneuver_browse_sessions(
     storage = get_storage(request)
     limit = max(1, min(limit, 200))
     db = storage._conn()
-    # Imported-results rows (from Clubspot etc.) appear as races but have no
-    # instrument data — filter them out so the picker only shows sessions
-    # the boat actually sailed.
+    # Imported-results rows (source='clubspot' etc.) appear as races but were
+    # never sailed by this boat — filter them out so the picker only shows
+    # live-sailed sessions, and require maneuvers to also be present so
+    # ghost races (duplicated across classes in the same regatta window)
+    # don't clutter the list.
     sql = (
         "SELECT r.id, r.name, r.slug, r.start_utc, r.regatta_id, "
         "       reg.name AS regatta_name, "
@@ -1403,7 +1405,10 @@ async def api_maneuver_browse_sessions(
         "  FROM races r "
         "  LEFT JOIN regattas reg ON reg.id = r.regatta_id "
     )
-    conds: list[str] = ["EXISTS (SELECT 1 FROM maneuvers m WHERE m.session_id = r.id)"]
+    conds: list[str] = [
+        "(r.source IS NULL OR r.source = 'live')",
+        "EXISTS (SELECT 1 FROM maneuvers m WHERE m.session_id = r.id)",
+    ]
     params: list[Any] = []
     if regatta_id is not None:
         conds.append("r.regatta_id = ?")
@@ -1441,6 +1446,7 @@ async def api_maneuver_browse_regattas(
         "       COUNT(r.id) AS session_count "
         "  FROM regattas reg "
         "  JOIN races r ON r.regatta_id = reg.id "
+        " WHERE (r.source IS NULL OR r.source = 'live') "
         " GROUP BY reg.id "
         " ORDER BY reg.start_date DESC NULLS LAST, reg.id DESC"
     )
@@ -1497,7 +1503,10 @@ async def api_maneuver_browse(
     elif regatta_id is not None:
         db = storage._conn()
         cur = await db.execute(
-            "SELECT id FROM races WHERE regatta_id = ? ORDER BY start_utc DESC",
+            "SELECT id FROM races "
+            " WHERE regatta_id = ? "
+            "   AND (source IS NULL OR source = 'live') "
+            " ORDER BY start_utc DESC",
             (regatta_id,),
         )
         resolved_session_ids = [r["id"] for r in await cur.fetchall()]
@@ -1505,7 +1514,9 @@ async def api_maneuver_browse(
         session_limit = max(1, min(session_limit, 100))
         db = storage._conn()
         cur = await db.execute(
-            "SELECT id FROM races ORDER BY start_utc DESC LIMIT ?",
+            "SELECT id FROM races "
+            " WHERE (source IS NULL OR source = 'live') "
+            " ORDER BY start_utc DESC LIMIT ?",
             (session_limit,),
         )
         resolved_session_ids = [r["id"] for r in await cur.fetchall()]

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1320,6 +1320,234 @@ async def api_session_maneuvers_compare(
     return JSONResponse({"maneuvers": selected, "video_sync": video_sync})
 
 
+def _parse_cross_session_ids(ids: str) -> list[tuple[int, int]]:
+    """Parse ``ids`` query param for cross-session compare (#584).
+
+    Accepts two forms in the same list:
+      * ``<session_id>:<maneuver_id>`` — cross-session pair
+      * bare ``<maneuver_id>`` — only valid when a session_id can be
+        inferred by the caller; raises ValueError otherwise
+
+    Returns a list of ``(session_id, maneuver_id)`` tuples. Raises
+    ``ValueError`` on malformed input.
+    """
+    pairs: list[tuple[int, int]] = []
+    for raw in ids.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        if ":" not in token:
+            raise ValueError(f"missing session_id in {token!r}")
+        sid_str, _, mid_str = token.partition(":")
+        if not sid_str or not mid_str:
+            raise ValueError(f"malformed id {token!r}")
+        pairs.append((int(sid_str), int(mid_str)))
+    return pairs
+
+
+@router.get("/api/maneuvers/compare")
+async def api_cross_session_maneuvers_compare(
+    request: Request,
+    ids: str = Query(..., description="Comma-separated <session_id>:<maneuver_id> pairs"),
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Cross-session version of the compare-page data feed (#584).
+
+    ``ids`` is a comma-separated list of ``<session_id>:<maneuver_id>``
+    pairs. Returns enriched maneuvers plus per-session ``video_sync`` so
+    the compare page can render cells drawn from different sessions.
+    """
+    storage = get_storage(request)
+    from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids
+
+    try:
+        pairs = _parse_cross_session_ids(ids)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="ids must be comma-separated <session_id>:<maneuver_id> pairs",
+        ) from exc
+
+    if not pairs:
+        raise HTTPException(status_code=422, detail="ids must not be empty")
+
+    maneuvers, video_sync_by_session = await enrich_maneuvers_for_ids(storage, pairs)
+    # JSONResponse serializes dict keys as strings, so callers get
+    # {"42": {...}, "43": {...}} which is fine for JS lookup.
+    return JSONResponse(
+        {
+            "maneuvers": maneuvers,
+            "video_sync_by_session": {str(k): v for k, v in video_sync_by_session.items()},
+        }
+    )
+
+
+@router.get("/api/maneuvers/sessions")
+async def api_maneuver_browse_sessions(
+    request: Request,
+    regatta_id: int | None = None,
+    limit: int = 50,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Recent sessions with maneuver counts, for the browser picker (#584)."""
+    storage = get_storage(request)
+    limit = max(1, min(limit, 200))
+    db = storage._conn()
+    sql = (
+        "SELECT r.id, r.name, r.slug, r.start_utc, r.regatta_id, "
+        "       reg.name AS regatta_name, "
+        "       (SELECT COUNT(*) FROM maneuvers m WHERE m.session_id = r.id) AS maneuver_count "
+        "  FROM races r "
+        "  LEFT JOIN regattas reg ON reg.id = r.regatta_id "
+    )
+    params: list[Any] = []
+    if regatta_id is not None:
+        sql += " WHERE r.regatta_id = ? "
+        params.append(regatta_id)
+    sql += " ORDER BY r.start_utc DESC LIMIT ? "
+    params.append(limit)
+    cur = await db.execute(sql, params)
+    rows = await cur.fetchall()
+    sessions = [
+        {
+            "id": r["id"],
+            "name": r["name"],
+            "slug": r["slug"] or "",
+            "start_utc": r["start_utc"],
+            "regatta_id": r["regatta_id"],
+            "regatta_name": r["regatta_name"],
+            "maneuver_count": r["maneuver_count"] or 0,
+        }
+        for r in rows
+    ]
+    return JSONResponse({"sessions": sessions})
+
+
+@router.get("/api/maneuvers/regattas")
+async def api_maneuver_browse_regattas(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Regattas that have at least one linked session, for the picker (#584)."""
+    storage = get_storage(request)
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT reg.id, reg.name, reg.start_date, reg.end_date, "
+        "       COUNT(r.id) AS session_count "
+        "  FROM regattas reg "
+        "  JOIN races r ON r.regatta_id = reg.id "
+        " GROUP BY reg.id "
+        " ORDER BY reg.start_date DESC NULLS LAST, reg.id DESC"
+    )
+    rows = await cur.fetchall()
+    regattas = [
+        {
+            "id": r["id"],
+            "name": r["name"],
+            "start_date": r["start_date"],
+            "end_date": r["end_date"],
+            "session_count": r["session_count"],
+        }
+        for r in rows
+    ]
+    return JSONResponse({"regattas": regattas})
+
+
+@router.get("/api/maneuvers/browse")
+async def api_maneuver_browse(
+    request: Request,
+    regatta_id: int | None = None,
+    session_ids: str | None = None,
+    type: str | None = None,
+    direction: str | None = None,
+    tws_min: float | None = None,
+    tws_max: float | None = None,
+    has_video: int = 0,
+    session_limit: int = 20,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Cross-session maneuver browser feed (#584).
+
+    Resolves a set of sessions from either ``regatta_id`` or an explicit
+    comma-separated ``session_ids`` list. When neither is given, falls
+    back to the most recent ``session_limit`` sessions. Returns enriched
+    maneuvers filtered by type/direction/wind-range, with session context
+    attached for rendering.
+    """
+    storage = get_storage(request)
+    from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids
+
+    if type is not None and type not in ("tack", "gybe", "rounding"):
+        raise HTTPException(status_code=422, detail="type must be tack|gybe|rounding")
+    if direction is not None and direction not in ("PS", "SP"):
+        raise HTTPException(status_code=422, detail="direction must be PS|SP")
+
+    resolved_session_ids: list[int] = []
+    if session_ids:
+        try:
+            resolved_session_ids = [int(x.strip()) for x in session_ids.split(",") if x.strip()]
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail="session_ids must be integers") from exc
+    elif regatta_id is not None:
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT id FROM races WHERE regatta_id = ? ORDER BY start_utc DESC",
+            (regatta_id,),
+        )
+        resolved_session_ids = [r["id"] for r in await cur.fetchall()]
+    else:
+        session_limit = max(1, min(session_limit, 100))
+        db = storage._conn()
+        cur = await db.execute(
+            "SELECT id FROM races ORDER BY start_utc DESC LIMIT ?",
+            (session_limit,),
+        )
+        resolved_session_ids = [r["id"] for r in await cur.fetchall()]
+
+    if not resolved_session_ids:
+        return JSONResponse({"maneuvers": [], "session_ids": []})
+
+    # Pull every maneuver_id from the resolved sessions and enrich via the
+    # shared helper — that keeps one code path for enrichment and reuses
+    # the per-session cache.
+    db = storage._conn()
+    placeholders = ",".join("?" * len(resolved_session_ids))
+    cur = await db.execute(
+        f"SELECT session_id, id FROM maneuvers WHERE session_id IN ({placeholders})",
+        resolved_session_ids,
+    )
+    pairs = [(r["session_id"], r["id"]) for r in await cur.fetchall()]
+
+    enriched, _ = await enrich_maneuvers_for_ids(storage, pairs)
+
+    def _keep(m: dict[str, Any]) -> bool:
+        if type is not None and m.get("type") != type:
+            return False
+        if direction is not None:
+            ang = m.get("turn_angle_deg")
+            if ang is None:
+                return False
+            is_ps = ang < 0
+            if direction == "PS" and not is_ps:
+                return False
+            if direction == "SP" and is_ps:
+                return False
+        if tws_min is not None or tws_max is not None:
+            t = m.get("entry_tws")
+            if t is None:
+                return False
+            if tws_min is not None and t < tws_min:
+                return False
+            if tws_max is not None and t > tws_max:
+                return False
+        return not (has_video and not m.get("youtube_url"))
+
+    filtered = [m for m in enriched if _keep(m)]
+    filtered.sort(key=lambda m: str(m.get("ts") or ""))
+
+    return JSONResponse({"maneuvers": filtered, "session_ids": resolved_session_ids})
+
+
 @router.post("/api/sessions/{session_id}/detect-maneuvers", status_code=202)
 async def api_detect_maneuvers(
     request: Request,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1320,18 +1320,24 @@ async def api_session_maneuvers_compare(
     return JSONResponse({"maneuvers": selected, "video_sync": video_sync})
 
 
-def _parse_cross_session_ids(ids: str) -> list[tuple[int, int]]:
+# Sentinel for synthesized race-start pseudo-maneuvers in cross-session URLs
+# and browser payloads. Starts are not detected by maneuver_detector; they
+# are generated on demand from the session's Vakaros race_start event so
+# users can compare the gun moment across races.
+_START_TOKEN = "S"
+
+
+def _parse_cross_session_ids(ids: str) -> list[tuple[int, int | str]]:
     """Parse ``ids`` query param for cross-session compare (#584).
 
     Accepts two forms in the same list:
-      * ``<session_id>:<maneuver_id>`` — cross-session pair
-      * bare ``<maneuver_id>`` — only valid when a session_id can be
-        inferred by the caller; raises ValueError otherwise
+      * ``<session_id>:<maneuver_id>`` — real detected maneuver
+      * ``<session_id>:S`` — synthesized race start for that session
 
-    Returns a list of ``(session_id, maneuver_id)`` tuples. Raises
-    ``ValueError`` on malformed input.
+    Returns a list of ``(session_id, maneuver_id_or_token)`` tuples.
+    Raises ``ValueError`` on malformed input.
     """
-    pairs: list[tuple[int, int]] = []
+    pairs: list[tuple[int, int | str]] = []
     for raw in ids.split(","):
         token = raw.strip()
         if not token:
@@ -1341,8 +1347,131 @@ def _parse_cross_session_ids(ids: str) -> list[tuple[int, int]]:
         sid_str, _, mid_str = token.partition(":")
         if not sid_str or not mid_str:
             raise ValueError(f"malformed id {token!r}")
-        pairs.append((int(sid_str), int(mid_str)))
+        sid = int(sid_str)
+        if mid_str == _START_TOKEN:
+            pairs.append((sid, _START_TOKEN))
+        else:
+            pairs.append((sid, int(mid_str)))
     return pairs
+
+
+async def _vakaros_gun_times(
+    db: Any,  # noqa: ANN401 — aiosqlite.Connection, kept generic to avoid import
+    session_ids: list[int],
+) -> dict[int, str | None]:
+    """Return ``{session_id: gun_utc_or_None}`` for each requested session.
+
+    The gun is the latest Vakaros ``race_start`` event inside the race
+    window; ``None`` when no Vakaros event is matched (e.g. practice
+    sessions or races sailed without a Vakaros device). Callers that
+    need a best-effort fallback to ``start_utc`` should apply it on
+    their own.
+    """
+    if not session_ids:
+        return {}
+    placeholders = ",".join("?" * len(session_ids))
+    cur = await db.execute(
+        f"""
+        SELECT r.id AS session_id,
+               (SELECT MAX(vre.ts)
+                  FROM vakaros_race_events vre
+                 WHERE vre.session_id = r.vakaros_session_id
+                   AND vre.event_type = 'race_start'
+                   AND vre.ts BETWEEN r.start_utc
+                                  AND COALESCE(r.end_utc, r.start_utc)) AS gun_utc
+          FROM races r
+         WHERE r.id IN ({placeholders})
+        """,
+        session_ids,
+    )
+    return {r["session_id"]: r["gun_utc"] for r in await cur.fetchall()}
+
+
+def _synth_start_entry(
+    *,
+    session_id: int,
+    session_name: str,
+    session_slug: str,
+    session_start_utc: str | None,
+    gun_utc: str,
+    video_sync: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build a synthetic ``type='start'`` maneuver payload for session gun.
+
+    The cell covers a 60-second window starting at the gun so the compare
+    page can render the crucial pre/post-gun moment. Video offset is
+    computed against the race video's ``sync_utc`` so the YouTube player
+    cues to the right point, matching how real maneuvers are deep-linked.
+    """
+    end_utc = None
+    try:
+        gun_dt = datetime.fromisoformat(gun_utc.replace(" ", "T").replace("Z", "+00:00"))
+        end_utc = (gun_dt + timedelta(seconds=60)).isoformat()
+    except ValueError:
+        pass
+
+    video_offset_s: float | None = None
+    youtube_url: str | None = None
+    if video_sync and video_sync.get("sync_utc"):
+        try:
+            sync_dt = datetime.fromisoformat(
+                str(video_sync["sync_utc"]).replace(" ", "T").replace("Z", "+00:00")
+            )
+            gun_dt2 = datetime.fromisoformat(gun_utc.replace(" ", "T").replace("Z", "+00:00"))
+            computed = (
+                float(video_sync.get("sync_offset_s") or 0.0) + (gun_dt2 - sync_dt).total_seconds()
+            )
+            # Only emit a YouTube link when the gun actually lies inside
+            # the video's recorded window.
+            duration = float(video_sync.get("duration_s") or 0.0)
+            if 0 <= computed <= (duration or computed + 1):
+                video_offset_s = round(computed, 1)
+                youtube_url = (
+                    f"https://www.youtube.com/watch?v={video_sync['video_id']}"
+                    f"&t={int(video_offset_s)}s"
+                )
+        except (ValueError, TypeError):
+            pass
+
+    return {
+        "id": _START_TOKEN,
+        "session_id": session_id,
+        "session_name": session_name,
+        "session_slug": session_slug,
+        "session_start_utc": session_start_utc,
+        "type": "start",
+        "ts": gun_utc,
+        "end_ts": end_utc,
+        "duration_sec": 60.0,
+        "loss_kts": None,
+        "vmg_loss_kts": None,
+        "tws_bin": None,
+        "twa_bin": None,
+        "details": {},
+        "entry_bsp": None,
+        "exit_bsp": None,
+        "entry_hdg": None,
+        "exit_hdg": None,
+        "entry_twa": None,
+        "exit_twa": None,
+        "entry_tws": None,
+        "exit_tws": None,
+        "entry_sog": None,
+        "min_bsp": None,
+        "turn_angle_deg": None,
+        "turn_rate_deg_s": None,
+        "distance_loss_m": None,
+        "time_to_recover_s": None,
+        "track": None,
+        "track_vakaros": None,
+        "twd_deg": None,
+        "ghost_m": None,
+        "lat": None,
+        "lon": None,
+        "rank": None,
+        "video_offset_s": video_offset_s,
+        "youtube_url": youtube_url,
+    }
 
 
 @router.get("/api/maneuvers/compare")
@@ -1371,9 +1500,60 @@ async def api_cross_session_maneuvers_compare(
     if not pairs:
         raise HTTPException(status_code=422, detail="ids must not be empty")
 
-    maneuvers, video_sync_by_session = await enrich_maneuvers_for_ids(storage, pairs)
-    # JSONResponse serializes dict keys as strings, so callers get
-    # {"42": {...}, "43": {...}} which is fine for JS lookup.
+    # Split real maneuver ids from start pseudo-ids so the enrichment
+    # helper only sees real rows.
+    real_pairs: list[tuple[int, int]] = [(sid, mid) for sid, mid in pairs if isinstance(mid, int)]
+    start_session_ids: list[int] = [sid for sid, mid in pairs if mid == _START_TOKEN]
+
+    maneuvers: list[dict[str, Any]] = []
+    video_sync_by_session: dict[int, dict[str, Any] | None] = {}
+    if real_pairs:
+        maneuvers, video_sync_by_session = await enrich_maneuvers_for_ids(storage, real_pairs)
+
+    if start_session_ids:
+        db = storage._conn()
+        # Sessions that didn't contribute real maneuvers aren't in the
+        # video_sync map yet — pull their race_video row directly.
+        missing = [sid for sid in set(start_session_ids) if sid not in video_sync_by_session]
+        for sid in missing:
+            video_cur = await db.execute(
+                "SELECT video_id, sync_utc, sync_offset_s, duration_s, youtube_url"
+                " FROM race_videos WHERE race_id = ? ORDER BY id LIMIT 1",
+                (sid,),
+            )
+            video_row = await video_cur.fetchone()
+            if video_row is not None:
+                video_sync_by_session[sid] = {
+                    "video_id": video_row["video_id"],
+                    "sync_utc": str(video_row["sync_utc"]),
+                    "sync_offset_s": float(video_row["sync_offset_s"] or 0.0),
+                    "duration_s": float(video_row["duration_s"] or 0.0),
+                    "youtube_url": video_row["youtube_url"],
+                }
+            else:
+                video_sync_by_session[sid] = None
+
+        guns = await _vakaros_gun_times(db, list(set(start_session_ids)))
+        for sid in start_session_ids:
+            gun = guns.get(sid)
+            if not gun:
+                # No Vakaros gun → no synthetic start (would be meaningless
+                # without a real race-start timestamp to anchor the clip).
+                continue
+            race = await storage.get_race(sid)
+            if race is None:
+                continue
+            maneuvers.append(
+                _synth_start_entry(
+                    session_id=sid,
+                    session_name=race.name,
+                    session_slug=race.slug or "",
+                    session_start_utc=race.start_utc.isoformat() if race.start_utc else None,
+                    gun_utc=gun,
+                    video_sync=video_sync_by_session.get(sid),
+                )
+            )
+
     return JSONResponse(
         {
             "maneuvers": maneuvers,
@@ -1497,8 +1677,8 @@ async def api_maneuver_browse(
     storage = get_storage(request)
     from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids
 
-    if type is not None and type not in ("tack", "gybe", "rounding"):
-        raise HTTPException(status_code=422, detail="type must be tack|gybe|rounding")
+    if type is not None and type not in ("tack", "gybe", "rounding", "start"):
+        raise HTTPException(status_code=422, detail="type must be tack|gybe|rounding|start")
     if direction is not None and direction not in ("PS", "SP"):
         raise HTTPException(status_code=422, detail="direction must be PS|SP")
     if session_type is not None and session_type not in ("race", "practice"):
@@ -1569,15 +1749,58 @@ async def api_maneuver_browse(
 
     # Pull every maneuver_id from the resolved sessions and enrich via the
     # shared helper — that keeps one code path for enrichment and reuses
-    # the per-session cache.
-    placeholders = ",".join("?" * len(resolved_session_ids))
-    cur = await db.execute(
-        f"SELECT session_id, id FROM maneuvers WHERE session_id IN ({placeholders})",
-        resolved_session_ids,
-    )
-    pairs = [(r["session_id"], r["id"]) for r in await cur.fetchall()]
+    # the per-session cache. Skip this work when the user has narrowed
+    # the filter to starts only, since starts are synthesized below.
+    enriched: list[dict[str, Any]] = []
+    browse_video_sync: dict[int, dict[str, Any] | None] = {}
+    if type != "start":
+        placeholders = ",".join("?" * len(resolved_session_ids))
+        cur = await db.execute(
+            f"SELECT session_id, id FROM maneuvers WHERE session_id IN ({placeholders})",
+            resolved_session_ids,
+        )
+        pairs = [(r["session_id"], r["id"]) for r in await cur.fetchall()]
+        enriched, browse_video_sync = await enrich_maneuvers_for_ids(storage, pairs)
 
-    enriched, _ = await enrich_maneuvers_for_ids(storage, pairs)
+    # Synthesize one "start" entry per resolved session that has a Vakaros
+    # race_start event. Skip sessions where no gun was recorded — synthetic
+    # starts are only useful when anchored to a real gun time.
+    if type in (None, "start"):
+        start_guns = await _vakaros_gun_times(db, resolved_session_ids)
+        for sid, gun in start_guns.items():
+            if not gun:
+                continue
+            race = await storage.get_race(sid)
+            if race is None:
+                continue
+            vs = browse_video_sync.get(sid)
+            if vs is None:
+                # Sessions without real maneuvers aren't in the map; pull
+                # video_sync directly.
+                video_cur = await db.execute(
+                    "SELECT video_id, sync_utc, sync_offset_s, duration_s, youtube_url"
+                    " FROM race_videos WHERE race_id = ? ORDER BY id LIMIT 1",
+                    (sid,),
+                )
+                video_row = await video_cur.fetchone()
+                if video_row is not None:
+                    vs = {
+                        "video_id": video_row["video_id"],
+                        "sync_utc": str(video_row["sync_utc"]),
+                        "sync_offset_s": float(video_row["sync_offset_s"] or 0.0),
+                        "duration_s": float(video_row["duration_s"] or 0.0),
+                        "youtube_url": video_row["youtube_url"],
+                    }
+            enriched.append(
+                _synth_start_entry(
+                    session_id=sid,
+                    session_name=race.name,
+                    session_slug=race.slug or "",
+                    session_start_utc=race.start_utc.isoformat() if race.start_utc else None,
+                    gun_utc=gun,
+                    video_sync=vs,
+                )
+            )
 
     # Optional: compute each session's effective race gun (latest Vakaros
     # race_start event inside the race window, falling back to start_utc)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1393,6 +1393,9 @@ async def api_maneuver_browse_sessions(
     storage = get_storage(request)
     limit = max(1, min(limit, 200))
     db = storage._conn()
+    # Imported-results rows (from Clubspot etc.) appear as races but have no
+    # instrument data — filter them out so the picker only shows sessions
+    # the boat actually sailed.
     sql = (
         "SELECT r.id, r.name, r.slug, r.start_utc, r.regatta_id, "
         "       reg.name AS regatta_name, "
@@ -1400,10 +1403,12 @@ async def api_maneuver_browse_sessions(
         "  FROM races r "
         "  LEFT JOIN regattas reg ON reg.id = r.regatta_id "
     )
+    conds: list[str] = ["EXISTS (SELECT 1 FROM maneuvers m WHERE m.session_id = r.id)"]
     params: list[Any] = []
     if regatta_id is not None:
-        sql += " WHERE r.regatta_id = ? "
+        conds.append("r.regatta_id = ?")
         params.append(regatta_id)
+    sql += " WHERE " + " AND ".join(conds)
     sql += " ORDER BY r.start_utc DESC LIMIT ? "
     params.append(limit)
     cur = await db.execute(sql, params)
@@ -1463,6 +1468,7 @@ async def api_maneuver_browse(
     tws_min: float | None = None,
     tws_max: float | None = None,
     has_video: int = 0,
+    post_start: int = 0,
     session_limit: int = 20,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
@@ -1520,6 +1526,31 @@ async def api_maneuver_browse(
 
     enriched, _ = await enrich_maneuvers_for_ids(storage, pairs)
 
+    # Optional: compute each session's effective race gun (latest Vakaros
+    # race_start event inside the race window, falling back to start_utc)
+    # so we can drop pre-gun maneuvers when post_start=1.
+    gun_by_session: dict[int, str] = {}
+    if post_start and resolved_session_ids:
+        placeholders = ",".join("?" * len(resolved_session_ids))
+        gun_cur = await db.execute(
+            f"""
+            SELECT r.id AS session_id,
+                   COALESCE(
+                     (SELECT MAX(vre.ts)
+                        FROM vakaros_race_events vre
+                       WHERE vre.session_id = r.vakaros_session_id
+                         AND vre.event_type = 'race_start'
+                         AND vre.ts BETWEEN r.start_utc
+                                        AND COALESCE(r.end_utc, r.start_utc)),
+                     r.start_utc
+                   ) AS gun_utc
+              FROM races r
+             WHERE r.id IN ({placeholders})
+            """,
+            resolved_session_ids,
+        )
+        gun_by_session = {r["session_id"]: r["gun_utc"] for r in await gun_cur.fetchall()}
+
     def _keep(m: dict[str, Any]) -> bool:
         if type is not None and m.get("type") != type:
             return False
@@ -1539,6 +1570,11 @@ async def api_maneuver_browse(
             if tws_min is not None and t < tws_min:
                 return False
             if tws_max is not None and t > tws_max:
+                return False
+        if post_start:
+            sid = m.get("session_id")
+            gun = gun_by_session.get(sid) if isinstance(sid, int) else None
+            if gun and str(m.get("ts") or "") < gun:
                 return False
         return not (has_video and not m.get("youtube_url"))
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1386,6 +1386,7 @@ async def api_cross_session_maneuvers_compare(
 async def api_maneuver_browse_sessions(
     request: Request,
     regatta_id: int | None = None,
+    session_type: str | None = None,
     limit: int = 50,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
@@ -1405,6 +1406,8 @@ async def api_maneuver_browse_sessions(
         "  FROM races r "
         "  LEFT JOIN regattas reg ON reg.id = r.regatta_id "
     )
+    if session_type is not None and session_type not in ("race", "practice"):
+        raise HTTPException(status_code=422, detail="session_type must be race|practice")
     conds: list[str] = [
         "(r.source IS NULL OR r.source = 'live')",
         "EXISTS (SELECT 1 FROM maneuvers m WHERE m.session_id = r.id)",
@@ -1413,6 +1416,9 @@ async def api_maneuver_browse_sessions(
     if regatta_id is not None:
         conds.append("r.regatta_id = ?")
         params.append(regatta_id)
+    if session_type is not None:
+        conds.append("r.session_type = ?")
+        params.append(session_type)
     sql += " WHERE " + " AND ".join(conds)
     sql += " ORDER BY r.start_utc DESC LIMIT ? "
     params.append(limit)
@@ -1469,10 +1475,12 @@ async def api_maneuver_browse(
     request: Request,
     regatta_id: int | None = None,
     session_ids: str | None = None,
+    session_type: str | None = None,
     type: str | None = None,
     direction: str | None = None,
     tws_min: float | None = None,
     tws_max: float | None = None,
+    tws_bands: str | None = None,
     has_video: int = 0,
     post_start: int = 0,
     session_limit: int = 20,
@@ -1493,32 +1501,67 @@ async def api_maneuver_browse(
         raise HTTPException(status_code=422, detail="type must be tack|gybe|rounding")
     if direction is not None and direction not in ("PS", "SP"):
         raise HTTPException(status_code=422, detail="direction must be PS|SP")
+    if session_type is not None and session_type not in ("race", "practice"):
+        raise HTTPException(status_code=422, detail="session_type must be race|practice")
+
+    # Parse optional multi-band wind filter. Each band is "min-max" (e.g.
+    # "8-10") or "min-" for an open-ended upper bound (e.g. "15-" for 15+
+    # knots). Empty tokens are ignored.
+    bands: list[tuple[float, float | None]] = []
+    if tws_bands:
+        for raw in tws_bands.split(","):
+            token = raw.strip()
+            if not token or "-" not in token:
+                continue
+            lo_s, _, hi_s = token.partition("-")
+            try:
+                lo = float(lo_s)
+                hi: float | None = float(hi_s) if hi_s else None
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422, detail=f"tws_bands token {token!r} must be numeric"
+                ) from exc
+            bands.append((lo, hi))
 
     resolved_session_ids: list[int] = []
+    db = storage._conn()
     if session_ids:
         try:
-            resolved_session_ids = [int(x.strip()) for x in session_ids.split(",") if x.strip()]
+            ids_in = [int(x.strip()) for x in session_ids.split(",") if x.strip()]
         except ValueError as exc:
             raise HTTPException(status_code=422, detail="session_ids must be integers") from exc
+        # Apply session_type filter against the requested ids too so the
+        # pill narrows the result set even when specific sessions are picked.
+        if session_type is not None and ids_in:
+            placeholders = ",".join("?" * len(ids_in))
+            cur = await db.execute(
+                f"SELECT id FROM races WHERE id IN ({placeholders}) AND session_type = ?",
+                [*ids_in, session_type],
+            )
+            resolved_session_ids = [r["id"] for r in await cur.fetchall()]
+        else:
+            resolved_session_ids = ids_in
     elif regatta_id is not None:
-        db = storage._conn()
-        cur = await db.execute(
-            "SELECT id FROM races "
-            " WHERE regatta_id = ? "
-            "   AND (source IS NULL OR source = 'live') "
-            " ORDER BY start_utc DESC",
-            (regatta_id,),
+        sql = (
+            "SELECT id FROM races  WHERE regatta_id = ?    AND (source IS NULL OR source = 'live') "
         )
+        qparams: list[Any] = [regatta_id]
+        if session_type is not None:
+            sql += "   AND session_type = ? "
+            qparams.append(session_type)
+        sql += " ORDER BY start_utc DESC"
+        cur = await db.execute(sql, qparams)
         resolved_session_ids = [r["id"] for r in await cur.fetchall()]
     else:
         session_limit = max(1, min(session_limit, 100))
-        db = storage._conn()
-        cur = await db.execute(
-            "SELECT id FROM races "
-            " WHERE (source IS NULL OR source = 'live') "
-            " ORDER BY start_utc DESC LIMIT ?",
-            (session_limit,),
-        )
+        sql = "SELECT id FROM races WHERE (source IS NULL OR source = 'live') "
+        qparams = []
+        if session_type is not None:
+            sql += "  AND session_type = ? "
+            qparams.append(session_type)
+        sql += " ORDER BY start_utc DESC LIMIT ?"
+        qparams.append(session_limit)
+        cur = await db.execute(sql, qparams)
         resolved_session_ids = [r["id"] for r in await cur.fetchall()]
 
     if not resolved_session_ids:
@@ -1527,7 +1570,6 @@ async def api_maneuver_browse(
     # Pull every maneuver_id from the resolved sessions and enrich via the
     # shared helper — that keeps one code path for enrichment and reuses
     # the per-session cache.
-    db = storage._conn()
     placeholders = ",".join("?" * len(resolved_session_ids))
     cur = await db.execute(
         f"SELECT session_id, id FROM maneuvers WHERE session_id IN ({placeholders})",
@@ -1574,13 +1616,15 @@ async def api_maneuver_browse(
                 return False
             if direction == "SP" and is_ps:
                 return False
-        if tws_min is not None or tws_max is not None:
+        if tws_min is not None or tws_max is not None or bands:
             t = m.get("entry_tws")
             if t is None:
                 return False
             if tws_min is not None and t < tws_min:
                 return False
             if tws_max is not None and t > tws_max:
+                return False
+            if bands and not any(t >= lo and (hi is None or t <= hi) for lo, hi in bands):
                 return False
         if post_start:
             sid = m.get("session_id")

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1327,6 +1327,28 @@ async def api_session_maneuvers_compare(
 _START_TOKEN = "S"
 
 
+def _classify_rounding_mark(m: dict[str, Any]) -> str | None:
+    """Tag a rounding as ``weather`` / ``leeward`` based on exit heading.
+
+    After a weather (windward) mark the boat is on a downwind leg
+    (exit_twa >= 90°). After a leeward mark the boat is on an upwind
+    leg (exit_twa < 90°). Falls back to entry_twa with inverted logic
+    when exit_twa is missing. Returns ``None`` for non-rounding
+    maneuvers or when TWA data is unavailable.
+    """
+    if m.get("type") != "rounding":
+        return None
+    exit_twa = m.get("exit_twa")
+    if exit_twa is not None:
+        return "weather" if exit_twa >= 90 else "leeward"
+    entry_twa = m.get("entry_twa")
+    if entry_twa is not None:
+        # Mirror logic: exiting inverts the mode — a rounding entered
+        # downwind exits upwind (leeward mark) and vice versa.
+        return "leeward" if entry_twa >= 90 else "weather"
+    return None
+
+
 def _parse_cross_session_ids(ids: str) -> list[tuple[int, int | str]]:
     """Parse ``ids`` query param for cross-session compare (#584).
 
@@ -1509,6 +1531,9 @@ async def api_cross_session_maneuvers_compare(
     video_sync_by_session: dict[int, dict[str, Any] | None] = {}
     if real_pairs:
         maneuvers, video_sync_by_session = await enrich_maneuvers_for_ids(storage, real_pairs)
+        for m in maneuvers:
+            if m.get("type") == "rounding":
+                m["mark"] = _classify_rounding_mark(m)
 
     if start_session_ids:
         db = storage._conn()
@@ -1677,8 +1702,18 @@ async def api_maneuver_browse(
     storage = get_storage(request)
     from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids
 
-    if type is not None and type not in ("tack", "gybe", "rounding", "start"):
-        raise HTTPException(status_code=422, detail="type must be tack|gybe|rounding|start")
+    if type is not None and type not in (
+        "tack",
+        "gybe",
+        "rounding",
+        "weather",
+        "leeward",
+        "start",
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="type must be tack|gybe|rounding|weather|leeward|start",
+        )
     if direction is not None and direction not in ("PS", "SP"):
         raise HTTPException(status_code=422, detail="direction must be PS|SP")
     if session_type is not None and session_type not in ("race", "practice"):
@@ -1761,6 +1796,11 @@ async def api_maneuver_browse(
         )
         pairs = [(r["session_id"], r["id"]) for r in await cur.fetchall()]
         enriched, browse_video_sync = await enrich_maneuvers_for_ids(storage, pairs)
+        # Tag each rounding with weather/leeward so the client can display
+        # the mark type and the weather/leeward type pills can filter.
+        for m in enriched:
+            if m.get("type") == "rounding":
+                m["mark"] = _classify_rounding_mark(m)
 
     # Synthesize one "start" entry per resolved session that has a Vakaros
     # race_start event. Skip sessions where no gun was recorded — synthetic
@@ -1828,7 +1868,12 @@ async def api_maneuver_browse(
         gun_by_session = {r["session_id"]: r["gun_utc"] for r in await gun_cur.fetchall()}
 
     def _keep(m: dict[str, Any]) -> bool:
-        if type is not None and m.get("type") != type:
+        if type in ("weather", "leeward"):
+            if m.get("type") != "rounding":
+                return False
+            if m.get("mark") != type:
+                return False
+        elif type is not None and m.get("type") != type:
             return False
         if direction is not None:
             ang = m.get("turn_angle_deg")

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -38,7 +38,7 @@ let _trackOverlayVisible = true;
 let _tickInterval = 0; // playback position poll timer
 let _gaugeVisible = true;
 let _compareFilter = new Set(); // active filter pills on the compare page
-const _CMP_TYPE_PILLS = ['tack', 'gybe', 'rounding', 'start'];
+const _CMP_TYPE_PILLS = ['tack', 'gybe', 'rounding', 'weather', 'leeward', 'start'];
 const _CMP_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
 const _CMP_RANK_PILLS = ['good', 'bad'];
 // Wind-range pill values look like "tws:8-10" or "tws:15+" so they share
@@ -916,7 +916,14 @@ function _updateRecoveryBar(p, sample) {
 function _matchesCompareFilter(m) {
   if (!_compareFilter.size) return true;
   const activeTypes = _CMP_TYPE_PILLS.filter(p => _compareFilter.has(p));
-  if (activeTypes.length && !activeTypes.includes(m.type)) return false;
+  if (activeTypes.length) {
+    const hitType = activeTypes.includes(m.type);
+    // weather/leeward pills match roundings with that mark (#584 follow-up).
+    const hitMark = m.type === 'rounding'
+      && ((activeTypes.includes('weather') && m.mark === 'weather')
+       || (activeTypes.includes('leeward') && m.mark === 'leeward'));
+    if (!hitType && !hitMark) return false;
+  }
   const activeRanks = _CMP_RANK_PILLS.filter(p => _compareFilter.has(p));
   if (activeRanks.length && !activeRanks.includes(m.rank)) return false;
   const activeDir = _CMP_DIR_PILLS.filter(p => _compareFilter.has(p));
@@ -1028,7 +1035,7 @@ function _renderFilterPills() {
   const container = document.getElementById('filter-pills');
   if (!container) return;
 
-  const pills = ['all', 'tack', 'gybe', 'rounding', 'start', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
+  const pills = ['all', 'tack', 'gybe', 'rounding', 'weather', 'leeward', 'start', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
   // Only show post-start when at least one session has a gun time recorded.
   const anyGun = Object.values(_raceGunMsBySession).some(Boolean);
   if (anyGun) pills.push('post-start');

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -12,10 +12,23 @@
 // State
 // ---------------------------------------------------------------------------
 
-const SESSION_ID = document.getElementById('app-config').dataset.sessionId;
+// SESSION_ID is null in cross-session mode (page loaded at /compare instead
+// of /session/{id}/compare). _crossSession switches data fetching between
+// the legacy per-session API and the cross-session /api/maneuvers/compare
+// endpoint introduced in #584.
+const SESSION_ID = document.getElementById('app-config').dataset.sessionId || null;
 let _players = [];   // { player, cueSeconds, maneuver, idx, nudge }
 let _allManeuvers = [];
+let _crossSession = false;
+// In single-session mode these are the one-and-only session's data;
+// in cross-session mode they stay empty and the *BySession maps are used.
 let _videoSync = null;
+// Per-session lookup tables — populated whether we're in single- or
+// cross-session mode so rendering paths can uniformly read by session_id.
+const _videoSyncBySession = Object.create(null);
+const _trackBySession = Object.create(null);
+const _replayBySession = Object.create(null);
+const _raceGunMsBySession = Object.create(null);
 let _playing = false;
 let _prerollS = 10;
 let _globalNudge = 0;  // seconds, applied to all videos (#568)
@@ -23,14 +36,21 @@ let _ytReady = false;
 let _muted = true; // default muted — multiple simultaneous audio is never useful
 let _trackOverlayVisible = true;
 let _tickInterval = 0; // playback position poll timer
-let _sessionTrack = null; // { coords: [[lng,lat],...], timestamps: [iso,...] }
-let _replaySamples = null; // [{ts:Date, hdg, cog, stw, sog, tws, twa, twd, aws, awa}]
-let _raceGunMs = null; // race start UTC in ms
 let _gaugeVisible = true;
 let _compareFilter = new Set(); // active filter pills on the compare page
 const _CMP_TYPE_PILLS = ['tack', 'gybe', 'rounding'];
 const _CMP_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
 const _CMP_RANK_PILLS = ['good', 'bad'];
+// Wind-range pill values look like "tws:8-10" or "tws:15+" so they share
+// the single `_compareFilter` set without colliding with other pill names.
+const _CMP_TWS_BANDS = [
+  { label: '0-6', min: 0, max: 6 },
+  { label: '6-8', min: 6, max: 8 },
+  { label: '8-10', min: 8, max: 10 },
+  { label: '10-12', min: 10, max: 12 },
+  { label: '12-15', min: 12, max: 15 },
+  { label: '15+', min: 15, max: null },
+];
 let _filterPanelOpen = false;
 
 // ---------------------------------------------------------------------------
@@ -41,27 +61,60 @@ let _filterPanelOpen = false;
   _loadYouTubeAPI();
   const ids = new URLSearchParams(window.location.search).get('ids');
   if (!ids) { _showEmpty(); return; }
-  const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${ids}`);
-  if (!resp.ok) { _showEmpty(); return; }
-  const data = await resp.json();
-  const maneuvers = data.maneuvers || [];
-  _videoSync = data.video_sync;
-  if (!maneuvers.length || !_videoSync) { _showEmpty(); return; }
+
+  // Decide which endpoint to use: any ":" in ids indicates cross-session
+  // <sid>:<mid> pairs (#584); otherwise fall back to the legacy
+  // /api/sessions/{sid}/maneuvers/compare path.
+  _crossSession = ids.includes(':') || !SESSION_ID;
+
+  let maneuvers = [];
+  if (_crossSession) {
+    const resp = await fetch(`/api/maneuvers/compare?ids=${encodeURIComponent(ids)}`);
+    if (!resp.ok) { _showEmpty(); return; }
+    const data = await resp.json();
+    maneuvers = data.maneuvers || [];
+    const vsb = data.video_sync_by_session || {};
+    for (const k of Object.keys(vsb)) _videoSyncBySession[Number(k)] = vsb[k];
+  } else {
+    const resp = await fetch(`/api/sessions/${SESSION_ID}/maneuvers/compare?ids=${ids}`);
+    if (!resp.ok) { _showEmpty(); return; }
+    const data = await resp.json();
+    maneuvers = data.maneuvers || [];
+    _videoSync = data.video_sync;
+    if (_videoSync) _videoSyncBySession[Number(SESSION_ID)] = _videoSync;
+    // Stamp session_id onto each maneuver so downstream code that
+    // looks up by session_id works uniformly across modes.
+    maneuvers.forEach(m => { if (m.session_id == null) m.session_id = Number(SESSION_ID); });
+  }
+
+  if (!maneuvers.length) { _showEmpty(); return; }
 
   _allManeuvers = maneuvers.filter(m => m.youtube_url);
   if (!_allManeuvers.length) { _showEmpty(); return; }
 
-  // Fetch session track and replay data in parallel
+  // Fetch track + replay for every distinct session represented in the
+  // maneuver set, in parallel. Each session's data is cached separately
+  // so cells render from the right source even when sessions are mixed.
+  const sessionIds = [...new Set(_allManeuvers.map(m => m.session_id).filter(x => x != null))];
+  await Promise.all(sessionIds.map(_loadSessionOverlays));
+
+  _updateHeaderLink();
+  _buildGrid();
+  document.getElementById('compare-controls').style.display = '';
+  window.addEventListener('resize', _onResize);
+})();
+
+async function _loadSessionOverlays(sid) {
   const [trackResult, replayResult] = await Promise.allSettled([
-    fetch(`/api/sessions/${SESSION_ID}/track`),
-    fetch(`/api/sessions/${SESSION_ID}/replay`),
+    fetch(`/api/sessions/${sid}/track`),
+    fetch(`/api/sessions/${sid}/replay`),
   ]);
   try {
     if (trackResult.status === 'fulfilled' && trackResult.value.ok) {
       const geo = await trackResult.value.json();
       const feat = (geo.features || [])[0];
       if (feat && feat.geometry && feat.geometry.coordinates) {
-        _sessionTrack = {
+        _trackBySession[sid] = {
           coords: feat.geometry.coordinates,
           timestamps: (feat.properties || {}).timestamps || [],
         };
@@ -71,21 +124,30 @@ let _filterPanelOpen = false;
   try {
     if (replayResult.status === 'fulfilled' && replayResult.value.ok) {
       const rData = await replayResult.value.json();
-      _replaySamples = (rData.samples || []).map(s => ({
+      _replayBySession[sid] = (rData.samples || []).map(s => ({
         ts: new Date(s.ts),
         hdg: s.hdg, cog: s.cog, stw: s.stw, sog: s.sog,
         tws: s.tws, twa: s.twa, twd: s.twd, aws: s.aws, awa: s.awa,
       }));
       if (rData.race_gun_utc) {
-        _raceGunMs = _parseUtcMs(rData.race_gun_utc);
+        _raceGunMsBySession[sid] = _parseUtcMs(rData.race_gun_utc);
       }
     }
   } catch (_e) { /* gauge overlay is optional */ }
+}
 
-  _buildGrid();
-  document.getElementById('compare-controls').style.display = '';
-  window.addEventListener('resize', _onResize);
-})();
+function _updateHeaderLink() {
+  // In cross-session mode the back-link goes to the browser page; in
+  // single-session mode it's already set by the server template.
+  if (!_crossSession) return;
+  const headerEl = document.getElementById('compare-header');
+  if (!headerEl) return;
+  const back = headerEl.querySelector('a.back-link');
+  if (back) {
+    back.href = '/maneuvers';
+    back.textContent = '\u2190 Maneuvers';
+  }
+}
 
 // ---------------------------------------------------------------------------
 // YouTube IFrame API
@@ -194,9 +256,18 @@ function _buildGrid() {
 
     const trackSvg = _renderTrackOverlay(m, i);
     const courseSvg = _renderCourseOverlay(m, i);
-    const gaugeSvg = _renderGaugePlaceholder(i);
+    const gaugeSvg = _renderGaugePlaceholder(m, i);
     const recoveryBar = _renderRecoveryBar(m, i);
     const wrapId = 'yt-wrap-' + i;
+    // In cross-session mode prepend the session label so users can tell
+    // which day/race a given cell came from.
+    const sessionTag = _crossSession && m.session_name
+      ? '<span style="color:var(--text-secondary);font-size:.68rem">'
+        + _esc((m.session_start_utc || '').slice(0, 10)) + ' '
+        + _esc(m.session_name) + '</span> &middot; '
+      : '';
+    const vs = _videoSyncBySession[m.session_id];
+    if (!vs) continue; // skip cells whose session has no video link
     cell.innerHTML =
       '<button class="cell-dismiss" onclick="dismissCell(' + i + ')" title="Remove from comparison">&#10005;</button>'
       + '<div class="yt-wrap" id="' + wrapId + '" style="height:' + Math.max(60, videoH) + 'px">'
@@ -207,6 +278,7 @@ function _buildGrid() {
       + recoveryBar
       + '</div>'
       + '<div class="cell-label">'
+      + sessionTag
       + '<b class="' + typeClass + '">' + _esc(m.type || 'maneuver') + '</b>'
       + dirHint + rank + ' ' + elapsed
       + (turn ? ' &middot; ' + turn : '')
@@ -223,9 +295,9 @@ function _buildGrid() {
       + '</div>';
     grid.appendChild(cell);
 
-    const entry = { divId, videoId: _videoSync.video_id, cueSeconds, maneuver: m, idx: i, nudge };
+    const entry = { divId, videoId: vs.video_id, cueSeconds, maneuver: m, idx: i, nudge };
     if (_ytReady) {
-      _createPlayer(divId, _videoSync.video_id, cueSeconds, m, i, nudge);
+      _createPlayer(divId, vs.video_id, cueSeconds, m, i, nudge);
     } else {
       _pendingPlayers.push(entry);
     }
@@ -453,8 +525,9 @@ function _renderTrackOverlay(m, idx) {
 }
 
 function _renderCourseOverlay(m, idx) {
-  if (!_sessionTrack || !_sessionTrack.coords.length) return '';
-  const coords = _sessionTrack.coords; // [lng, lat]
+  const sessionTrack = _trackBySession[m.session_id];
+  if (!sessionTrack || !sessionTrack.coords.length) return '';
+  const coords = sessionTrack.coords; // [lng, lat]
   if (coords.length < 2) return '';
 
   const size = 100;
@@ -571,8 +644,9 @@ function _tickUpdate() {
     }
 
     // --- Gauge update ---
-    if (_gaugeVisible && _replaySamples && _replaySamples.length) {
-      _updateGauge(p, videoTime);
+    if (_gaugeVisible) {
+      const samples = _replayBySession[p.maneuver.session_id];
+      if (samples && samples.length) _updateGauge(p, videoTime, samples);
     }
   }
 }
@@ -581,8 +655,9 @@ function _tickUpdate() {
 // Instrument gauge overlay (#572)
 // ---------------------------------------------------------------------------
 
-function _renderGaugePlaceholder(idx) {
-  if (!_replaySamples || !_replaySamples.length) return '';
+function _renderGaugePlaceholder(m, idx) {
+  const samples = _replayBySession[m.session_id];
+  if (!samples || !samples.length) return '';
   const s = 150; // gauge size
   const r = 62;  // compass radius
   const cx = s / 2, cy = s / 2;
@@ -651,15 +726,15 @@ function _renderGaugePlaceholder(idx) {
     + '</svg>';
 }
 
-function _updateGauge(p, videoTime) {
+function _updateGauge(p, videoTime, samples) {
   // Convert video time to UTC
   const mTs = _parseUtcMs(p.maneuver.ts);
   if (!mTs) return;
   const offsetS = p.maneuver.video_offset_s || 0;
   const utcMs = mTs + (videoTime - offsetS) * 1000;
 
-  // Binary search for nearest sample
-  const sample = _sampleAtTime(utcMs);
+  // Binary search for nearest sample in this maneuver's session replay
+  const sample = _sampleAtTime(utcMs, samples);
   if (!sample) return;
 
   const idx = p.idx;
@@ -719,15 +794,15 @@ function _parseUtcMs(iso) {
   return isNaN(d.getTime()) ? null : d.getTime();
 }
 
-function _sampleAtTime(utcMs) {
-  if (!_replaySamples || !_replaySamples.length) return null;
-  let lo = 0, hi = _replaySamples.length - 1;
+function _sampleAtTime(utcMs, samples) {
+  if (!samples || !samples.length) return null;
+  let lo = 0, hi = samples.length - 1;
   while (lo < hi) {
     const mid = (lo + hi + 1) >> 1;
-    if (_replaySamples[mid].ts.getTime() <= utcMs) lo = mid;
+    if (samples[mid].ts.getTime() <= utcMs) lo = mid;
     else hi = mid - 1;
   }
-  return _replaySamples[lo];
+  return samples[lo];
 }
 
 function toggleGaugeOverlay() {
@@ -751,7 +826,8 @@ function toggleGaugeOverlay() {
 // ---------------------------------------------------------------------------
 
 function _renderRecoveryBar(m, idx) {
-  if (!_replaySamples || !_replaySamples.length) return '';
+  const samples = _replayBySession[m.session_id];
+  if (!samples || !samples.length) return '';
   if (m.entry_bsp == null || m.entry_bsp <= 0) return '';
 
   const w = 28, h = 150;
@@ -850,9 +926,21 @@ function _matchesCompareFilter(m) {
     if (activeDir.includes('P\u2192S') && !isPS) return false;
     if (activeDir.includes('S\u2192P') && isPS) return false;
   }
-  if (_compareFilter.has('post-start') && _raceGunMs) {
-    const mTs = _parseUtcMs(m.ts);
-    if (!mTs || mTs < _raceGunMs) return false;
+  if (_compareFilter.has('post-start')) {
+    const gunMs = _raceGunMsBySession[m.session_id];
+    if (gunMs) {
+      const mTs = _parseUtcMs(m.ts);
+      if (!mTs || mTs < gunMs) return false;
+    }
+  }
+  // Wind-range bands (#584). Pill values are "tws:<label>"; a single band
+  // filter applies but if two are on we union them (logical OR).
+  const activeTws = _CMP_TWS_BANDS.filter(b => _compareFilter.has('tws:' + b.label));
+  if (activeTws.length) {
+    const t = m.entry_tws;
+    if (t == null) return false;
+    const inAny = activeTws.some(b => t >= b.min && (b.max == null || t <= b.max));
+    if (!inAny) return false;
   }
   return true;
 }
@@ -941,13 +1029,19 @@ function _renderFilterPills() {
   if (!container) return;
 
   const pills = ['all', 'tack', 'gybe', 'rounding', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
-  if (_raceGunMs) pills.push('post-start');
+  // Only show post-start when at least one session has a gun time recorded.
+  const anyGun = Object.values(_raceGunMsBySession).some(Boolean);
+  if (anyGun) pills.push('post-start');
+  // Wind-range pills (#584).
+  for (const b of _CMP_TWS_BANDS) pills.push('tws:' + b.label);
+
   container.innerHTML = pills.map(f => {
     const active = f === 'all' ? _compareFilter.size === 0 : _compareFilter.has(f);
     const style = 'font-size:.72rem;padding:2px 8px;border:1px solid var(--border);background:'
       + (active ? 'var(--accent)' : 'transparent') + ';color:'
       + (active ? 'var(--bg-primary)' : 'var(--text-secondary)') + ';cursor:pointer;border-radius:3px';
-    return '<button style="' + style + '" onclick="setCompareFilter(\'' + f + '\')">' + f + '</button>';
+    const label = f.startsWith('tws:') ? f.slice(4) + ' kt' : f;
+    return '<button style="' + style + '" onclick="setCompareFilter(\'' + f + '\')" title="' + f + '">' + label + '</button>';
   }).join('');
 }
 

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -38,7 +38,7 @@ let _trackOverlayVisible = true;
 let _tickInterval = 0; // playback position poll timer
 let _gaugeVisible = true;
 let _compareFilter = new Set(); // active filter pills on the compare page
-const _CMP_TYPE_PILLS = ['tack', 'gybe', 'rounding'];
+const _CMP_TYPE_PILLS = ['tack', 'gybe', 'rounding', 'start'];
 const _CMP_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
 const _CMP_RANK_PILLS = ['good', 'bad'];
 // Wind-range pill values look like "tws:8-10" or "tws:15+" so they share
@@ -1028,7 +1028,7 @@ function _renderFilterPills() {
   const container = document.getElementById('filter-pills');
   if (!container) return;
 
-  const pills = ['all', 'tack', 'gybe', 'rounding', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
+  const pills = ['all', 'tack', 'gybe', 'rounding', 'start', 'P\u2192S', 'S\u2192P', 'good', 'bad'];
   // Only show post-start when at least one session has a gun time recorded.
   const anyGun = Object.values(_raceGunMsBySession).some(Boolean);
   if (anyGun) pills.push('post-start');

--- a/src/helmlog/static/compare.js
+++ b/src/helmlog/static/compare.js
@@ -29,6 +29,10 @@ const _videoSyncBySession = Object.create(null);
 const _trackBySession = Object.create(null);
 const _replayBySession = Object.create(null);
 const _raceGunMsBySession = Object.create(null);
+// Start-line geometry per session — {pin:[lat,lon], boat:[lat,lon]} or null.
+// Populated alongside track/replay when a cell is a "start" maneuver so the
+// start overlay can compute live distance-to-line during playback (#584).
+const _startLineBySession = Object.create(null);
 let _playing = false;
 let _prerollS = 10;
 let _globalNudge = 0;  // seconds, applied to all videos (#568)
@@ -105,10 +109,18 @@ let _filterPanelOpen = false;
 })();
 
 async function _loadSessionOverlays(sid) {
-  const [trackResult, replayResult] = await Promise.allSettled([
+  // Only fetch course-overlay (start line) when this session contributes a
+  // start maneuver — a large majority of compares will be tack/gybe/rounding
+  // and don't need it.
+  const needStartLine = _allManeuvers.some(
+    m => m.session_id === sid && m.type === 'start'
+  );
+  const tasks = [
     fetch(`/api/sessions/${sid}/track`),
     fetch(`/api/sessions/${sid}/replay`),
-  ]);
+  ];
+  if (needStartLine) tasks.push(fetch(`/api/sessions/${sid}/course-overlay`));
+  const [trackResult, replayResult, overlayResult] = await Promise.allSettled(tasks);
   try {
     if (trackResult.status === 'fulfilled' && trackResult.value.ok) {
       const geo = await trackResult.value.json();
@@ -134,6 +146,15 @@ async function _loadSessionOverlays(sid) {
       }
     }
   } catch (_e) { /* gauge overlay is optional */ }
+  try {
+    if (overlayResult && overlayResult.status === 'fulfilled' && overlayResult.value.ok) {
+      const od = await overlayResult.value.json();
+      const sl = od && od.start_line;
+      if (sl && sl.pin && sl.boat) {
+        _startLineBySession[sid] = { pin: sl.pin, boat: sl.boat };
+      }
+    }
+  } catch (_e) { /* start line is optional */ }
 }
 
 function _updateHeaderLink() {
@@ -258,6 +279,7 @@ function _buildGrid() {
     const courseSvg = _renderCourseOverlay(m, i);
     const gaugeSvg = _renderGaugePlaceholder(m, i);
     const recoveryBar = _renderRecoveryBar(m, i);
+    const startSvg = _renderStartOverlay(m, i);
     const wrapId = 'yt-wrap-' + i;
     // In cross-session mode prepend the session label so users can tell
     // which day/race a given cell came from.
@@ -276,6 +298,7 @@ function _buildGrid() {
       + courseSvg
       + gaugeSvg
       + recoveryBar
+      + startSvg
       + '</div>'
       + '<div class="cell-label">'
       + sessionTag
@@ -648,6 +671,9 @@ function _tickUpdate() {
       const samples = _replayBySession[p.maneuver.session_id];
       if (samples && samples.length) _updateGauge(p, videoTime, samples);
     }
+
+    // --- Start overlay update (countdown + DTL) ---
+    if (p.maneuver.type === 'start') _updateStartOverlay(p, videoTime);
   }
 }
 
@@ -907,6 +933,118 @@ function _updateRecoveryBar(p, sample) {
     pctEl.textContent = Math.round(pct) + '%';
     pctEl.setAttribute('fill', color);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Start overlay — countdown to gun + distance to line (#584 follow-up)
+// ---------------------------------------------------------------------------
+
+function _renderStartOverlay(m, idx) {
+  if (m.type !== 'start') return '';
+  const w = 150, h = 56;
+  return '<svg class="start-overlay" id="start-svg-' + idx + '" width="' + w + '" height="' + h + '">'
+    // Background pill
+    + '<rect x="0" y="0" width="' + w + '" height="' + h + '" rx="8" fill="rgba(0,0,0,.72)"/>'
+    // Countdown label (small, above)
+    + '<text x="' + (w / 2) + '" y="12" text-anchor="middle" font-size="8" fill="rgba(255,255,255,.55)" letter-spacing="1">COUNTDOWN</text>'
+    // Countdown value (large, centered)
+    + '<text id="start-countdown-' + idx + '" x="' + (w / 2) + '" y="32" text-anchor="middle" font-size="20" font-weight="700" font-family="monospace" fill="#f59e0b">T-0:00</text>'
+    // DTL label + value (right-aligned on row below)
+    + '<text x="6" y="50" font-size="8" fill="rgba(255,255,255,.55)" letter-spacing="1">DTL</text>'
+    + '<text id="start-dtl-' + idx + '" x="' + (w - 6) + '" y="50" text-anchor="end" font-size="12" font-weight="700" font-family="monospace" fill="#60a5fa">\u2014</text>'
+    + '</svg>';
+}
+
+function _updateStartOverlay(p, videoTime) {
+  const m = p.maneuver;
+  if (m.type !== 'start') return;
+  const idx = p.idx;
+
+  // Countdown: delta relative to the gun in seconds.
+  const delta = videoTime - (m.video_offset_s || 0);
+  const countdownEl = document.getElementById('start-countdown-' + idx);
+  if (countdownEl) {
+    const absS = Math.abs(delta);
+    const mm = Math.floor(absS / 60);
+    const ss = Math.floor(absS % 60);
+    const mmss = String(mm).padStart(1, '0') + ':' + String(ss).padStart(2, '0');
+    let label;
+    let color;
+    if (Math.abs(delta) < 0.5) {
+      label = 'GUN';
+      color = '#3db86e';
+    } else if (delta < 0) {
+      label = 'T-' + mmss;
+      color = '#f59e0b'; // amber pre-gun
+    } else {
+      label = 'T+' + mmss;
+      color = '#60a5fa'; // blue post-gun
+    }
+    countdownEl.textContent = label;
+    countdownEl.setAttribute('fill', color);
+  }
+
+  // Distance to line: look up boat position at the current UTC time and
+  // drop a perpendicular onto the pin\u2194boat segment. Falls back to an em
+  // dash when any piece of data is unavailable.
+  const dtlEl = document.getElementById('start-dtl-' + idx);
+  if (!dtlEl) return;
+  const sid = m.session_id;
+  const line = _startLineBySession[sid];
+  const track = _trackBySession[sid];
+  if (!line || !track || !track.coords || !track.timestamps || !track.timestamps.length) {
+    dtlEl.textContent = '\u2014';
+    return;
+  }
+  const gunMs = _parseUtcMs(m.ts);
+  if (gunMs == null) { dtlEl.textContent = '\u2014'; return; }
+  const utcMs = gunMs + delta * 1000;
+  const pos = _positionAtTime(track, utcMs);
+  if (!pos) { dtlEl.textContent = '\u2014'; return; }
+  const dtl = _distanceToLine(line.pin, line.boat, pos);
+  if (dtl == null) { dtlEl.textContent = '\u2014'; return; }
+  dtlEl.textContent = Math.round(dtl) + 'm';
+  // Red when on/over the line after the gun, amber when close pre-gun.
+  if (delta >= 0 && dtl < 5) dtlEl.setAttribute('fill', '#3db86e');
+  else if (delta < 0 && dtl < 10) dtlEl.setAttribute('fill', '#f59e0b');
+  else dtlEl.setAttribute('fill', '#60a5fa');
+}
+
+function _positionAtTime(track, utcMs) {
+  const timestamps = track.timestamps;
+  const coords = track.coords;
+  if (!timestamps.length || timestamps.length !== coords.length) return null;
+  // Binary search for the largest timestamp <= utcMs.
+  let lo = 0, hi = timestamps.length - 1;
+  const tsMs = (i) => {
+    const iso = timestamps[i];
+    if (!iso) return NaN;
+    let s = iso.replace(' ', 'T');
+    if (!s.endsWith('Z') && !s.includes('+')) s += 'Z';
+    return new Date(s).getTime();
+  };
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (tsMs(mid) <= utcMs) lo = mid;
+    else hi = mid - 1;
+  }
+  const c = coords[lo];
+  if (!c || c.length < 2) return null;
+  return { lat: c[1], lon: c[0] };
+}
+
+function _distanceToLine(pin, boat, pos) {
+  const pinLat = pin[0], pinLon = pin[1];
+  const boatLat = boat[0], boatLon = boat[1];
+  const mPerDegLat = 111320;
+  const mPerDegLon = 111320 * Math.cos(pinLat * Math.PI / 180);
+  const vx = (boatLon - pinLon) * mPerDegLon;
+  const vy = (boatLat - pinLat) * mPerDegLat;
+  const px = (pos.lon - pinLon) * mPerDegLon;
+  const py = (pos.lat - pinLat) * mPerDegLat;
+  const segLen = Math.hypot(vx, vy);
+  if (segLen === 0) return null;
+  return Math.abs(vx * py - vy * px) / segLen;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -28,6 +28,7 @@ const state = {
   selectedSessionIds: new Set(),
   type: null,              // 'tack'|'gybe'|'rounding'|null
   direction: null,         // 'PS'|'SP'|null
+  postStart: false,        // drop pre-gun maneuvers when true
   twsBand: null,           // index into TWS_BANDS, or null
   hasVideo: false,
   maneuvers: [],
@@ -135,6 +136,14 @@ function renderPills() {
     + DIR_PILLS.map(d => '<button class="mv-pill' + (state.direction === d.value ? ' active' : '')
       + '" onclick="mvSetDir(\'' + d.value + '\')">' + d.label + '</button>').join('');
 
+  const phaseEl = document.getElementById('mv-phase-pills');
+  if (phaseEl) {
+    phaseEl.innerHTML = '<button class="mv-pill' + (!state.postStart ? ' active' : '')
+      + '" onclick="mvSetPhase(false)">all</button>'
+      + '<button class="mv-pill' + (state.postStart ? ' active' : '')
+      + '" onclick="mvSetPhase(true)" title="Hide pre-gun maneuvers">post-start</button>';
+  }
+
   const twsEl = document.getElementById('mv-tws-pills');
   twsEl.innerHTML = '<button class="mv-pill' + (state.twsBand == null ? ' active' : '')
     + '" onclick="mvSetTws(null)">any</button>'
@@ -145,6 +154,7 @@ function renderPills() {
 function mvSetType(t) { state.type = t; renderPills(); reload(); }
 function mvSetDir(d) { state.direction = d; renderPills(); reload(); }
 function mvSetTws(i) { state.twsBand = i; renderPills(); reload(); }
+function mvSetPhase(on) { state.postStart = !!on; renderPills(); reload(); }
 
 // ---------------------------------------------------------------------------
 // Fetch + render results
@@ -173,6 +183,7 @@ async function reload() {
       if (band.max != null) params.set('tws_max', String(band.max));
     }
     if (state.hasVideo) params.set('has_video', '1');
+    if (state.postStart) params.set('post_start', '1');
 
     const r = await fetch('/api/maneuvers/browse?' + params.toString());
     if (!r.ok) { state.maneuvers = []; renderResults(); return; }

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const TYPE_PILLS = ['tack', 'gybe', 'rounding', 'start'];
+const TYPE_PILLS = ['tack', 'gybe', 'rounding', 'weather', 'leeward', 'start'];
 const DIR_PILLS = [
   { label: 'P\u2192S', value: 'PS' },
   { label: 'S\u2192P', value: 'SP' },
@@ -260,6 +260,11 @@ function renderResults() {
     const turnTxt = m.turn_angle_deg != null ? Math.abs(m.turn_angle_deg).toFixed(0) + '\u00b0' : '—';
     const durTxt = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '—';
     const typeCls = 'mv-badge-' + (m.type || '');
+    // Annotate roundings with the mark type so users can tell weather
+    // from leeward at a glance.
+    const typeLabel = (m.type === 'rounding' && m.mark)
+      ? 'rounding (' + (m.mark === 'weather' ? 'W' : 'L') + ')'
+      : (m.type || '');
     const dir = m.turn_angle_deg != null
       ? (m.turn_angle_deg < 0 ? 'P\u2192S' : 'S\u2192P')
       : '';
@@ -271,7 +276,7 @@ function renderResults() {
       + '<td><input type="checkbox" ' + (sel ? 'checked' : '') + ' onclick="event.stopPropagation();mvToggleRow(\'' + k + '\')"/></td>'
       + '<td>' + _esc(date) + ' \u00b7 ' + _esc(m.session_name || '') + '</td>'
       + '<td>' + _esc(time) + '</td>'
-      + '<td class="' + typeCls + '">' + _esc(m.type || '') + '</td>'
+      + '<td class="' + typeCls + '">' + _esc(typeLabel) + '</td>'
       + '<td>' + dir + '</td>'
       + '<td class="mv-num">' + twsTxt + '</td>'
       + '<td class="mv-num">' + turnTxt + '</td>'

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -1,0 +1,299 @@
+/* maneuvers.js — Cross-session maneuver browser (#584).
+ *
+ * Pools maneuvers from many sessions, filters by regatta/session/type/
+ * direction/wind-range, and hands a set of (session_id, maneuver_id)
+ * pairs to the /compare page for synced video playback.
+ */
+
+'use strict';
+
+const TYPE_PILLS = ['tack', 'gybe', 'rounding'];
+const DIR_PILLS = [
+  { label: 'P\u2192S', value: 'PS' },
+  { label: 'S\u2192P', value: 'SP' },
+];
+const TWS_BANDS = [
+  { label: '0-6', min: 0, max: 6 },
+  { label: '6-8', min: 6, max: 8 },
+  { label: '8-10', min: 8, max: 10 },
+  { label: '10-12', min: 10, max: 12 },
+  { label: '12-15', min: 12, max: 15 },
+  { label: '15+', min: 15, max: null },
+];
+
+const state = {
+  regattaId: '',
+  sessionLimit: 20,
+  sessions: [],            // [{id, name, slug, start_utc, maneuver_count, ...}]
+  selectedSessionIds: new Set(),
+  type: null,              // 'tack'|'gybe'|'rounding'|null
+  direction: null,         // 'PS'|'SP'|null
+  twsBand: null,           // index into TWS_BANDS, or null
+  hasVideo: false,
+  maneuvers: [],
+  selected: new Set(),     // composite keys "sid:mid"
+  loading: false,
+};
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+(async function init() {
+  renderPills();
+  await Promise.all([loadRegattas(), loadSessions()]);
+  await reload();
+})();
+
+async function loadRegattas() {
+  try {
+    const r = await fetch('/api/maneuvers/regattas');
+    if (!r.ok) return;
+    const data = await r.json();
+    const sel = document.getElementById('mv-regatta');
+    for (const reg of data.regattas || []) {
+      const opt = document.createElement('option');
+      opt.value = String(reg.id);
+      const label = reg.name + (reg.session_count ? ' (' + reg.session_count + ')' : '');
+      opt.textContent = label;
+      sel.appendChild(opt);
+    }
+  } catch (_e) { /* ok */ }
+}
+
+async function loadSessions() {
+  const container = document.getElementById('mv-sessions');
+  container.textContent = 'Loading...';
+  const params = new URLSearchParams();
+  if (state.regattaId) params.set('regatta_id', state.regattaId);
+  params.set('limit', state.regattaId ? '200' : String(state.sessionLimit));
+  try {
+    const r = await fetch('/api/maneuvers/sessions?' + params.toString());
+    if (!r.ok) { container.textContent = 'Failed to load sessions'; return; }
+    const data = await r.json();
+    state.sessions = data.sessions || [];
+    state.selectedSessionIds = new Set(state.sessions.map(s => s.id));
+    renderSessions();
+  } catch (_e) { container.textContent = 'Failed to load sessions'; }
+}
+
+function renderSessions() {
+  const container = document.getElementById('mv-sessions');
+  if (!state.sessions.length) { container.textContent = 'No sessions found.'; return; }
+  const rows = state.sessions.map(s => {
+    const checked = state.selectedSessionIds.has(s.id) ? 'checked' : '';
+    const date = (s.start_utc || '').slice(0, 10);
+    return '<label>'
+      + '<input type="checkbox" value="' + s.id + '" ' + checked
+      + ' onchange="mvToggleSession(' + s.id + ', this.checked)"/>'
+      + '<span>' + date + ' \u00b7 ' + _esc(s.name) + '</span>'
+      + '<span class="mv-session-count">' + (s.maneuver_count || 0) + '</span>'
+      + '</label>';
+  }).join('');
+  container.innerHTML = rows;
+}
+
+function mvToggleSession(id, on) {
+  if (on) state.selectedSessionIds.add(id);
+  else state.selectedSessionIds.delete(id);
+  reload();
+}
+
+function mvSelectAllSessions(on) {
+  if (on) state.selectedSessionIds = new Set(state.sessions.map(s => s.id));
+  else state.selectedSessionIds = new Set();
+  renderSessions();
+  reload();
+}
+
+function mvOnRegattaChange() {
+  state.regattaId = document.getElementById('mv-regatta').value;
+  loadSessions().then(reload);
+}
+
+function mvReloadSessions() {
+  const raw = document.getElementById('mv-session-limit').value;
+  const n = Number(raw);
+  if (Number.isFinite(n) && n > 0) state.sessionLimit = Math.min(100, Math.max(1, Math.floor(n)));
+  loadSessions().then(reload);
+}
+
+// ---------------------------------------------------------------------------
+// Filter pills
+// ---------------------------------------------------------------------------
+
+function renderPills() {
+  const typeEl = document.getElementById('mv-type-pills');
+  typeEl.innerHTML = '<button class="mv-pill' + (state.type == null ? ' active' : '')
+    + '" onclick="mvSetType(null)">all</button>'
+    + TYPE_PILLS.map(t => '<button class="mv-pill' + (state.type === t ? ' active' : '')
+      + '" onclick="mvSetType(\'' + t + '\')">' + t + '</button>').join('');
+
+  const dirEl = document.getElementById('mv-dir-pills');
+  dirEl.innerHTML = '<button class="mv-pill' + (state.direction == null ? ' active' : '')
+    + '" onclick="mvSetDir(null)">all</button>'
+    + DIR_PILLS.map(d => '<button class="mv-pill' + (state.direction === d.value ? ' active' : '')
+      + '" onclick="mvSetDir(\'' + d.value + '\')">' + d.label + '</button>').join('');
+
+  const twsEl = document.getElementById('mv-tws-pills');
+  twsEl.innerHTML = '<button class="mv-pill' + (state.twsBand == null ? ' active' : '')
+    + '" onclick="mvSetTws(null)">any</button>'
+    + TWS_BANDS.map((b, i) => '<button class="mv-pill' + (state.twsBand === i ? ' active' : '')
+      + '" onclick="mvSetTws(' + i + ')">' + b.label + '</button>').join('');
+}
+
+function mvSetType(t) { state.type = t; renderPills(); reload(); }
+function mvSetDir(d) { state.direction = d; renderPills(); reload(); }
+function mvSetTws(i) { state.twsBand = i; renderPills(); reload(); }
+
+// ---------------------------------------------------------------------------
+// Fetch + render results
+// ---------------------------------------------------------------------------
+
+async function reload() {
+  if (state.loading) return;
+  state.loading = true;
+  try {
+    const params = new URLSearchParams();
+    if (state.regattaId && state.selectedSessionIds.size === state.sessions.length) {
+      params.set('regatta_id', state.regattaId);
+    } else if (state.selectedSessionIds.size) {
+      params.set('session_ids', [...state.selectedSessionIds].join(','));
+    } else {
+      // no sessions selected — show nothing
+      state.maneuvers = [];
+      renderResults();
+      return;
+    }
+    if (state.type) params.set('type', state.type);
+    if (state.direction) params.set('direction', state.direction);
+    if (state.twsBand != null) {
+      const band = TWS_BANDS[state.twsBand];
+      params.set('tws_min', String(band.min));
+      if (band.max != null) params.set('tws_max', String(band.max));
+    }
+    if (state.hasVideo) params.set('has_video', '1');
+
+    const r = await fetch('/api/maneuvers/browse?' + params.toString());
+    if (!r.ok) { state.maneuvers = []; renderResults(); return; }
+    const data = await r.json();
+    state.maneuvers = data.maneuvers || [];
+    // Purge selection entries that no longer appear in the filtered list
+    const ids = new Set(state.maneuvers.map(m => m.session_id + ':' + m.id));
+    for (const k of [...state.selected]) if (!ids.has(k)) state.selected.delete(k);
+    renderResults();
+  } finally {
+    state.loading = false;
+  }
+}
+
+function mvReload() {
+  state.hasVideo = document.getElementById('mv-has-video').checked;
+  reload();
+}
+
+function renderResults() {
+  const tbody = document.getElementById('mv-tbody');
+  const empty = document.getElementById('mv-empty');
+  document.getElementById('mv-count').textContent =
+    state.maneuvers.length + ' maneuver' + (state.maneuvers.length !== 1 ? 's' : '');
+
+  if (!state.maneuvers.length) {
+    tbody.innerHTML = '';
+    empty.style.display = '';
+    updateSelectedCount();
+    return;
+  }
+  empty.style.display = 'none';
+
+  tbody.innerHTML = state.maneuvers.map(m => {
+    const k = m.session_id + ':' + m.id;
+    const sel = state.selected.has(k);
+    const date = (m.session_start_utc || '').slice(0, 10);
+    const time = _fmtTime(m.ts);
+    const twsTxt = m.entry_tws != null ? m.entry_tws.toFixed(1) : '—';
+    const turnTxt = m.turn_angle_deg != null ? Math.abs(m.turn_angle_deg).toFixed(0) + '\u00b0' : '—';
+    const durTxt = m.duration_sec != null ? m.duration_sec.toFixed(1) + 's' : '—';
+    const typeCls = 'mv-badge-' + (m.type || '');
+    const dir = m.turn_angle_deg != null
+      ? (m.turn_angle_deg < 0 ? 'P\u2192S' : 'S\u2192P')
+      : '';
+    const video = m.youtube_url
+      ? '<span class="mv-video">&#9654;</span>'
+      : '<span class="mv-no-video">\u2014</span>';
+    const rank = m.rank ? m.rank : '';
+    return '<tr class="' + (sel ? 'selected' : '') + '" data-k="' + k + '" onclick="mvToggleRow(\'' + k + '\')">'
+      + '<td><input type="checkbox" ' + (sel ? 'checked' : '') + ' onclick="event.stopPropagation();mvToggleRow(\'' + k + '\')"/></td>'
+      + '<td>' + _esc(date) + ' \u00b7 ' + _esc(m.session_name || '') + '</td>'
+      + '<td>' + _esc(time) + '</td>'
+      + '<td class="' + typeCls + '">' + _esc(m.type || '') + '</td>'
+      + '<td>' + dir + '</td>'
+      + '<td class="mv-num">' + twsTxt + '</td>'
+      + '<td class="mv-num">' + turnTxt + '</td>'
+      + '<td class="mv-num">' + durTxt + '</td>'
+      + '<td>' + _esc(rank) + '</td>'
+      + '<td>' + video + '</td>'
+      + '</tr>';
+  }).join('');
+
+  updateSelectedCount();
+}
+
+function mvToggleRow(k) {
+  if (state.selected.has(k)) state.selected.delete(k);
+  else state.selected.add(k);
+  const tr = document.querySelector('tr[data-k="' + k + '"]');
+  if (tr) {
+    tr.classList.toggle('selected', state.selected.has(k));
+    const cb = tr.querySelector('input[type="checkbox"]');
+    if (cb) cb.checked = state.selected.has(k);
+  }
+  updateSelectedCount();
+}
+
+function mvToggleAll(on) {
+  if (on) state.selected = new Set(state.maneuvers.map(m => m.session_id + ':' + m.id));
+  else state.selected = new Set();
+  renderResults();
+}
+
+function updateSelectedCount() {
+  const n = state.selected.size;
+  const el = document.getElementById('mv-selected-count');
+  el.textContent = n ? '(' + n + ' selected)' : '';
+  const btn = document.getElementById('mv-compare-btn');
+  btn.disabled = n === 0;
+  const all = document.getElementById('mv-check-all');
+  if (all) all.checked = n > 0 && n === state.maneuvers.length;
+}
+
+function mvOpenCompare() {
+  if (!state.selected.size) return;
+  // Preserve the current table order so cells appear in the same sequence.
+  const orderedKeys = state.maneuvers
+    .map(m => m.session_id + ':' + m.id)
+    .filter(k => state.selected.has(k));
+  if (!orderedKeys.length) return;
+  window.open('/compare?ids=' + orderedKeys.join(','), '_blank');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function _fmtTime(iso) {
+  if (!iso) return '';
+  try {
+    let s = String(iso).replace(' ', 'T');
+    if (!s.endsWith('Z') && !s.includes('+')) s += 'Z';
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch (_e) { return ''; }
+}
+
+function _esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s == null ? '' : String(s);
+  return d.innerHTML;
+}

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const TYPE_PILLS = ['tack', 'gybe', 'rounding'];
+const TYPE_PILLS = ['tack', 'gybe', 'rounding', 'start'];
 const DIR_PILLS = [
   { label: 'P\u2192S', value: 'PS' },
   { label: 'S\u2192P', value: 'SP' },

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -24,12 +24,13 @@ const TWS_BANDS = [
 const state = {
   regattaId: '',
   sessionLimit: 20,
+  sessionType: null,       // 'race'|'practice'|null — scopes both picker and query
   sessions: [],            // [{id, name, slug, start_utc, maneuver_count, ...}]
   selectedSessionIds: new Set(),
   type: null,              // 'tack'|'gybe'|'rounding'|null
   direction: null,         // 'PS'|'SP'|null
   postStart: false,        // drop pre-gun maneuvers when true
-  twsBand: null,           // index into TWS_BANDS, or null
+  twsBands: new Set(),     // indices into TWS_BANDS — empty = any
   hasVideo: false,
   maneuvers: [],
   selected: new Set(),     // composite keys "sid:mid"
@@ -67,6 +68,7 @@ async function loadSessions() {
   container.textContent = 'Loading...';
   const params = new URLSearchParams();
   if (state.regattaId) params.set('regatta_id', state.regattaId);
+  if (state.sessionType) params.set('session_type', state.sessionType);
   params.set('limit', state.regattaId ? '200' : String(state.sessionLimit));
   try {
     const r = await fetch('/api/maneuvers/sessions?' + params.toString());
@@ -124,6 +126,19 @@ function mvReloadSessions() {
 // ---------------------------------------------------------------------------
 
 function renderPills() {
+  const stEl = document.getElementById('mv-sessiontype-pills');
+  if (stEl) {
+    const entries = [
+      { value: null, label: 'all' },
+      { value: 'race', label: 'race' },
+      { value: 'practice', label: 'practice' },
+    ];
+    stEl.innerHTML = entries.map(e => '<button class="mv-pill'
+      + (state.sessionType === e.value ? ' active' : '')
+      + '" onclick="mvSetSessionType(' + (e.value == null ? 'null' : '\'' + e.value + '\'') + ')">'
+      + e.label + '</button>').join('');
+  }
+
   const typeEl = document.getElementById('mv-type-pills');
   typeEl.innerHTML = '<button class="mv-pill' + (state.type == null ? ' active' : '')
     + '" onclick="mvSetType(null)">all</button>'
@@ -145,16 +160,29 @@ function renderPills() {
   }
 
   const twsEl = document.getElementById('mv-tws-pills');
-  twsEl.innerHTML = '<button class="mv-pill' + (state.twsBand == null ? ' active' : '')
-    + '" onclick="mvSetTws(null)">any</button>'
-    + TWS_BANDS.map((b, i) => '<button class="mv-pill' + (state.twsBand === i ? ' active' : '')
-      + '" onclick="mvSetTws(' + i + ')">' + b.label + '</button>').join('');
+  const anyActive = state.twsBands.size === 0;
+  twsEl.innerHTML = '<button class="mv-pill' + (anyActive ? ' active' : '')
+    + '" onclick="mvClearTws()">any</button>'
+    + TWS_BANDS.map((b, i) => '<button class="mv-pill'
+      + (state.twsBands.has(i) ? ' active' : '')
+      + '" onclick="mvToggleTws(' + i + ')">' + b.label + '</button>').join('');
 }
 
 function mvSetType(t) { state.type = t; renderPills(); reload(); }
 function mvSetDir(d) { state.direction = d; renderPills(); reload(); }
-function mvSetTws(i) { state.twsBand = i; renderPills(); reload(); }
+function mvToggleTws(i) {
+  if (state.twsBands.has(i)) state.twsBands.delete(i);
+  else state.twsBands.add(i);
+  renderPills();
+  reload();
+}
+function mvClearTws() { state.twsBands.clear(); renderPills(); reload(); }
 function mvSetPhase(on) { state.postStart = !!on; renderPills(); reload(); }
+function mvSetSessionType(t) {
+  state.sessionType = t;
+  renderPills();
+  loadSessions().then(reload);
+}
 
 // ---------------------------------------------------------------------------
 // Fetch + render results
@@ -177,10 +205,16 @@ async function reload() {
     }
     if (state.type) params.set('type', state.type);
     if (state.direction) params.set('direction', state.direction);
-    if (state.twsBand != null) {
-      const band = TWS_BANDS[state.twsBand];
-      params.set('tws_min', String(band.min));
-      if (band.max != null) params.set('tws_max', String(band.max));
+    if (state.sessionType) params.set('session_type', state.sessionType);
+    if (state.twsBands.size) {
+      // Send selected bands as a comma-separated "min-max" list; the server
+      // treats them as a logical OR so 8-10 + 10-12 captures the 8-12 range
+      // and non-adjacent bands like 6-8 + 12-15 union correctly too.
+      const bands = [...state.twsBands].sort((a, b) => a - b).map(i => {
+        const b = TWS_BANDS[i];
+        return b.max == null ? b.min + '-' : b.min + '-' + b.max;
+      });
+      params.set('tws_bands', bands.join(','));
     }
     if (state.hasVideo) params.set('has_video', '1');
     if (state.postStart) params.set('post_start', '1');

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -18,6 +18,7 @@
   <div id="nav-links" class="nav-links">
     <a href="/"{% if active_page == "/" %} class="active"{% endif %}>Home</a>
     <a href="/history"{% if active_page == "/history" %} class="active"{% endif %}>History</a>
+    <a href="/maneuvers"{% if active_page == "/maneuvers" %} class="active"{% endif %}>Maneuvers</a>
     <a href="/sails"{% if active_page == "/sails" %} class="active"{% endif %}>Sails</a>
     <a href="/attention"{% if active_page == "/attention" %} class="active"{% endif %} id="nav-attention">Attention<span id="notif-badge" style="display:none;background:var(--danger);color:var(--bg-primary);font-size:.65rem;padding:1px 5px;border-radius:8px;margin-left:4px;font-weight:700"></span></a>
     <a href="/admin/boats"{% if active_page == "/admin/boats" %} class="active"{% endif %}>Boats</a>

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -41,12 +41,17 @@ footer,.site-nav{display:none}
 
 {% block content %}
 <div id="app-config"
-  data-session-id="{{ session_id }}"
+  data-session-id="{{ session_id or '' }}"
   data-session-slug="{{ session_slug or '' }}"
+  data-cross-session="{{ '1' if cross_session else '' }}"
   style="display:none"></div>
 
 <div class="compare-header" id="compare-header">
+  {% if cross_session %}
+  <a href="/maneuvers" class="back-link">&larr; Maneuvers</a>
+  {% else %}
   <a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link">&larr; {{ session_name }}</a>
+  {% endif %}
   <span style="font-size:.82rem;font-weight:600;color:var(--text-primary)">Compare</span>
   <span id="compare-subtitle" style="font-size:.72rem;color:var(--text-secondary)"></span>
   <span style="flex:1"></span>

--- a/src/helmlog/templates/compare.html
+++ b/src/helmlog/templates/compare.html
@@ -36,6 +36,7 @@ footer,.site-nav{display:none}
 .track-overlay{position:absolute;bottom:6px;left:6px;z-index:5;pointer-events:none;opacity:.85;filter:drop-shadow(0 1px 2px rgba(0,0,0,.5))}
 .gauge-overlay{position:absolute;top:6px;left:6px;z-index:5;pointer-events:none;opacity:.9;filter:drop-shadow(0 1px 2px rgba(0,0,0,.5))}
 .recovery-overlay{position:absolute;top:6px;left:158px;z-index:5;pointer-events:none;opacity:.9;filter:drop-shadow(0 1px 2px rgba(0,0,0,.5))}
+.start-overlay{position:absolute;top:6px;left:50%;transform:translateX(-50%);z-index:5;pointer-events:none;opacity:.95;filter:drop-shadow(0 1px 2px rgba(0,0,0,.6))}
 </style>
 {% endblock %}
 

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+{% block title %}Maneuvers — HelmLog{% endblock %}
+
+{% block extra_css %}
+<style>
+.mv-filters{display:flex;flex-direction:column;gap:10px;margin-bottom:12px}
+.mv-row{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.mv-row label{font-size:.75rem;color:var(--text-secondary);display:flex;align-items:center;gap:6px}
+.mv-row select,.mv-row input[type=number]{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.8rem}
+.mv-pill{font-size:.72rem;padding:3px 9px;border:1px solid var(--border);border-radius:3px;background:transparent;color:var(--text-secondary);cursor:pointer}
+.mv-pill.active{background:var(--accent);color:var(--bg-primary);border-color:var(--accent)}
+.mv-session-picker{max-height:160px;overflow-y:auto;border:1px solid var(--border);border-radius:4px;padding:6px;background:var(--bg-secondary);font-size:.78rem}
+.mv-session-picker label{display:flex;align-items:center;gap:6px;padding:2px 0;cursor:pointer}
+.mv-session-picker label:hover{background:var(--bg-input)}
+.mv-session-picker .mv-session-count{color:var(--text-secondary);font-size:.7rem;margin-left:auto}
+.mv-results{border:1px solid var(--border);border-radius:4px;background:var(--bg-secondary);overflow:hidden}
+.mv-results-header{display:flex;align-items:center;gap:10px;padding:8px 10px;border-bottom:1px solid var(--border);background:var(--bg-input)}
+.mv-results-header strong{font-size:.85rem}
+.mv-results-header .spacer{flex:1}
+.mv-results-header button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:5px 14px;font-size:.8rem;cursor:pointer;font-weight:600}
+.mv-results-header button:disabled{opacity:.4;cursor:not-allowed}
+.mv-table{width:100%;border-collapse:collapse;font-size:.78rem}
+.mv-table th,.mv-table td{padding:5px 8px;text-align:left;border-bottom:1px solid var(--border)}
+.mv-table th{font-size:.7rem;font-weight:600;color:var(--text-secondary);background:var(--bg-input);text-transform:uppercase;letter-spacing:.03em;position:sticky;top:0}
+.mv-table tbody tr{cursor:pointer}
+.mv-table tbody tr:hover{background:var(--bg-input)}
+.mv-table tbody tr.selected{background:rgba(var(--accent-rgb,100,140,200),.12)}
+.mv-table td.mv-num{text-align:right;font-variant-numeric:tabular-nums}
+.mv-table .mv-video{color:var(--success)}
+.mv-table .mv-no-video{color:var(--text-secondary);opacity:.4}
+.mv-empty{padding:20px;text-align:center;color:var(--text-secondary);font-size:.85rem}
+.mv-badge-tack{color:var(--accent)}
+.mv-badge-gybe{color:var(--warning)}
+.mv-badge-rounding{color:var(--success)}
+.mv-scroll{max-height:calc(100vh - 380px);overflow-y:auto}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1 style="margin-bottom:8px">Maneuvers</h1>
+<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:12px">
+  Browse maneuvers across sessions, filter by wind, then compare videos side-by-side.
+</div>
+
+<div class="card">
+  <div class="mv-filters">
+    <div class="mv-row">
+      <label>Regatta / Series
+        <select id="mv-regatta" onchange="mvOnRegattaChange()">
+          <option value="">All recent sessions</option>
+        </select>
+      </label>
+      <label>Recent sessions limit
+        <input id="mv-session-limit" type="number" min="1" max="100" value="20" style="width:70px"
+          onchange="mvReloadSessions()"/>
+      </label>
+      <label style="margin-left:auto">
+        <input type="checkbox" id="mv-has-video" onchange="mvReload()"/>
+        Video available
+      </label>
+    </div>
+
+    <div class="mv-row" style="align-items:flex-start">
+      <div style="flex:1;min-width:260px">
+        <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Sessions
+          <button class="mv-pill" onclick="mvSelectAllSessions(true)" style="margin-left:6px">All</button>
+          <button class="mv-pill" onclick="mvSelectAllSessions(false)">None</button>
+        </div>
+        <div class="mv-session-picker" id="mv-sessions">Loading...</div>
+      </div>
+      <div style="flex:1;min-width:260px">
+        <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Type</div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-type-pills"></div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Direction</div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-dir-pills"></div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Wind (TWS kts)</div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-tws-pills"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mv-results" style="margin-top:12px">
+  <div class="mv-results-header">
+    <strong id="mv-count">0 maneuvers</strong>
+    <span id="mv-selected-count" style="font-size:.75rem;color:var(--text-secondary)"></span>
+    <span class="spacer"></span>
+    <button id="mv-compare-btn" onclick="mvOpenCompare()" disabled>Compare Selected</button>
+  </div>
+  <div class="mv-scroll">
+    <table class="mv-table" id="mv-table">
+      <thead>
+        <tr>
+          <th style="width:28px"><input type="checkbox" id="mv-check-all" onchange="mvToggleAll(this.checked)"/></th>
+          <th>Session</th>
+          <th>Time</th>
+          <th>Type</th>
+          <th>Dir</th>
+          <th class="mv-num">TWS</th>
+          <th class="mv-num">Turn</th>
+          <th class="mv-num">Duration</th>
+          <th>Rank</th>
+          <th>Video</th>
+        </tr>
+      </thead>
+      <tbody id="mv-tbody"></tbody>
+    </table>
+    <div class="mv-empty" id="mv-empty" style="display:none">No maneuvers match the current filters.</div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/maneuvers.js?v={{ git_sha }}"></script>
+{% endblock %}

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -73,6 +73,8 @@
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-type-pills"></div>
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Direction</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-dir-pills"></div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Race phase</div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-phase-pills"></div>
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Wind (TWS kts)</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-tws-pills"></div>
       </div>

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -69,13 +69,17 @@
         <div class="mv-session-picker" id="mv-sessions">Loading...</div>
       </div>
       <div style="flex:1;min-width:260px">
-        <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Type</div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Session type</div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-sessiontype-pills"></div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Type</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-type-pills"></div>
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Direction</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-dir-pills"></div>
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Race phase</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-phase-pills"></div>
-        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Wind (TWS kts)</div>
+        <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">
+          Wind (TWS kts) <span style="opacity:.6">— click multiple to combine</span>
+        </div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-tws-pills"></div>
       </div>
     </div>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4694,6 +4694,48 @@ async def test_cross_session_compare_resolves_start_token(storage: Storage) -> N
 
 
 @pytest.mark.asyncio
+async def test_maneuver_browse_tags_rounding_mark(storage: Storage) -> None:
+    """Each rounding gets a mark=weather|leeward field classified by exit_twa."""
+    # Without instrument data, enrichment produces entry_twa/exit_twa = None,
+    # so _classify_rounding_mark returns None. We patch exit_twa directly on
+    # the enriched payload via a monkey-patched maneuver — easier to just
+    # verify the classifier directly.
+    from helmlog.routes.sessions import _classify_rounding_mark
+
+    assert _classify_rounding_mark({"type": "rounding", "exit_twa": 120}) == "weather"
+    assert _classify_rounding_mark({"type": "rounding", "exit_twa": 40}) == "leeward"
+    assert _classify_rounding_mark({"type": "rounding", "entry_twa": 40}) == "weather"
+    assert _classify_rounding_mark({"type": "rounding", "entry_twa": 120}) == "leeward"
+    assert _classify_rounding_mark({"type": "rounding"}) is None
+    assert _classify_rounding_mark({"type": "tack", "exit_twa": 40}) is None
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_filter_weather_implies_rounding(storage: Storage) -> None:
+    """type=weather only returns roundings (tacks/gybes are excluded)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="Marks", count=2)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}&type=weather")
+    assert resp.status_code == 200
+    # Seeded maneuvers are tacks — none should pass a weather-mark filter.
+    assert resp.json()["maneuvers"] == []
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_rejects_bad_mark_type(storage: Storage) -> None:
+    """Unknown type token (not tack/gybe/rounding/weather/leeward/start) → 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/browse?type=windward")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_maneuver_browse_post_start_filter(storage: Storage) -> None:
     """post_start=1 drops maneuvers whose ts is before the session's start_utc.
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4527,6 +4527,71 @@ async def test_maneuver_browse_rejects_bad_direction(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_maneuver_browse_sessions_filters_by_session_type(storage: Storage) -> None:
+    """session_type=race hides practice sessions from the picker (and vice versa)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="RaceOnly", count=1)
+        # Tag a second seeded session as practice
+        await client.post("/api/races/stop")
+        practice_id, _ = await _seed_maneuvers(storage, client, event="PracOnly", count=1)
+        await storage._conn().execute(
+            "UPDATE races SET session_type = 'practice' WHERE id = ?", (practice_id,)
+        )
+        await storage._conn().commit()
+
+        race_resp = await client.get("/api/maneuvers/sessions?session_type=race")
+        prac_resp = await client.get("/api/maneuvers/sessions?session_type=practice")
+
+    race_ids = {s["id"] for s in race_resp.json()["sessions"]}
+    prac_ids = {s["id"] for s in prac_resp.json()["sessions"]}
+    assert race_id in race_ids and practice_id not in race_ids
+    assert practice_id in prac_ids and race_id not in prac_ids
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_sessions_rejects_bad_session_type(storage: Storage) -> None:
+    """Unknown session_type value returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/sessions?session_type=dinghy")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_tws_bands_multi(storage: Storage) -> None:
+    """tws_bands accepts multiple non-contiguous bands as a logical OR."""
+    # No instrument data is seeded, so entry_tws is None and any wind
+    # filter excludes all maneuvers — exercising the code path is enough
+    # to catch parse/filter regressions.
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="BandMulti", count=2)
+        ok = await client.get(
+            f"/api/maneuvers/browse?session_ids={race_id}&tws_bands=6-8,12-15,15-"
+        )
+    assert ok.status_code == 200
+    assert ok.json()["maneuvers"] == []
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_tws_bands_rejects_non_numeric(storage: Storage) -> None:
+    """Non-numeric tws_bands token returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/browse?tws_bands=foo-bar")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_maneuver_browse_post_start_filter(storage: Storage) -> None:
     """post_start=1 drops maneuvers whose ts is before the session's start_utc.
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4406,6 +4406,48 @@ async def test_maneuver_browse_sessions_excludes_empty(storage: Storage) -> None
 
 
 @pytest.mark.asyncio
+async def test_maneuver_browse_sessions_excludes_imported(storage: Storage) -> None:
+    """Races imported from external results (source != 'live') are hidden even
+    if they have maneuver rows (duplicated across classes in the same window)."""
+    from helmlog.maneuver_detector import Maneuver
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        live_race, _ = await _seed_maneuvers(storage, client, event="Live", count=1)
+        # Create a second race, tag it as imported (source != 'live'), and
+        # attach a maneuver so only the source filter can exclude it.
+        await client.post("/api/races/stop")
+        await _set_event(client, "Imported")
+        imported_race = (await client.post("/api/races/start")).json()["id"]
+        await storage.write_maneuvers(
+            imported_race,
+            [
+                Maneuver(
+                    type="tack",
+                    ts=datetime(2026, 2, 26, 15, 0, 0, tzinfo=UTC),
+                    end_ts=datetime(2026, 2, 26, 15, 0, 8, tzinfo=UTC),
+                    duration_sec=8.0,
+                    loss_kts=0.5,
+                    vmg_loss_kts=None,
+                    tws_bin=12,
+                    twa_bin=40,
+                )
+            ],
+        )
+        await storage._conn().execute(
+            "UPDATE races SET source = 'clubspot' WHERE id = ?", (imported_race,)
+        )
+        await storage._conn().commit()
+        resp = await client.get("/api/maneuvers/sessions")
+    assert resp.status_code == 200
+    ids = {s["id"] for s in resp.json()["sessions"]}
+    assert live_race in ids
+    assert imported_race not in ids
+
+
+@pytest.mark.asyncio
 async def test_maneuver_browse_regattas_endpoint(storage: Storage) -> None:
     """GET /api/maneuvers/regattas returns only regattas with linked sessions."""
     app = create_app(storage)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -4589,6 +4589,108 @@ async def test_maneuver_browse_tws_bands_rejects_non_numeric(storage: Storage) -
     ) as client:
         resp = await client.get("/api/maneuvers/browse?tws_bands=foo-bar")
     assert resp.status_code == 422
+
+
+async def _attach_vakaros_gun(storage: Storage, race_id: int, gun_ts: datetime) -> None:
+    """Give a race a matched Vakaros session + race_start event at ``gun_ts``."""
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO vakaros_sessions "
+        "(source_hash, source_file, start_utc, end_utc, ingested_at) "
+        "VALUES (?, 'test.csv', ?, ?, ?)",
+        (
+            f"hash-{race_id}",
+            gun_ts.isoformat(),
+            (gun_ts + timedelta(hours=1)).isoformat(),
+            gun_ts.isoformat(),
+        ),
+    )
+    vak_session_id = cur.lastrowid
+    await db.execute(
+        "INSERT INTO vakaros_race_events "
+        "(session_id, event_type, ts, timer_value_s) VALUES (?, 'race_start', ?, 0)",
+        (vak_session_id, gun_ts.isoformat()),
+    )
+    await db.execute(
+        "UPDATE races SET vakaros_session_id = ?, start_utc = ?, end_utc = ? WHERE id = ?",
+        (
+            vak_session_id,
+            (gun_ts - timedelta(minutes=10)).isoformat(),
+            (gun_ts + timedelta(hours=1)).isoformat(),
+            race_id,
+        ),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_synthesizes_start(storage: Storage) -> None:
+    """A session with a Vakaros race_start event gets a synthetic start entry."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="Start", count=1)
+        gun_ts = datetime(2026, 2, 26, 14, 20, 0, tzinfo=UTC)
+        await _attach_vakaros_gun(storage, race_id, gun_ts)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    starts = [m for m in data["maneuvers"] if m["type"] == "start"]
+    assert len(starts) == 1
+    assert starts[0]["session_id"] == race_id
+    assert starts[0]["id"] == "S"
+    assert starts[0]["ts"].startswith("2026-02-26T14:20:00")
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_start_filter_excludes_others(storage: Storage) -> None:
+    """type=start returns only synthesized starts; real maneuvers are dropped."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="StartOnly", count=2)
+        gun_ts = datetime(2026, 2, 26, 14, 20, 0, tzinfo=UTC)
+        await _attach_vakaros_gun(storage, race_id, gun_ts)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}&type=start")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["maneuvers"]) == 1
+    assert data["maneuvers"][0]["type"] == "start"
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_no_start_without_vakaros_gun(storage: Storage) -> None:
+    """Sessions without a Vakaros race_start event get no synthesized start."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="NoGun", count=1)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    starts = [m for m in data["maneuvers"] if m["type"] == "start"]
+    assert starts == []
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_resolves_start_token(storage: Storage) -> None:
+    """ids=<sid>:S resolves to a synthesized start on the compare endpoint."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="CmpStart", count=1)
+        gun_ts = datetime(2026, 2, 26, 14, 20, 0, tzinfo=UTC)
+        await _attach_vakaros_gun(storage, race_id, gun_ts)
+        resp = await client.get(f"/api/maneuvers/compare?ids={race_id}:S")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["maneuvers"]) == 1
+    assert data["maneuvers"][0]["type"] == "start"
+    assert data["maneuvers"][0]["id"] == "S"
 
 
 @pytest.mark.asyncio

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4388,6 +4388,24 @@ async def test_maneuver_browse_sessions_endpoint(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_maneuver_browse_sessions_excludes_empty(storage: Storage) -> None:
+    """Sessions with zero maneuvers (imported-results rows) are filtered out."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        with_race, _ = await _seed_maneuvers(storage, client, event="HasMan", count=1)
+        await client.post("/api/races/stop")
+        await _set_event(client, "NoMan")
+        empty_race = (await client.post("/api/races/start")).json()["id"]
+        resp = await client.get("/api/maneuvers/sessions")
+    assert resp.status_code == 200
+    ids = {s["id"] for s in resp.json()["sessions"]}
+    assert with_race in ids
+    assert empty_race not in ids
+
+
+@pytest.mark.asyncio
 async def test_maneuver_browse_regattas_endpoint(storage: Storage) -> None:
     """GET /api/maneuvers/regattas returns only regattas with linked sessions."""
     app = create_app(storage)
@@ -4464,3 +4482,33 @@ async def test_maneuver_browse_rejects_bad_direction(storage: Storage) -> None:
     ) as client:
         resp = await client.get("/api/maneuvers/browse?direction=X")
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_post_start_filter(storage: Storage) -> None:
+    """post_start=1 drops maneuvers whose ts is before the session's start_utc.
+
+    With no Vakaros race_start event, the server falls back to the race's
+    stored start_utc as the effective gun. The seeded tacks use
+    ts = 14:10, 14:11 UTC; start_utc is set to 14:30 via _END_UTC below
+    so both maneuvers land pre-start.
+    """
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="PostStart", count=2)
+        # Push the race start forward so the seeded maneuvers (ts 14:10,14:11)
+        # are firmly before the "gun" (14:30 Z).
+        await storage._conn().execute(
+            "UPDATE races SET start_utc = ? WHERE id = ?",
+            ("2026-02-26T14:30:00+00:00", race_id),
+        )
+        await storage._conn().commit()
+
+        without_filter = await client.get(f"/api/maneuvers/browse?session_ids={race_id}")
+        with_filter = await client.get(f"/api/maneuvers/browse?session_ids={race_id}&post_start=1")
+    assert without_filter.status_code == 200
+    assert with_filter.status_code == 200
+    assert len(without_filter.json()["maneuvers"]) == 2
+    assert with_filter.json()["maneuvers"] == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4251,3 +4251,216 @@ async def test_compare_api_empty_ids(storage: Storage) -> None:
         race_id = (await client.post("/api/races/start")).json()["id"]
         resp = await client.get(f"/api/sessions/{race_id}/maneuvers/compare?ids=")
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cross-session maneuver compare + browser (#584)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_maneuvers(
+    storage: Storage, client: httpx.AsyncClient, *, event: str, count: int = 2
+) -> tuple[int, list[int]]:
+    """Create a race and seed ``count`` tacks; return (race_id, [maneuver_ids])."""
+    from helmlog.maneuver_detector import Maneuver
+
+    await _set_event(client, event)
+    race_id = (await client.post("/api/races/start")).json()["id"]
+    maneuvers = [
+        Maneuver(
+            type="tack",
+            ts=datetime(2026, 2, 26, 14, 10 + i, 0, tzinfo=UTC),
+            end_ts=datetime(2026, 2, 26, 14, 10 + i, 8, tzinfo=UTC),
+            duration_sec=8.0,
+            loss_kts=0.5,
+            vmg_loss_kts=None,
+            tws_bin=12,
+            twa_bin=40,
+        )
+        for i in range(count)
+    ]
+    await storage.write_maneuvers(race_id, maneuvers)
+    rows = await storage.get_session_maneuvers(race_id)
+    return race_id, [r["id"] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_api_parses_pairs(storage: Storage) -> None:
+    """GET /api/maneuvers/compare?ids=sid:mid returns maneuvers keyed by session."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, mids = await _seed_maneuvers(storage, client, event="CrossA", count=2)
+        ids = f"{race_id}:{mids[0]},{race_id}:{mids[1]}"
+        resp = await client.get(f"/api/maneuvers/compare?ids={ids}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["maneuvers"]) == 2
+    assert str(race_id) in data["video_sync_by_session"]
+    # Each maneuver must carry its session context for cross-session rendering.
+    for m in data["maneuvers"]:
+        assert m["session_id"] == race_id
+        assert m.get("session_name")
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_api_mixes_sessions(storage: Storage) -> None:
+    """Pairs from two different sessions return a per-session video_sync map."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1, m1_ids = await _seed_maneuvers(storage, client, event="MixA", count=1)
+        # End the first race before starting the second to avoid overlap.
+        await client.post("/api/races/stop")
+        r2, m2_ids = await _seed_maneuvers(storage, client, event="MixB", count=1)
+        ids = f"{r1}:{m1_ids[0]},{r2}:{m2_ids[0]}"
+        resp = await client.get(f"/api/maneuvers/compare?ids={ids}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["maneuvers"]) == 2
+    sessions = {m["session_id"] for m in data["maneuvers"]}
+    assert sessions == {r1, r2}
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_api_rejects_bare_ids(storage: Storage) -> None:
+    """Legacy comma-separated integer ids must fail on the cross-session endpoint."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/compare?ids=1,2,3")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_api_rejects_malformed(storage: Storage) -> None:
+    """Malformed id pairs (missing half, non-integer) return 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        for bad in ("foo:bar", "1:", ":1", "abc"):
+            resp = await client.get(f"/api/maneuvers/compare?ids={bad}")
+            assert resp.status_code == 422, f"{bad} should be rejected"
+
+
+@pytest.mark.asyncio
+async def test_cross_session_compare_page_renders(storage: Storage) -> None:
+    """GET /compare renders without a session path parameter."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/compare")
+    assert resp.status_code == 200
+    assert b"compare-grid" in resp.content
+
+
+@pytest.mark.asyncio
+async def test_maneuvers_browser_page_renders(storage: Storage) -> None:
+    """GET /maneuvers renders the browser page."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/maneuvers")
+    assert resp.status_code == 200
+    assert b"mv-sessions" in resp.content
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_sessions_endpoint(storage: Storage) -> None:
+    """GET /api/maneuvers/sessions lists sessions with maneuver counts."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="BrowseA", count=3)
+        resp = await client.get("/api/maneuvers/sessions")
+    assert resp.status_code == 200
+    sessions = resp.json()["sessions"]
+    match = [s for s in sessions if s["id"] == race_id]
+    assert match, "seeded race must appear in sessions list"
+    assert match[0]["maneuver_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_regattas_endpoint(storage: Storage) -> None:
+    """GET /api/maneuvers/regattas returns only regattas with linked sessions."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/regattas")
+    assert resp.status_code == 200
+    assert "regattas" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_by_session_ids(storage: Storage) -> None:
+    """GET /api/maneuvers/browse?session_ids= returns only those sessions' maneuvers."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="BrowseB", count=2)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_ids"] == [race_id]
+    # All returned maneuvers must belong to that session.
+    for m in data["maneuvers"]:
+        assert m["session_id"] == race_id
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_filters_by_type(storage: Storage) -> None:
+    """Type filter excludes non-matching maneuvers."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="BrowseC", count=2)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}&type=gybe")
+    assert resp.status_code == 200
+    assert resp.json()["maneuvers"] == []
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_filters_by_wind(storage: Storage) -> None:
+    """Wind-range filter drops maneuvers whose entry_tws is None or out of band."""
+    # Seeded maneuvers have no instrument data, so entry_tws is None; any
+    # explicit wind filter must exclude them.
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="BrowseD", count=2)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}&tws_min=8&tws_max=10")
+    assert resp.status_code == 200
+    assert resp.json()["maneuvers"] == []
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_rejects_bad_type(storage: Storage) -> None:
+    """Invalid type value returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/browse?type=turtle")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_rejects_bad_direction(storage: Storage) -> None:
+    """Invalid direction value returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/browse?direction=X")
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Implements the first slice of #584 — pool maneuvers across sessions and filter by wind range, so debriefs can line up a statistically meaningful set of tacks or gybes at similar TWS across many sessions.

- **New `/maneuvers` page** (linked from the nav between History and Sails) pools maneuvers across recent sessions, with filters for regatta/series, session multi-select, type, direction (P→S / S→P), wind-range bands (0-6 … 15+ kt), and a \"video available\" toggle.
- **Generalized compare URL**: `/compare?ids=<session_id>:<maneuver_id>,...` accepts pairs from different sessions. The legacy `/session/{id}/compare?ids=1,2,3` URL still works unchanged.
- **Per-session video sync + track + gauge overlays** on the compare page so each cell renders against the right session's data when sessions are mixed. Cells show the session date/name label in cross-session mode.
- **Wind-range pills** on the compare page's existing filter panel (#581), matching the new bands in the browser.
- **API**:
  - `GET /api/maneuvers/compare?ids=<sid>:<mid>,...` — cross-session enrichment feed
  - `GET /api/maneuvers/browse?regatta_id=&session_ids=&type=&direction=&tws_min=&tws_max=&has_video=` — browser data
  - `GET /api/maneuvers/sessions?regatta_id=&limit=` — session picker data
  - `GET /api/maneuvers/regattas` — regatta dropdown data
- New helper `enrich_maneuvers_for_ids()` groups pairs by session and reuses the existing per-session `enrich_session_maneuvers()` cache.

Closes #584

## Follow-ups (not in this PR)

Issue #584 also asked for session filters by crew, sails, and race results. Those will land as follow-up PRs — each has real UI design decisions (chip picker vs. dropdown vs. autocomplete) and didn't fit cleanly into one reviewable diff. To-do:

- Session filter: crew (against `race_crew`)
- Session filter: sails (against `race_sails`)
- Session filter: race results (place ≤ N, status filter)
- Maneuver quality rank filter on the browser page
- Migrate session-page \"Compare Videos\" button to `sid:mid` URL form

## Test plan

- [x] `uv run pytest` — 1941 passed, 2 skipped
- [x] `uv run ruff check .` + `ruff format --check .`
- [x] `uv run mypy src/` — no issues
- [ ] Manual: open `/maneuvers`, filter by wind band, compare selections across two sessions
- [ ] Manual: verify legacy `/session/{id}/compare?ids=1,2` still loads and renders the same as before
- [ ] Manual: verify session labels appear on cells only in cross-session mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)