### PR TITLE
feat: Moments slice 2 — anchored threads + anchor picker (#478)

### DIFF
--- a/src/helmlog/anchor_match.py
+++ b/src/helmlog/anchor_match.py
@@ -1,0 +1,119 @@
+"""Predicate: does a cursor position "match" an anchor?
+
+Used by:
+- UI cursor-highlight logic (mirrored in JS)
+- Tests asserting the decision table on #478
+
+Pure function — takes decoded anchor + cursor + a lookup bag for entity
+anchors (maneuvers, bookmarks, races) whose payloads live in other
+tables. Missing lookup rows return False (defensive: a stale anchor
+should not spuriously match).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from helmlog.anchors import Anchor
+
+DEFAULT_WINDOW_SECONDS: float = 15.0
+START_WINDOW_SECONDS: float = 60.0
+
+CursorLike = datetime | str
+
+
+@dataclass(frozen=True, slots=True)
+class Lookups:
+    """Resolved entity payloads keyed by id.
+
+    - maneuvers: id -> (ts, end_ts | None) as ISO strings
+    - bookmarks: id -> t_start ISO string
+    - races:     id -> start_utc ISO string
+    """
+
+    maneuvers: dict[int, tuple[str, str | None]] = field(default_factory=dict)
+    bookmarks: dict[int, str] = field(default_factory=dict)
+    races: dict[int, str] = field(default_factory=dict)
+
+
+def _to_dt(value: CursorLike | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else None
+    if isinstance(value, str):
+        # Accept "…Z" suffix as UTC.
+        iso = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(iso)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else None
+    return None
+
+
+def anchor_matches_cursor(anchor: Anchor, cursor: CursorLike, lookups: Lookups) -> bool:
+    """Return True if `cursor` is within the anchor's active window."""
+    c = _to_dt(cursor)
+    if c is None:
+        return False
+
+    kind = anchor.kind
+
+    if kind == "timestamp":
+        t = _to_dt(anchor.t_start)
+        if t is None:
+            return False
+        return abs((c - t).total_seconds()) <= DEFAULT_WINDOW_SECONDS
+
+    if kind == "segment":
+        start = _to_dt(anchor.t_start)
+        end = _to_dt(anchor.t_end)
+        if start is None or end is None:
+            return False
+        return start <= c < end
+
+    if kind == "maneuver":
+        if anchor.entity_id is None:
+            return False
+        record = lookups.maneuvers.get(anchor.entity_id)
+        if record is None:
+            return False
+        ts_s, end_ts_s = record
+        ts = _to_dt(ts_s)
+        if ts is None:
+            return False
+        end_ts = _to_dt(end_ts_s) if end_ts_s is not None else None
+        if end_ts is None:
+            return abs((c - ts).total_seconds()) <= DEFAULT_WINDOW_SECONDS
+        return ts <= c <= end_ts
+
+    if kind == "bookmark":
+        if anchor.entity_id is None:
+            return False
+        t_start_s = lookups.bookmarks.get(anchor.entity_id)
+        if t_start_s is None:
+            return False
+        t = _to_dt(t_start_s)
+        if t is None:
+            return False
+        return abs((c - t).total_seconds()) <= DEFAULT_WINDOW_SECONDS
+
+    if kind == "race":
+        # Thread-scope check happens upstream; if the thread is on this
+        # session, a race anchor is always active.
+        return anchor.entity_id is not None
+
+    if kind == "start":
+        if anchor.entity_id is None:
+            return False
+        start_s = lookups.races.get(anchor.entity_id)
+        if start_s is None:
+            return False
+        start = _to_dt(start_s)
+        if start is None:
+            return False
+        return abs((c - start).total_seconds()) <= START_WINDOW_SECONDS
+
+    return False

--- a/src/helmlog/routes/comments.py
+++ b/src/helmlog/routes/comments.py
@@ -19,23 +19,45 @@ async def api_create_thread(
     session_id: int,
     user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
-    """Create a comment thread for a session."""
+    """Create a comment thread for a session.
+
+    Body: `{ "title": str?, "anchor": Anchor? }`. The Anchor schema is
+    `{kind, entity_id?, t_start?, t_end?}` — see `helmlog.anchors`.
+    Legacy keys `anchor_timestamp` / `mark_reference` return 400 (cutover
+    landed in #478 / slice 2 of the Moments epic).
+    """
+    from helmlog.anchors import Anchor, AnchorError  # noqa: PLC0415
+    from helmlog.storage import AnchorScopeError  # noqa: PLC0415
+
     storage = get_storage(request)
     body = await request.json()
-    anchor_timestamp: str | None = body.get("anchor_timestamp")
-    mark_reference: str | None = body.get("mark_reference")
+    if "anchor_timestamp" in body or "mark_reference" in body:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "anchor_timestamp / mark_reference are no longer accepted; "
+                "use the `anchor` object ({kind, entity_id?, t_start?, t_end?})."
+            ),
+        )
     title: str | None = body.get("title")
-    from helmlog.storage import _MARK_REFERENCES  # noqa: PLC0415
+    anchor_payload = body.get("anchor")
+    anchor: Anchor | None = None
+    if anchor_payload is not None:
+        if not isinstance(anchor_payload, dict):
+            raise HTTPException(status_code=400, detail="anchor must be an object")
+        try:
+            anchor = Anchor.from_dict(anchor_payload)
+        except AnchorError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    if mark_reference and mark_reference not in _MARK_REFERENCES:
-        raise HTTPException(status_code=400, detail=f"Unknown mark reference: {mark_reference!r}")
-    thread_id = await storage.create_comment_thread(
-        session_id,
-        user["id"],
-        anchor_timestamp=anchor_timestamp,
-        mark_reference=mark_reference,
-        title=title,
-    )
+    try:
+        thread_id = await storage.create_comment_thread(
+            session_id, user["id"], anchor=anchor, title=title
+        )
+    except AnchorError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except AnchorScopeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     await audit(
         request, "thread.create", detail=f"thread={thread_id} session={session_id}", user=user
     )
@@ -44,6 +66,21 @@ async def api_create_thread(
 
     await notify_new_thread(storage, thread_id, session_id, user["id"])
     return JSONResponse({"id": thread_id}, status_code=201)
+
+
+@router.get("/api/sessions/{session_id}/anchors")
+async def api_list_session_anchors(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return a pre-labelled, t_start-ordered list of pickable anchors.
+
+    Consumed by the anchor-picker typeahead when composing a thread.
+    """
+    storage = get_storage(request)
+    anchors = await storage.list_session_anchors(session_id)
+    return JSONResponse(anchors)
 
 
 @router.get("/api/sessions/{session_id}/threads")

--- a/src/helmlog/static/anchor-picker.js
+++ b/src/helmlog/static/anchor-picker.js
@@ -153,10 +153,22 @@ class AnchorPicker extends HTMLElement {
   }
 
   _normalize(raw) {
+    // The /api/sessions/{id}/anchors endpoint includes a `t_start` on every
+    // row so the picker can render a time label, but the Anchor schema only
+    // allows `t_start` on kind=timestamp/segment. Strip it for entity-ref
+    // kinds or the server rejects the payload.
     const a = { kind: raw.kind };
-    if (raw.entity_id !== undefined && raw.entity_id !== null) a.entity_id = raw.entity_id;
-    if (raw.t_start) a.t_start = raw.t_start;
-    if (raw.t_end) a.t_end = raw.t_end;
+    if (raw.kind === 'timestamp') {
+      if (raw.t_start) a.t_start = raw.t_start;
+    } else if (raw.kind === 'segment') {
+      if (raw.t_start) a.t_start = raw.t_start;
+      if (raw.t_end) a.t_end = raw.t_end;
+    } else {
+      // maneuver | bookmark | race | start — entity_id only
+      if (raw.entity_id !== undefined && raw.entity_id !== null) {
+        a.entity_id = raw.entity_id;
+      }
+    }
     return a;
   }
 

--- a/src/helmlog/static/anchor-picker.js
+++ b/src/helmlog/static/anchor-picker.js
@@ -1,0 +1,206 @@
+// Anchor-picker custom element (#478 / #588 slice 2).
+//
+// <anchor-picker session-id="123"></anchor-picker>
+//
+// Fetches pickable anchors from /api/sessions/{id}/anchors, renders a text
+// input + filtered dropdown, and emits a `change` event when the user picks
+// one:
+//
+//   picker.addEventListener('change', ev => {
+//     ev.detail.anchor  // {kind, entity_id?, t_start?, t_end?} | null
+//     ev.detail.label   // human-readable label for display (string | null)
+//   });
+//
+// Keyboard: ArrowUp/Down navigate, Enter picks, Escape cancels. Typing
+// filters by substring against the label. If the user presses Enter with no
+// list item selected and the `fallbackToCursor` attribute is present (the
+// default when composing a new thread), the picker emits an ad-hoc
+// timestamp anchor at the current replay cursor.
+//
+// This is the reusable primitive — slice 3 (#587) will add a second mode
+// for tag selection using the same keyboard model and rendering.
+
+class AnchorPicker extends HTMLElement {
+  static get observedAttributes() { return ['session-id']; }
+
+  constructor() {
+    super();
+    this._anchors = [];
+    this._filtered = [];
+    this._selectedIdx = -1;
+    this._selectedAnchor = null;
+    this._fallbackCursor = null; // set by host (session.js) when composing
+  }
+
+  connectedCallback() {
+    this._render();
+    this._wire();
+    this._refresh();
+  }
+
+  attributeChangedCallback(name) {
+    if (name === 'session-id' && this._listEl) this._refresh();
+  }
+
+  get sessionId() { return this.getAttribute('session-id'); }
+  get value() { return this._selectedAnchor; }
+
+  set fallbackCursor(utc) { this._fallbackCursor = utc; }
+
+  clear() {
+    this._selectedAnchor = null;
+    this._selectedIdx = -1;
+    if (this._inputEl) this._inputEl.value = '';
+    this._renderBadge(null);
+    this._renderList();
+  }
+
+  _render() {
+    this.style.display = 'block';
+    this.innerHTML = `
+      <div class="anchor-picker-row" style="display:flex;gap:6px;align-items:center">
+        <input class="anchor-picker-input" type="text" placeholder="Search anchors\u2026"
+               autocomplete="off" style="flex:1" />
+        <span class="anchor-picker-badge" style="font-size:.72rem;color:var(--text-secondary)"></span>
+        <button type="button" class="anchor-picker-clear"
+                style="background:none;border:none;color:var(--text-secondary);cursor:pointer;font-size:.72rem;text-decoration:underline;display:none">clear</button>
+      </div>
+      <div class="anchor-picker-list" role="listbox"
+           style="display:none;max-height:220px;overflow:auto;border:1px solid var(--border);border-radius:4px;margin-top:4px;background:var(--bg-primary)"></div>
+    `;
+    this._inputEl = this.querySelector('.anchor-picker-input');
+    this._badgeEl = this.querySelector('.anchor-picker-badge');
+    this._clearEl = this.querySelector('.anchor-picker-clear');
+    this._listEl = this.querySelector('.anchor-picker-list');
+  }
+
+  _wire() {
+    this._inputEl.addEventListener('input', () => this._onInput());
+    this._inputEl.addEventListener('focus', () => this._showList());
+    this._inputEl.addEventListener('keydown', (ev) => this._onKey(ev));
+    this._inputEl.addEventListener('blur', () => setTimeout(() => this._hideList(), 150));
+    this._clearEl.addEventListener('click', () => this._emit(null, null));
+    this._listEl.addEventListener('mousedown', (ev) => {
+      const item = ev.target.closest('[data-idx]');
+      if (!item) return;
+      ev.preventDefault();
+      this._pick(parseInt(item.dataset.idx, 10));
+    });
+  }
+
+  async _refresh() {
+    if (!this.sessionId) { this._anchors = []; return; }
+    try {
+      const resp = await fetch(`/api/sessions/${this.sessionId}/anchors`);
+      if (!resp.ok) return;
+      this._anchors = await resp.json();
+      this._filtered = this._anchors.slice();
+      this._renderList();
+    } catch { /* silent */ }
+  }
+
+  _onInput() {
+    const q = this._inputEl.value.trim().toLowerCase();
+    this._filtered = q
+      ? this._anchors.filter(a => (a.label || '').toLowerCase().includes(q))
+      : this._anchors.slice();
+    this._selectedIdx = this._filtered.length ? 0 : -1;
+    this._renderList();
+    this._showList();
+  }
+
+  _onKey(ev) {
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      if (!this._filtered.length) return;
+      this._selectedIdx = Math.min(this._filtered.length - 1, this._selectedIdx + 1);
+      this._renderList();
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      this._selectedIdx = Math.max(0, this._selectedIdx - 1);
+      this._renderList();
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      if (this._selectedIdx >= 0 && this._filtered[this._selectedIdx]) {
+        this._pickAnchor(this._filtered[this._selectedIdx]);
+      } else if (this._fallbackCursor) {
+        // No selection — use current playhead as raw timestamp anchor
+        this._pickAnchor({
+          kind: 'timestamp',
+          t_start: this._fallbackCursor,
+          label: 'Current replay time',
+        });
+      }
+    } else if (ev.key === 'Escape') {
+      this._hideList();
+      this._inputEl.blur();
+    }
+  }
+
+  _pick(idx) {
+    const a = this._filtered[idx];
+    if (a) this._pickAnchor(a);
+  }
+
+  _pickAnchor(raw) {
+    const anchor = this._normalize(raw);
+    const label = raw.label || '';
+    this._selectedAnchor = anchor;
+    this._inputEl.value = label;
+    this._renderBadge(label);
+    this._hideList();
+    this._emit(anchor, label);
+  }
+
+  _normalize(raw) {
+    const a = { kind: raw.kind };
+    if (raw.entity_id !== undefined && raw.entity_id !== null) a.entity_id = raw.entity_id;
+    if (raw.t_start) a.t_start = raw.t_start;
+    if (raw.t_end) a.t_end = raw.t_end;
+    return a;
+  }
+
+  _emit(anchor, label) {
+    this._selectedAnchor = anchor;
+    if (!anchor) {
+      this._inputEl.value = '';
+      this._renderBadge(null);
+    }
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: { anchor, label },
+      bubbles: true,
+    }));
+  }
+
+  _renderBadge(label) {
+    if (label) {
+      this._badgeEl.textContent = label.length > 40 ? label.slice(0, 37) + '\u2026' : label;
+      this._badgeEl.style.color = 'var(--warning)';
+      this._clearEl.style.display = '';
+    } else {
+      this._badgeEl.textContent = '';
+      this._clearEl.style.display = 'none';
+    }
+  }
+
+  _renderList() {
+    if (!this._filtered.length) {
+      this._listEl.innerHTML = '<div style="padding:6px 8px;color:var(--text-secondary);font-size:.78rem">No matches</div>';
+      return;
+    }
+    this._listEl.innerHTML = this._filtered.map((a, idx) => {
+      const selected = idx === this._selectedIdx;
+      const bg = selected ? 'background:var(--bg-secondary);' : '';
+      const kindBadge = `<span style="color:var(--text-secondary);font-size:.66rem;margin-right:6px">${a.kind}</span>`;
+      const label = (a.label || '').replace(/</g, '&lt;');
+      return `<div role="option" data-idx="${idx}" style="padding:6px 8px;cursor:pointer;font-size:.82rem;${bg}">${kindBadge}${label}</div>`;
+    }).join('');
+  }
+
+  _showList() { this._listEl.style.display = ''; }
+  _hideList() { this._listEl.style.display = 'none'; }
+}
+
+if (!customElements.get('anchor-picker')) {
+  customElements.define('anchor-picker', AnchorPicker);
+}

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -5623,9 +5623,14 @@ async function loadDiscussion() {
   const card = document.getElementById('discussion-card');
   card.style.display = '';
   const body = document.getElementById('discussion-body');
-  const r = await fetch('/api/sessions/' + SESSION_ID + '/threads');
-  if (!r.ok) { body.innerHTML = '<span style="color:var(--text-secondary)">Failed to load</span>'; return; }
-  _threads = await r.json();
+  // Fetch anchor index in parallel so entity-ref chips can resolve labels
+  _anchorIndex = null;
+  const [threadsResp] = await Promise.all([
+    fetch('/api/sessions/' + SESSION_ID + '/threads'),
+    _ensureAnchorIndex(),
+  ]);
+  if (!threadsResp.ok) { body.innerHTML = '<span style="color:var(--text-secondary)">Failed to load</span>'; return; }
+  _threads = await threadsResp.json();
   const totalUnread = _threads.reduce((s, t) => s + (t.unread_count || 0), 0);
   const badge = document.getElementById('discussion-badge');
   badge.textContent = totalUnread > 0 ? '(' + totalUnread + ' unread)' : '';
@@ -5635,13 +5640,7 @@ async function loadDiscussion() {
     return;
   }
   body.innerHTML = _threads.map(t => {
-    const anchor = t.mark_reference
-      ? '<span class="thread-anchor">' + esc(t.mark_reference.replace(/_/g, ' ')) + '</span>'
-      : t.anchor_timestamp
-        ? '<span class="thread-anchor" style="cursor:pointer;text-decoration:underline" '
-          + 'onclick="event.stopPropagation();seekToThreadAnchor(\'' + esc(t.anchor_timestamp) + '\')" '
-          + 'title="Seek playback to this moment">' + fmtTime(t.anchor_timestamp) + '</span>'
-        : '';
+    const anchor = _renderAnchorChip(t.anchor);
     const unread = t.unread_count > 0
       ? '<span class="thread-unread">' + t.unread_count + '</span>'
       : '';
@@ -5668,6 +5667,111 @@ function seekToThreadAnchor(ts) {
   if (isNaN(utc.getTime())) return;
   _seekTo(utc, 'thread');
 }
+
+// Resolve an entity-ref anchor (maneuver / bookmark / race / start) to a
+// clickable seek target. Uses the session-wide anchor index fetched when
+// the discussion panel loads, avoiding one /anchors fetch per thread.
+let _anchorIndex = null; // {kind: {entity_id: {t_start, label}}}
+
+async function _ensureAnchorIndex() {
+  if (_anchorIndex) return _anchorIndex;
+  try {
+    const r = await fetch('/api/sessions/' + SESSION_ID + '/anchors');
+    if (!r.ok) { _anchorIndex = {}; return _anchorIndex; }
+    const rows = await r.json();
+    _anchorIndex = {};
+    for (const a of rows) {
+      if (!_anchorIndex[a.kind]) _anchorIndex[a.kind] = {};
+      _anchorIndex[a.kind][a.entity_id] = {t_start: a.t_start, label: a.label};
+    }
+  } catch { _anchorIndex = {}; }
+  return _anchorIndex;
+}
+
+function _anchorSeekTime(anchor) {
+  if (!anchor) return null;
+  if (anchor.kind === 'timestamp' || anchor.kind === 'segment') return anchor.t_start || null;
+  if (!_anchorIndex) return null;
+  const resolved = _anchorIndex[anchor.kind] && _anchorIndex[anchor.kind][anchor.entity_id];
+  return resolved ? resolved.t_start : null;
+}
+
+function _anchorDisplayLabel(anchor) {
+  if (!anchor) return '';
+  if (anchor.kind === 'timestamp') return fmtTime(anchor.t_start);
+  if (anchor.kind === 'segment') return fmtTime(anchor.t_start) + '\u2013' + fmtTime(anchor.t_end);
+  if (_anchorIndex) {
+    const resolved = _anchorIndex[anchor.kind] && _anchorIndex[anchor.kind][anchor.entity_id];
+    if (resolved) return resolved.label;
+  }
+  return anchor.kind;
+}
+
+function _renderAnchorChip(anchor) {
+  if (!anchor) return '';
+  const seekTo = _anchorSeekTime(anchor);
+  const label = esc(_anchorDisplayLabel(anchor));
+  if (seekTo) {
+    return '<span class="thread-anchor" style="cursor:pointer;text-decoration:underline" '
+      + 'onclick="event.stopPropagation();seekToThreadAnchor(\'' + esc(seekTo) + '\')" '
+      + 'title="Seek playback to this moment">' + label + '</span>';
+  }
+  return '<span class="thread-anchor">' + label + '</span>';
+}
+
+// Cursor-vs-anchor match predicate — mirrors anchor_match.py for the
+// client-side highlight pass. Returns true if `cursor` (Date) is within
+// the anchor's active window. Maneuver/bookmark/start lookups come from
+// _anchorIndex (populated by _ensureAnchorIndex).
+const _ANCHOR_MATCH_WINDOW_S = 15;
+const _ANCHOR_MATCH_START_WINDOW_S = 60;
+
+function _parseUtc(s) {
+  if (!s) return null;
+  const d = new Date(s.endsWith('Z') || s.includes('+') ? s : s + 'Z');
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function anchorMatchesCursor(anchor, cursor) {
+  if (!anchor || !cursor) return false;
+  const k = anchor.kind;
+  if (k === 'timestamp') {
+    const t = _parseUtc(anchor.t_start);
+    return !!t && Math.abs((cursor - t) / 1000) <= _ANCHOR_MATCH_WINDOW_S;
+  }
+  if (k === 'segment') {
+    const s = _parseUtc(anchor.t_start), e = _parseUtc(anchor.t_end);
+    return !!s && !!e && cursor >= s && cursor < e;
+  }
+  if (k === 'race') return true;
+  if (!_anchorIndex) return false;
+  const entry = _anchorIndex[k] && _anchorIndex[k][anchor.entity_id];
+  if (!entry) return false;
+  const base = _parseUtc(entry.t_start);
+  if (!base) return false;
+  if (k === 'start') {
+    return Math.abs((cursor - base) / 1000) <= _ANCHOR_MATCH_START_WINDOW_S;
+  }
+  // maneuver / bookmark — point anchors with a ±15s window
+  return Math.abs((cursor - base) / 1000) <= _ANCHOR_MATCH_WINDOW_S;
+}
+
+function _refreshThreadHighlights(utc) {
+  if (!utc || !_threads || !_threads.length) return;
+  const active = new Set();
+  for (const t of _threads) {
+    if (anchorMatchesCursor(t.anchor, utc)) active.add(t.id);
+  }
+  const items = document.querySelectorAll('.thread-item');
+  items.forEach(el => {
+    const m = el.getAttribute('onclick') && el.getAttribute('onclick').match(/openThread\((\d+)\)/);
+    if (!m) return;
+    const id = parseInt(m[1], 10);
+    el.classList.toggle('thread-active', active.has(id));
+  });
+}
+
+registerSurface('threads', function(utc) { _refreshThreadHighlights(utc); });
 
 function _checkThreadHash() {
   // Prefer query params (?thread=<id>&comment=<id>) — survive Slack unfurls.
@@ -5727,8 +5831,9 @@ function _addDiscussionMarkers() {
   if (!_map || !_trackData) return;
 
   _threads.forEach(t => {
-    if (!t.anchor_timestamp) return;
-    const ts = new Date(t.anchor_timestamp.endsWith('Z') || t.anchor_timestamp.includes('+') ? t.anchor_timestamp : t.anchor_timestamp + 'Z');
+    const seekTo = _anchorSeekTime(t.anchor);
+    if (!seekTo) return;
+    const ts = new Date(seekTo.endsWith('Z') || seekTo.includes('+') ? seekTo : seekTo + 'Z');
     const idx = _indexForUtc(ts);
     const latLng = _trackData.latLngs[idx];
     if (!latLng) return;
@@ -5747,7 +5852,7 @@ function _addDiscussionMarkers() {
 
     const popup = '<div style="max-width:260px">'
       + '<div style="font-weight:600;color:var(--text-primary);font-size:.82rem">' + title + unread + '</div>'
-      + '<div style="font-size:.7rem;color:var(--text-secondary)">' + esc(author) + ' &middot; ' + count + ' &middot; ' + fmtTime(t.anchor_timestamp) + '</div>'
+      + '<div style="font-size:.7rem;color:var(--text-secondary)">' + esc(author) + ' &middot; ' + count + ' &middot; ' + esc(_anchorDisplayLabel(t.anchor)) + '</div>'
       + resolvedHtml
       + '<div id="discussion-marker-preview-' + t.id + '">'
       + '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">Loading\u2026</div></div>'
@@ -5816,82 +5921,50 @@ function showNewThreadForm(anchorTimestamp) {
   const form = document.createElement('div');
   form.className = 'thread-form';
   form.style.marginBottom = '10px';
-  // Default anchor to the current playback position if the caller didn't pass one
-  if (!anchorTimestamp && _playClock.positionUtc) {
-    anchorTimestamp = _playClock.positionUtc.toISOString();
-  }
-  const anchorLabel = anchorTimestamp ? fmtTime(anchorTimestamp) : '';
-  const anchorHidden = anchorTimestamp
-    ? '<input type="hidden" id="new-thread-anchor-ts" value="' + esc(anchorTimestamp) + '"/>'
-      + '<div id="new-thread-anchor-row" style="font-size:.72rem;color:var(--warning);margin-bottom:6px">'
-      + 'Anchored at <span id="new-thread-anchor-label">' + anchorLabel + '</span> '
-      + '<button type="button" onclick="clearNewThreadAnchor()" '
-      + 'style="background:none;border:none;color:var(--text-secondary);cursor:pointer;font-size:.72rem;text-decoration:underline">clear</button>'
-      + '</div>'
-    : '<input type="hidden" id="new-thread-anchor-ts" value=""/>'
-      + '<div id="new-thread-anchor-row" style="font-size:.72rem;color:var(--text-secondary);margin-bottom:6px">'
-      + 'Race-general thread (no anchor) '
-      + '<button type="button" onclick="useCurrentAnchor()" '
-      + 'style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.72rem;text-decoration:underline">use current time</button>'
-      + '</div>';
-  form.innerHTML = anchorHidden
+  const cursor = _playClock.positionUtc ? _playClock.positionUtc.toISOString() : null;
+  form.innerHTML = ''
     + '<div style="display:flex;gap:6px;margin-bottom:6px">'
     + '<input id="new-thread-title" placeholder="Thread title (optional)" style="flex:1"/>'
-    + '<select id="new-thread-mark" style="width:auto"><option value="">No mark anchor</option>'
-    + '<option value="start">Start</option>'
-    + '<option value="weather_mark_1">Weather Mark 1</option><option value="weather_mark_2">Weather Mark 2</option>'
-    + '<option value="leeward_mark_1">Leeward Mark 1</option><option value="leeward_mark_2">Leeward Mark 2</option>'
-    + '<option value="gate_1">Gate 1</option><option value="gate_2">Gate 2</option>'
-    + '<option value="offset_mark_1">Offset Mark 1</option>'
-    + '<option value="finish">Finish</option>'
-    + '</select></div>'
-    + '<textarea id="new-thread-body" placeholder="First comment\u2026"></textarea>'
+    + '</div>'
+    + '<div style="margin-bottom:6px;font-size:.72rem;color:var(--text-secondary)">'
+    + 'Anchor (optional):'
+    + '</div>'
+    + '<anchor-picker id="new-thread-anchor-picker" session-id="' + esc(SESSION_ID) + '"></anchor-picker>'
+    + '<textarea id="new-thread-body" placeholder="First comment\u2026" style="margin-top:8px"></textarea>'
     + '<div style="margin-top:6px;display:flex;gap:6px">'
     + '<button class="btn-thread" onclick="submitNewThread()">Create Thread</button>'
     + '<button class="btn-thread" style="background:none;color:var(--text-secondary)" onclick="loadDiscussion()">Cancel</button>'
     + '</div>';
   body.prepend(form);
-}
-
-function clearNewThreadAnchor() {
-  const inp = document.getElementById('new-thread-anchor-ts');
-  if (inp) inp.value = '';
-  const row = document.getElementById('new-thread-anchor-row');
-  if (row) {
-    row.style.color = 'var(--text-secondary)';
-    row.innerHTML = 'Race-general thread (no anchor) '
-      + '<button type="button" onclick="useCurrentAnchor()" '
-      + 'style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.72rem;text-decoration:underline">use current time</button>';
-  }
-}
-
-function useCurrentAnchor() {
-  if (!_playClock.positionUtc) return;
-  const utc = _playClock.positionUtc.toISOString();
-  const inp = document.getElementById('new-thread-anchor-ts');
-  if (inp) inp.value = utc;
-  const row = document.getElementById('new-thread-anchor-row');
-  if (row) {
-    row.style.color = 'var(--warning)';
-    row.innerHTML = 'Anchored at <span id="new-thread-anchor-label">' + fmtTime(utc) + '</span> '
-      + '<button type="button" onclick="clearNewThreadAnchor()" '
-      + 'style="background:none;border:none;color:var(--text-secondary);cursor:pointer;font-size:.72rem;text-decoration:underline">clear</button>';
+  const picker = document.getElementById('new-thread-anchor-picker');
+  if (picker) {
+    picker.fallbackCursor = cursor;
+    // If caller passed a preferred timestamp (e.g. map-click), preselect it
+    if (anchorTimestamp) {
+      picker.addEventListener('connected', () => {}, {once: true});
+      setTimeout(() => {
+        picker._pickAnchor({kind: 'timestamp', t_start: anchorTimestamp, label: fmtTime(anchorTimestamp)});
+      }, 0);
+    }
   }
 }
 
 async function submitNewThread() {
   const title = document.getElementById('new-thread-title').value.trim();
-  const mark = document.getElementById('new-thread-mark').value || null;
-  const anchorTs = document.getElementById('new-thread-anchor-ts').value || null;
+  const picker = document.getElementById('new-thread-anchor-picker');
+  const anchor = picker ? picker.value : null;
   const firstComment = document.getElementById('new-thread-body').value.trim();
   const payload = {};
   if (title) payload.title = title;
-  if (mark) payload.mark_reference = mark;
-  if (anchorTs) payload.anchor_timestamp = anchorTs;
+  if (anchor) payload.anchor = anchor;
   const r = await fetch('/api/sessions/' + SESSION_ID + '/threads', {
     method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(payload)
   });
-  if (!r.ok) { alert('Failed to create thread'); return; }
+  if (!r.ok) {
+    const detail = await r.json().catch(() => ({}));
+    alert('Failed to create thread: ' + (detail.detail || r.status));
+    return;
+  }
   const {id} = await r.json();
   if (firstComment) {
     await fetch('/api/threads/' + id + '/comments', {
@@ -5911,13 +5984,8 @@ async function openThread(threadId, scrollToCommentId) {
   if (!r.ok) { loadDiscussion(); return; }
   const t = await r.json();
   const title = _threadTitle(t);
-  const anchor = t.mark_reference
-    ? '<span class="thread-anchor">' + esc(t.mark_reference.replace(/_/g, ' ')) + '</span>'
-    : t.anchor_timestamp
-      ? '<span class="thread-anchor" style="cursor:pointer;text-decoration:underline" '
-        + 'onclick="seekToThreadAnchor(\'' + esc(t.anchor_timestamp) + '\')" '
-        + 'title="Seek playback to this moment">' + fmtTime(t.anchor_timestamp) + '</span>'
-      : '';
+  await _ensureAnchorIndex();
+  const anchor = _renderAnchorChip(t.anchor);
   let resolveBtn = '';
   if (t.resolved) {
     resolveBtn = '<button class="btn-unresolve" onclick="unresolveThread(' + t.id + ')">Unresolve</button>';

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -5952,7 +5952,13 @@ function showNewThreadForm(anchorTimestamp) {
 async function submitNewThread() {
   const title = document.getElementById('new-thread-title').value.trim();
   const picker = document.getElementById('new-thread-anchor-picker');
-  const anchor = picker ? picker.value : null;
+  let anchor = picker ? picker.value : null;
+  // Fallback: if the user didn't pick anything and the replay has a
+  // cursor, anchor at that timestamp. Matches the picker's Enter-on-empty
+  // behaviour for users who click Create Thread without touching the picker.
+  if (!anchor && _playClock.positionUtc) {
+    anchor = {kind: 'timestamp', t_start: _playClock.positionUtc.toISOString()};
+  }
   const firstComment = document.getElementById('new-thread-body').value.trim();
   const payload = {};
   if (title) payload.title = title;

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from helmlog.races import Race
     from helmlog.vakaros import VakarosSession
 
+from helmlog.anchors import Anchor, validate_anchor
 from helmlog.nmea2000 import (
     COGSOGRecord,
     DepthRecord,
@@ -39,6 +40,28 @@ from helmlog.nmea2000 import (
     WindRecord,
 )
 from helmlog.video import VideoSession
+
+
+class AnchorScopeError(ValueError):
+    """Raised when an anchor's referenced entity does not scope to the expected session."""
+
+
+def _project_thread_anchor(row: dict[str, Any]) -> dict[str, Any]:
+    """Build a serializable `anchor` key from the four anchor_* columns."""
+    kind = row.get("anchor_kind")
+    if kind is None:
+        row["anchor"] = None
+        return row
+    anchor: dict[str, Any] = {"kind": kind}
+    if row.get("anchor_entity_id") is not None:
+        anchor["entity_id"] = row["anchor_entity_id"]
+    if row.get("anchor_t_start") is not None:
+        anchor["t_start"] = row["anchor_t_start"]
+    if row.get("anchor_t_end") is not None:
+        anchor["t_end"] = row["anchor_t_end"]
+    row["anchor"] = anchor
+    return row
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
@@ -149,23 +172,11 @@ _LIVE_KEYS = (
     "rudder_deg",
 )
 
-_MARK_REFERENCES: frozenset[str] = frozenset(
-    {
-        "start",
-        "finish",
-        *(f"weather_mark_{i}" for i in range(1, 10)),
-        *(f"leeward_mark_{i}" for i in range(1, 10)),
-        *(f"gate_{i}" for i in range(1, 10)),
-        *(f"offset_mark_{i}" for i in range(1, 10)),
-    }
-)
-
-
 # ---------------------------------------------------------------------------
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 70
+_CURRENT_VERSION: int = 71
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1643,6 +1654,19 @@ _MIGRATIONS: dict[int, str] = {
                anchor_t_start = anchor_timestamp
          WHERE anchor_timestamp IS NOT NULL
            AND anchor_kind IS NULL;
+    """,
+    71: """
+        -- #478 / #588 slice 2: clean cutover of legacy thread anchor columns.
+        -- Rows with a mark_reference carry their label into the title so the
+        -- human-readable info isn't lost, then the legacy columns are dropped.
+
+        UPDATE comment_threads
+           SET title = TRIM('[' || REPLACE(mark_reference, '_', ' ') || '] '
+                          || COALESCE(title, ''))
+         WHERE mark_reference IS NOT NULL;
+
+        ALTER TABLE comment_threads DROP COLUMN anchor_timestamp;
+        ALTER TABLE comment_threads DROP COLUMN mark_reference;
     """,
 }
 
@@ -6208,6 +6232,66 @@ class Storage:
         return cur.rowcount > 0
 
     # ------------------------------------------------------------------
+    # Anchor picker data source (#478 / #588 slice 2)
+    # ------------------------------------------------------------------
+
+    async def list_session_anchors(self, session_id: int) -> list[dict[str, Any]]:
+        """Return pickable anchors for a session.
+
+        Each entry is a dict with keys: kind, entity_id, label, t_start.
+        Ordered by t_start so the anchor-picker can render a timeline-ordered
+        list. Consumed by `GET /api/sessions/{id}/anchors`.
+        """
+        race = await self.get_race(session_id)
+        if race is None:
+            return []
+
+        start_utc = race.start_utc.isoformat() if race.start_utc else None
+        race_label = race.name or f"Race {session_id}"
+
+        out: list[dict[str, Any]] = []
+        if start_utc is not None:
+            out.append(
+                {
+                    "kind": "race",
+                    "entity_id": session_id,
+                    "label": race_label,
+                    "t_start": start_utc,
+                }
+            )
+            out.append(
+                {
+                    "kind": "start",
+                    "entity_id": session_id,
+                    "label": "Start sequence",
+                    "t_start": start_utc,
+                }
+            )
+
+        for mv in await self.get_session_maneuvers(session_id):
+            out.append(
+                {
+                    "kind": "maneuver",
+                    "entity_id": mv["id"],
+                    "label": f"{(mv['type'] or 'Maneuver').title()} · {mv['ts']}",
+                    "t_start": mv["ts"],
+                }
+            )
+
+        for bm in await self.list_bookmarks_for_session(session_id):
+            out.append(
+                {
+                    "kind": "bookmark",
+                    "entity_id": bm["id"],
+                    "label": f"Bookmark: {bm['name']}",
+                    "t_start": bm["anchor_t_start"],
+                }
+            )
+
+        out.sort(key=lambda a: (a["t_start"] or "", a["kind"]))
+        return out
+
+    # ------------------------------------------------------------------
     # Avatars (#100)
     # ------------------------------------------------------------------
 
@@ -7572,28 +7656,88 @@ class Storage:
         session_id: int,
         created_by: int,
         *,
-        anchor_timestamp: str | None = None,
-        mark_reference: str | None = None,
+        anchor: Anchor | None = None,
         title: str | None = None,
     ) -> int:
         """Create a comment thread anchored to a session.
+
+        If `anchor` is supplied, it is validated structurally and entity-ref
+        kinds are scoped to this session (the maneuver / bookmark must
+        belong to `session_id`, the race / start entity_id must *equal*
+        `session_id`). Raises `AnchorScopeError` on violation.
 
         Returns the new thread ID.
         """
         from datetime import UTC
         from datetime import datetime as _datetime
 
+        if anchor is not None:
+            validate_anchor(anchor)
+            await self._assert_anchor_in_session(anchor, session_id)
+
         now = _datetime.now(UTC).isoformat()
         db = self._conn()
         cur = await db.execute(
             "INSERT INTO comment_threads"
-            " (session_id, anchor_timestamp, mark_reference, title,"
-            "  created_by, created_at, updated_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (session_id, anchor_timestamp, mark_reference, title, created_by, now, now),
+            " (session_id, anchor_kind, anchor_entity_id, anchor_t_start, anchor_t_end,"
+            "  title, created_by, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                session_id,
+                anchor.kind if anchor else None,
+                anchor.entity_id if anchor else None,
+                anchor.t_start if anchor else None,
+                anchor.t_end if anchor else None,
+                title,
+                created_by,
+                now,
+                now,
+            ),
         )
         await db.commit()
         return cur.lastrowid or 0
+
+    async def _assert_anchor_in_session(self, anchor: Anchor, session_id: int) -> None:
+        """Entity-ref anchor kinds must scope to the thread's session.
+
+        Raises AnchorScopeError on violation. No-op for timestamp / segment
+        kinds (no entity to scope).
+        """
+        kind = anchor.kind
+        ent = anchor.entity_id
+        if ent is None or kind in {"timestamp", "segment"}:
+            return
+
+        if kind == "maneuver":
+            cur = await self._read_conn().execute(
+                "SELECT 1 FROM maneuvers WHERE id = ? AND session_id = ?",
+                (ent, session_id),
+            )
+            if await cur.fetchone() is None:
+                raise AnchorScopeError(f"maneuver {ent} is not part of session {session_id}")
+            return
+
+        if kind == "bookmark":
+            cur = await self._read_conn().execute(
+                "SELECT 1 FROM bookmarks WHERE id = ? AND session_id = ?",
+                (ent, session_id),
+            )
+            if await cur.fetchone() is None:
+                raise AnchorScopeError(f"bookmark {ent} is not part of session {session_id}")
+            return
+
+        if kind in {"race", "start"}:
+            # For helmlog, a session *is* a race — entity_id must equal session_id.
+            if ent != session_id:
+                raise AnchorScopeError(
+                    f"{kind} anchor entity_id {ent} must equal session_id {session_id}"
+                )
+            return
+
+        if kind == "rounding":
+            raise AnchorScopeError(
+                "anchor kind 'rounding' is not yet supported (no rounding entity)"
+            )
 
     async def list_comment_threads(
         self,
@@ -7603,7 +7747,8 @@ class Storage:
         """Return threads for a session with unread counts per user."""
         db = self._conn()
         cur = await db.execute(
-            "SELECT t.id, t.session_id, t.anchor_timestamp, t.mark_reference,"
+            "SELECT t.id, t.session_id,"
+            "   t.anchor_kind, t.anchor_entity_id, t.anchor_t_start, t.anchor_t_end,"
             "   t.title, t.created_by, t.created_at, t.updated_at,"
             "   t.resolved, t.resolved_at, t.resolved_by, t.resolution_summary,"
             "   u.name AS author_name, u.email AS author_email,"
@@ -7621,7 +7766,7 @@ class Storage:
             (user_id, session_id),
         )
         rows = await cur.fetchall()
-        return [dict(r) for r in rows]
+        return [_project_thread_anchor(dict(r)) for r in rows]
 
     async def get_comment_thread(
         self,
@@ -7639,7 +7784,7 @@ class Storage:
         row = await cur.fetchone()
         if row is None:
             return None
-        thread = dict(row)
+        thread = _project_thread_anchor(dict(row))
         cur = await db.execute(
             "SELECT c.id, c.thread_id, c.author, c.body, c.created_at, c.edited_at,"
             "   u.name AS author_name, u.email AS author_email"

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -46,6 +46,21 @@ class AnchorScopeError(ValueError):
     """Raised when an anchor's referenced entity does not scope to the expected session."""
 
 
+def _hms_from_iso(iso: str | None) -> str:
+    """Return the HH:MM:SS portion of an ISO 8601 timestamp.
+
+    Used by anchor-picker labels where the full ISO is visually noisy but
+    the time-of-day is the useful information. Falls back to the raw
+    input if parsing fails, so malformed rows still surface.
+    """
+    if not iso:
+        return ""
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).strftime("%H:%M:%S")
+    except (ValueError, TypeError):
+        return iso
+
+
 def _project_thread_anchor(row: dict[str, Any]) -> dict[str, Any]:
     """Build a serializable `anchor` key from the four anchor_* columns."""
     kind = row.get("anchor_kind")
@@ -6273,7 +6288,7 @@ class Storage:
                 {
                     "kind": "maneuver",
                     "entity_id": mv["id"],
-                    "label": f"{(mv['type'] or 'Maneuver').title()} · {mv['ts']}",
+                    "label": f"{(mv['type'] or 'Maneuver').title()} · {_hms_from_iso(mv['ts'])}",
                     "t_start": mv["ts"],
                 }
             )
@@ -6283,7 +6298,7 @@ class Storage:
                 {
                     "kind": "bookmark",
                     "entity_id": bm["id"],
-                    "label": f"Bookmark: {bm['name']}",
+                    "label": f"Bookmark: {bm['name']} · {_hms_from_iso(bm['anchor_t_start'])}",
                     "t_start": bm["anchor_t_start"],
                 }
             )

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -33,9 +33,10 @@
 .badge-rounding{color:var(--success)}
 .wf-mark-label{background:var(--bg-primary)!important;border:1px solid var(--warning)!important;color:var(--text-primary)!important;font-size:.7rem!important;padding:1px 4px!important;border-radius:3px!important;box-shadow:none!important}
 .wf-mark-label::before{border-right-color:var(--warning)!important}
-.thread-item{padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px;cursor:pointer;transition:border-color .15s}
+.thread-item{padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px;cursor:pointer;transition:border-color .15s,background .15s}
 .thread-item:hover{border-color:var(--accent-strong)}
 .thread-item.resolved{opacity:.7}
+.thread-item.thread-active{border-color:var(--accent);background:var(--bg-secondary)}
 .thread-anchor{font-size:.7rem;color:var(--warning);margin-left:6px}
 .thread-unread{background:var(--accent-strong);color:var(--bg-primary);font-size:.65rem;padding:1px 5px;border-radius:8px;margin-left:6px}
 .comment-item{padding:6px 0;border-bottom:1px solid var(--border);font-size:.8rem}
@@ -407,6 +408,7 @@
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/tag-chip.js?v={{ git_sha }}"></script>
+<script src="/static/anchor-picker.js?v={{ git_sha }}"></script>
 <script src="/static/session.js?v={{ git_sha }}"></script>
 <script>
 async function renameSession() {

--- a/tests/test_anchor_match.py
+++ b/tests/test_anchor_match.py
@@ -1,0 +1,188 @@
+"""Unit tests for the cursor-vs-anchor match predicate (decision table 2 on #478).
+
+| Anchor kind | Match predicate                                           | Window    |
+|-------------|-----------------------------------------------------------|-----------|
+| timestamp   | abs(cursor - t_start) <= W                                | 15s       |
+| segment     | t_start <= cursor < t_end                                 | exact     |
+| maneuver    | maneuver.ts <= cursor <= maneuver.end_ts (fallback ±W)    | exact/15s |
+| bookmark    | abs(cursor - bookmark.t_start) <= W                       | 15s       |
+| race        | always active on the thread's session                     | -         |
+| start       | abs(cursor - race.start_utc) <= W_start                   | 60s       |
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from helmlog.anchor_match import (
+    DEFAULT_WINDOW_SECONDS,
+    START_WINDOW_SECONDS,
+    Lookups,
+    anchor_matches_cursor,
+)
+from helmlog.anchors import Anchor
+
+_BASE = datetime(2024, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _at(offset_seconds: float) -> datetime:
+    return _BASE + timedelta(seconds=offset_seconds)
+
+
+# ---------------------------------------------------------------------------
+# timestamp — point ± 15s
+# ---------------------------------------------------------------------------
+
+
+def test_timestamp_matches_within_window() -> None:
+    a = Anchor(kind="timestamp", t_start=_iso(_BASE))
+    assert anchor_matches_cursor(a, _at(DEFAULT_WINDOW_SECONDS - 1), Lookups())
+    assert anchor_matches_cursor(a, _at(-(DEFAULT_WINDOW_SECONDS - 1)), Lookups())
+
+
+def test_timestamp_misses_outside_window() -> None:
+    a = Anchor(kind="timestamp", t_start=_iso(_BASE))
+    assert not anchor_matches_cursor(a, _at(DEFAULT_WINDOW_SECONDS + 1), Lookups())
+
+
+def test_timestamp_at_window_boundary_matches() -> None:
+    a = Anchor(kind="timestamp", t_start=_iso(_BASE))
+    assert anchor_matches_cursor(a, _at(DEFAULT_WINDOW_SECONDS), Lookups())
+
+
+# ---------------------------------------------------------------------------
+# segment — [t_start, t_end)
+# ---------------------------------------------------------------------------
+
+
+def test_segment_matches_inside() -> None:
+    a = Anchor(kind="segment", t_start=_iso(_BASE), t_end=_iso(_at(30)))
+    assert anchor_matches_cursor(a, _at(15), Lookups())
+
+
+def test_segment_matches_at_start() -> None:
+    a = Anchor(kind="segment", t_start=_iso(_BASE), t_end=_iso(_at(30)))
+    assert anchor_matches_cursor(a, _BASE, Lookups())
+
+
+def test_segment_misses_at_end_boundary() -> None:
+    """End is exclusive — cursor == t_end is not a match."""
+    a = Anchor(kind="segment", t_start=_iso(_BASE), t_end=_iso(_at(30)))
+    assert not anchor_matches_cursor(a, _at(30), Lookups())
+
+
+def test_segment_misses_before_start() -> None:
+    a = Anchor(kind="segment", t_start=_iso(_BASE), t_end=_iso(_at(30)))
+    assert not anchor_matches_cursor(a, _at(-1), Lookups())
+
+
+# ---------------------------------------------------------------------------
+# maneuver — resolved from lookups
+# ---------------------------------------------------------------------------
+
+
+def test_maneuver_matches_within_range() -> None:
+    a = Anchor(kind="maneuver", entity_id=42)
+    lookups = Lookups(maneuvers={42: (_iso(_BASE), _iso(_at(10)))})
+    assert anchor_matches_cursor(a, _at(5), lookups)
+
+
+def test_maneuver_matches_null_end_ts_with_window() -> None:
+    """When end_ts is null, fall back to ±15s around ts."""
+    a = Anchor(kind="maneuver", entity_id=42)
+    lookups = Lookups(maneuvers={42: (_iso(_BASE), None)})
+    assert anchor_matches_cursor(a, _at(DEFAULT_WINDOW_SECONDS - 1), lookups)
+    assert not anchor_matches_cursor(a, _at(DEFAULT_WINDOW_SECONDS + 1), lookups)
+
+
+def test_maneuver_misses_when_not_in_lookups() -> None:
+    a = Anchor(kind="maneuver", entity_id=999)
+    assert not anchor_matches_cursor(a, _BASE, Lookups())
+
+
+# ---------------------------------------------------------------------------
+# bookmark — point ± 15s using bookmark's t_start
+# ---------------------------------------------------------------------------
+
+
+def test_bookmark_matches_within_window() -> None:
+    a = Anchor(kind="bookmark", entity_id=7)
+    lookups = Lookups(bookmarks={7: _iso(_BASE)})
+    assert anchor_matches_cursor(a, _at(10), lookups)
+
+
+def test_bookmark_misses_outside_window() -> None:
+    a = Anchor(kind="bookmark", entity_id=7)
+    lookups = Lookups(bookmarks={7: _iso(_BASE)})
+    assert not anchor_matches_cursor(a, _at(100), lookups)
+
+
+def test_bookmark_misses_when_not_in_lookups() -> None:
+    a = Anchor(kind="bookmark", entity_id=42)
+    assert not anchor_matches_cursor(a, _BASE, Lookups())
+
+
+# ---------------------------------------------------------------------------
+# race — always active on the thread's session
+# ---------------------------------------------------------------------------
+
+
+def test_race_always_active() -> None:
+    a = Anchor(kind="race", entity_id=7)
+    assert anchor_matches_cursor(a, _at(-3600), Lookups())
+    assert anchor_matches_cursor(a, _at(3600), Lookups())
+
+
+# ---------------------------------------------------------------------------
+# start — ± 60s around race.start_utc
+# ---------------------------------------------------------------------------
+
+
+def test_start_matches_within_start_window() -> None:
+    a = Anchor(kind="start", entity_id=7)
+    lookups = Lookups(races={7: _iso(_BASE)})
+    assert anchor_matches_cursor(a, _at(START_WINDOW_SECONDS - 1), lookups)
+    assert anchor_matches_cursor(a, _at(-(START_WINDOW_SECONDS - 1)), lookups)
+
+
+def test_start_misses_outside_start_window() -> None:
+    a = Anchor(kind="start", entity_id=7)
+    lookups = Lookups(races={7: _iso(_BASE)})
+    assert not anchor_matches_cursor(a, _at(START_WINDOW_SECONDS + 1), lookups)
+
+
+def test_start_misses_when_race_not_in_lookups() -> None:
+    a = Anchor(kind="start", entity_id=99)
+    assert not anchor_matches_cursor(a, _BASE, Lookups())
+
+
+# ---------------------------------------------------------------------------
+# Invalid / missing data
+# ---------------------------------------------------------------------------
+
+
+def test_timestamp_without_t_start_misses() -> None:
+    """Defensive: a malformed anchor should silently not match."""
+    a = Anchor(kind="timestamp")
+    assert not anchor_matches_cursor(a, _BASE, Lookups())
+
+
+def test_unknown_kind_misses() -> None:
+    a = Anchor(kind="bogus")
+    assert not anchor_matches_cursor(a, _BASE, Lookups())
+
+
+@pytest.mark.parametrize(
+    "iso_cursor",
+    ["2024-06-15T12:00:00+00:00", "2024-06-15T12:00:00Z"],
+)
+def test_accepts_string_cursor(iso_cursor: str) -> None:
+    """Callers may pass a string cursor (datetime or ISO-Z)."""
+    a = Anchor(kind="timestamp", t_start=_iso(_BASE))
+    assert anchor_matches_cursor(a, iso_cursor, Lookups())

--- a/tests/test_migration_v71.py
+++ b/tests/test_migration_v71.py
@@ -1,0 +1,193 @@
+"""Tests for migration v71 — clean cutover of legacy thread anchor columns.
+
+v71:
+- Rewrites `comment_threads.title` to prepend a human-readable label when
+  the row has a non-NULL `mark_reference` (so the information isn't lost).
+- Drops `comment_threads.anchor_timestamp` and `mark_reference` columns.
+
+Tested against a DB built up to v70 with legacy-shape rows pre-seeded,
+then v71 applied.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+_T0 = "2024-06-15T12:00:00+00:00"
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    """Apply a single migration, tolerating duplicate-column ADDs.
+
+    Mirrors the same resilience as `Storage._conn().migrate()` — some ADD
+    COLUMN statements in historical migrations overlap with fresh CREATE
+    TABLEs, so we swallow duplicate-column errors.
+    """
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    """Return an in-memory DB with migrations applied up through `version`."""
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+async def _apply_v71(db: aiosqlite.Connection) -> None:
+    await _apply_migration(db, 71)
+
+
+async def _seed_session(db: aiosqlite.Connection) -> int:
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        ("test-s", "E", 1, "2024-06-15", _T0),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+@pytest.mark.asyncio
+async def test_v71_drops_legacy_columns() -> None:
+    db = await _build_db_at(70)
+    try:
+        await _apply_v71(db)
+        async with db.execute("PRAGMA table_info(comment_threads)") as cur:
+            cols = {r[1] for r in await cur.fetchall()}
+        assert "anchor_timestamp" not in cols
+        assert "mark_reference" not in cols
+        # Anchor columns from v70 remain:
+        assert {"anchor_kind", "anchor_entity_id", "anchor_t_start", "anchor_t_end"} <= cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v71_prepends_mark_label_to_existing_title() -> None:
+    db = await _build_db_at(70)
+    try:
+        sid = await _seed_session(db)
+        await db.execute(
+            "INSERT INTO comment_threads "
+            "(session_id, anchor_timestamp, mark_reference, title, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (sid, _T0, "weather_mark_2", "Bad tack", _T0, _T0),
+        )
+        await db.commit()
+        await _apply_v71(db)
+        async with db.execute("SELECT title FROM comment_threads") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["title"] == "[weather mark 2] Bad tack"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v71_handles_null_title() -> None:
+    db = await _build_db_at(70)
+    try:
+        sid = await _seed_session(db)
+        await db.execute(
+            "INSERT INTO comment_threads "
+            "(session_id, mark_reference, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            (sid, "gate_1", _T0, _T0),
+        )
+        await db.commit()
+        await _apply_v71(db)
+        async with db.execute("SELECT title FROM comment_threads") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["title"] == "[gate 1]"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v71_leaves_plain_threads_untouched() -> None:
+    db = await _build_db_at(70)
+    try:
+        sid = await _seed_session(db)
+        await db.execute(
+            "INSERT INTO comment_threads "
+            "(session_id, anchor_timestamp, title, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (sid, _T0, "General", _T0, _T0),
+        )
+        await db.commit()
+        await _apply_v71(db)
+        async with db.execute("SELECT title FROM comment_threads") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["title"] == "General"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v71_preserves_anchor_backfill_from_v70() -> None:
+    """Slice-1 backfill of anchor_t_start should survive v71 column drops."""
+    # Build at v69 so the thread exists before v70's backfill runs.
+    db = await _build_db_at(69)
+    try:
+        sid = await _seed_session(db)
+        await db.execute(
+            "INSERT INTO comment_threads "
+            "(session_id, anchor_timestamp, title, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (sid, _T0, "General", _T0, _T0),
+        )
+        await db.commit()
+
+        await _apply_migration(db, 70)
+        async with db.execute("SELECT anchor_kind, anchor_t_start FROM comment_threads") as cur:
+            pre = await cur.fetchone()
+        assert pre is not None
+        assert pre["anchor_kind"] == "timestamp"
+        assert pre["anchor_t_start"] == _T0
+
+        await _apply_v71(db)
+        async with db.execute("SELECT anchor_kind, anchor_t_start FROM comment_threads") as cur:
+            post = await cur.fetchone()
+        assert post is not None
+        assert post["anchor_kind"] == "timestamp"
+        assert post["anchor_t_start"] == _T0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_version_is_71_on_fresh_db() -> None:
+    """Using the real Storage class (all migrations) — schema version is 71."""
+    from helmlog.storage import Storage, StorageConfig
+
+    s = Storage(StorageConfig(db_path=":memory:"))
+    await s.connect()
+    try:
+        assert s._db is not None
+        async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 71
+    finally:
+        await s.close()

--- a/tests/test_storage_bookmarks.py
+++ b/tests/test_storage_bookmarks.py
@@ -60,12 +60,14 @@ async def _create_user(s: Storage, email: str = "a@example.com") -> int:
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_70(storage: Storage) -> None:
+async def test_bookmarks_migration_applied(storage: Storage) -> None:
+    """Slice-1 migration (v70) lives in the applied set regardless of newer versions."""
     assert storage._db is not None
-    async with storage._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+    async with storage._db.execute(
+        "SELECT 1 FROM schema_version WHERE version = 70"
+    ) as cur:
         row = await cur.fetchone()
     assert row is not None
-    assert row[0] == 70
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_threads_anchored.py
+++ b/tests/test_storage_threads_anchored.py
@@ -1,0 +1,234 @@
+"""Storage tests for anchored thread CRUD + anchor-picker data source (#478)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.anchors import Anchor
+from helmlog.storage import AnchorScopeError
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+_T0 = "2024-06-15T12:00:00+00:00"
+_T1 = "2024-06-15T12:00:30+00:00"
+
+
+async def _session(s: Storage, idx: int = 1) -> int:
+    now = datetime.now(UTC).isoformat()
+    assert s._db is not None
+    cur = await s._db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"s{idx}", "E", idx, "2024-06-15", now),
+    )
+    await s._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+async def _user(s: Storage, uid: int) -> None:
+    assert s._db is not None
+    await s._db.execute(
+        "INSERT INTO users (id, email, role, created_at) VALUES (?, ?, 'viewer', ?)",
+        (uid, f"u{uid}@e.com", _T0),
+    )
+    await s._db.commit()
+
+
+async def _maneuver(s: Storage, session_id: int) -> int:
+    assert s._db is not None
+    cur = await s._db.execute(
+        "INSERT INTO maneuvers (session_id, type, ts, end_ts) VALUES (?, 'tack', ?, ?)",
+        (session_id, _T0, _T1),
+    )
+    await s._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# create_comment_thread with new `anchor` kwarg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_timestamp_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    tid = await storage.create_comment_thread(
+        sid, 1, anchor=Anchor(kind="timestamp", t_start=_T0), title="Layline call"
+    )
+    thread = await storage.get_comment_thread(tid)
+    assert thread is not None
+    assert thread["anchor"] == {"kind": "timestamp", "t_start": _T0}
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_no_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    tid = await storage.create_comment_thread(sid, 1, title="General discussion")
+    thread = await storage.get_comment_thread(tid)
+    assert thread is not None
+    assert thread["anchor"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_maneuver_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    mid = await _maneuver(storage, sid)
+    tid = await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="maneuver", entity_id=mid))
+    thread = await storage.get_comment_thread(tid)
+    assert thread is not None
+    assert thread["anchor"] == {"kind": "maneuver", "entity_id": mid}
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_bookmark_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    bid = await storage.create_bookmark(
+        session_id=sid, user_id=1, name="bad call", note=None, t_start=_T0
+    )
+    tid = await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="bookmark", entity_id=bid))
+    thread = await storage.get_comment_thread(tid)
+    assert thread is not None
+    assert thread["anchor"] == {"kind": "bookmark", "entity_id": bid}
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_race_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    tid = await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="race", entity_id=sid))
+    thread = await storage.get_comment_thread(tid)
+    assert thread is not None
+    assert thread["anchor"] == {"kind": "race", "entity_id": sid}
+
+
+# ---------------------------------------------------------------------------
+# Cross-entity scoping (decision table 1 rule)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maneuver_anchor_must_belong_to_session(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    await _user(storage, 1)
+    mid_in_b = await _maneuver(storage, sid_b)
+
+    with pytest.raises(AnchorScopeError, match="maneuver"):
+        await storage.create_comment_thread(
+            sid_a, 1, anchor=Anchor(kind="maneuver", entity_id=mid_in_b)
+        )
+
+
+@pytest.mark.asyncio
+async def test_bookmark_anchor_must_belong_to_session(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    await _user(storage, 1)
+    bid_in_b = await storage.create_bookmark(
+        session_id=sid_b, user_id=1, name="x", note=None, t_start=_T0
+    )
+    with pytest.raises(AnchorScopeError, match="bookmark"):
+        await storage.create_comment_thread(
+            sid_a, 1, anchor=Anchor(kind="bookmark", entity_id=bid_in_b)
+        )
+
+
+@pytest.mark.asyncio
+async def test_race_anchor_entity_id_must_equal_session(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    await _user(storage, 1)
+    with pytest.raises(AnchorScopeError, match="race"):
+        await storage.create_comment_thread(sid_a, 1, anchor=Anchor(kind="race", entity_id=sid_b))
+
+
+@pytest.mark.asyncio
+async def test_rounding_kind_rejected_for_threads(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    with pytest.raises(AnchorScopeError, match="rounding"):
+        await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="rounding", entity_id=1))
+
+
+@pytest.mark.asyncio
+async def test_missing_entity_rejected(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    with pytest.raises(AnchorScopeError, match="maneuver"):
+        await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="maneuver", entity_id=9999))
+
+
+# ---------------------------------------------------------------------------
+# list_comment_threads projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_threads_projects_anchor(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    await storage.create_comment_thread(sid, 1, anchor=Anchor(kind="timestamp", t_start=_T0))
+    await storage.create_comment_thread(sid, 1, title="No anchor")
+
+    threads = await storage.list_comment_threads(sid, 1)
+    assert len(threads) == 2
+    anchors = [t["anchor"] for t in threads]
+    assert {"kind": "timestamp", "t_start": _T0} in anchors
+    assert None in anchors
+
+
+# ---------------------------------------------------------------------------
+# list_session_anchors (picker data source)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_includes_race_and_start(storage: Storage) -> None:
+    sid = await _session(storage)
+    anchors = await storage.list_session_anchors(sid)
+    kinds = {a["kind"] for a in anchors}
+    assert "race" in kinds
+    assert "start" in kinds
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_includes_maneuvers_and_bookmarks(
+    storage: Storage,
+) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    mid = await _maneuver(storage, sid)
+    bid = await storage.create_bookmark(
+        session_id=sid, user_id=1, name="spot", note=None, t_start=_T1
+    )
+    anchors = await storage.list_session_anchors(sid)
+    by_kind_id = {(a["kind"], a["entity_id"]) for a in anchors}
+    assert ("maneuver", mid) in by_kind_id
+    assert ("bookmark", bid) in by_kind_id
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_orders_by_t_start(storage: Storage) -> None:
+    sid = await _session(storage)
+    await _user(storage, 1)
+    # Bookmark at later time; maneuver earlier. Race+start are at session start.
+    await storage.create_bookmark(
+        session_id=sid, user_id=1, name="late", note=None, t_start="2024-06-15T12:05:00+00:00"
+    )
+    anchors = await storage.list_session_anchors(sid)
+    starts = [a["t_start"] for a in anchors]
+    assert starts == sorted(starts)
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_empty_for_missing_session(storage: Storage) -> None:
+    assert await storage.list_session_anchors(9999) == []

--- a/tests/test_threads_anchored_api.py
+++ b/tests/test_threads_anchored_api.py
@@ -165,6 +165,24 @@ async def test_create_thread_rejects_bad_anchor_shape(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_thread_rejects_maneuver_with_t_start(storage: Storage) -> None:
+    """Regression: the anchor-picker used to forward the entity's display
+    timestamp as an Anchor field, which the validator rightly rejects."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        mid = await _seed_maneuver(storage, sid)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"anchor": {"kind": "maneuver", "entity_id": mid, "t_start": _T0}},
+        )
+        assert resp.status_code == 400
+        assert "t_start" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_list_threads_projects_anchor(storage: Storage) -> None:
     app = create_app(storage)
     async with httpx.AsyncClient(

--- a/tests/test_threads_anchored_api.py
+++ b/tests/test_threads_anchored_api.py
@@ -1,0 +1,219 @@
+"""API tests for anchored thread routes + anchor-picker endpoint (#478)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+_T0 = "2024-06-15T12:00:00+00:00"
+_T1 = "2024-06-15T12:00:30+00:00"
+
+
+async def _make_session(client: httpx.AsyncClient) -> int:
+    await client.post("/api/event", json={"event_name": "ThreadTest"})
+    resp = await client.post("/api/races/start")
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _make_session_direct(storage: Storage, idx: int) -> int:
+    now = datetime.now(UTC).isoformat()
+    assert storage._db is not None
+    cur = await storage._db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"t-{idx}", "E", idx, "2024-06-15", now),
+    )
+    await storage._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+async def _seed_maneuver(storage: Storage, session_id: int, ts: str = _T0) -> int:
+    assert storage._db is not None
+    cur = await storage._db.execute(
+        "INSERT INTO maneuvers (session_id, type, ts, end_ts) VALUES (?, 'tack', ?, ?)",
+        (session_id, ts, _T1),
+    )
+    await storage._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# POST /threads with new anchor shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_timestamp_anchor(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"title": "Layline", "anchor": {"kind": "timestamp", "t_start": _T0}},
+        )
+        assert resp.status_code == 201
+        tid = resp.json()["id"]
+
+        resp = await client.get(f"/api/threads/{tid}")
+        data = resp.json()
+        assert data["title"] == "Layline"
+        assert data["anchor"] == {"kind": "timestamp", "t_start": _T0}
+
+
+@pytest.mark.asyncio
+async def test_create_thread_no_anchor(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(f"/api/sessions/{sid}/threads", json={"title": "General"})
+        assert resp.status_code == 201
+        tid = resp.json()["id"]
+        data = (await client.get(f"/api/threads/{tid}")).json()
+        assert data["anchor"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_thread_with_maneuver_anchor(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        mid = await _seed_maneuver(storage, sid)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"anchor": {"kind": "maneuver", "entity_id": mid}},
+        )
+        assert resp.status_code == 201
+        tid = resp.json()["id"]
+        data = (await client.get(f"/api/threads/{tid}")).json()
+        assert data["anchor"] == {"kind": "maneuver", "entity_id": mid}
+
+
+@pytest.mark.asyncio
+async def test_create_thread_rejects_legacy_payload(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"title": "x", "anchor_timestamp": _T0},
+        )
+        assert resp.status_code == 400
+        assert "anchor_timestamp" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_thread_rejects_legacy_mark_reference(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"mark_reference": "weather_mark_1"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_thread_rejects_cross_session_maneuver(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid_a = await _make_session_direct(storage, 1)
+        sid_b = await _make_session_direct(storage, 2)
+        mid_in_b = await _seed_maneuver(storage, sid_b)
+        resp = await client.post(
+            f"/api/sessions/{sid_a}/threads",
+            json={"anchor": {"kind": "maneuver", "entity_id": mid_in_b}},
+        )
+        assert resp.status_code == 400
+        assert "maneuver" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_thread_rejects_bad_anchor_shape(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"anchor": {"kind": "timestamp"}},  # missing t_start
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_threads_projects_anchor(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        await client.post(
+            f"/api/sessions/{sid}/threads",
+            json={"title": "with anchor", "anchor": {"kind": "timestamp", "t_start": _T0}},
+        )
+        await client.post(f"/api/sessions/{sid}/threads", json={"title": "no anchor"})
+        resp = await client.get(f"/api/sessions/{sid}/threads")
+        assert resp.status_code == 200
+        threads = resp.json()
+        anchors = [t["anchor"] for t in threads]
+        assert {"kind": "timestamp", "t_start": _T0} in anchors
+        assert None in anchors
+
+
+# ---------------------------------------------------------------------------
+# GET /api/sessions/{id}/anchors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_endpoint(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        await _seed_maneuver(storage, sid)
+        await client.post(
+            f"/api/sessions/{sid}/bookmarks",
+            json={"name": "bm", "t_start": _T1},
+        )
+        resp = await client.get(f"/api/sessions/{sid}/anchors")
+        assert resp.status_code == 200
+        data = resp.json()
+        kinds = {a["kind"] for a in data}
+        assert {"race", "start", "maneuver", "bookmark"} <= kinds
+
+
+@pytest.mark.asyncio
+async def test_list_session_anchors_empty_for_missing_session(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions/9999/anchors")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3353,7 +3353,10 @@ async def test_create_thread_and_list(storage: Storage) -> None:
         race_id = await _make_race_for_comments(client)
         resp = await client.post(
             f"/api/sessions/{race_id}/threads",
-            json={"title": "Bad tack at weather mark", "mark_reference": "weather_mark_1"},
+            json={
+                "title": "Bad tack at weather mark",
+                "anchor": {"kind": "race", "entity_id": race_id},
+            },
         )
         assert resp.status_code == 201
         thread_id = resp.json()["id"]
@@ -3364,14 +3367,14 @@ async def test_create_thread_and_list(storage: Storage) -> None:
         assert len(threads) == 1
         assert threads[0]["id"] == thread_id
         assert threads[0]["title"] == "Bad tack at weather mark"
-        assert threads[0]["mark_reference"] == "weather_mark_1"
+        assert threads[0]["anchor"] == {"kind": "race", "entity_id": race_id}
         assert threads[0]["comment_count"] == 0
         assert threads[0]["unread_count"] == 0
 
 
 @pytest.mark.asyncio
-async def test_create_thread_invalid_mark_reference(storage: Storage) -> None:
-    """POST with unknown mark reference returns 400."""
+async def test_create_thread_rejects_legacy_mark_reference(storage: Storage) -> None:
+    """Legacy mark_reference payload returns 400 after #478 cutover."""
     app = create_app(storage)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
@@ -3379,7 +3382,7 @@ async def test_create_thread_invalid_mark_reference(storage: Storage) -> None:
         race_id = await _make_race_for_comments(client)
         resp = await client.post(
             f"/api/sessions/{race_id}/threads",
-            json={"mark_reference": "bogus_mark"},
+            json={"mark_reference": "weather_mark_1"},
         )
         assert resp.status_code == 400
 
@@ -3402,8 +3405,7 @@ async def test_thread_general_discussion(storage: Storage) -> None:
         resp = await client.get(f"/api/threads/{thread_id}")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["anchor_timestamp"] is None
-        assert data["mark_reference"] is None
+        assert data["anchor"] is None
 
 
 @pytest.mark.asyncio
@@ -3686,7 +3688,7 @@ async def test_redact_comment_author_api(storage: Storage) -> None:
 
 @pytest.mark.asyncio
 async def test_thread_with_anchor_timestamp(storage: Storage) -> None:
-    """Thread can be anchored to a specific timestamp."""
+    """Thread can be anchored to a specific timestamp via the new Anchor shape."""
     app = create_app(storage)
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
@@ -3695,13 +3697,13 @@ async def test_thread_with_anchor_timestamp(storage: Storage) -> None:
         ts = "2026-03-12T14:05:30Z"
         resp = await client.post(
             f"/api/sessions/{race_id}/threads",
-            json={"title": "At this moment", "anchor_timestamp": ts},
+            json={"title": "At this moment", "anchor": {"kind": "timestamp", "t_start": ts}},
         )
         assert resp.status_code == 201
         thread_id = resp.json()["id"]
 
         resp = await client.get(f"/api/threads/{thread_id}")
-        assert resp.json()["anchor_timestamp"] == ts
+        assert resp.json()["anchor"] == {"kind": "timestamp", "t_start": ts}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 2 of the Moments epic (#588). Threads get first-class anchors, a
reusable picker, and cursor-driven highlighting. This PR completes the
clean cutover from the legacy `anchor_timestamp` + `mark_reference`
fields to the `Anchor` schema established in slice 1.

- **Migration v71** — backfills the human-readable mark label into
  `title` (e.g. `[weather mark 2] Bad tack`), then drops the legacy
  `anchor_timestamp` / `mark_reference` columns. Forward-only.
- **Storage** — `create_comment_thread()` takes an `Anchor` kwarg and
  enforces cross-entity scoping: a maneuver / bookmark anchor must
  belong to the thread's session, race / start entity_id must equal
  `session_id`. Raises `AnchorScopeError` on violation; routes map to 400.
- **`anchor_match.py`** — pure Python predicate mirroring the JS cursor
  highlight logic. 21 tests cover decision-table 2 (15s for point
  anchors, 60s for start sequence, exact for segment / maneuver).
- **API** — `POST /api/sessions/{id}/threads` now requires
  `{"anchor": {...}}`; legacy keys return 400. New
  `GET /api/sessions/{id}/anchors` feeds the picker with a pre-labelled
  list (race, start, maneuvers, bookmarks).
- **UI** — `<anchor-picker>` custom element replaces the legacy mark
  select on the thread-compose form. Thread-list items toggle a
  `.thread-active` class as the replay cursor moves across their anchor
  window.

### Spec + decisions

- Spec: https://github.com/weaties/helmlog/issues/478#issuecomment-4270506864
- Clean-cutover decision (drop legacy columns in this PR): https://github.com/weaties/helmlog/issues/478#issuecomment-4270523038

### Data licensing review

Ran `/data-license` — **compliant**. Full report:
https://github.com/weaties/helmlog/issues/478#issuecomment-4270618242

Key calls:
- No peer_api / federation exposure (slice 2 is boat-local, per epic)
- Migration v71 preserves the mark label in `title` — no user content lost
- Cross-entity scoping prevents threads in session A from pointing at
  entities in session B, even locally

### Risk tier

**Critical** — `storage.py` migration + thread ACL path. Spec, data-license,
and full test suite all completed before merge readiness.

### Explicitly out of scope (tracked separately)

- `kind='rounding'` — no rounding entity exists yet
- Tag attach on threads — slice 3 / #587
- Co-op replication of threads — combined Moments follow-up

Closes #478

## Test plan

- [x] `uv run pytest` — 2076 passed, 2 skipped (full suite, 8m)
- [x] `uv run ruff check .` / `format --check .` — clean
- [x] `uv run mypy src/` — clean
- [x] Decision table 1 (anchor kinds + cross-entity scoping) — 15 storage
      tests (including rejections for cross-session maneuver / bookmark,
      mismatched race id, rounding kind, and missing entities)
- [x] Decision table 2 (cursor-vs-anchor match) — 21 unit tests in
      `tests/test_anchor_match.py`
- [x] API cutover — 10 tests for new Anchor shape, legacy-key rejection,
      and `/api/sessions/{id}/anchors` endpoint shape
- [x] Migration v71 — 6 tests asserting the backfill, column drops, and
      slice-1 backfill preservation
- [ ] **Browser smoke** — pick a maneuver / bookmark / start from the
      anchor picker when composing a thread, verify the thread list item
      highlights as the playhead crosses the anchor window, confirm
      `?thread=<id>` deep links still work from PR #562. **Needs a human
      validation pass on the Pi before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)