### PR TITLE
fix: include synthesized sessions in history page

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -3393,7 +3393,7 @@ class Storage:
                 race_params.append(session_type)
             else:
                 race_where.append("r.session_type IN ('race', 'practice', 'synthesized')")
-            race_where.append("(r.source IS NULL OR r.source = 'live')")
+            race_where.append("(r.source IS NULL OR r.source IN ('live', 'synthesized'))")
             if q:
                 race_where.append("(r.name LIKE ? OR r.event LIKE ?)")
                 like = f"%{q}%"

--- a/tests/test_web_synthesize.py
+++ b/tests/test_web_synthesize.py
@@ -181,3 +181,43 @@ async def test_sessions_filter_synthesized(storage: Storage) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert "sessions" in data
+
+
+@pytest.mark.asyncio
+async def test_synthesized_session_appears_in_default_list(storage: Storage) -> None:
+    """Synthesized sessions must appear in the unfiltered /api/sessions list.
+
+    Regression: the source='synthesized' filter was excluding them because
+    list_sessions only allowed source IN (NULL, 'live').
+    """
+    await storage.set_daily_event("2026-03-10", "TestRegatta")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        create_resp = await client.post(
+            "/api/sessions/synthesize",
+            json={
+                "course_type": "windward_leeward",
+                "wind_direction": 180,
+                "start_lat": 47.70,
+                "start_lon": -122.44,
+                "laps": 1,
+                "seed": 42,
+            },
+        )
+        assert create_resp.status_code == 201
+        session_id = create_resp.json()["id"]
+
+        # Default list (no type filter) must include the synthesized session
+        list_resp = await client.get("/api/sessions")
+        assert list_resp.status_code == 200
+        ids = [s["id"] for s in list_resp.json()["sessions"]]
+        assert session_id in ids
+
+        # Explicit type=synthesized filter must also include it
+        filtered_resp = await client.get("/api/sessions?type=synthesized")
+        assert filtered_resp.status_code == 200
+        filtered_ids = [s["id"] for s in filtered_resp.json()["sessions"]]
+        assert session_id in filtered_ids


### PR DESCRIPTION
## Summary

- `list_sessions()` source filter excluded synthesized sessions (`source='synthesized'`) because it only allowed `NULL` or `'live'`
- Added `'synthesized'` to the source allowlist in the query
- Added regression test that creates a synthesized session and verifies it appears in both the default and type-filtered session lists

Fixes #590

## Test plan

- [x] Regression test `test_synthesized_session_appears_in_default_list` passes
- [x] Full test suite green (2023 passed, 5 runs)
- [x] Lint and format clean
- [ ] Verify on Pi: synthesize a session, confirm it appears on `/history`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)