### PR TITLE
feat: Moments slice 3 — tags across sessions, maneuvers, threads, bookmarks (#587)

### DIFF
--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -502,3 +502,17 @@ async def admin_vakaros_ingest(
 
         params.append(f"flash_error={quote(result.error)}")
     return RedirectResponse(url="/admin/vakaros?" + "&".join(params), status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Tags admin (#587 / #588 slice 3)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/admin/tags", response_class=HTMLResponse, include_in_schema=False)
+async def admin_tags_page(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    get_storage(request)
+    return templates.TemplateResponse(request, "admin/tags.html", tpl_ctx(request, "/admin/tags"))

--- a/src/helmlog/routes/bookmarks.py
+++ b/src/helmlog/routes/bookmarks.py
@@ -82,8 +82,15 @@ async def api_create_bookmark(
 async def api_list_bookmarks(
     request: Request,
     session_id: int,
+    tags: str | None = None,
+    tag_mode: str = "and",
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
+    """List bookmarks on a session.
+
+    `?tags=1,2` filters to bookmarks carrying the given tag ids; `tag_mode`
+    is `and` (default — must have all) or `or` (must have any).
+    """
     storage = get_storage(request)
 
     session = await storage.get_race(session_id)
@@ -91,6 +98,22 @@ async def api_list_bookmarks(
         raise HTTPException(status_code=404, detail="Session not found")
 
     rows = await storage.list_bookmarks_for_session(session_id)
+    if tags:
+        try:
+            tag_ids = [int(s) for s in tags.split(",") if s.strip()]
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="tags must be comma-separated ints"
+            ) from exc
+        if tag_ids:
+            try:
+                allowed = set(
+                    await storage.list_entities_with_tags("bookmark", tag_ids, mode=tag_mode)
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            rows = [r for r in rows if r["id"] in allowed]
+
     return JSONResponse([_serialize(r) for r in rows])
 
 

--- a/src/helmlog/routes/bookmarks.py
+++ b/src/helmlog/routes/bookmarks.py
@@ -88,8 +88,10 @@ async def api_list_bookmarks(
 ) -> JSONResponse:
     """List bookmarks on a session.
 
-    `?tags=1,2` filters to bookmarks carrying the given tag ids; `tag_mode`
-    is `and` (default — must have all) or `or` (must have any).
+    Response: `{bookmarks: [...], available_tags: [...]}`. Each bookmark
+    carries a `tags` array; `available_tags` is computed across the
+    pre-tag-filter set so the chip row stays populated when a tag is
+    active. `?tags=1,2&tag_mode=and|or` narrows the list.
     """
     storage = get_storage(request)
 
@@ -98,6 +100,23 @@ async def api_list_bookmarks(
         raise HTTPException(status_code=404, detail="Session not found")
 
     rows = await storage.list_bookmarks_for_session(session_id)
+    bm_ids = [r["id"] for r in rows]
+    tag_map = await storage.list_tags_for_entities("bookmark", bm_ids)
+    for r in rows:
+        r["tags"] = tag_map.get(r["id"], [])
+
+    # available_tags computed from the pre-tag-filter set so chip row
+    # offers every tag a user could add to narrow further.
+    available_counts: dict[int, dict[str, Any]] = {}
+    for r in rows:
+        for t in r.get("tags") or []:
+            entry = available_counts.setdefault(
+                t["id"],
+                {"id": t["id"], "name": t["name"], "color": t["color"], "count": 0},
+            )
+            entry["count"] += 1
+    available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
+
     if tags:
         try:
             tag_ids = [int(s) for s in tags.split(",") if s.strip()]
@@ -108,13 +127,18 @@ async def api_list_bookmarks(
         if tag_ids:
             try:
                 allowed = set(
-                    await storage.list_entities_with_tags("bookmark", tag_ids, mode=tag_mode)
+                    await storage.list_entities_with_tags(
+                        "bookmark", tag_ids, mode=tag_mode
+                    )
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             rows = [r for r in rows if r["id"] in allowed]
 
-    return JSONResponse([_serialize(r) for r in rows])
+    serialized = [{**_serialize(r), "tags": r.get("tags") or []} for r in rows]
+    return JSONResponse(
+        {"bookmarks": serialized, "available_tags": available_tags}
+    )
 
 
 def _may_modify(user: dict[str, Any], bm: dict[str, Any]) -> bool:

--- a/src/helmlog/routes/comments.py
+++ b/src/helmlog/routes/comments.py
@@ -93,10 +93,33 @@ async def api_list_threads(
 ) -> JSONResponse:
     """List threads for a session with unread counts.
 
-    `?tags=1,2&tag_mode=and|or` filters to threads carrying the given tags.
+    Response: `{threads: [...], available_tags: [...]}`. Each thread gets
+    a `tags` array; `available_tags` stays populated across the chip row
+    even when a tag filter is active. `?tags=1,2&tag_mode=and|or` narrows
+    the list.
     """
     storage = get_storage(request)
     threads = await storage.list_comment_threads(session_id, user["id"])
+    thread_ids = [t["id"] for t in threads]
+    tag_map = await storage.list_tags_for_entities("thread", thread_ids)
+    for t in threads:
+        t["tags"] = tag_map.get(t["id"], [])
+
+    available_counts: dict[int, dict[str, Any]] = {}
+    for t in threads:
+        for tag in t.get("tags") or []:
+            entry = available_counts.setdefault(
+                tag["id"],
+                {
+                    "id": tag["id"],
+                    "name": tag["name"],
+                    "color": tag["color"],
+                    "count": 0,
+                },
+            )
+            entry["count"] += 1
+    available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
+
     if tags:
         try:
             tag_ids = [int(s) for s in tags.split(",") if s.strip()]
@@ -107,12 +130,14 @@ async def api_list_threads(
         if tag_ids:
             try:
                 allowed = set(
-                    await storage.list_entities_with_tags("thread", tag_ids, mode=tag_mode)
+                    await storage.list_entities_with_tags(
+                        "thread", tag_ids, mode=tag_mode
+                    )
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             threads = [t for t in threads if t["id"] in allowed]
-    return JSONResponse(threads)
+    return JSONResponse({"threads": threads, "available_tags": available_tags})
 
 
 @router.get("/api/threads/{thread_id}")

--- a/src/helmlog/routes/comments.py
+++ b/src/helmlog/routes/comments.py
@@ -87,11 +87,31 @@ async def api_list_session_anchors(
 async def api_list_threads(
     request: Request,
     session_id: int,
+    tags: str | None = None,
+    tag_mode: str = "and",
     user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
-    """List threads for a session with unread counts."""
+    """List threads for a session with unread counts.
+
+    `?tags=1,2&tag_mode=and|or` filters to threads carrying the given tags.
+    """
     storage = get_storage(request)
     threads = await storage.list_comment_threads(session_id, user["id"])
+    if tags:
+        try:
+            tag_ids = [int(s) for s in tags.split(",") if s.strip()]
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="tags must be comma-separated ints"
+            ) from exc
+        if tag_ids:
+            try:
+                allowed = set(
+                    await storage.list_entities_with_tags("thread", tag_ids, mode=tag_mode)
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            threads = [t for t in threads if t["id"] in allowed]
     return JSONResponse(threads)
 
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1966,14 +1966,12 @@ async def api_sessions(
             detail="type must be 'race', 'practice', 'debrief', or 'synthesized'",
         )
     limit = max(1, min(limit, 200))
-    total, sessions = await storage.list_sessions(
-        q=q or None,
-        session_type=type,
-        from_date=from_date,
-        to_date=to_date,
-        limit=limit,
-        offset=offset,
-    )
+
+    # Tag filter — if tag ids are supplied, narrow to sessions whose row OR
+    # any constituent entity (maneuver / bookmark / thread) carries the tags.
+    # We pre-compute the full matching-id set up front, then page through it
+    # after list_sessions applies the other filters, so total is accurate.
+    tag_filter_ids: set[int] | None = None
     if tags:
         try:
             tag_ids = [int(s) for s in tags.split(",") if s.strip()]
@@ -1983,13 +1981,46 @@ async def api_sessions(
             ) from exc
         if tag_ids:
             try:
-                allowed = set(
-                    await storage.list_entities_with_tags("session", tag_ids, mode=tag_mode)
+                tag_filter_ids = set(
+                    await storage.sessions_matching_tags(tag_ids, mode=tag_mode)
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
-            sessions = [s for s in sessions if s["id"] in allowed]
-            total = len(sessions)
+            if not tag_filter_ids:
+                return JSONResponse({"total": 0, "sessions": []})
+
+    if tag_filter_ids is not None:
+        # Pull an oversized slice from list_sessions, filter, then paginate.
+        # This is OK because the pre-narrowed tag set is usually small and
+        # the other filters (text / date / type) stay indexed.
+        _total_unfiltered, all_matches = await storage.list_sessions(
+            q=q or None,
+            session_type=type,
+            from_date=from_date,
+            to_date=to_date,
+            limit=10_000,
+            offset=0,
+        )
+        filtered = [s for s in all_matches if s["id"] in tag_filter_ids]
+        total = len(filtered)
+        sessions = filtered[offset : offset + limit]
+    else:
+        total, sessions = await storage.list_sessions(
+            q=q or None,
+            session_type=type,
+            from_date=from_date,
+            to_date=to_date,
+            limit=limit,
+            offset=offset,
+        )
+
+    # Attach per-session tag summary (grouped by entity type) so history rows
+    # can render tag chips labelled with where each tag is attached.
+    ids = [s["id"] for s in sessions]
+    tag_summary = await storage.list_session_tag_summary(ids)
+    for s in sessions:
+        s["tag_summary"] = tag_summary.get(s["id"], [])
+
     return JSONResponse({"total": total, "sessions": sessions})
 
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1232,6 +1232,13 @@ async def api_session_maneuvers(
     from helmlog.analysis.maneuvers import enrich_session_maneuvers
 
     enriched, _video_sync = await enrich_session_maneuvers(storage, session_id)
+    # Attach tags in one batch query so the client-side tag filter can work
+    # without N+1 round-trips (#587).
+    ids = [m["id"] for m in enriched if m.get("id") is not None]
+    tag_map = await storage.list_tags_for_entities("maneuver", ids)
+    for m in enriched:
+        mid = m.get("id")
+        m["tags"] = tag_map.get(mid, []) if mid is not None else []
     return JSONResponse(enriched)
 
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1621,7 +1621,7 @@ async def api_maneuver_browse_sessions(
     if session_type is not None and session_type not in ("race", "practice"):
         raise HTTPException(status_code=422, detail="session_type must be race|practice")
     conds: list[str] = [
-        "(r.source IS NULL OR r.source = 'live')",
+        "(r.source IS NULL OR r.source IN ('live', 'synthesized'))",
         "EXISTS (SELECT 1 FROM maneuvers m WHERE m.session_id = r.id)",
     ]
     params: list[Any] = []
@@ -1696,6 +1696,8 @@ async def api_maneuver_browse(
     has_video: int = 0,
     post_start: int = 0,
     session_limit: int = 20,
+    tags: str | None = None,
+    tag_mode: str = "and",
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     """Cross-session maneuver browser feed (#584).
@@ -1765,7 +1767,7 @@ async def api_maneuver_browse(
             resolved_session_ids = ids_in
     elif regatta_id is not None:
         sql = (
-            "SELECT id FROM races  WHERE regatta_id = ?    AND (source IS NULL OR source = 'live') "
+            "SELECT id FROM races  WHERE regatta_id = ?    AND (source IS NULL OR source IN ('live', 'synthesized')) "
         )
         qparams: list[Any] = [regatta_id]
         if session_type is not None:
@@ -1776,7 +1778,7 @@ async def api_maneuver_browse(
         resolved_session_ids = [r["id"] for r in await cur.fetchall()]
     else:
         session_limit = max(1, min(session_limit, 100))
-        sql = "SELECT id FROM races WHERE (source IS NULL OR source = 'live') "
+        sql = "SELECT id FROM races WHERE (source IS NULL OR source IN ('live', 'synthesized')) "
         qparams = []
         if session_type is not None:
             sql += "  AND session_type = ? "
@@ -1910,6 +1912,38 @@ async def api_maneuver_browse(
 
     filtered = [m for m in enriched if _keep(m)]
     filtered.sort(key=lambda m: str(m.get("ts") or ""))
+
+    # Attach tags in one batch query so client-side tag filter chips can
+    # render and filter without N+1 lookups (#587).
+    maneuver_ids = [m["id"] for m in filtered if m.get("id") is not None]
+    tag_map = await storage.list_tags_for_entities("maneuver", maneuver_ids)
+    for m in filtered:
+        mid = m.get("id")
+        m["tags"] = tag_map.get(mid, []) if mid is not None else []
+
+    # Optional tag filter — AND/OR over the selected tag ids against each
+    # maneuver's attached tags. Unknown tag ids are silently dropped.
+    if tags:
+        try:
+            tag_ids = [int(s) for s in tags.split(",") if s.strip()]
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="tags must be comma-separated ints"
+            ) from exc
+        if tag_mode not in {"and", "or"}:
+            raise HTTPException(
+                status_code=400, detail="tag_mode must be 'and' or 'or'"
+            )
+        if tag_ids:
+            wanted = set(tag_ids)
+
+            def _tag_match(m: dict[str, Any]) -> bool:
+                have = {t["id"] for t in m.get("tags") or []}
+                if tag_mode == "or":
+                    return bool(have & wanted)
+                return wanted.issubset(have)
+
+            filtered = [m for m in filtered if _tag_match(m)]
 
     return JSONResponse({"maneuvers": filtered, "session_ids": resolved_session_ids})
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1946,6 +1946,8 @@ async def api_sessions(
     type: str | None = None,
     from_date: str | None = None,
     to_date: str | None = None,
+    tags: str | None = None,
+    tag_mode: str = "and",
     limit: int = 25,
     offset: int = 0,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
@@ -1965,6 +1967,22 @@ async def api_sessions(
         limit=limit,
         offset=offset,
     )
+    if tags:
+        try:
+            tag_ids = [int(s) for s in tags.split(",") if s.strip()]
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="tags must be comma-separated ints"
+            ) from exc
+        if tag_ids:
+            try:
+                allowed = set(
+                    await storage.list_entities_with_tags("session", tag_ids, mode=tag_mode)
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            sessions = [s for s in sessions if s["id"] in allowed]
+            total = len(sessions)
     return JSONResponse({"total": total, "sessions": sessions})
 
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1921,6 +1921,18 @@ async def api_maneuver_browse(
         mid = m.get("id")
         m["tags"] = tag_map.get(mid, []) if mid is not None else []
 
+    # Compute available_tags (counts per tag) across the non-tag-filtered
+    # set so the client-side chip row can always offer every tag that
+    # could be added to the filter, regardless of which tags are active.
+    available_counts: dict[int, dict[str, Any]] = {}
+    for m in filtered:
+        for t in m.get("tags") or []:
+            entry = available_counts.setdefault(
+                t["id"], {"id": t["id"], "name": t["name"], "color": t["color"], "count": 0}
+            )
+            entry["count"] += 1
+    available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
+
     # Optional tag filter — AND/OR over the selected tag ids against each
     # maneuver's attached tags. Unknown tag ids are silently dropped.
     if tags:
@@ -1945,7 +1957,13 @@ async def api_maneuver_browse(
 
             filtered = [m for m in filtered if _tag_match(m)]
 
-    return JSONResponse({"maneuvers": filtered, "session_ids": resolved_session_ids})
+    return JSONResponse(
+        {
+            "maneuvers": filtered,
+            "session_ids": resolved_session_ids,
+            "available_tags": available_tags,
+        }
+    )
 
 
 @router.post("/api/sessions/{session_id}/detect-maneuvers", status_code=202)
@@ -2023,39 +2041,51 @@ async def api_sessions(
             if not tag_filter_ids:
                 return JSONResponse({"total": 0, "sessions": []})
 
+    # Pull the full set of sessions matching non-tag filters so we can
+    # compute available_tags across it. The chip row shows every tag
+    # reachable from the current non-tag filters — without this, selecting
+    # one tag would collapse the chip row down to just that tag and the
+    # user couldn't add a second one for AND/OR.
+    _all_total, all_non_tag_matches = await storage.list_sessions(
+        q=q or None,
+        session_type=type,
+        from_date=from_date,
+        to_date=to_date,
+        limit=10_000,
+        offset=0,
+    )
     if tag_filter_ids is not None:
-        # Pull an oversized slice from list_sessions, filter, then paginate.
-        # This is OK because the pre-narrowed tag set is usually small and
-        # the other filters (text / date / type) stay indexed.
-        _total_unfiltered, all_matches = await storage.list_sessions(
-            q=q or None,
-            session_type=type,
-            from_date=from_date,
-            to_date=to_date,
-            limit=10_000,
-            offset=0,
-        )
-        filtered = [s for s in all_matches if s["id"] in tag_filter_ids]
+        filtered = [s for s in all_non_tag_matches if s["id"] in tag_filter_ids]
         total = len(filtered)
         sessions = filtered[offset : offset + limit]
     else:
-        total, sessions = await storage.list_sessions(
-            q=q or None,
-            session_type=type,
-            from_date=from_date,
-            to_date=to_date,
-            limit=limit,
-            offset=offset,
-        )
+        total = _all_total
+        sessions = all_non_tag_matches[offset : offset + limit]
 
-    # Attach per-session tag summary (grouped by entity type) so history rows
-    # can render tag chips labelled with where each tag is attached.
-    ids = [s["id"] for s in sessions]
-    tag_summary = await storage.list_session_tag_summary(ids)
+    # Aggregate available tags across ALL non-tag-filtered sessions so the
+    # chip row doesn't collapse when the user applies a tag filter.
+    all_ids = [s["id"] for s in all_non_tag_matches]
+    all_tag_summary = await storage.list_session_tag_summary(all_ids)
+    available_counts: dict[int, dict[str, Any]] = {}
+    for sid in all_ids:
+        for r in all_tag_summary.get(sid, []):
+            entry = available_counts.setdefault(
+                r["id"],
+                {"id": r["id"], "name": r["name"], "color": r["color"], "count": 0},
+            )
+            entry["count"] += r["count"]
+    available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
+
+    # Per-session tag summary only needed for the visible page.
+    page_tag_summary = await storage.list_session_tag_summary(
+        [s["id"] for s in sessions]
+    )
     for s in sessions:
-        s["tag_summary"] = tag_summary.get(s["id"], [])
+        s["tag_summary"] = page_tag_summary.get(s["id"], [])
 
-    return JSONResponse({"total": total, "sessions": sessions})
+    return JSONResponse(
+        {"total": total, "sessions": sessions, "available_tags": available_tags}
+    )
 
 
 @router.get("/api/grafana/annotations")

--- a/src/helmlog/routes/tags.py
+++ b/src/helmlog/routes/tags.py
@@ -66,9 +66,20 @@ async def api_update_tag(
     body: dict[str, Any],
     _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
 ) -> JSONResponse:
-    """Admin only — rename/recolor affects the shared tag namespace."""
+    """Admin only — rename/recolor affects the shared tag namespace.
+
+    ``{"color": null}`` in the body clears the color back to NULL; omitting
+    the key leaves color unchanged.
+    """
     storage = get_storage(request)
-    found = await storage.update_tag(tag_id, name=body.get("name"), color=body.get("color"))
+    # Sentinel to distinguish "color absent" from "color: null".
+    _missing = object()
+    color_in = body.get("color", _missing)
+    clear_color = color_in is None and "color" in body
+    color: str | None = color_in if isinstance(color_in, str) else None
+    found = await storage.update_tag(
+        tag_id, name=body.get("name"), color=color, clear_color=clear_color
+    )
     if not found:
         raise HTTPException(status_code=404, detail="Tag not found")
     await audit(request, "tag.update", detail=str(tag_id), user=_user)

--- a/src/helmlog/routes/tags.py
+++ b/src/helmlog/routes/tags.py
@@ -1,4 +1,11 @@
-"""Route handlers for tags."""
+"""Route handlers for tags (#587 / #588 slice 3).
+
+Tag CRUD + merge live under /api/tags; attach/detach/list go through the
+polymorphic /api/entities/{entity_type}/{entity_id}/tags path. The old
+per-entity routes (/api/sessions/{id}/tags, /api/notes/{id}/tags) are
+back-compat shims so existing UI keeps working through this PR — they
+delegate to the generic attach/detach.
+"""
 
 from __future__ import annotations
 
@@ -9,17 +16,26 @@ from fastapi.responses import JSONResponse
 
 from helmlog.auth import require_auth
 from helmlog.routes._helpers import audit, get_storage
+from helmlog.storage import ENTITY_TYPES
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# /api/tags — CRUD + merge
+# ---------------------------------------------------------------------------
 
 
 @router.get("/api/tags")
 async def api_list_tags(
     request: Request,
+    order_by: str = "name",
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
+    if order_by not in {"name", "usage"}:
+        raise HTTPException(status_code=400, detail="order_by must be 'name' or 'usage'")
     storage = get_storage(request)
-    tags = await storage.list_tags()
+    tags = await storage.list_tags(order_by=order_by)
     return JSONResponse(tags)
 
 
@@ -27,8 +43,9 @@ async def api_list_tags(
 async def api_create_tag(
     request: Request,
     body: dict[str, Any],
-    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
+    """Any authed user can create tags (supports inline-create UX)."""
     storage = get_storage(request)
     name = (body.get("name") or "").strip().lower()
     if not name:
@@ -49,6 +66,7 @@ async def api_update_tag(
     body: dict[str, Any],
     _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
 ) -> JSONResponse:
+    """Admin only — rename/recolor affects the shared tag namespace."""
     storage = get_storage(request)
     found = await storage.update_tag(tag_id, name=body.get("name"), color=body.get("color"))
     if not found:
@@ -63,6 +81,7 @@ async def api_delete_tag(
     tag_id: int,
     _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
 ) -> None:
+    """Admin only. Cascades through entity_tags via ON DELETE CASCADE."""
     storage = get_storage(request)
     found = await storage.delete_tag(tag_id)
     if not found:
@@ -70,23 +89,128 @@ async def api_delete_tag(
     await audit(request, "tag.delete", detail=str(tag_id), user=_user)
 
 
+@router.post("/api/tags/{source_id}/merge-into/{target_id}", status_code=200)
+async def api_merge_tags(
+    request: Request,
+    source_id: int,
+    target_id: int,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Admin only. Source absorbed into target; source is deleted."""
+    storage = get_storage(request)
+    try:
+        await storage.merge_tags(source_id, target_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    await audit(
+        request,
+        "tag.merge",
+        detail=f"source={source_id} target={target_id}",
+        user=_user,
+    )
+    return JSONResponse({"source_id": source_id, "target_id": target_id, "merged": True})
+
+
+# ---------------------------------------------------------------------------
+# /api/entities/{entity_type}/{entity_id}/tags — polymorphic attach/detach
+# ---------------------------------------------------------------------------
+
+
+def _validate_entity_type(entity_type: str) -> None:
+    if entity_type not in ENTITY_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown entity_type {entity_type!r} (allowed: {sorted(ENTITY_TYPES)})",
+        )
+
+
+@router.get("/api/entities/{entity_type}/{entity_id}/tags")
+async def api_list_entity_tags(
+    request: Request,
+    entity_type: str,
+    entity_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    _validate_entity_type(entity_type)
+    storage = get_storage(request)
+    tags = await storage.list_tags_for_entity(entity_type, entity_id)
+    return JSONResponse(tags)
+
+
+@router.post("/api/entities/{entity_type}/{entity_id}/tags", status_code=201)
+async def api_attach_entity_tag(
+    request: Request,
+    entity_type: str,
+    entity_id: int,
+    body: dict[str, Any],
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Attach a tag. Body: {tag_id} OR {name} for inline-create-and-attach."""
+    _validate_entity_type(entity_type)
+    storage = get_storage(request)
+    tag_id = body.get("tag_id")
+    name = body.get("name")
+    if tag_id is None and not name:
+        raise HTTPException(status_code=422, detail="tag_id or name is required")
+    if tag_id is None:
+        assert isinstance(name, str)
+        tag_id = await storage.get_or_create_tag(name.strip().lower())
+    await storage.attach_tag(entity_type, entity_id, int(tag_id), user_id=user.get("id"))
+    await audit(
+        request,
+        "tag.attach",
+        detail=f"{entity_type}={entity_id} tag={tag_id}",
+        user=user,
+    )
+    return JSONResponse(
+        {"entity_type": entity_type, "entity_id": entity_id, "tag_id": tag_id},
+        status_code=201,
+    )
+
+
+@router.delete("/api/entities/{entity_type}/{entity_id}/tags/{tag_id}", status_code=204)
+async def api_detach_entity_tag(
+    request: Request,
+    entity_type: str,
+    entity_id: int,
+    tag_id: int,
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> None:
+    _validate_entity_type(entity_type)
+    storage = get_storage(request)
+    await storage.detach_tag(entity_type, entity_id, tag_id)
+    await audit(
+        request,
+        "tag.detach",
+        detail=f"{entity_type}={entity_id} tag={tag_id}",
+        user=user,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Back-compat shims — legacy per-entity routes delegate to the generic path.
+# Kept so the existing UI keeps working mid-rollout; removable once all
+# callers migrate to /api/entities/.../tags.
+# ---------------------------------------------------------------------------
+
+
 @router.post("/api/sessions/{session_id}/tags", status_code=201)
 async def api_add_session_tag(
     request: Request,
     session_id: int,
     body: dict[str, Any],
-    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     storage = get_storage(request)
     tag_id = body.get("tag_id")
-    tag_name = body.get("tag_name")
+    tag_name = body.get("tag_name") or body.get("name")
     if tag_id is None and not tag_name:
         raise HTTPException(status_code=422, detail="tag_id or tag_name is required")
     if tag_id is None:
         assert isinstance(tag_name, str)
         tag_id = await storage.get_or_create_tag(tag_name)
-    await storage.add_session_tag(session_id, tag_id)
-    await audit(request, "session.tag.add", detail=f"session={session_id} tag={tag_id}", user=_user)
+    await storage.attach_tag("session", session_id, int(tag_id), user_id=user.get("id"))
+    await audit(request, "session.tag.add", detail=f"session={session_id} tag={tag_id}", user=user)
     return JSONResponse({"session_id": session_id, "tag_id": tag_id}, status_code=201)
 
 
@@ -95,12 +219,15 @@ async def api_remove_session_tag(
     request: Request,
     session_id: int,
     tag_id: int,
-    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> None:
     storage = get_storage(request)
-    await storage.remove_session_tag(session_id, tag_id)
+    await storage.detach_tag("session", session_id, tag_id)
     await audit(
-        request, "session.tag.remove", detail=f"session={session_id} tag={tag_id}", user=_user
+        request,
+        "session.tag.remove",
+        detail=f"session={session_id} tag={tag_id}",
+        user=user,
     )
 
 
@@ -111,7 +238,7 @@ async def api_get_session_tags(
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     storage = get_storage(request)
-    tags = await storage.get_session_tags(session_id)
+    tags = await storage.list_tags_for_entity("session", session_id)
     return JSONResponse(tags)
 
 
@@ -120,18 +247,18 @@ async def api_add_note_tag(
     request: Request,
     note_id: int,
     body: dict[str, Any],
-    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     storage = get_storage(request)
     tag_id = body.get("tag_id")
-    tag_name = body.get("tag_name")
+    tag_name = body.get("tag_name") or body.get("name")
     if tag_id is None and not tag_name:
         raise HTTPException(status_code=422, detail="tag_id or tag_name is required")
     if tag_id is None:
         assert isinstance(tag_name, str)
         tag_id = await storage.get_or_create_tag(tag_name)
-    await storage.add_note_tag(note_id, tag_id)
-    await audit(request, "note.tag.add", detail=f"note={note_id} tag={tag_id}", user=_user)
+    await storage.attach_tag("session_note", note_id, int(tag_id), user_id=user.get("id"))
+    await audit(request, "note.tag.add", detail=f"note={note_id} tag={tag_id}", user=user)
     return JSONResponse({"note_id": note_id, "tag_id": tag_id}, status_code=201)
 
 
@@ -140,11 +267,16 @@ async def api_remove_note_tag(
     request: Request,
     note_id: int,
     tag_id: int,
-    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+    user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> None:
     storage = get_storage(request)
-    await storage.remove_note_tag(note_id, tag_id)
-    await audit(request, "note.tag.remove", detail=f"note={note_id} tag={tag_id}", user=_user)
+    await storage.detach_tag("session_note", note_id, tag_id)
+    await audit(
+        request,
+        "note.tag.remove",
+        detail=f"note={note_id} tag={tag_id}",
+        user=user,
+    )
 
 
 @router.get("/api/notes/{note_id}/tags")
@@ -154,5 +286,5 @@ async def api_get_note_tags(
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     storage = get_storage(request)
-    tags = await storage.get_note_tags(note_id)
+    tags = await storage.list_tags_for_entity("session_note", note_id)
     return JSONResponse(tags)

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -9,6 +9,7 @@ const summaryCache = new Map();
 // Tag filter state — mirrors the maneuvers panel pattern.
 const tagFilter = new Set();
 let tagMode = 'and'; // 'and' | 'or'
+let availableTags = []; // [{id, name, color, count}] from server, pre-tag-filter
 
 function setType(btn, t) {
   currentType = t;
@@ -40,6 +41,7 @@ async function load() {
   params.set('offset', currentOffset);
   const r = await fetch('/api/sessions?' + params);
   const data = await r.json();
+  availableTags = data.available_tags || [];
   render(data);
   renderTagFilterRow(data.sessions);
 }
@@ -108,17 +110,15 @@ function renderTagFilterRow(sessions) {
   const clearLink = document.getElementById('tag-clear');
   if (!wrap || !chipsHost) return;
 
-  // Aggregate tags from all sessions on the page.
+  // Use server-provided available_tags (computed across all sessions
+  // matching the non-tag filters) so selecting a tag doesn't collapse
+  // the chip row down to the current result.
   const byId = new Map();
-  for (const s of sessions || []) {
-    for (const r of (s.tag_summary || [])) {
-      const cur = byId.get(r.id) || {id: r.id, name: r.name, color: r.color, count: 0};
-      cur.count += r.count;
-      byId.set(r.id, cur);
-    }
+  for (const t of availableTags) {
+    byId.set(t.id, {id: t.id, name: t.name, color: t.color, count: t.count || 0});
   }
-  // Always include currently-selected tags even if the current page doesn't
-  // contain them, so the user can still deselect.
+  // Always include currently-selected tags even if not in available_tags,
+  // so the user can still deselect them.
   for (const tid of tagFilter) {
     if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
   }

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -140,17 +140,14 @@ function renderTagFilterRow(sessions) {
       + esc(t.name) + '<span class="etype">' + countLbl + '</span></span>';
   }).join('');
 
-  // Mode toggle only meaningful when 2+ tags are active.
-  if (tagFilter.size > 1) {
-    modeWrap.style.display = '';
-    modeWrap.innerHTML = '<span class="tag-mode-toggle">'
-      + '<button class="' + (tagMode === 'and' ? 'active' : '') + '" title="Match sessions that contain every selected tag" onclick="setTagMode(\'and\')">all</button>'
-      + '<button class="' + (tagMode === 'or' ? 'active' : '') + '" title="Match sessions that contain any selected tag" onclick="setTagMode(\'or\')">any</button>'
-      + '</span>';
-  } else {
-    modeWrap.style.display = 'none';
-    modeWrap.innerHTML = '';
-  }
+  // Mode toggle always visible when the tag row is shown, dimmed when
+  // fewer than 2 tags are active so users discover the control up front.
+  modeWrap.style.display = '';
+  const dimStyle = tagFilter.size < 2 ? 'opacity:.6' : '';
+  modeWrap.innerHTML = '<span class="tag-mode-toggle" style="' + dimStyle + '">'
+    + '<button class="' + (tagMode === 'and' ? 'active' : '') + '" title="Match sessions that contain every selected tag" onclick="setTagMode(\'and\')">all</button>'
+    + '<button class="' + (tagMode === 'or' ? 'active' : '') + '" title="Match sessions that contain any selected tag" onclick="setTagMode(\'or\')">any</button>'
+    + '</span>';
 
   clearLink.style.display = tagFilter.size ? '' : 'none';
 }

--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -6,6 +6,10 @@ const LIMIT = 25;
 let loadTimer = null;
 const summaryCache = new Map();
 
+// Tag filter state — mirrors the maneuvers panel pattern.
+const tagFilter = new Set();
+let tagMode = 'and'; // 'and' | 'or'
+
 function setType(btn, t) {
   currentType = t;
   currentOffset = 0;
@@ -28,11 +32,147 @@ async function load() {
   const to = document.getElementById('to-date').value;
   if (from) params.set('from_date', from);
   if (to) params.set('to_date', to);
+  if (tagFilter.size) {
+    params.set('tags', [...tagFilter].join(','));
+    params.set('tag_mode', tagMode);
+  }
   params.set('limit', LIMIT);
   params.set('offset', currentOffset);
   const r = await fetch('/api/sessions?' + params);
   const data = await r.json();
   render(data);
+  renderTagFilterRow(data.sessions);
+}
+
+function esc(s) {
+  return (s == null ? '' : String(s)).replace(/[&<>"']/g, c => (
+    {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]
+  ));
+}
+
+function _etypeLabel(et, count) {
+  if (et === 'session') return 'session';
+  // Pluralize when count > 1 for readability.
+  if (count > 1) return et + 's';
+  return et;
+}
+
+function _entityTypeOrder(a, b) {
+  const order = {session: 0, thread: 1, bookmark: 2, maneuver: 3};
+  return (order[a] ?? 99) - (order[b] ?? 99);
+}
+
+// Collapse tag_summary into [{id, name, color, parts: [{et, count}]}] so one
+// chip renders per tag with a compact entity-type label.
+function _groupTagSummary(rows) {
+  const byId = new Map();
+  for (const r of rows) {
+    const existing = byId.get(r.id) || {id: r.id, name: r.name, color: r.color, parts: []};
+    existing.parts.push({et: r.entity_type, count: r.count});
+    byId.set(r.id, existing);
+  }
+  // Sort tags by name; inside each tag, order the parts (session first).
+  const out = [...byId.values()];
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  for (const t of out) {
+    t.parts.sort((a, b) => _entityTypeOrder(a.et, b.et));
+  }
+  return out;
+}
+
+function renderSessionTagChips(summary) {
+  if (!summary || !summary.length) return '';
+  const grouped = _groupTagSummary(summary);
+  const chips = grouped.map(g => {
+    const swatch = g.color
+      ? '<span class="swatch" style="background:' + g.color + '"></span>'
+      : '';
+    const labels = g.parts.map(p => {
+      const lbl = _etypeLabel(p.et, p.count);
+      return p.count > 1 ? p.count + ' ' + lbl : lbl;
+    }).join(', ');
+    return '<span class="hist-tag-chip" title="' + esc(labels) + '">'
+      + swatch + esc(g.name)
+      + ' <span class="etype">(' + esc(labels) + ')</span></span>';
+  }).join('');
+  return '<div class="hist-tag-row-chips">' + chips + '</div>';
+}
+
+// Build the filter chip row from whatever tags the current result page
+// surfaces. This keeps the list focused on tags actually in use rather
+// than every tag in the system.
+function renderTagFilterRow(sessions) {
+  const wrap = document.getElementById('tag-filter-row');
+  const chipsHost = document.getElementById('tag-filter-chips');
+  const modeWrap = document.getElementById('tag-mode-wrap');
+  const clearLink = document.getElementById('tag-clear');
+  if (!wrap || !chipsHost) return;
+
+  // Aggregate tags from all sessions on the page.
+  const byId = new Map();
+  for (const s of sessions || []) {
+    for (const r of (s.tag_summary || [])) {
+      const cur = byId.get(r.id) || {id: r.id, name: r.name, color: r.color, count: 0};
+      cur.count += r.count;
+      byId.set(r.id, cur);
+    }
+  }
+  // Always include currently-selected tags even if the current page doesn't
+  // contain them, so the user can still deselect.
+  for (const tid of tagFilter) {
+    if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
+  }
+
+  if (byId.size === 0) {
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = '';
+  const sorted = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  chipsHost.innerHTML = sorted.map(t => {
+    const active = tagFilter.has(t.id);
+    const swatch = t.color
+      ? '<span class="swatch" style="background:' + t.color + '"></span>'
+      : '';
+    const countLbl = t.count ? ' (' + t.count + ')' : '';
+    return '<span class="hist-tag-chip' + (active ? ' active' : '') + '"'
+      + ' onclick="toggleTagFilter(' + t.id + ')">' + swatch
+      + esc(t.name) + '<span class="etype">' + countLbl + '</span></span>';
+  }).join('');
+
+  // Mode toggle only meaningful when 2+ tags are active.
+  if (tagFilter.size > 1) {
+    modeWrap.style.display = '';
+    modeWrap.innerHTML = '<span class="tag-mode-toggle">'
+      + '<button class="' + (tagMode === 'and' ? 'active' : '') + '" title="Match sessions that contain every selected tag" onclick="setTagMode(\'and\')">all</button>'
+      + '<button class="' + (tagMode === 'or' ? 'active' : '') + '" title="Match sessions that contain any selected tag" onclick="setTagMode(\'or\')">any</button>'
+      + '</span>';
+  } else {
+    modeWrap.style.display = 'none';
+    modeWrap.innerHTML = '';
+  }
+
+  clearLink.style.display = tagFilter.size ? '' : 'none';
+}
+
+function toggleTagFilter(tagId) {
+  if (tagFilter.has(tagId)) tagFilter.delete(tagId);
+  else tagFilter.add(tagId);
+  currentOffset = 0;
+  load();
+}
+
+function setTagMode(mode) {
+  if (mode !== 'and' && mode !== 'or') return;
+  tagMode = mode;
+  currentOffset = 0;
+  load();
+}
+
+function clearTagFilter() {
+  tagFilter.clear();
+  currentOffset = 0;
+  load();
 }
 
 function render(data) {
@@ -48,16 +188,18 @@ function render(data) {
     const dur = (s.end_utc && s.duration_s != null) ? ' (' + fmtDuration(Math.round(s.duration_s)) + ')' : '';
     const parent = s.parent_race_name ? '<div class="session-meta">Debrief of ' + s.parent_race_name + '</div>' : '';
     const displayName = s.shared_name || s.name;
-    const nameLink = '<a href="/session/' + s.id + '" style="color:inherit;text-decoration:none">' + displayName + '</a>';
-    const localNameHint = s.shared_name ? '<div style="font-size:.72rem;color:var(--text-secondary);margin-top:1px">Local: ' + s.name + '</div>' : '';
+    const nameLink = '<a href="/session/' + s.id + '" style="color:inherit;text-decoration:none">' + esc(displayName) + '</a>';
+    const localNameHint = s.shared_name ? '<div style="font-size:.72rem;color:var(--text-secondary);margin-top:1px">Local: ' + esc(s.name) + '</div>' : '';
     const showSummary = s.type !== 'debrief' && s.end_utc;
     const summaryHtml = showSummary
       ? '<div class="session-summary" id="hist-summary-' + s.id + '"><div class="summary-skeleton"></div></div>'
       : '';
+    const tagChips = renderSessionTagChips(s.tag_summary);
     return '<div class="card"><div class="session-name">' + nameLink + '</div>'
       + '<div class="session-meta">' + s.date + ' &nbsp;·&nbsp; ' + start + ' → ' + end + dur + '</div>'
       + localNameHint
       + parent
+      + tagChips
       + summaryHtml
       + '</div>';
   }).join('');

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -392,12 +392,14 @@ function renderTagFilterRow() {
       + ' onclick="mvToggleTagFilter(' + t.id + ')">'
       + swatch + _esc(t.name) + ' <span class="mv-tag-count">(' + t.count + ')</span></span>';
   }).join('');
-  const modeToggle = state.tagFilter.size > 1
-    ? '<span class="mv-tag-mode">'
-      + '<button class="' + (state.tagMode === 'and' ? 'active' : '') + '" title="Match maneuvers with every selected tag" onclick="mvSetTagMode(\'and\')">all</button>'
-      + '<button class="' + (state.tagMode === 'or' ? 'active' : '') + '" title="Match maneuvers with any selected tag" onclick="mvSetTagMode(\'or\')">any</button>'
-      + '</span>'
-    : '';
+  // Always show the mode toggle when the tag row is visible, so users
+  // discover the control before they've selected tags. Dimmed until a
+  // filter is active to signal it's a preference, not an active setting.
+  const dim = state.tagFilter.size < 2 ? ';opacity:.6' : '';
+  const modeToggle = '<span class="mv-tag-mode" style="margin-left:6px' + dim + '">'
+    + '<button class="' + (state.tagMode === 'and' ? 'active' : '') + '" title="Match maneuvers with every selected tag" onclick="mvSetTagMode(\'and\')">all</button>'
+    + '<button class="' + (state.tagMode === 'or' ? 'active' : '') + '" title="Match maneuvers with any selected tag" onclick="mvSetTagMode(\'or\')">any</button>'
+    + '</span>';
   const clearBtn = state.tagFilter.size
     ? '<a href="#" onclick="event.preventDefault();mvClearTagFilter()" style="font-size:.7rem;color:var(--text-secondary);margin-left:6px">clear</a>'
     : '';

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -32,6 +32,8 @@ const state = {
   postStart: false,        // drop pre-gun maneuvers when true
   twsBands: new Set(),     // indices into TWS_BANDS — empty = any
   hasVideo: false,
+  tagFilter: new Set(),    // tag ids
+  tagMode: 'and',          // 'and'|'or'
   maneuvers: [],
   selected: new Set(),     // composite keys "sid:mid"
   loading: false,
@@ -218,6 +220,10 @@ async function reload() {
     }
     if (state.hasVideo) params.set('has_video', '1');
     if (state.postStart) params.set('post_start', '1');
+    if (state.tagFilter.size) {
+      params.set('tags', [...state.tagFilter].join(','));
+      params.set('tag_mode', state.tagMode);
+    }
 
     const r = await fetch('/api/maneuvers/browse?' + params.toString());
     if (!r.ok) { state.maneuvers = []; renderResults(); return; }
@@ -226,6 +232,7 @@ async function reload() {
     // Purge selection entries that no longer appear in the filtered list
     const ids = new Set(state.maneuvers.map(m => m.session_id + ':' + m.id));
     for (const k of [...state.selected]) if (!ids.has(k)) state.selected.delete(k);
+    renderTagFilterRow();
     renderResults();
   } finally {
     state.loading = false;
@@ -272,6 +279,7 @@ function renderResults() {
       ? '<span class="mv-video">&#9654;</span>'
       : '<span class="mv-no-video">\u2014</span>';
     const rank = m.rank ? m.rank : '';
+    const tagCell = _renderRowTagChips(m.tags);
     return '<tr class="' + (sel ? 'selected' : '') + '" data-k="' + k + '" onclick="mvToggleRow(\'' + k + '\')">'
       + '<td><input type="checkbox" ' + (sel ? 'checked' : '') + ' onclick="event.stopPropagation();mvToggleRow(\'' + k + '\')"/></td>'
       + '<td>' + _esc(date) + ' \u00b7 ' + _esc(m.session_name || '') + '</td>'
@@ -283,6 +291,7 @@ function renderResults() {
       + '<td class="mv-num">' + durTxt + '</td>'
       + '<td>' + _esc(rank) + '</td>'
       + '<td>' + video + '</td>'
+      + '<td>' + tagCell + '</td>'
       + '</tr>';
   }).join('');
 
@@ -346,4 +355,78 @@ function _esc(s) {
   const d = document.createElement('div');
   d.textContent = s == null ? '' : String(s);
   return d.innerHTML;
+}
+
+// ---------------------------------------------------------------------------
+// Tag filter chip row (#587)
+// ---------------------------------------------------------------------------
+
+function renderTagFilterRow() {
+  const wrap = document.getElementById('mv-tag-filter');
+  if (!wrap) return;
+  const byId = new Map();
+  for (const m of state.maneuvers) {
+    for (const t of (m.tags || [])) {
+      const cur = byId.get(t.id) || {id: t.id, name: t.name, color: t.color, count: 0};
+      cur.count++;
+      byId.set(t.id, cur);
+    }
+  }
+  // Keep currently-selected tags visible even if the filtered set no
+  // longer contains them, so the user can deselect.
+  for (const tid of state.tagFilter) {
+    if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
+  }
+  if (byId.size === 0) {
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = '';
+  const sorted = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const chips = sorted.map(t => {
+    const active = state.tagFilter.has(t.id);
+    const swatch = t.color
+      ? '<span class="mv-tag-swatch" style="background:' + t.color + '"></span>'
+      : '';
+    return '<span class="mv-tag-chip' + (active ? ' active' : '') + '"'
+      + ' onclick="mvToggleTagFilter(' + t.id + ')">'
+      + swatch + _esc(t.name) + ' <span class="mv-tag-count">(' + t.count + ')</span></span>';
+  }).join('');
+  const modeToggle = state.tagFilter.size > 1
+    ? '<span class="mv-tag-mode">'
+      + '<button class="' + (state.tagMode === 'and' ? 'active' : '') + '" title="Match maneuvers with every selected tag" onclick="mvSetTagMode(\'and\')">all</button>'
+      + '<button class="' + (state.tagMode === 'or' ? 'active' : '') + '" title="Match maneuvers with any selected tag" onclick="mvSetTagMode(\'or\')">any</button>'
+      + '</span>'
+    : '';
+  const clearBtn = state.tagFilter.size
+    ? '<a href="#" onclick="event.preventDefault();mvClearTagFilter()" style="font-size:.7rem;color:var(--text-secondary);margin-left:6px">clear</a>'
+    : '';
+  wrap.innerHTML = '<span class="mv-label">Tags</span>' + chips + modeToggle + clearBtn;
+}
+
+function mvToggleTagFilter(tagId) {
+  if (state.tagFilter.has(tagId)) state.tagFilter.delete(tagId);
+  else state.tagFilter.add(tagId);
+  reload();
+}
+
+function mvSetTagMode(mode) {
+  if (mode !== 'and' && mode !== 'or') return;
+  state.tagMode = mode;
+  reload();
+}
+
+function mvClearTagFilter() {
+  state.tagFilter.clear();
+  reload();
+}
+
+function _renderRowTagChips(tags) {
+  if (!tags || !tags.length) return '';
+  return tags.map(t => {
+    const swatch = t.color
+      ? '<span class="mv-tag-swatch" style="background:' + t.color + '"></span>'
+      : '';
+    return '<span class="mv-tag-chip mv-tag-chip-row">' + swatch + _esc(t.name) + '</span>';
+  }).join(' ');
 }

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -34,6 +34,7 @@ const state = {
   hasVideo: false,
   tagFilter: new Set(),    // tag ids
   tagMode: 'and',          // 'and'|'or'
+  availableTags: [],       // [{id, name, color, count}] pre-tag-filter
   maneuvers: [],
   selected: new Set(),     // composite keys "sid:mid"
   loading: false,
@@ -229,6 +230,7 @@ async function reload() {
     if (!r.ok) { state.maneuvers = []; renderResults(); return; }
     const data = await r.json();
     state.maneuvers = data.maneuvers || [];
+    state.availableTags = data.available_tags || [];
     // Purge selection entries that no longer appear in the filtered list
     const ids = new Set(state.maneuvers.map(m => m.session_id + ':' + m.id));
     for (const k of [...state.selected]) if (!ids.has(k)) state.selected.delete(k);
@@ -364,16 +366,15 @@ function _esc(s) {
 function renderTagFilterRow() {
   const wrap = document.getElementById('mv-tag-filter');
   if (!wrap) return;
+  // available_tags comes from the server computed against the pre-tag-filter
+  // set, so every tag that could narrow the result is always offered even
+  // when a chip is already active.
   const byId = new Map();
-  for (const m of state.maneuvers) {
-    for (const t of (m.tags || [])) {
-      const cur = byId.get(t.id) || {id: t.id, name: t.name, color: t.color, count: 0};
-      cur.count++;
-      byId.set(t.id, cur);
-    }
+  for (const t of (state.availableTags || [])) {
+    byId.set(t.id, {id: t.id, name: t.name, color: t.color, count: t.count || 0});
   }
-  // Keep currently-selected tags visible even if the filtered set no
-  // longer contains them, so the user can deselect.
+  // Keep currently-selected tags visible even if the result set no longer
+  // contains them so the user can still deselect.
   for (const tid of state.tagFilter) {
     if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
   }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4904,7 +4904,8 @@ function _renderManeuverDetail(m) {
     ];
     el.innerHTML = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:4px 12px;font-size:.72rem;background:var(--bg-secondary);padding:8px;border-radius:3px">'
       + rows.map(([k, v]) => '<div><span style="color:var(--text-secondary)">' + k + '</span> <b>' + esc(v) + '</b></div>').join('')
-      + '</div>';
+      + '</div>'
+      + _renderManeuverTagRow(m);
     return;
   }
 
@@ -4968,6 +4969,17 @@ function _renderManeuverDetail(m) {
   el.innerHTML = '<div style="display:flex;gap:10px;align-items:flex-start;flex-wrap:wrap">'
     + '<div style="flex:1;min-width:260px">' + metricsGrid + '</div>'
     + (diagram ? '<div>' + diagram + '</div>' : '')
+    + '</div>'
+    + _renderManeuverTagRow(m);
+}
+
+// Small tag-picker strip rendered beneath the maneuver detail metrics
+// whenever a maneuver is selected in the session page table.
+function _renderManeuverTagRow(m) {
+  if (!m || m.id == null) return '';
+  return '<div style="margin-top:8px;padding:8px;background:var(--bg-secondary);border-radius:3px">'
+    + '<div style="font-size:.7rem;color:var(--text-secondary);margin-bottom:4px">Tags</div>'
+    + '<tag-picker entity-type="maneuver" entity-id="' + esc(String(m.id)) + '"></tag-picker>'
     + '</div>';
 }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4872,12 +4872,13 @@ function renderManeuverCard() {
     const clearBtn = _maneuverTagFilter.size
       ? '<button style="font-size:.68rem;padding:2px 6px;border:none;background:none;color:var(--text-secondary);cursor:pointer;text-decoration:underline" onclick="clearManeuverTagFilter()">clear</button>'
       : '';
-    const modeToggle = _maneuverTagFilter.size > 1
-      ? '<span style="display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px">'
-        +   _tagModeBtn('and', 'all')
-        +   _tagModeBtn('or', 'any')
-        + '</span>'
-      : '';
+    // Mode toggle always visible when the tag row is shown, dimmed when
+    // fewer than 2 tags are active so users discover the control.
+    const modeDim = _maneuverTagFilter.size < 2 ? ';opacity:.6' : '';
+    const modeToggle = '<span style="display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px' + modeDim + '">'
+      +   _tagModeBtn('and', 'all')
+      +   _tagModeBtn('or', 'any')
+      + '</span>';
     tagFilterBar = '<div style="display:flex;gap:4px;margin-bottom:6px;flex-wrap:wrap;align-items:center">'
       + '<span style="font-size:.68rem;color:var(--text-secondary);margin-right:2px">Tags:</span>'
       + chips + modeToggle + clearBtn

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6023,6 +6023,10 @@ async function openThread(threadId, scrollToCommentId) {
     + '<div style="flex-shrink:0;display:flex;gap:6px">' + copyThreadBtn + resolveBtn + '</div>'
     + '</div>'
     + resolutionHtml
+    + '<div style="margin-top:4px;margin-bottom:6px">'
+    + '<div style="font-size:.7rem;color:var(--text-secondary);margin-bottom:3px">Tags</div>'
+    + '<tag-picker entity-type="thread" entity-id="' + t.id + '"></tag-picker>'
+    + '</div>'
     + '<div id="thread-comments">' + (commentsHtml || '<span style="color:var(--text-secondary)">No comments yet</span>') + '</div>'
     + '<div class="thread-form" style="margin-top:8px">'
     + '<textarea id="reply-body" placeholder="Reply\u2026"></textarea>'

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4153,6 +4153,8 @@ let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distan
 // Active filter pills. Multi-select: combined with AND across dimensions
 // (type, rank, time) and OR within a dimension. Empty set == "all".
 let _maneuverFilter = new Set();
+// Tag filter is a separate Set of tag ids. AND semantics against m.tags.
+let _maneuverTagFilter = new Set();
 const _MANEUVER_TYPE_PILLS = ['tack', 'gybe', 'rounding'];
 const _MANEUVER_RANK_PILLS = ['good', 'bad'];
 const _MANEUVER_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
@@ -4654,27 +4656,46 @@ function _raceStartMs() {
 }
 
 function _matchesManeuverFilter(m) {
-  if (!_maneuverFilter.size) return true;
-  const activeTypes = _MANEUVER_TYPE_PILLS.filter(p => _maneuverFilter.has(p));
-  if (activeTypes.length && !activeTypes.includes(m.type)) return false;
-  const activeRanks = _MANEUVER_RANK_PILLS.filter(p => _maneuverFilter.has(p));
-  if (activeRanks.length && !activeRanks.includes(m.rank)) return false;
-  // Direction filter: P→S = negative turn_angle_deg, S→P = positive
-  const activeDir = _MANEUVER_DIR_PILLS.filter(p => _maneuverFilter.has(p));
-  if (activeDir.length) {
-    if (m.turn_angle_deg == null) return false;
-    const isPS = m.turn_angle_deg < 0;  // P→S = negative
-    if (activeDir.includes('P\u2192S') && !isPS) return false;
-    if (activeDir.includes('S\u2192P') && isPS) return false;
+  if (_maneuverFilter.size) {
+    const activeTypes = _MANEUVER_TYPE_PILLS.filter(p => _maneuverFilter.has(p));
+    if (activeTypes.length && !activeTypes.includes(m.type)) return false;
+    const activeRanks = _MANEUVER_RANK_PILLS.filter(p => _maneuverFilter.has(p));
+    if (activeRanks.length && !activeRanks.includes(m.rank)) return false;
+    // Direction filter: P→S = negative turn_angle_deg, S→P = positive
+    const activeDir = _MANEUVER_DIR_PILLS.filter(p => _maneuverFilter.has(p));
+    if (activeDir.length) {
+      if (m.turn_angle_deg == null) return false;
+      const isPS = m.turn_angle_deg < 0;  // P→S = negative
+      if (activeDir.includes('P\u2192S') && !isPS) return false;
+      if (activeDir.includes('S\u2192P') && isPS) return false;
+    }
+    if (_maneuverFilter.has('post-start')) {
+      const startMs = _raceStartMs();
+      if (startMs != null) {
+        const t = _parseUtc(m.ts);
+        if (t == null || t.getTime() < startMs) return false;
+      }
+    }
   }
-  if (_maneuverFilter.has('post-start')) {
-    const startMs = _raceStartMs();
-    if (startMs != null) {
-      const t = _parseUtc(m.ts);
-      if (t == null || t.getTime() < startMs) return false;
+  // Tag filter — AND semantics across selected tag ids.
+  if (_maneuverTagFilter.size) {
+    const have = new Set((m.tags || []).map(t => t.id));
+    for (const tid of _maneuverTagFilter) {
+      if (!have.has(tid)) return false;
     }
   }
   return true;
+}
+
+function setManeuverTagFilter(tagId) {
+  if (_maneuverTagFilter.has(tagId)) _maneuverTagFilter.delete(tagId);
+  else _maneuverTagFilter.add(tagId);
+  renderManeuverCard();
+}
+
+function clearManeuverTagFilter() {
+  _maneuverTagFilter.clear();
+  renderManeuverCard();
 }
 
 function _renderOverlaySvg() {
@@ -4796,6 +4817,40 @@ function renderManeuverCard() {
       }).join('')
     + '</div>';
 
+  // Tag filter bar — only show tags that are actually attached to at least
+  // one maneuver in this session, so unused tags don't clutter the UI.
+  const tagUsage = new Map(); // id → {name, color, count}
+  for (const m of _maneuvers) {
+    for (const t of (m.tags || [])) {
+      const row = tagUsage.get(t.id) || {name: t.name, color: t.color, count: 0};
+      row.count++;
+      tagUsage.set(t.id, row);
+    }
+  }
+  let tagFilterBar = '';
+  if (tagUsage.size > 0) {
+    const sorted = [...tagUsage.entries()].sort((a, b) => a[1].name.localeCompare(b[1].name));
+    const chips = sorted.map(([id, row]) => {
+      const active = _maneuverTagFilter.has(id);
+      const borderColor = row.color || 'var(--border)';
+      const style = 'font-size:.7rem;padding:2px 8px;border:1px solid ' + borderColor
+        + ';background:' + (active ? 'var(--accent)' : 'transparent') + ';color:'
+        + (active ? 'var(--bg-primary)' : 'var(--text-primary)')
+        + ';cursor:pointer;border-radius:10px';
+      const swatch = row.color
+        ? '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + row.color + ';margin-right:4px;vertical-align:middle"></span>'
+        : '';
+      return '<button style="' + style + '" onclick="setManeuverTagFilter(' + id + ')">' + swatch + esc(row.name) + ' (' + row.count + ')</button>';
+    }).join('');
+    const clearBtn = _maneuverTagFilter.size
+      ? '<button style="font-size:.68rem;padding:2px 6px;border:none;background:none;color:var(--text-secondary);cursor:pointer;text-decoration:underline" onclick="clearManeuverTagFilter()">clear</button>'
+      : '';
+    tagFilterBar = '<div style="display:flex;gap:4px;margin-bottom:6px;flex-wrap:wrap;align-items:center">'
+      + '<span style="font-size:.68rem;color:var(--text-secondary);margin-right:2px">Tags:</span>'
+      + chips + clearBtn
+      + '</div>';
+  }
+
   const items = _maneuverRows();
   let rows = items.map((m) => {
     const idx = _maneuvers.indexOf(m);
@@ -4863,7 +4918,7 @@ function renderManeuverCard() {
     + '<button style="' + compareBtnStyle + '" onclick="openManeuverCompare()" title="Open synced video comparison for selected maneuvers">Compare Videos</button>'
     + '</div>';
 
-  body.innerHTML = summary + filterBar + overlayBlock + selectBar
+  body.innerHTML = summary + filterBar + tagFilterBar + overlayBlock + selectBar
     + '<table class="maneuver-table"><thead><tr>'
     + '<th title="Include in overlay"></th>'
     + _manHeader('Type', 'type')

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4153,8 +4153,9 @@ let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distan
 // Active filter pills. Multi-select: combined with AND across dimensions
 // (type, rank, time) and OR within a dimension. Empty set == "all".
 let _maneuverFilter = new Set();
-// Tag filter is a separate Set of tag ids. AND semantics against m.tags.
+// Tag filter state: a Set of tag ids + an AND/OR mode for multi-select.
 let _maneuverTagFilter = new Set();
+let _maneuverTagMode = 'and'; // 'and' | 'or'
 const _MANEUVER_TYPE_PILLS = ['tack', 'gybe', 'rounding'];
 const _MANEUVER_RANK_PILLS = ['good', 'bad'];
 const _MANEUVER_DIR_PILLS = ['P\u2192S', 'S\u2192P'];
@@ -4677,11 +4678,19 @@ function _matchesManeuverFilter(m) {
       }
     }
   }
-  // Tag filter — AND semantics across selected tag ids.
+  // Tag filter — AND or OR semantics across selected tag ids.
   if (_maneuverTagFilter.size) {
     const have = new Set((m.tags || []).map(t => t.id));
-    for (const tid of _maneuverTagFilter) {
-      if (!have.has(tid)) return false;
+    if (_maneuverTagMode === 'or') {
+      let matched = false;
+      for (const tid of _maneuverTagFilter) {
+        if (have.has(tid)) { matched = true; break; }
+      }
+      if (!matched) return false;
+    } else {
+      for (const tid of _maneuverTagFilter) {
+        if (!have.has(tid)) return false;
+      }
     }
   }
   return true;
@@ -4693,9 +4702,27 @@ function setManeuverTagFilter(tagId) {
   renderManeuverCard();
 }
 
+function setManeuverTagMode(mode) {
+  if (mode !== 'and' && mode !== 'or') return;
+  _maneuverTagMode = mode;
+  renderManeuverCard();
+}
+
 function clearManeuverTagFilter() {
   _maneuverTagFilter.clear();
   renderManeuverCard();
+}
+
+function _tagModeBtn(mode, label) {
+  const active = _maneuverTagMode === mode;
+  const title = mode === 'and'
+    ? 'Match maneuvers with all selected tags'
+    : 'Match maneuvers with any selected tag';
+  const style = 'font-size:.68rem;padding:2px 8px;border:none;background:'
+    + (active ? 'var(--accent)' : 'transparent') + ';color:'
+    + (active ? 'var(--bg-primary)' : 'var(--text-secondary)') + ';cursor:pointer';
+  return '<button style="' + style + '" title="' + title
+    + '" onclick="setManeuverTagMode(\'' + mode + '\')">' + label + '</button>';
 }
 
 function _renderOverlaySvg() {
@@ -4845,9 +4872,15 @@ function renderManeuverCard() {
     const clearBtn = _maneuverTagFilter.size
       ? '<button style="font-size:.68rem;padding:2px 6px;border:none;background:none;color:var(--text-secondary);cursor:pointer;text-decoration:underline" onclick="clearManeuverTagFilter()">clear</button>'
       : '';
+    const modeToggle = _maneuverTagFilter.size > 1
+      ? '<span style="display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px">'
+        +   _tagModeBtn('and', 'all')
+        +   _tagModeBtn('or', 'any')
+        + '</span>'
+      : '';
     tagFilterBar = '<div style="display:flex;gap:4px;margin-bottom:6px;flex-wrap:wrap;align-items:center">'
       + '<span style="font-size:.68rem;color:var(--text-secondary);margin-right:2px">Tags:</span>'
-      + chips + clearBtn
+      + chips + modeToggle + clearBtn
       + '</div>';
   }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -5720,27 +5720,46 @@ function _threadTitle(t) {
   return 'Thread #' + t.id;
 }
 
+// Tag filter state for the Discussion card.
+const _threadTagFilter = new Set();
+let _threadTagMode = 'and';
+let _threadAvailableTags = [];
+
 async function loadDiscussion() {
   const card = document.getElementById('discussion-card');
   card.style.display = '';
   const body = document.getElementById('discussion-body');
   // Fetch anchor index in parallel so entity-ref chips can resolve labels
   _anchorIndex = null;
+  const params = new URLSearchParams();
+  if (_threadTagFilter.size) {
+    params.set('tags', [..._threadTagFilter].join(','));
+    params.set('tag_mode', _threadTagMode);
+  }
+  const qs = params.toString();
+  const threadsUrl = '/api/sessions/' + SESSION_ID + '/threads' + (qs ? '?' + qs : '');
   const [threadsResp] = await Promise.all([
-    fetch('/api/sessions/' + SESSION_ID + '/threads'),
+    fetch(threadsUrl),
     _ensureAnchorIndex(),
   ]);
   if (!threadsResp.ok) { body.innerHTML = '<span style="color:var(--text-secondary)">Failed to load</span>'; return; }
-  _threads = await threadsResp.json();
+  const data = await threadsResp.json();
+  _threads = data.threads || [];
+  _threadAvailableTags = data.available_tags || [];
   const totalUnread = _threads.reduce((s, t) => s + (t.unread_count || 0), 0);
   const badge = document.getElementById('discussion-badge');
   badge.textContent = totalUnread > 0 ? '(' + totalUnread + ' unread)' : '';
   _addDiscussionMarkers();
+
+  const filterBar = _renderThreadTagFilterRow();
   if (!_threads.length) {
-    body.innerHTML = '<span style="color:var(--text-secondary)">No discussions yet. Start one with + New Thread above.</span>';
+    const emptyMsg = _threadTagFilter.size
+      ? '<span style="color:var(--text-secondary)">No discussions match the current tag filter.</span>'
+      : '<span style="color:var(--text-secondary)">No discussions yet. Start one with + New Thread above.</span>';
+    body.innerHTML = filterBar + emptyMsg;
     return;
   }
-  body.innerHTML = _threads.map(t => {
+  const threadItems = _threads.map(t => {
     const anchor = _renderAnchorChip(t.anchor);
     const unread = t.unread_count > 0
       ? '<span class="thread-unread">' + t.unread_count + '</span>'
@@ -5754,12 +5773,60 @@ async function loadDiscussion() {
       ? '<div style="background:var(--bg-secondary);border:1px solid var(--success);border-radius:4px;padding:4px 8px;margin-top:4px;font-size:.72rem;color:var(--success)">'
         + '<strong>Resolution:</strong> ' + esc(t.resolution_summary) + '</div>'
       : '';
+    const tagChips = _renderRowTagChipsInline(t.tags);
     return '<div class="thread-item' + resolved + '" onclick="openThread(' + t.id + ')">'
       + '<div><strong style="color:var(--text-primary)">' + title + '</strong>' + anchor + unread + resolvedTag + '</div>'
       + '<div style="font-size:.72rem;color:var(--text-secondary);margin-top:2px">' + esc(author) + ' &middot; ' + count + ' &middot; ' + fmtTime(t.created_at) + '</div>'
       + resolutionHtml
+      + tagChips
       + '</div>';
   }).join('');
+  body.innerHTML = filterBar + threadItems;
+}
+
+function _renderThreadTagFilterRow() {
+  const byId = new Map();
+  for (const t of _threadAvailableTags) {
+    byId.set(t.id, {id: t.id, name: t.name, color: t.color, count: t.count || 0});
+  }
+  for (const tid of _threadTagFilter) {
+    if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
+  }
+  if (byId.size === 0) return '';
+  const sorted = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const chips = sorted.map(t => {
+    const active = _threadTagFilter.has(t.id);
+    const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
+    return `<span class="session-tag-chip${active ? ' active' : ''}" onclick="event.stopPropagation();_toggleThreadTagFilter(${t.id})">${swatch}${esc(t.name)} <span class="session-tag-count">(${t.count})</span></span>`;
+  }).join('');
+  const dim = _threadTagFilter.size < 2 ? ';opacity:.6' : '';
+  const modeToggle = `<span class="session-tag-mode" style="margin-left:6px${dim}">`
+    + `<button class="${_threadTagMode === 'and' ? 'active' : ''}" onclick="event.stopPropagation();_setThreadTagMode('and')" title="Require every selected tag">all</button>`
+    + `<button class="${_threadTagMode === 'or' ? 'active' : ''}" onclick="event.stopPropagation();_setThreadTagMode('or')" title="Match any selected tag">any</button>`
+    + '</span>';
+  const clear = _threadTagFilter.size
+    ? '<a href="#" onclick="event.preventDefault();event.stopPropagation();_clearThreadTagFilter()" style="font-size:.7rem;color:var(--text-secondary);margin-left:6px">clear</a>'
+    : '';
+  return '<div class="session-tag-filter-row">'
+    + '<span class="session-tag-label">Tags</span>' + chips + modeToggle + clear
+    + '</div>';
+}
+
+function _toggleThreadTagFilter(id) {
+  if (_threadTagFilter.has(id)) _threadTagFilter.delete(id);
+  else _threadTagFilter.add(id);
+  loadDiscussion();
+}
+function _setThreadTagMode(m) { _threadTagMode = m; loadDiscussion(); }
+function _clearThreadTagFilter() { _threadTagFilter.clear(); loadDiscussion(); }
+
+function _renderRowTagChipsInline(tags) {
+  if (!tags || !tags.length) return '';
+  const chips = tags.map(t => {
+    const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
+    return `<span class="session-tag-chip" style="cursor:default;font-size:.66rem">${swatch}${esc(t.name)}</span>`;
+  }).join(' ');
+  return '<div style="margin-top:4px;display:flex;flex-wrap:wrap;gap:3px">' + chips + '</div>';
 }
 
 function seekToThreadAnchor(ts) {

--- a/src/helmlog/static/tag-picker.js
+++ b/src/helmlog/static/tag-picker.js
@@ -1,0 +1,190 @@
+// Tag-picker custom element (#587 / #588 slice 3).
+//
+//   <tag-picker entity-type="bookmark" entity-id="42"></tag-picker>
+//
+// Loads the tag list from GET /api/tags?order_by=usage and the current
+// attachments from GET /api/entities/{type}/{id}/tags. User can:
+// - Type to filter (prefix/substring match on name)
+// - Arrow up/down to navigate; Enter to attach the highlighted tag
+// - Hit Enter with no match to inline-create a new tag and attach it in
+//   one POST (server accepts {name: "..."})
+// - Click a chip's × to detach
+//
+// Emits `change` events with detail = current attachment list so hosts
+// (e.g. thread compose form) can re-render the badge strip.
+
+class TagPicker extends HTMLElement {
+  static get observedAttributes() { return ['entity-type', 'entity-id']; }
+
+  constructor() {
+    super();
+    this._allTags = [];
+    this._attached = []; // [{id, name, color}]
+    this._filtered = [];
+    this._selectedIdx = 0;
+  }
+
+  connectedCallback() { this._render(); this._wire(); this._refresh(); }
+  attributeChangedCallback() { if (this._inputEl) this._refresh(); }
+
+  get entityType() { return this.getAttribute('entity-type'); }
+  get entityId() { return this.getAttribute('entity-id'); }
+
+  async _refresh() {
+    try {
+      const [allResp, attachedResp] = await Promise.all([
+        fetch('/api/tags?order_by=usage'),
+        this.entityType && this.entityId
+          ? fetch(`/api/entities/${this.entityType}/${this.entityId}/tags`)
+          : Promise.resolve({ok: false}),
+      ]);
+      if (allResp.ok) this._allTags = await allResp.json();
+      if (attachedResp.ok) this._attached = await attachedResp.json();
+    } catch { /* non-fatal */ }
+    this._renderChips();
+    this._onInput();
+  }
+
+  _render() {
+    this.style.display = 'block';
+    this.innerHTML = `
+      <div class="tag-picker-chips" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px"></div>
+      <div style="display:flex;gap:6px;align-items:center">
+        <input class="tag-picker-input" type="text" placeholder="Add tag\u2026"
+               autocomplete="off" style="flex:1" />
+      </div>
+      <div class="tag-picker-list" role="listbox"
+           style="display:none;max-height:200px;overflow:auto;border:1px solid var(--border);border-radius:4px;margin-top:4px;background:var(--bg-primary)"></div>
+    `;
+    this._chipsEl = this.querySelector('.tag-picker-chips');
+    this._inputEl = this.querySelector('.tag-picker-input');
+    this._listEl = this.querySelector('.tag-picker-list');
+  }
+
+  _wire() {
+    this._inputEl.addEventListener('input', () => this._onInput());
+    this._inputEl.addEventListener('focus', () => this._show());
+    this._inputEl.addEventListener('keydown', (ev) => this._onKey(ev));
+    this._inputEl.addEventListener('blur', () => setTimeout(() => this._hide(), 150));
+    this._listEl.addEventListener('mousedown', (ev) => {
+      const item = ev.target.closest('[data-idx]');
+      if (!item) return;
+      ev.preventDefault();
+      this._attach(this._filtered[parseInt(item.dataset.idx, 10)]);
+    });
+  }
+
+  _attachedIds() { return new Set(this._attached.map(t => t.id)); }
+
+  _onInput() {
+    const q = this._inputEl.value.trim().toLowerCase();
+    const attached = this._attachedIds();
+    const unattached = this._allTags.filter(t => !attached.has(t.id));
+    this._filtered = q
+      ? unattached.filter(t => t.name.includes(q))
+      : unattached;
+    this._selectedIdx = this._filtered.length ? 0 : -1;
+    this._renderList(q);
+  }
+
+  _onKey(ev) {
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      if (!this._filtered.length) return;
+      this._selectedIdx = Math.min(this._filtered.length - 1, this._selectedIdx + 1);
+      this._renderList(this._inputEl.value.trim().toLowerCase());
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      this._selectedIdx = Math.max(0, this._selectedIdx - 1);
+      this._renderList(this._inputEl.value.trim().toLowerCase());
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      const q = this._inputEl.value.trim().toLowerCase();
+      if (this._selectedIdx >= 0 && this._filtered[this._selectedIdx]) {
+        this._attach(this._filtered[this._selectedIdx]);
+      } else if (q) {
+        this._attach({name: q}); // inline-create via {name} payload
+      }
+    } else if (ev.key === 'Escape') {
+      this._hide();
+      this._inputEl.blur();
+    }
+  }
+
+  async _attach(tagOrName) {
+    if (!this.entityType || !this.entityId) return;
+    const body = tagOrName.id ? {tag_id: tagOrName.id} : {name: tagOrName.name};
+    try {
+      const r = await fetch(`/api/entities/${this.entityType}/${this.entityId}/tags`, {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) return;
+    } catch { return; }
+    this._inputEl.value = '';
+    await this._refresh();
+    this._emit();
+  }
+
+  async _detach(tagId) {
+    if (!this.entityType || !this.entityId) return;
+    try {
+      const r = await fetch(
+        `/api/entities/${this.entityType}/${this.entityId}/tags/${tagId}`,
+        {method: 'DELETE'}
+      );
+      if (!r.ok && r.status !== 204) return;
+    } catch { return; }
+    await this._refresh();
+    this._emit();
+  }
+
+  _renderChips() {
+    if (!this._attached.length) {
+      this._chipsEl.innerHTML = '<span style="font-size:.72rem;color:var(--text-secondary)">No tags</span>';
+      return;
+    }
+    this._chipsEl.innerHTML = this._attached.map(t => {
+      const color = t.color || 'var(--accent)';
+      const name = (t.name || '').replace(/</g, '&lt;');
+      return `<span class="tp-chip" data-tag-id="${t.id}" style="display:inline-flex;align-items:center;gap:4px;padding:1px 6px 1px 8px;border-radius:10px;font-size:.72rem;background:var(--bg-secondary);border:1px solid ${color}">${name}<button type="button" data-detach="${t.id}" style="background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:0 2px">&times;</button></span>`;
+    }).join('');
+    this._chipsEl.querySelectorAll('[data-detach]').forEach(btn => {
+      btn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        this._detach(parseInt(btn.dataset.detach, 10));
+      });
+    });
+  }
+
+  _renderList(q) {
+    if (!this._filtered.length) {
+      if (q) {
+        this._listEl.innerHTML = `<div style="padding:6px 8px;font-size:.78rem;color:var(--accent);cursor:pointer" data-inline-create>Create tag &ldquo;${q.replace(/</g, '&lt;')}&rdquo; (Enter)</div>`;
+      } else {
+        this._listEl.innerHTML = '<div style="padding:6px 8px;color:var(--text-secondary);font-size:.78rem">No more tags to add</div>';
+      }
+      return;
+    }
+    this._listEl.innerHTML = this._filtered.map((t, idx) => {
+      const selected = idx === this._selectedIdx;
+      const bg = selected ? 'background:var(--bg-secondary);' : '';
+      const count = t.usage_count ? ` <span style="color:var(--text-secondary);font-size:.7rem">(${t.usage_count})</span>` : '';
+      const name = (t.name || '').replace(/</g, '&lt;');
+      return `<div role="option" data-idx="${idx}" style="padding:6px 8px;cursor:pointer;font-size:.82rem;${bg}">${name}${count}</div>`;
+    }).join('');
+  }
+
+  _show() { this._listEl.style.display = ''; }
+  _hide() { this._listEl.style.display = 'none'; }
+
+  _emit() {
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: {attached: this._attached.slice()}, bubbles: true,
+    }));
+  }
+}
+
+if (!customElements.get('tag-picker')) {
+  customElements.define('tag-picker', TagPicker);
+}

--- a/src/helmlog/static/tag-picker.js
+++ b/src/helmlog/static/tag-picker.js
@@ -24,7 +24,20 @@ class TagPicker extends HTMLElement {
     this._selectedIdx = 0;
   }
 
-  connectedCallback() { this._render(); this._wire(); this._refresh(); }
+  connectedCallback() {
+    this._render();
+    this._wire();
+    this._refresh();
+    // Refresh on cross-picker tag creation so newly-created tags appear in
+    // sibling pickers' dropdowns without a page reload.
+    this._onTagsChanged = () => this._refreshAllTags();
+    window.addEventListener('tags-changed', this._onTagsChanged);
+  }
+  disconnectedCallback() {
+    if (this._onTagsChanged) {
+      window.removeEventListener('tags-changed', this._onTagsChanged);
+    }
+  }
   attributeChangedCallback() { if (this._inputEl) this._refresh(); }
 
   get entityType() { return this.getAttribute('entity-type'); }
@@ -45,6 +58,16 @@ class TagPicker extends HTMLElement {
     this._onInput();
   }
 
+  async _refreshAllTags() {
+    try {
+      const r = await fetch('/api/tags?order_by=usage');
+      if (r.ok) {
+        this._allTags = await r.json();
+        this._onInput();
+      }
+    } catch { /* non-fatal */ }
+  }
+
   _render() {
     this.style.display = 'block';
     this.innerHTML = `
@@ -63,7 +86,11 @@ class TagPicker extends HTMLElement {
 
   _wire() {
     this._inputEl.addEventListener('input', () => this._onInput());
-    this._inputEl.addEventListener('focus', () => this._show());
+    this._inputEl.addEventListener('focus', () => {
+      // Pick up any tags created elsewhere since last render.
+      this._refreshAllTags();
+      this._show();
+    });
     this._inputEl.addEventListener('keydown', (ev) => this._onKey(ev));
     this._inputEl.addEventListener('blur', () => setTimeout(() => this._hide(), 150));
     this._listEl.addEventListener('mousedown', (ev) => {
@@ -114,6 +141,9 @@ class TagPicker extends HTMLElement {
   async _attach(tagOrName) {
     if (!this.entityType || !this.entityId) return;
     const body = tagOrName.id ? {tag_id: tagOrName.id} : {name: tagOrName.name};
+    // Inline-create path — an existing tag attach won't change the global
+    // tag set, but a POST with {name} will.
+    const isInlineCreate = !tagOrName.id;
     try {
       const r = await fetch(`/api/entities/${this.entityType}/${this.entityId}/tags`, {
         method: 'POST', headers: {'Content-Type': 'application/json'},
@@ -124,6 +154,9 @@ class TagPicker extends HTMLElement {
     this._inputEl.value = '';
     await this._refresh();
     this._emit();
+    if (isInlineCreate) {
+      window.dispatchEvent(new CustomEvent('tags-changed'));
+    }
   }
 
   async _detach(tagId) {

--- a/src/helmlog/static/tag-picker.js
+++ b/src/helmlog/static/tag-picker.js
@@ -204,7 +204,10 @@ class TagPicker extends HTMLElement {
       const bg = selected ? 'background:var(--bg-secondary);' : '';
       const count = t.usage_count ? ` <span style="color:var(--text-secondary);font-size:.7rem">(${t.usage_count})</span>` : '';
       const name = (t.name || '').replace(/</g, '&lt;');
-      return `<div role="option" data-idx="${idx}" style="padding:6px 8px;cursor:pointer;font-size:.82rem;${bg}">${name}${count}</div>`;
+      const swatch = t.color
+        ? `<span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${t.color};vertical-align:middle;margin-right:6px;border:1px solid var(--border)"></span>`
+        : `<span style="display:inline-block;width:10px;height:10px;margin-right:6px;vertical-align:middle"></span>`;
+      return `<div role="option" data-idx="${idx}" style="padding:6px 8px;cursor:pointer;font-size:.82rem;${bg}">${swatch}${name}${count}</div>`;
     }).join('');
   }
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -6145,6 +6145,34 @@ class Storage:
         await db.commit()
         return cur.rowcount > 0
 
+    async def list_tags_for_entities(
+        self, entity_type: str, entity_ids: list[int]
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Return a {entity_id: [tag, ...]} map for the given ids in one query.
+
+        Missing ids resolve to an empty list. Callers commonly pass "all
+        maneuvers in session X" and want each row enriched with its tags
+        without issuing N separate queries.
+        """
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(f"unknown entity_type {entity_type!r}")
+        out: dict[int, list[dict[str, Any]]] = {eid: [] for eid in entity_ids}
+        if not entity_ids:
+            return out
+        placeholders = ",".join("?" * len(entity_ids))
+        cur = await self._read_conn().execute(
+            f"SELECT et.entity_id, t.id, t.name, t.color"  # noqa: S608
+            f" FROM entity_tags et JOIN tags t ON et.tag_id = t.id"
+            f" WHERE et.entity_type = ? AND et.entity_id IN ({placeholders})"
+            f" ORDER BY t.name",
+            (entity_type, *entity_ids),
+        )
+        for r in await cur.fetchall():
+            out.setdefault(r["entity_id"], []).append(
+                {"id": r["id"], "name": r["name"], "color": r["color"]}
+            )
+        return out
+
     async def list_tags_for_entity(self, entity_type: str, entity_id: int) -> list[dict[str, Any]]:
         """Return tags attached to a specific entity, ordered by name."""
         if entity_type not in ENTITY_TYPES:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -6145,6 +6145,110 @@ class Storage:
         await db.commit()
         return cur.rowcount > 0
 
+    async def sessions_matching_tags(
+        self, tag_ids: list[int], mode: str = "and"
+    ) -> list[int]:
+        """Return session ids whose session row OR any constituent entity
+        (maneuver / bookmark / thread) carries the given tag set.
+
+        AND = every tag must appear somewhere under the session.
+        OR  = at least one tag must appear somewhere under the session.
+        Unknown tag ids are silently dropped, matching the stale-filter
+        tolerance rule used by list_entities_with_tags.
+        """
+        if mode not in {"and", "or"}:
+            raise ValueError(f"mode must be 'and' or 'or', got {mode!r}")
+        if not tag_ids:
+            return []
+        placeholders = ",".join("?" * len(tag_ids))
+        cur = await self._read_conn().execute(
+            f"SELECT id FROM tags WHERE id IN ({placeholders})",  # noqa: S608
+            tag_ids,
+        )
+        known = {r["id"] for r in await cur.fetchall()}
+        filtered = [t for t in tag_ids if t in known]
+        if not filtered:
+            return []
+        placeholders = ",".join("?" * len(filtered))
+        # Union of (session_id, tag_id) pairs across each tagged layer.
+        union = (
+            f"SELECT et.entity_id AS session_id, et.tag_id FROM entity_tags et "
+            f" WHERE et.entity_type = 'session' AND et.tag_id IN ({placeholders}) "
+            f"UNION "
+            f"SELECT m.session_id, et.tag_id FROM entity_tags et "
+            f" JOIN maneuvers m ON m.id = et.entity_id "
+            f" WHERE et.entity_type = 'maneuver' AND et.tag_id IN ({placeholders}) "
+            f"UNION "
+            f"SELECT b.session_id, et.tag_id FROM entity_tags et "
+            f" JOIN bookmarks b ON b.id = et.entity_id "
+            f" WHERE et.entity_type = 'bookmark' AND et.tag_id IN ({placeholders}) "
+            f"UNION "
+            f"SELECT ct.session_id, et.tag_id FROM entity_tags et "
+            f" JOIN comment_threads ct ON ct.id = et.entity_id "
+            f" WHERE et.entity_type = 'thread' AND et.tag_id IN ({placeholders})"
+        )
+        if mode == "and":
+            sql = (
+                f"SELECT session_id FROM ({union}) "  # noqa: S608
+                f"GROUP BY session_id HAVING COUNT(DISTINCT tag_id) = ?"
+            )
+            params = (*filtered, *filtered, *filtered, *filtered, len(filtered))
+        else:
+            sql = f"SELECT DISTINCT session_id FROM ({union})"  # noqa: S608
+            params = (*filtered, *filtered, *filtered, *filtered)
+        cur = await self._read_conn().execute(sql, params)
+        return [r["session_id"] for r in await cur.fetchall()]
+
+    async def list_session_tag_summary(
+        self, session_ids: list[int]
+    ) -> dict[int, list[dict[str, Any]]]:
+        """Return {session_id: [{tag_id, name, color, entity_type, count}, ...]}.
+
+        One row per (session, tag, entity_type) combo with a count. Lets a
+        history row render "weather (session) · good (3 maneuvers)".
+        """
+        out: dict[int, list[dict[str, Any]]] = {sid: [] for sid in session_ids}
+        if not session_ids:
+            return out
+        placeholders = ",".join("?" * len(session_ids))
+        union = (
+            f"SELECT et.tag_id, 'session' AS et_type, et.entity_id AS session_id "
+            f" FROM entity_tags et "
+            f" WHERE et.entity_type = 'session' AND et.entity_id IN ({placeholders}) "
+            f"UNION ALL "
+            f"SELECT et.tag_id, 'maneuver' AS et_type, m.session_id "
+            f" FROM entity_tags et JOIN maneuvers m ON m.id = et.entity_id "
+            f" WHERE et.entity_type = 'maneuver' AND m.session_id IN ({placeholders}) "
+            f"UNION ALL "
+            f"SELECT et.tag_id, 'bookmark' AS et_type, b.session_id "
+            f" FROM entity_tags et JOIN bookmarks b ON b.id = et.entity_id "
+            f" WHERE et.entity_type = 'bookmark' AND b.session_id IN ({placeholders}) "
+            f"UNION ALL "
+            f"SELECT et.tag_id, 'thread' AS et_type, ct.session_id "
+            f" FROM entity_tags et JOIN comment_threads ct ON ct.id = et.entity_id "
+            f" WHERE et.entity_type = 'thread' AND ct.session_id IN ({placeholders})"
+        )
+        sql = (
+            f"SELECT u.session_id, u.tag_id, u.et_type, COUNT(*) AS n, "  # noqa: S608
+            f"       t.name, t.color "
+            f" FROM ({union}) u JOIN tags t ON t.id = u.tag_id "
+            f" GROUP BY u.session_id, u.tag_id, u.et_type "
+            f" ORDER BY t.name, u.et_type"
+        )
+        params = (*session_ids, *session_ids, *session_ids, *session_ids)
+        cur = await self._read_conn().execute(sql, params)
+        for r in await cur.fetchall():
+            out.setdefault(r["session_id"], []).append(
+                {
+                    "id": r["tag_id"],
+                    "name": r["name"],
+                    "color": r["color"],
+                    "entity_type": r["et_type"],
+                    "count": r["n"],
+                }
+            )
+        return out
+
     async def list_tags_for_entities(
         self, entity_type: str, entity_ids: list[int]
     ) -> dict[int, list[dict[str, Any]]]:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -46,6 +46,13 @@ class AnchorScopeError(ValueError):
     """Raised when an anchor's referenced entity does not scope to the expected session."""
 
 
+# Valid values for entity_tags.entity_type. Extended carefully — every
+# addition needs a list_entity_ids() branch in storage plus attach UI.
+ENTITY_TYPES: frozenset[str] = frozenset(
+    {"session", "maneuver", "thread", "bookmark", "session_note"}
+)
+
+
 def _hms_from_iso(iso: str | None) -> str:
     """Return the HH:MM:SS portion of an ISO 8601 timestamp.
 
@@ -191,7 +198,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 71
+_CURRENT_VERSION: int = 72
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1682,6 +1689,28 @@ _MIGRATIONS: dict[int, str] = {
 
         ALTER TABLE comment_threads DROP COLUMN anchor_timestamp;
         ALTER TABLE comment_threads DROP COLUMN mark_reference;
+    """,
+    72: """
+        -- #587 / #588 slice 3. Folds the legacy tag join tables into the
+        -- polymorphic entity_tags introduced in slice 1. session_tags and
+        -- note_tags rows get copied across, tags.usage_count is backfilled
+        -- from the combined counts, and the old tables are dropped.
+
+        INSERT OR IGNORE INTO entity_tags (tag_id, entity_type, entity_id, created_at)
+        SELECT tag_id, 'session', session_id, '2024-01-01T00:00:00+00:00'
+          FROM session_tags;
+
+        INSERT OR IGNORE INTO entity_tags (tag_id, entity_type, entity_id, created_at)
+        SELECT tag_id, 'session_note', note_id, '2024-01-01T00:00:00+00:00'
+          FROM note_tags;
+
+        UPDATE tags
+           SET usage_count = (
+                 SELECT COUNT(*) FROM entity_tags WHERE entity_tags.tag_id = tags.id
+               );
+
+        DROP TABLE session_tags;
+        DROP TABLE note_tags;
     """,
 }
 
@@ -6048,72 +6077,180 @@ class Storage:
         row = await cur.fetchone()
         return dict(row) if row else None
 
-    async def list_tags(self) -> list[dict[str, Any]]:
-        """Return all tags with usage counts."""
-        cur = await self._read_conn().execute(
-            "SELECT t.id, t.name, t.color, t.created_at,"
-            " (SELECT COUNT(*) FROM session_tags st WHERE st.tag_id = t.id) AS session_count,"
-            " (SELECT COUNT(*) FROM note_tags nt WHERE nt.tag_id = t.id) AS note_count"
-            " FROM tags t ORDER BY t.name"
-        )
-        rows = await cur.fetchall()
-        return [dict(r) for r in rows]
+    async def list_tags(self, *, order_by: str = "name") -> list[dict[str, Any]]:
+        """Return all tags with usage counts, ordered by name or usage.
 
-    async def add_session_tag(self, session_id: int, tag_id: int) -> None:
-        """Tag a session. Idempotent."""
-        db = self._conn()
-        await db.execute(
-            "INSERT OR IGNORE INTO session_tags (session_id, tag_id) VALUES (?, ?)",
-            (session_id, tag_id),
+        order_by="usage" sorts by usage_count DESC, last_used_at DESC,
+        name ASC — the picker's most-useful-first ordering.
+        """
+        if order_by not in {"name", "usage"}:
+            raise ValueError(f"order_by must be 'name' or 'usage', got {order_by!r}")
+        sql = "SELECT id, name, color, created_at, usage_count, last_used_at FROM tags ORDER BY "
+        sql += (
+            "usage_count DESC, COALESCE(last_used_at, '') DESC, name"
+            if order_by == "usage"
+            else "name"
         )
+        cur = await self._read_conn().execute(sql)
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def attach_tag(
+        self,
+        entity_type: str,
+        entity_id: int,
+        tag_id: int,
+        *,
+        user_id: int | None,
+    ) -> None:
+        """Attach a tag to an entity. Idempotent; duplicate call is a no-op.
+
+        On a new attachment, increments tags.usage_count and stamps
+        tags.last_used_at to the current UTC time.
+        """
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(
+                f"unknown entity_type {entity_type!r} (allowed: {sorted(ENTITY_TYPES)})"
+            )
+        now = datetime.now(UTC).isoformat()
+        db = self._conn()
+        cur = await db.execute(
+            "INSERT OR IGNORE INTO entity_tags "
+            "(tag_id, entity_type, entity_id, created_at, created_by) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (tag_id, entity_type, entity_id, now, user_id),
+        )
+        if cur.rowcount > 0:
+            await db.execute(
+                "UPDATE tags SET usage_count = usage_count + 1, last_used_at = ? WHERE id = ?",
+                (now, tag_id),
+            )
         await db.commit()
 
-    async def remove_session_tag(self, session_id: int, tag_id: int) -> None:
-        """Remove a tag from a session."""
+    async def detach_tag(self, entity_type: str, entity_id: int, tag_id: int) -> bool:
+        """Remove a tag from an entity. Returns True if a row was removed."""
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(
+                f"unknown entity_type {entity_type!r} (allowed: {sorted(ENTITY_TYPES)})"
+            )
         db = self._conn()
-        await db.execute(
-            "DELETE FROM session_tags WHERE session_id = ? AND tag_id = ?",
-            (session_id, tag_id),
+        cur = await db.execute(
+            "DELETE FROM entity_tags WHERE tag_id = ? AND entity_type = ? AND entity_id = ?",
+            (tag_id, entity_type, entity_id),
         )
+        if cur.rowcount > 0:
+            await db.execute(
+                "UPDATE tags SET usage_count = MAX(0, usage_count - 1) WHERE id = ?",
+                (tag_id,),
+            )
         await db.commit()
+        return cur.rowcount > 0
 
-    async def get_session_tags(self, session_id: int) -> list[dict[str, Any]]:
-        """Return tags for a session."""
+    async def list_tags_for_entity(self, entity_type: str, entity_id: int) -> list[dict[str, Any]]:
+        """Return tags attached to a specific entity, ordered by name."""
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(f"unknown entity_type {entity_type!r}")
         cur = await self._read_conn().execute(
             "SELECT t.id, t.name, t.color FROM tags t"
-            " JOIN session_tags st ON t.id = st.tag_id"
-            " WHERE st.session_id = ? ORDER BY t.name",
-            (session_id,),
+            " JOIN entity_tags et ON t.id = et.tag_id"
+            " WHERE et.entity_type = ? AND et.entity_id = ?"
+            " ORDER BY t.name",
+            (entity_type, entity_id),
         )
         return [dict(r) for r in await cur.fetchall()]
 
-    async def add_note_tag(self, note_id: int, tag_id: int) -> None:
-        """Tag a note. Idempotent."""
-        db = self._conn()
-        await db.execute(
-            "INSERT OR IGNORE INTO note_tags (note_id, tag_id) VALUES (?, ?)",
-            (note_id, tag_id),
-        )
-        await db.commit()
+    async def list_entities_with_tags(
+        self, entity_type: str, tag_ids: list[int], mode: str = "and"
+    ) -> list[int]:
+        """Return entity_ids of this type that match the tag filter.
 
-    async def remove_note_tag(self, note_id: int, tag_id: int) -> None:
-        """Remove a tag from a note."""
-        db = self._conn()
-        await db.execute(
-            "DELETE FROM note_tags WHERE note_id = ? AND tag_id = ?",
-            (note_id, tag_id),
-        )
-        await db.commit()
+        - Empty tag_ids → return every entity of this type.
+        - mode="and": entity must carry *every* tag in the list.
+        - mode="or":  entity must carry *any* tag in the list.
+        - Unknown tag ids are silently dropped (stale-filter tolerance).
+        """
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(f"unknown entity_type {entity_type!r}")
+        if mode not in {"and", "or"}:
+            raise ValueError(f"mode must be 'and' or 'or', got {mode!r}")
 
-    async def get_note_tags(self, note_id: int) -> list[dict[str, Any]]:
-        """Return tags for a note."""
+        if not tag_ids:
+            return await self._all_entity_ids(entity_type)
+
+        # Drop unknown ids before querying so they don't skew AND matches.
+        placeholders = ",".join("?" * len(tag_ids))
         cur = await self._read_conn().execute(
-            "SELECT t.id, t.name, t.color FROM tags t"
-            " JOIN note_tags nt ON t.id = nt.tag_id"
-            " WHERE nt.note_id = ? ORDER BY t.name",
-            (note_id,),
+            f"SELECT id FROM tags WHERE id IN ({placeholders})",  # noqa: S608
+            tag_ids,
         )
-        return [dict(r) for r in await cur.fetchall()]
+        known = {r["id"] for r in await cur.fetchall()}
+        filtered = [t for t in tag_ids if t in known]
+        if not filtered:
+            return await self._all_entity_ids(entity_type)
+
+        placeholders = ",".join("?" * len(filtered))
+        if mode == "or":
+            cur = await self._read_conn().execute(
+                f"SELECT DISTINCT entity_id FROM entity_tags "  # noqa: S608
+                f"WHERE entity_type = ? AND tag_id IN ({placeholders})",
+                (entity_type, *filtered),
+            )
+        else:  # and
+            cur = await self._read_conn().execute(
+                f"SELECT entity_id FROM entity_tags "  # noqa: S608
+                f"WHERE entity_type = ? AND tag_id IN ({placeholders}) "
+                f"GROUP BY entity_id HAVING COUNT(DISTINCT tag_id) = ?",
+                (entity_type, *filtered, len(filtered)),
+            )
+        return [r["entity_id"] for r in await cur.fetchall()]
+
+    async def _all_entity_ids(self, entity_type: str) -> list[int]:
+        """Return all entity ids of a given type. Source-of-truth per type."""
+        table_col = {
+            "session": ("races", "id"),
+            "maneuver": ("maneuvers", "id"),
+            "thread": ("comment_threads", "id"),
+            "bookmark": ("bookmarks", "id"),
+            "session_note": ("session_notes", "id"),
+        }[entity_type]
+        table, col = table_col
+        cur = await self._read_conn().execute(
+            f"SELECT {col} AS entity_id FROM {table} ORDER BY {col}"  # noqa: S608
+        )
+        return [r["entity_id"] for r in await cur.fetchall()]
+
+    async def merge_tags(self, source_id: int, target_id: int) -> None:
+        """Merge `source` into `target`. Source is deleted; source's entity
+        associations are reassigned to target (de-duping where an entity
+        already had both), and target.usage_count is recomputed from the
+        resulting entity_tags rows.
+        """
+        if source_id == target_id:
+            raise ValueError("cannot merge a tag into itself (source == target)")
+        db = self._conn()
+        for check_id, label in ((source_id, "source"), (target_id, "target")):
+            cur = await db.execute("SELECT id FROM tags WHERE id=?", (check_id,))
+            if await cur.fetchone() is None:
+                raise ValueError(f"{label} tag {check_id} does not exist")
+
+        # Move source rows to target, ignoring duplicates that would violate
+        # the (tag_id, entity_type, entity_id) PK.
+        await db.execute(
+            "INSERT OR IGNORE INTO entity_tags "
+            "(tag_id, entity_type, entity_id, created_at, created_by) "
+            "SELECT ?, entity_type, entity_id, created_at, created_by "
+            "FROM entity_tags WHERE tag_id = ?",
+            (target_id, source_id),
+        )
+        await db.execute("DELETE FROM entity_tags WHERE tag_id = ?", (source_id,))
+        # Recompute usage_count on target from the entity_tags rows.
+        await db.execute(
+            "UPDATE tags SET usage_count = "
+            "(SELECT COUNT(*) FROM entity_tags WHERE tag_id = ?) "
+            "WHERE id = ?",
+            (target_id, target_id),
+        )
+        await db.execute("DELETE FROM tags WHERE id = ?", (source_id,))
+        await db.commit()
 
     async def get_or_create_tag(self, name: str, color: str | None = None) -> int:
         """Return the tag id for *name*, creating it if it doesn't exist."""
@@ -6146,10 +6283,12 @@ class Storage:
         return cur.rowcount > 0
 
     async def delete_tag(self, tag_id: int) -> bool:
-        """Delete a tag and all its associations. Returns True if found."""
+        """Delete a tag. entity_tags.tag_id has ON DELETE CASCADE, so any
+        attachments are removed automatically (requires PRAGMA foreign_keys=ON
+        on the connection; tests explicitly enable it where they assert the
+        cascade). Returns True if the tag existed.
+        """
         db = self._conn()
-        await db.execute("DELETE FROM session_tags WHERE tag_id = ?", (tag_id,))
-        await db.execute("DELETE FROM note_tags WHERE tag_id = ?", (tag_id,))
         cur = await db.execute("DELETE FROM tags WHERE id = ?", (tag_id,))
         await db.commit()
         return cur.rowcount > 0

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -6260,15 +6260,26 @@ class Storage:
         return await self.create_tag(name, color)
 
     async def update_tag(
-        self, tag_id: int, *, name: str | None = None, color: str | None = None
+        self,
+        tag_id: int,
+        *,
+        name: str | None = None,
+        color: str | None = None,
+        clear_color: bool = False,
     ) -> bool:
-        """Update a tag's name or color. Returns True if found."""
+        """Update a tag's name or color. Returns True if found.
+
+        Pass ``clear_color=True`` to explicitly set color to NULL; a
+        ``color=None`` argument by itself is treated as "don't change".
+        """
         parts: list[str] = []
         params: list[Any] = []
         if name is not None:
             parts.append("name = ?")
             params.append(name.strip().lower())
-        if color is not None:
+        if clear_color:
+            parts.append("color = NULL")
+        elif color is not None:
             parts.append("color = ?")
             params.append(color)
         if not parts:

--- a/src/helmlog/templates/admin/tags.html
+++ b/src/helmlog/templates/admin/tags.html
@@ -18,10 +18,13 @@ input.inline{background:var(--bg-input);border:1px solid var(--border);border-ra
 <h1 style="margin-bottom:12px">Tag Manager</h1>
 
 <div class="card">
-  <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+  <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
     <input id="new-tag-name" class="inline" placeholder="New tag name" />
     <input id="new-tag-color" class="inline" type="color" style="width:40px;padding:2px" />
     <button class="btn-sm btn-edit" onclick="createTag()">Create</button>
+    <span style="flex:1"></span>
+    <input id="tag-filter" class="inline" type="search" placeholder="Filter tags\u2026" style="min-width:180px" oninput="filterTags()" />
+    <span id="tag-filter-count" style="font-size:.72rem;color:var(--text-secondary)"></span>
   </div>
   <div id="tag-flash" style="font-size:.78rem;margin-bottom:6px;color:var(--text-secondary)"></div>
   <table>
@@ -32,6 +35,7 @@ input.inline{background:var(--bg-input);border:1px solid var(--border);border-ra
     </thead>
     <tbody id="tags-tbody"></tbody>
   </table>
+  <div id="tags-empty-filter" style="display:none;text-align:center;color:var(--text-secondary);padding:20px;font-size:.82rem">No tags match that filter.</div>
 </div>
 
 <script>
@@ -45,7 +49,7 @@ async function loadTags() {
       ? '<span style="display:inline-block;width:14px;height:14px;border-radius:3px;background:' + t.color + ';border:1px solid var(--border);vertical-align:middle"></span>'
       : '<span style="color:var(--text-secondary);font-size:.72rem">&ndash;</span>';
     const last = t.last_used_at ? new Date(t.last_used_at).toLocaleString() : '';
-    return '<tr>'
+    return '<tr data-tag-name="' + esc(t.name) + '">'
       + '<td><strong>' + esc(t.name) + '</strong></td>'
       + '<td>' + swatch + '</td>'
       + '<td>' + (t.usage_count || 0) + '</td>'
@@ -59,6 +63,28 @@ async function loadTags() {
   }).join('');
   if (!rows.length) {
     tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--text-secondary);padding:20px">No tags yet.</td></tr>';
+  }
+  filterTags();
+}
+
+function filterTags() {
+  const q = (document.getElementById('tag-filter').value || '').trim().toLowerCase();
+  const rows = document.querySelectorAll('#tags-tbody tr[data-tag-name]');
+  let shown = 0;
+  rows.forEach(row => {
+    const name = row.dataset.tagName || '';
+    const match = !q || name.includes(q);
+    row.style.display = match ? '' : 'none';
+    if (match) shown++;
+  });
+  const count = document.getElementById('tag-filter-count');
+  const emptyMsg = document.getElementById('tags-empty-filter');
+  if (q && rows.length) {
+    count.textContent = shown + '/' + rows.length;
+    emptyMsg.style.display = shown === 0 ? '' : 'none';
+  } else {
+    count.textContent = '';
+    emptyMsg.style.display = 'none';
   }
 }
 

--- a/src/helmlog/templates/admin/tags.html
+++ b/src/helmlog/templates/admin/tags.html
@@ -18,6 +18,12 @@ input.inline{background:var(--bg-input);border:1px solid var(--border);border-ra
 .merge-list li{padding:6px 10px;cursor:pointer;font-size:.82rem;display:flex;align-items:center;gap:8px}
 .merge-list li:hover{background:var(--bg-input)}
 .merge-list li.selected{background:var(--bg-input);border-left:3px solid var(--warning)}
+.color-cell{display:flex;align-items:center;gap:6px}
+.color-swatch-input{width:28px;height:22px;padding:0;border:1px solid var(--border);border-radius:4px;background:none;cursor:pointer}
+.color-swatch-input::-webkit-color-swatch-wrapper{padding:0}
+.color-swatch-input::-webkit-color-swatch{border:none;border-radius:3px}
+.color-clear-btn{background:none;border:none;color:var(--text-secondary);cursor:pointer;font-size:.9rem;padding:0 2px;line-height:1}
+.color-clear-btn:hover{color:var(--danger)}
 </style>
 {% endblock %}
 {% block content %}
@@ -54,9 +60,13 @@ async function loadTags() {
   _allTags = rows;
   const tbody = document.getElementById('tags-tbody');
   tbody.innerHTML = rows.map(t => {
-    const swatch = t.color
-      ? '<span style="display:inline-block;width:14px;height:14px;border-radius:3px;background:' + t.color + ';border:1px solid var(--border);vertical-align:middle"></span>'
-      : '<span style="color:var(--text-secondary);font-size:.72rem">&ndash;</span>';
+    const colorValue = t.color || '#6b7280';
+    const clearBtn = t.color
+      ? '<button class="color-clear-btn" title="Clear color" onclick="clearTagColor(' + t.id + ')">&times;</button>'
+      : '';
+    const swatch = '<div class="color-cell">'
+      + '<input type="color" class="color-swatch-input" value="' + esc(colorValue) + '" title="Click to change color" onchange="setTagColor(' + t.id + ',this.value)" />'
+      + clearBtn + '</div>';
     const last = t.last_used_at ? new Date(t.last_used_at).toLocaleString() : '';
     return '<tr data-tag-name="' + esc(t.name) + '">'
       + '<td><strong>' + esc(t.name) + '</strong></td>'
@@ -111,6 +121,26 @@ async function createTag() {
   document.getElementById('new-tag-name').value = '';
   await loadTags();
   flash('Tag created');
+}
+
+async function setTagColor(id, color) {
+  const r = await fetch('/api/tags/' + id, {
+    method: 'PATCH', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({color}),
+  });
+  if (!r.ok) { flash('Color update failed: ' + r.status, true); return; }
+  await loadTags();
+  flash('Color updated');
+}
+
+async function clearTagColor(id) {
+  const r = await fetch('/api/tags/' + id, {
+    method: 'PATCH', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({color: null}),
+  });
+  if (!r.ok) { flash('Color clear failed: ' + r.status, true); return; }
+  await loadTags();
+  flash('Color cleared');
 }
 
 async function renameTag(id, current) {

--- a/src/helmlog/templates/admin/tags.html
+++ b/src/helmlog/templates/admin/tags.html
@@ -12,6 +12,12 @@ td{padding:7px 8px;border-bottom:1px solid var(--border);vertical-align:middle}
 .btn-del{color:var(--danger);border-color:var(--danger)}
 .btn-merge{color:var(--warning);border-color:var(--warning)}
 input.inline{background:var(--bg-input);border:1px solid var(--border);border-radius:4px;padding:4px 6px;color:var(--text-primary);font-size:.82rem}
+.modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000}
+.modal-panel{background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;width:min(420px,92vw);max-height:80vh;display:flex;flex-direction:column;padding:14px}
+.merge-list{list-style:none;padding:0;margin:0;overflow-y:auto;flex:1;border:1px solid var(--border);border-radius:4px;background:var(--bg-primary)}
+.merge-list li{padding:6px 10px;cursor:pointer;font-size:.82rem;display:flex;align-items:center;gap:8px}
+.merge-list li:hover{background:var(--bg-input)}
+.merge-list li.selected{background:var(--bg-input);border-left:3px solid var(--warning)}
 </style>
 {% endblock %}
 {% block content %}
@@ -39,10 +45,13 @@ input.inline{background:var(--bg-input);border:1px solid var(--border);border-ra
 </div>
 
 <script>
+let _allTags = [];
+
 async function loadTags() {
   const r = await fetch('/api/tags?order_by=usage');
   if (!r.ok) return;
   const rows = await r.json();
+  _allTags = rows;
   const tbody = document.getElementById('tags-tbody');
   tbody.innerHTML = rows.map(t => {
     const swatch = t.color
@@ -124,17 +133,113 @@ async function deleteTag(id, name) {
   flash('Deleted');
 }
 
-async function mergeTagInto(sourceId, sourceName) {
-  const target = window.prompt('Merge "' + sourceName + '" into which tag? Enter tag name:');
+// Merge modal — typeahead picker over all tags except the source.
+let _mergeState = null;
+
+function mergeTagInto(sourceId, sourceName) {
+  const candidates = _allTags.filter(t => t.id !== sourceId);
+  _mergeState = {sourceId, sourceName, candidates, filtered: candidates.slice(), selectedIdx: candidates.length ? 0 : -1};
+
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.id = 'merge-overlay';
+  overlay.innerHTML = ''
+    + '<div class="modal-panel" onclick="event.stopPropagation()">'
+    +   '<div style="font-size:.9rem;margin-bottom:8px">Merge <strong>' + esc(sourceName) + '</strong> into\u2026</div>'
+    +   '<input id="merge-filter" class="inline" type="search" autocomplete="off" placeholder="Type to filter\u2026" style="margin-bottom:8px" />'
+    +   '<ul class="merge-list" id="merge-list"></ul>'
+    +   '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:10px">'
+    +     '<button class="btn-sm" onclick="closeMerge()">Cancel</button>'
+    +     '<button class="btn-sm btn-merge" id="merge-confirm" onclick="confirmMerge()" disabled>Merge</button>'
+    +   '</div>'
+    + '</div>';
+  overlay.addEventListener('click', closeMerge);
+  document.body.appendChild(overlay);
+
+  const inp = document.getElementById('merge-filter');
+  inp.addEventListener('input', () => {
+    const q = inp.value.trim().toLowerCase();
+    _mergeState.filtered = q
+      ? candidates.filter(t => t.name.includes(q))
+      : candidates.slice();
+    _mergeState.selectedIdx = _mergeState.filtered.length ? 0 : -1;
+    _renderMergeList();
+  });
+  inp.addEventListener('keydown', (ev) => {
+    if (!_mergeState) return;
+    const f = _mergeState.filtered;
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      _mergeState.selectedIdx = Math.min(f.length - 1, _mergeState.selectedIdx + 1);
+      _renderMergeList();
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      _mergeState.selectedIdx = Math.max(0, _mergeState.selectedIdx - 1);
+      _renderMergeList();
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      confirmMerge();
+    } else if (ev.key === 'Escape') {
+      ev.preventDefault();
+      closeMerge();
+    }
+  });
+  setTimeout(() => inp.focus(), 0);
+  _renderMergeList();
+}
+
+function _renderMergeList() {
+  if (!_mergeState) return;
+  const ul = document.getElementById('merge-list');
+  const list = _mergeState.filtered;
+  if (!list.length) {
+    ul.innerHTML = '<li style="color:var(--text-secondary);cursor:default">No matching tags.</li>';
+    document.getElementById('merge-confirm').disabled = true;
+    return;
+  }
+  ul.innerHTML = list.map((t, idx) => {
+    const swatch = t.color
+      ? '<span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:' + t.color + '"></span>'
+      : '<span style="width:10px;height:10px"></span>';
+    const selCls = idx === _mergeState.selectedIdx ? ' selected' : '';
+    const count = t.usage_count ? ' <span style="color:var(--text-secondary);font-size:.72rem;margin-left:auto">' + t.usage_count + '</span>' : '';
+    return '<li class="merge-row' + selCls + '" data-idx="' + idx + '">' + swatch + esc(t.name) + count + '</li>';
+  }).join('');
+  ul.querySelectorAll('[data-idx]').forEach(el => {
+    el.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      _mergeState.selectedIdx = parseInt(el.dataset.idx, 10);
+      _renderMergeList();
+    });
+    el.addEventListener('dblclick', (ev) => {
+      ev.stopPropagation();
+      _mergeState.selectedIdx = parseInt(el.dataset.idx, 10);
+      confirmMerge();
+    });
+  });
+  document.getElementById('merge-confirm').disabled = _mergeState.selectedIdx < 0;
+}
+
+function closeMerge() {
+  const overlay = document.getElementById('merge-overlay');
+  if (overlay) overlay.remove();
+  _mergeState = null;
+}
+
+async function confirmMerge() {
+  if (!_mergeState) return;
+  const target = _mergeState.filtered[_mergeState.selectedIdx];
   if (!target) return;
-  const all = await (await fetch('/api/tags')).json();
-  const t = all.find(x => x.name === target.trim().toLowerCase());
-  if (!t) { flash('Target tag not found: ' + target, true); return; }
-  if (t.id === sourceId) { flash('Cannot merge into self', true); return; }
-  const r = await fetch('/api/tags/' + sourceId + '/merge-into/' + t.id, {method: 'POST'});
-  if (!r.ok) { flash('Merge failed: ' + r.status, true); return; }
+  const {sourceId, sourceName} = _mergeState;
+  closeMerge();
+  const r = await fetch('/api/tags/' + sourceId + '/merge-into/' + target.id, {method: 'POST'});
+  if (!r.ok) {
+    const detail = await r.json().catch(() => ({}));
+    flash('Merge failed: ' + (detail.detail || r.status), true);
+    return;
+  }
   await loadTags();
-  flash('Merged into ' + t.name);
+  flash('Merged "' + sourceName + '" into "' + target.name + '"');
 }
 
 function flash(msg, isErr) {

--- a/src/helmlog/templates/admin/tags.html
+++ b/src/helmlog/templates/admin/tags.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+{% block title %}Tags — HelmLog{% endblock %}
+{% block extra_css %}
+<style>
+h1{font-size:1.3rem;font-weight:700;color:var(--accent)}
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:12px}
+table{width:100%;border-collapse:collapse;font-size:.87rem}
+th{text-align:left;color:var(--text-secondary);font-size:.75rem;text-transform:uppercase;letter-spacing:.06em;padding:6px 8px;border-bottom:1px solid var(--border)}
+td{padding:7px 8px;border-bottom:1px solid var(--border);vertical-align:middle}
+.btn-sm{padding:6px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);font-size:.78rem;cursor:pointer}
+.btn-edit{color:var(--accent);border-color:var(--accent-strong)}
+.btn-del{color:var(--danger);border-color:var(--danger)}
+.btn-merge{color:var(--warning);border-color:var(--warning)}
+input.inline{background:var(--bg-input);border:1px solid var(--border);border-radius:4px;padding:4px 6px;color:var(--text-primary);font-size:.82rem}
+</style>
+{% endblock %}
+{% block content %}
+<h1 style="margin-bottom:12px">Tag Manager</h1>
+
+<div class="card">
+  <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+    <input id="new-tag-name" class="inline" placeholder="New tag name" />
+    <input id="new-tag-color" class="inline" type="color" style="width:40px;padding:2px" />
+    <button class="btn-sm btn-edit" onclick="createTag()">Create</button>
+  </div>
+  <div id="tag-flash" style="font-size:.78rem;margin-bottom:6px;color:var(--text-secondary)"></div>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th><th>Color</th><th>Usage</th><th>Last used</th><th>Actions</th>
+      </tr>
+    </thead>
+    <tbody id="tags-tbody"></tbody>
+  </table>
+</div>
+
+<script>
+async function loadTags() {
+  const r = await fetch('/api/tags?order_by=usage');
+  if (!r.ok) return;
+  const rows = await r.json();
+  const tbody = document.getElementById('tags-tbody');
+  tbody.innerHTML = rows.map(t => {
+    const swatch = t.color
+      ? '<span style="display:inline-block;width:14px;height:14px;border-radius:3px;background:' + t.color + ';border:1px solid var(--border);vertical-align:middle"></span>'
+      : '<span style="color:var(--text-secondary);font-size:.72rem">&ndash;</span>';
+    const last = t.last_used_at ? new Date(t.last_used_at).toLocaleString() : '';
+    return '<tr>'
+      + '<td><strong>' + esc(t.name) + '</strong></td>'
+      + '<td>' + swatch + '</td>'
+      + '<td>' + (t.usage_count || 0) + '</td>'
+      + '<td><span style="font-size:.72rem;color:var(--text-secondary)">' + esc(last) + '</span></td>'
+      + '<td style="display:flex;gap:4px;flex-wrap:wrap">'
+      +   '<button class="btn-sm btn-edit" onclick="renameTag(' + t.id + ',\'' + esc(t.name) + '\')">Rename</button>'
+      +   '<button class="btn-sm btn-merge" onclick="mergeTagInto(' + t.id + ',\'' + esc(t.name) + '\')">Merge\u2026</button>'
+      +   '<button class="btn-sm btn-del" onclick="deleteTag(' + t.id + ',\'' + esc(t.name) + '\')">Delete</button>'
+      + '</td>'
+      + '</tr>';
+  }).join('');
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--text-secondary);padding:20px">No tags yet.</td></tr>';
+  }
+}
+
+function esc(s) { return (s == null ? '' : String(s)).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+async function createTag() {
+  const name = document.getElementById('new-tag-name').value.trim().toLowerCase();
+  const color = document.getElementById('new-tag-color').value;
+  if (!name) { flash('Name required', true); return; }
+  const r = await fetch('/api/tags', {
+    method: 'POST', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name, color}),
+  });
+  if (!r.ok) { flash('Create failed: ' + r.status, true); return; }
+  document.getElementById('new-tag-name').value = '';
+  await loadTags();
+  flash('Tag created');
+}
+
+async function renameTag(id, current) {
+  const name = window.prompt('Rename tag:', current);
+  if (!name || name === current) return;
+  const r = await fetch('/api/tags/' + id, {
+    method: 'PATCH', headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({name: name.trim().toLowerCase()}),
+  });
+  if (!r.ok) { flash('Rename failed: ' + r.status, true); return; }
+  await loadTags();
+  flash('Renamed');
+}
+
+async function deleteTag(id, name) {
+  if (!window.confirm('Delete tag "' + name + '"? Any attachments are removed.')) return;
+  const r = await fetch('/api/tags/' + id, {method: 'DELETE'});
+  if (!r.ok && r.status !== 204) { flash('Delete failed: ' + r.status, true); return; }
+  await loadTags();
+  flash('Deleted');
+}
+
+async function mergeTagInto(sourceId, sourceName) {
+  const target = window.prompt('Merge "' + sourceName + '" into which tag? Enter tag name:');
+  if (!target) return;
+  const all = await (await fetch('/api/tags')).json();
+  const t = all.find(x => x.name === target.trim().toLowerCase());
+  if (!t) { flash('Target tag not found: ' + target, true); return; }
+  if (t.id === sourceId) { flash('Cannot merge into self', true); return; }
+  const r = await fetch('/api/tags/' + sourceId + '/merge-into/' + t.id, {method: 'POST'});
+  if (!r.ok) { flash('Merge failed: ' + r.status, true); return; }
+  await loadTags();
+  flash('Merged into ' + t.name);
+}
+
+function flash(msg, isErr) {
+  const el = document.getElementById('tag-flash');
+  el.textContent = msg;
+  el.style.color = isErr ? 'var(--danger)' : 'var(--success)';
+  setTimeout(() => { el.textContent = ''; }, 3000);
+}
+
+document.addEventListener('DOMContentLoaded', loadTags);
+</script>
+{% endblock %}

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -31,6 +31,7 @@
     <a href="/admin/network" class="admin-link{% if active_page == "/admin/network" %} active{% endif %}">Network</a>
     <a href="/admin/events" class="admin-link{% if active_page == "/admin/events" %} active{% endif %}">Events</a>
     <a href="/admin/settings" class="admin-link{% if active_page == "/admin/settings" %} active{% endif %}">Settings</a>
+    <a href="/admin/tags" class="admin-link{% if active_page == "/admin/tags" %} active{% endif %}">Tags</a>
     <a href="/admin/federation" class="admin-link{% if active_page == "/admin/federation" %} active{% endif %}">Federation</a>
     <a href="/admin/race-results" class="admin-link{% if active_page == "/admin/race-results" %} active{% endif %}">Results</a>
     <a href="/admin/analysis" class="admin-link{% if active_page == "/admin/analysis" %} active{% endif %}">Analysis</a>

--- a/src/helmlog/templates/history.html
+++ b/src/helmlog/templates/history.html
@@ -1,5 +1,18 @@
 {% extends "base.html" %}
 {% block title %}Session History — HelmLog{% endblock %}
+{% block extra_css %}
+<style>
+.hist-tag-chip{display:inline-flex;align-items:center;gap:4px;padding:1px 6px;border-radius:10px;font-size:.7rem;border:1px solid var(--border);background:var(--bg-secondary);cursor:pointer;margin-right:4px;margin-bottom:3px}
+.hist-tag-chip.active{background:var(--accent);color:var(--bg-primary)}
+.hist-tag-chip .swatch{display:inline-block;width:8px;height:8px;border-radius:50%}
+.hist-tag-chip .etype{font-size:.62rem;color:var(--text-secondary);margin-left:3px}
+.hist-tag-chip.active .etype{color:var(--bg-primary);opacity:.75}
+.hist-tag-row-chips{display:flex;flex-wrap:wrap;gap:3px;margin-top:6px}
+.tag-mode-toggle{display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px;vertical-align:middle}
+.tag-mode-toggle button{font-size:.68rem;padding:2px 8px;border:none;background:transparent;color:var(--text-secondary);cursor:pointer}
+.tag-mode-toggle button.active{background:var(--accent);color:var(--bg-primary)}
+</style>
+{% endblock %}
 
 {% block content %}
 <h1 style="margin-bottom:12px">Session History</h1>
@@ -13,7 +26,7 @@
     <button class="filter-btn" onclick="setType(this,'practice')">Practice</button>
     <button class="filter-btn" onclick="setType(this,'synthesized')">Synth</button>
   </div>
-  <div style="display:flex;gap:8px">
+  <div style="display:flex;gap:8px;margin-bottom:10px">
     <div style="flex:1">
       <div class="label">From</div>
       <input id="from-date" type="date" class="event-input" onchange="load()"/>
@@ -22,6 +35,14 @@
       <div class="label">To</div>
       <input id="to-date" type="date" class="event-input" onchange="load()"/>
     </div>
+  </div>
+  <div id="tag-filter-row" style="display:none">
+    <div class="label" style="display:flex;align-items:center;gap:6px">
+      <span>Tags</span>
+      <span id="tag-mode-wrap" style="display:none"></span>
+      <a href="#" id="tag-clear" style="display:none;font-size:.7rem;color:var(--text-secondary)" onclick="event.preventDefault();clearTagFilter()">clear</a>
+    </div>
+    <div id="tag-filter-chips" class="hist-tag-row-chips"></div>
   </div>
 </div>
 

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -33,6 +33,17 @@
 .mv-badge-gybe{color:var(--warning)}
 .mv-badge-rounding{color:var(--success)}
 .mv-scroll{max-height:calc(100vh - 380px);overflow-y:auto}
+.mv-tag-chip{display:inline-flex;align-items:center;gap:4px;padding:1px 7px;border-radius:10px;font-size:.7rem;border:1px solid var(--border);background:var(--bg-secondary);cursor:pointer;margin-right:3px;margin-bottom:3px;color:var(--text-primary)}
+.mv-tag-chip.active{background:var(--accent);color:var(--bg-primary)}
+.mv-tag-chip-row{cursor:default;padding:0 6px;font-size:.66rem;background:transparent}
+.mv-tag-count{color:var(--text-secondary);font-size:.62rem;margin-left:2px}
+.mv-tag-chip.active .mv-tag-count{color:var(--bg-primary);opacity:.8}
+.mv-tag-swatch{display:inline-block;width:8px;height:8px;border-radius:50%}
+.mv-tag-mode{display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px;vertical-align:middle}
+.mv-tag-mode button{font-size:.68rem;padding:2px 8px;border:none;background:transparent;color:var(--text-secondary);cursor:pointer}
+.mv-tag-mode button.active{background:var(--accent);color:var(--bg-primary)}
+.mv-label{font-size:.72rem;color:var(--text-secondary);margin-right:6px;text-transform:uppercase;letter-spacing:.06em}
+#mv-tag-filter{padding:8px 10px;border-bottom:1px solid var(--border);background:var(--bg-input);display:flex;flex-wrap:wrap;align-items:center;gap:4px}
 </style>
 {% endblock %}
 
@@ -93,6 +104,7 @@
     <span class="spacer"></span>
     <button id="mv-compare-btn" onclick="mvOpenCompare()" disabled>Compare Selected</button>
   </div>
+  <div id="mv-tag-filter" style="display:none"></div>
   <div class="mv-scroll">
     <table class="mv-table" id="mv-table">
       <thead>
@@ -107,6 +119,7 @@
           <th class="mv-num">Duration</th>
           <th>Rank</th>
           <th>Video</th>
+          <th>Tags</th>
         </tr>
       </thead>
       <tbody id="mv-tbody"></tbody>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -37,6 +37,16 @@
 .thread-item:hover{border-color:var(--accent-strong)}
 .thread-item.resolved{opacity:.7}
 .thread-item.thread-active{border-color:var(--accent);background:var(--bg-secondary)}
+.session-tag-filter-row{display:flex;flex-wrap:wrap;gap:4px;align-items:center;margin-bottom:6px;padding:4px 0}
+.session-tag-label{font-size:.68rem;color:var(--text-secondary);text-transform:uppercase;letter-spacing:.06em;margin-right:4px}
+.session-tag-chip{display:inline-flex;align-items:center;gap:4px;padding:1px 7px;border-radius:10px;font-size:.7rem;border:1px solid var(--border);background:var(--bg-secondary);cursor:pointer;color:var(--text-primary)}
+.session-tag-chip.active{background:var(--accent);color:var(--bg-primary)}
+.session-tag-chip .hist-tag-chip-swatch{display:inline-block;width:8px;height:8px;border-radius:50%}
+.session-tag-count{color:var(--text-secondary);font-size:.62rem;margin-left:2px}
+.session-tag-chip.active .session-tag-count{color:var(--bg-primary);opacity:.8}
+.session-tag-mode{display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;vertical-align:middle}
+.session-tag-mode button{font-size:.68rem;padding:2px 8px;border:none;background:transparent;color:var(--text-secondary);cursor:pointer}
+.session-tag-mode button.active{background:var(--accent);color:var(--bg-primary)}
 .thread-anchor{font-size:.7rem;color:var(--warning);margin-left:6px}
 .thread-unread{background:var(--accent-strong);color:var(--bg-primary);font-size:.65rem;padding:1px 5px;border-radius:8px;margin-left:6px}
 .comment-item{padding:6px 0;border-bottom:1px solid var(--border);font-size:.8rem}
@@ -227,6 +237,7 @@
 <div id="bookmarks-card" class="card" style="display:none">
   <div class="section-title" onclick="toggleSection('bookmarks')">Bookmarks <span id="bookmarks-toggle">&#9660;</span></div>
   <div class="section-body" id="bookmarks-body">
+    <div id="bookmarks-tag-filter" class="session-tag-filter-row" style="display:none"></div>
     <ul id="bookmarks-list" style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px"></ul>
     <p id="bookmarks-empty" style="font-size:.78rem;color:var(--text-secondary);margin:0;display:none">No bookmarks on this session yet. Use the &#128278; Bookmark button in the replay controls to add one.</p>
   </div>
@@ -480,14 +491,65 @@ async function dropBookmark() {
   } catch (err) { window.alert(`Create failed: ${err}`); }
 }
 
+// Tag filter state for the Bookmarks card.
+const _bookmarkTagFilter = new Set();
+let _bookmarkTagMode = 'and'; // 'and'|'or'
+let _bookmarkAvailableTags = [];
+
 async function loadBookmarks() {
   try {
-    const resp = await fetch(`/api/sessions/${_sessionId()}/bookmarks`);
+    const params = new URLSearchParams();
+    if (_bookmarkTagFilter.size) {
+      params.set('tags', [...(_bookmarkTagFilter)].join(','));
+      params.set('tag_mode', _bookmarkTagMode);
+    }
+    const qs = params.toString();
+    const url = `/api/sessions/${_sessionId()}/bookmarks` + (qs ? '?' + qs : '');
+    const resp = await fetch(url);
     if (!resp.ok) return;
-    const rows = await resp.json();
-    _renderBookmarks(rows);
+    const data = await resp.json();
+    _bookmarkAvailableTags = data.available_tags || [];
+    _renderBookmarks(data.bookmarks || []);
+    _renderBookmarkTagFilterRow();
   } catch (err) { /* non-fatal */ }
 }
+
+function _renderBookmarkTagFilterRow() {
+  const wrap = document.getElementById('bookmarks-tag-filter');
+  if (!wrap) return;
+  const byId = new Map();
+  for (const t of _bookmarkAvailableTags) {
+    byId.set(t.id, {id: t.id, name: t.name, color: t.color, count: t.count || 0});
+  }
+  for (const tid of _bookmarkTagFilter) {
+    if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
+  }
+  if (byId.size === 0) { wrap.style.display = 'none'; return; }
+  wrap.style.display = '';
+  const sorted = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const chips = sorted.map(t => {
+    const active = _bookmarkTagFilter.has(t.id);
+    const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
+    return `<span class="session-tag-chip${active ? ' active' : ''}" onclick="_toggleBookmarkTagFilter(${t.id})">${swatch}${esc(t.name)} <span class="session-tag-count">(${t.count})</span></span>`;
+  }).join('');
+  const dim = _bookmarkTagFilter.size < 2 ? ';opacity:.6' : '';
+  const modeToggle = `<span class="session-tag-mode" style="margin-left:6px${dim}">`
+    + `<button class="${_bookmarkTagMode === 'and' ? 'active' : ''}" onclick="_setBookmarkTagMode('and')" title="Require every selected tag">all</button>`
+    + `<button class="${_bookmarkTagMode === 'or' ? 'active' : ''}" onclick="_setBookmarkTagMode('or')" title="Match any selected tag">any</button>`
+    + '</span>';
+  const clear = _bookmarkTagFilter.size
+    ? '<a href="#" onclick="event.preventDefault();_clearBookmarkTagFilter()" style="font-size:.7rem;color:var(--text-secondary);margin-left:6px">clear</a>'
+    : '';
+  wrap.innerHTML = '<span class="session-tag-label">Tags</span>' + chips + modeToggle + clear;
+}
+
+function _toggleBookmarkTagFilter(id) {
+  if (_bookmarkTagFilter.has(id)) _bookmarkTagFilter.delete(id);
+  else _bookmarkTagFilter.add(id);
+  loadBookmarks();
+}
+function _setBookmarkTagMode(m) { _bookmarkTagMode = m; loadBookmarks(); }
+function _clearBookmarkTagFilter() { _bookmarkTagFilter.clear(); loadBookmarks(); }
 
 function _renderBookmarks(rows) {
   const card = document.getElementById('bookmarks-card');
@@ -497,7 +559,10 @@ function _renderBookmarks(rows) {
   card.style.display = '';
   list.innerHTML = '';
   if (!rows || rows.length === 0) {
-    empty.style.display = '';
+    empty.style.display = _bookmarkTagFilter.size ? 'none' : '';
+    if (_bookmarkTagFilter.size) {
+      list.innerHTML = '<li style="list-style:none;padding:8px;color:var(--text-secondary);font-size:.78rem">No bookmarks match the current tag filter.</li>';
+    }
     return;
   }
   empty.style.display = 'none';
@@ -544,11 +609,29 @@ function _renderBookmarks(rows) {
     mainRow.appendChild(renameBtn);
     mainRow.appendChild(delBtn);
 
+    // Inline tag chip strip shown below the main row when tags are attached,
+    // so users can see the tags at a glance without expanding the picker.
+    const chipStrip = document.createElement('div');
+    chipStrip.style.cssText = 'display:flex;flex-wrap:wrap;gap:3px;padding-left:72px';
+    const tags = Array.isArray(bm.tags) ? bm.tags : [];
+    if (tags.length) {
+      chipStrip.innerHTML = tags.map(t => {
+        const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
+        const name = (t.name || '').replace(/</g, '&lt;');
+        return `<span class="session-tag-chip" style="cursor:default;font-size:.66rem">${swatch}${name}</span>`;
+      }).join('');
+    } else {
+      chipStrip.style.display = 'none';
+    }
+
     const tagRow = document.createElement('div');
     tagRow.style.cssText = 'display:none;padding-left:72px';
     const picker = document.createElement('tag-picker');
     picker.setAttribute('entity-type', 'bookmark');
     picker.setAttribute('entity-id', String(bm.id));
+    // When the user attaches/detaches from the expanded picker, refresh
+    // the list so the inline chip strip + filter row pick up the change.
+    picker.addEventListener('change', () => { loadBookmarks(); });
     tagRow.appendChild(picker);
 
     tagBtn.onclick = () => {
@@ -556,6 +639,7 @@ function _renderBookmarks(rows) {
     };
 
     li.appendChild(mainRow);
+    if (tags.length) li.appendChild(chipStrip);
     li.appendChild(tagRow);
     list.appendChild(li);
   }

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -102,6 +102,10 @@
     </button>
     {% endif %}
   </div>
+  <div id="session-tags-row" style="margin-top:8px">
+    <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Tags</div>
+    <tag-picker entity-type="session" entity-id="{{ session_id }}"></tag-picker>
+  </div>
 </div>
 
 <div id="track-container" class="card" style="display:none">
@@ -408,6 +412,7 @@
 {% block scripts %}
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/tag-chip.js?v={{ git_sha }}"></script>
+<script src="/static/tag-picker.js?v={{ git_sha }}"></script>
 <script src="/static/anchor-picker.js?v={{ git_sha }}"></script>
 <script src="/static/session.js?v={{ git_sha }}"></script>
 <script>
@@ -498,7 +503,10 @@ function _renderBookmarks(rows) {
   empty.style.display = 'none';
   for (const bm of rows) {
     const li = document.createElement('li');
-    li.style.cssText = 'display:flex;align-items:center;gap:8px;padding:6px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px';
+    li.style.cssText = 'display:flex;flex-direction:column;gap:4px;padding:6px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px';
+
+    const mainRow = document.createElement('div');
+    mainRow.style.cssText = 'display:flex;align-items:center;gap:8px';
     const timeLabel = document.createElement('span');
     timeLabel.style.cssText = 'font-family:monospace;font-size:.72rem;color:var(--text-secondary);min-width:64px';
     timeLabel.textContent = _fmtBookmarkTime(bm.t_start);
@@ -512,6 +520,11 @@ function _renderBookmarks(rows) {
       noteEl.style.cssText = 'font-size:.72rem;color:var(--text-secondary);flex:2';
       noteEl.textContent = bm.note;
     }
+    const tagBtn = document.createElement('button');
+    tagBtn.type = 'button';
+    tagBtn.title = 'Tags';
+    tagBtn.style.cssText = 'background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:2px 4px';
+    tagBtn.innerHTML = '&#127991;';
     const renameBtn = document.createElement('button');
     renameBtn.type = 'button';
     renameBtn.title = 'Rename';
@@ -524,11 +537,26 @@ function _renderBookmarks(rows) {
     delBtn.style.cssText = 'background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:2px 4px';
     delBtn.innerHTML = '&#128465;';
     delBtn.onclick = () => deleteBookmark(bm.id);
-    li.appendChild(timeLabel);
-    li.appendChild(title);
-    if (bm.note) li.appendChild(noteEl);
-    li.appendChild(renameBtn);
-    li.appendChild(delBtn);
+    mainRow.appendChild(timeLabel);
+    mainRow.appendChild(title);
+    if (bm.note) mainRow.appendChild(noteEl);
+    mainRow.appendChild(tagBtn);
+    mainRow.appendChild(renameBtn);
+    mainRow.appendChild(delBtn);
+
+    const tagRow = document.createElement('div');
+    tagRow.style.cssText = 'display:none;padding-left:72px';
+    const picker = document.createElement('tag-picker');
+    picker.setAttribute('entity-type', 'bookmark');
+    picker.setAttribute('entity-id', String(bm.id));
+    tagRow.appendChild(picker);
+
+    tagBtn.onclick = () => {
+      tagRow.style.display = tagRow.style.display === 'none' ? '' : 'none';
+    };
+
+    li.appendChild(mainRow);
+    li.appendChild(tagRow);
     list.appendChild(li);
   }
 }

--- a/src/helmlog/triggers.py
+++ b/src/helmlog/triggers.py
@@ -186,9 +186,9 @@ async def scan_transcript(
 
         # Tag the note
         tag_id = await storage.get_or_create_tag(m.rule.tag, _tag_color(m.rule.tag))
-        await storage.add_note_tag(note_id, tag_id)
+        await storage.attach_tag("session_note", note_id, tag_id, user_id=None)
         auto_tag_id = await storage.get_or_create_tag("auto-detected", "#eab308")
-        await storage.add_note_tag(note_id, auto_tag_id)
+        await storage.attach_tag("session_note", note_id, auto_tag_id, user_id=None)
 
         logger.info(
             "Auto-note created: {} at {} (audio_session={})",
@@ -217,8 +217,9 @@ async def _check_existing_note(
     db = storage._conn()
     cur = await db.execute(
         "SELECT sn.id FROM session_notes sn"
-        " JOIN note_tags nt ON sn.id = nt.note_id"
-        " JOIN tags t ON nt.tag_id = t.id"
+        " JOIN entity_tags et"
+        "   ON et.entity_type = 'session_note' AND et.entity_id = sn.id"
+        " JOIN tags t ON et.tag_id = t.id"
         " WHERE t.name = 'auto-detected'"
         " AND sn.ts BETWEEN ? AND ?"
         " AND (sn.race_id = ? OR sn.audio_session_id = ?)"

--- a/tests/test_bookmarks_api.py
+++ b/tests/test_bookmarks_api.py
@@ -137,7 +137,7 @@ async def test_list_bookmarks_returns_in_time_order(storage: Storage) -> None:
         )
         resp = await client.get(f"/api/sessions/{sid}/bookmarks")
         assert resp.status_code == 200
-        names = [b["name"] for b in resp.json()]
+        names = [b["name"] for b in resp.json()["bookmarks"]]
         assert names == ["early", "late"]
 
 
@@ -219,7 +219,7 @@ async def test_delete_bookmark_as_admin_mock(storage: Storage) -> None:
         assert resp.status_code == 204
 
         resp = await client.get(f"/api/sessions/{sid}/bookmarks")
-        assert resp.json() == []
+        assert resp.json()["bookmarks"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_migration_v71.py
+++ b/tests/test_migration_v71.py
@@ -177,17 +177,18 @@ async def test_v71_preserves_anchor_backfill_from_v70() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_71_on_fresh_db() -> None:
-    """Using the real Storage class (all migrations) — schema version is 71."""
+async def test_v71_migration_applied_on_fresh_db() -> None:
+    """Confirm v71 is in the applied migration set regardless of newer versions."""
     from helmlog.storage import Storage, StorageConfig
 
     s = Storage(StorageConfig(db_path=":memory:"))
     await s.connect()
     try:
         assert s._db is not None
-        async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+        async with s._db.execute(
+            "SELECT 1 FROM schema_version WHERE version = 71"
+        ) as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == 71
     finally:
         await s.close()

--- a/tests/test_migration_v72.py
+++ b/tests/test_migration_v72.py
@@ -1,0 +1,176 @@
+"""Tests for migration v72 — entity_tags cutover for #587 / slice 3.
+
+v72:
+- Copies rows from `session_tags` to `entity_tags` with entity_type='session'.
+- Copies rows from `note_tags` to `entity_tags` with entity_type='session_note'.
+- Backfills `tags.usage_count` and `tags.last_used_at` from the combined rows.
+- Drops `session_tags` and `note_tags` tables.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+_T0 = "2024-06-15T12:00:00+00:00"
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+async def _seed_session(db: aiosqlite.Connection, idx: int = 1) -> int:
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"s{idx}", "E", idx, "2024-06-15", _T0),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+async def _seed_note(db: aiosqlite.Connection, sid: int) -> int:
+    cur = await db.execute(
+        "INSERT INTO session_notes (race_id, ts, note_type, body, created_at) "
+        "VALUES (?, ?, 'freeform', 'note', ?)",
+        (sid, _T0, _T0),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+async def _seed_tag(db: aiosqlite.Connection, name: str) -> int:
+    cur = await db.execute("INSERT INTO tags (name, created_at) VALUES (?, ?)", (name, _T0))
+    await db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+@pytest.mark.asyncio
+async def test_v72_drops_legacy_tag_join_tables() -> None:
+    db = await _build_db_at(71)
+    try:
+        await _apply_migration(db, 72)
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('session_tags', 'note_tags')"
+        ) as cur:
+            rows = await cur.fetchall()
+        assert rows == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v72_migrates_session_tags_to_entity_tags() -> None:
+    db = await _build_db_at(71)
+    try:
+        sid = await _seed_session(db)
+        tid = await _seed_tag(db, "weather")
+        await db.execute("INSERT INTO session_tags (session_id, tag_id) VALUES (?, ?)", (sid, tid))
+        await db.commit()
+
+        await _apply_migration(db, 72)
+
+        async with db.execute("SELECT entity_type, entity_id, tag_id FROM entity_tags") as cur:
+            rows = [dict(r) for r in await cur.fetchall()]
+        assert rows == [{"entity_type": "session", "entity_id": sid, "tag_id": tid}]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v72_migrates_note_tags_to_entity_tags() -> None:
+    db = await _build_db_at(71)
+    try:
+        sid = await _seed_session(db)
+        nid = await _seed_note(db, sid)
+        tid = await _seed_tag(db, "debrief")
+        await db.execute("INSERT INTO note_tags (note_id, tag_id) VALUES (?, ?)", (nid, tid))
+        await db.commit()
+
+        await _apply_migration(db, 72)
+
+        async with db.execute("SELECT entity_type, entity_id, tag_id FROM entity_tags") as cur:
+            rows = [dict(r) for r in await cur.fetchall()]
+        assert rows == [{"entity_type": "session_note", "entity_id": nid, "tag_id": tid}]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v72_backfills_tag_usage_count() -> None:
+    db = await _build_db_at(71)
+    try:
+        sid1 = await _seed_session(db, 1)
+        sid2 = await _seed_session(db, 2)
+        nid = await _seed_note(db, sid1)
+        tid = await _seed_tag(db, "hot")
+        await db.execute("INSERT INTO session_tags (session_id, tag_id) VALUES (?, ?)", (sid1, tid))
+        await db.execute("INSERT INTO session_tags (session_id, tag_id) VALUES (?, ?)", (sid2, tid))
+        await db.execute("INSERT INTO note_tags (note_id, tag_id) VALUES (?, ?)", (nid, tid))
+        await db.commit()
+
+        await _apply_migration(db, 72)
+
+        async with db.execute("SELECT usage_count FROM tags WHERE id=?", (tid,)) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["usage_count"] == 3
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v72_leaves_untagged_tag_with_usage_zero() -> None:
+    db = await _build_db_at(71)
+    try:
+        _unused = await _seed_tag(db, "dormant")
+        await _apply_migration(db, 72)
+        async with db.execute("SELECT usage_count FROM tags WHERE name='dormant'") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["usage_count"] == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_version_is_72_on_fresh_db() -> None:
+    from helmlog.storage import Storage, StorageConfig
+
+    s = Storage(StorageConfig(db_path=":memory:"))
+    await s.connect()
+    try:
+        assert s._db is not None
+        async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 72
+    finally:
+        await s.close()

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -83,17 +83,17 @@ async def test_session_tags(storage: Storage) -> None:
     now = datetime.now(UTC)
     race = await storage.start_race("Test", now, now.date().isoformat(), 1, "Test Race 1", "race")
     tag_id = await storage.create_tag("windy")
-    await storage.add_session_tag(race.id, tag_id)
-    tags = await storage.get_session_tags(race.id)
+    await storage.attach_tag("session", race.id, tag_id, user_id=None)
+    tags = await storage.list_tags_for_entity("session", race.id)
     assert len(tags) == 1
     assert tags[0]["name"] == "windy"
 
     # Idempotent
-    await storage.add_session_tag(race.id, tag_id)
-    assert len(await storage.get_session_tags(race.id)) == 1
+    await storage.attach_tag("session", race.id, tag_id, user_id=None)
+    assert len(await storage.list_tags_for_entity("session", race.id)) == 1
 
-    await storage.remove_session_tag(race.id, tag_id)
-    assert len(await storage.get_session_tags(race.id)) == 0
+    await storage.detach_tag("session", race.id, tag_id)
+    assert len(await storage.list_tags_for_entity("session", race.id)) == 0
 
 
 @pytest.mark.asyncio
@@ -102,13 +102,13 @@ async def test_note_tags(storage: Storage) -> None:
     race = await storage.start_race("Test", now, now.date().isoformat(), 1, "Test Race 1", "race")
     note_id = await storage.create_note(now.isoformat(), "test note", race_id=race.id)
     tag_id = await storage.create_tag("protest", "#e53e3e")
-    await storage.add_note_tag(note_id, tag_id)
-    tags = await storage.get_note_tags(note_id)
+    await storage.attach_tag("session_note", note_id, tag_id, user_id=None)
+    tags = await storage.list_tags_for_entity("session_note", note_id)
     assert len(tags) == 1
     assert tags[0]["name"] == "protest"
 
-    await storage.remove_note_tag(note_id, tag_id)
-    assert len(await storage.get_note_tags(note_id)) == 0
+    await storage.detach_tag("session_note", note_id, tag_id)
+    assert len(await storage.list_tags_for_entity("session_note", note_id)) == 0
 
 
 @pytest.mark.asyncio
@@ -126,10 +126,12 @@ async def test_delete_tag(storage: Storage) -> None:
     tag_id = await storage.create_tag("temp")
     now = datetime.now(UTC)
     race = await storage.start_race("T", now, now.date().isoformat(), 1, "T R1", "race")
-    await storage.add_session_tag(race.id, tag_id)
+    await storage.attach_tag("session", race.id, tag_id, user_id=None)
+    assert storage._db is not None
+    await storage._db.execute("PRAGMA foreign_keys = ON")
     found = await storage.delete_tag(tag_id)
     assert found is True
-    assert len(await storage.get_session_tags(race.id)) == 0
+    assert len(await storage.list_tags_for_entity("session", race.id)) == 0
     assert await storage.get_tag_by_name("temp") is None
 
 
@@ -139,12 +141,12 @@ async def test_tag_usage_counts(storage: Storage) -> None:
     now = datetime.now(UTC)
     race = await storage.start_race("T", now, now.date().isoformat(), 1, "T R1", "race")
     note_id = await storage.create_note(now.isoformat(), "test", race_id=race.id)
-    await storage.add_session_tag(race.id, tag_id)
-    await storage.add_note_tag(note_id, tag_id)
+    await storage.attach_tag("session", race.id, tag_id, user_id=None)
+    await storage.attach_tag("session_note", note_id, tag_id, user_id=None)
     tags = await storage.list_tags()
     t = next(t for t in tags if t["id"] == tag_id)
-    assert t["session_count"] == 1
-    assert t["note_count"] == 1
+    # Combined across entity types
+    assert t["usage_count"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +187,7 @@ async def test_trigger_scan_creates_notes(storage: Storage) -> None:
     assert len(auto_notes) == 1
 
     # Verify tags
-    note_tags = await storage.get_note_tags(auto_notes[0]["id"])
+    note_tags = await storage.list_tags_for_entity("session_note", auto_notes[0]["id"])
     tag_names = {t["name"] for t in note_tags}
     assert "protest" in tag_names
     assert "auto-detected" in tag_names

--- a/tests/test_storage_bookmarks.py
+++ b/tests/test_storage_bookmarks.py
@@ -63,9 +63,7 @@ async def _create_user(s: Storage, email: str = "a@example.com") -> int:
 async def test_bookmarks_migration_applied(storage: Storage) -> None:
     """Slice-1 migration (v70) lives in the applied set regardless of newer versions."""
     assert storage._db is not None
-    async with storage._db.execute(
-        "SELECT 1 FROM schema_version WHERE version = 70"
-    ) as cur:
+    async with storage._db.execute("SELECT 1 FROM schema_version WHERE version = 70") as cur:
         row = await cur.fetchone()
     assert row is not None
 

--- a/tests/test_storage_entity_tags.py
+++ b/tests/test_storage_entity_tags.py
@@ -1,0 +1,344 @@
+"""Tests for the generic entity-tag storage API (#587).
+
+Covers:
+- attach_tag / detach_tag / list_tags_for_entity
+- list_tags(order_by='name'|'usage')
+- list_entities_with_tags — decision table 2 from the /spec
+- merge_tags
+- ENTITY_TYPES validation
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.storage import ENTITY_TYPES
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+_T0 = "2024-06-15T12:00:00+00:00"
+
+
+async def _session(s: Storage, idx: int = 1) -> int:
+    now = datetime.now(UTC).isoformat()
+    assert s._db is not None
+    cur = await s._db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"s{idx}", "E", idx, "2024-06-15", now),
+    )
+    await s._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# ENTITY_TYPES validation
+# ---------------------------------------------------------------------------
+
+
+def test_entity_types_constant() -> None:
+    assert frozenset({"session", "maneuver", "thread", "bookmark", "session_note"}) == ENTITY_TYPES
+
+
+@pytest.mark.asyncio
+async def test_attach_rejects_unknown_entity_type(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("weather")
+    with pytest.raises(ValueError, match="entity_type"):
+        await storage.attach_tag("bogus", sid, tid, user_id=None)
+
+
+# ---------------------------------------------------------------------------
+# attach / detach / list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_then_list(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("weather")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+
+    tags = await storage.list_tags_for_entity("session", sid)
+    assert len(tags) == 1
+    assert tags[0]["id"] == tid
+    assert tags[0]["name"] == "weather"
+
+
+@pytest.mark.asyncio
+async def test_attach_is_idempotent(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("weather")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    tags = await storage.list_tags_for_entity("session", sid)
+    assert len(tags) == 1
+
+
+@pytest.mark.asyncio
+async def test_detach(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("weather")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    changed = await storage.detach_tag("session", sid, tid)
+    assert changed is True
+    assert await storage.list_tags_for_entity("session", sid) == []
+
+
+@pytest.mark.asyncio
+async def test_detach_missing_returns_false(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("nope")
+    assert await storage.detach_tag("session", sid, tid) is False
+
+
+# ---------------------------------------------------------------------------
+# usage_count / last_used_at maintenance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_increments_usage_count(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    tid = await storage.create_tag("hot")
+
+    await storage.attach_tag("session", sid_a, tid, user_id=None)
+    await storage.attach_tag("session", sid_b, tid, user_id=None)
+
+    assert storage._db is not None
+    async with storage._db.execute(
+        "SELECT usage_count, last_used_at FROM tags WHERE id=?", (tid,)
+    ) as cur:
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["usage_count"] == 2
+    assert row["last_used_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_detach_decrements_usage_count(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("hot")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    await storage.detach_tag("session", sid, tid)
+
+    assert storage._db is not None
+    async with storage._db.execute("SELECT usage_count FROM tags WHERE id=?", (tid,)) as cur:
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["usage_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_attach_idempotent_does_not_double_count(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("hot")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    await storage.attach_tag("session", sid, tid, user_id=None)
+
+    assert storage._db is not None
+    async with storage._db.execute("SELECT usage_count FROM tags WHERE id=?", (tid,)) as cur:
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["usage_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# list_tags ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tags_order_by_name(storage: Storage) -> None:
+    await storage.create_tag("zebra")
+    await storage.create_tag("alpha")
+    await storage.create_tag("mongoose")
+    names = [t["name"] for t in await storage.list_tags(order_by="name")]
+    assert names == ["alpha", "mongoose", "zebra"]
+
+
+@pytest.mark.asyncio
+async def test_list_tags_order_by_usage(storage: Storage) -> None:
+    sid = await _session(storage)
+    t_hot = await storage.create_tag("hot")
+    await storage.create_tag("cold")
+    t_warm = await storage.create_tag("warm")
+
+    await storage.attach_tag("session", sid, t_hot, user_id=None)
+    await storage.attach_tag("session", sid, t_warm, user_id=None)
+    sid2 = await _session(storage, 2)
+    await storage.attach_tag("session", sid2, t_hot, user_id=None)
+
+    names = [t["name"] for t in await storage.list_tags(order_by="usage")]
+    # hot (2) comes first, warm (1), cold (0)
+    assert names[:2] == ["hot", "warm"]
+    assert names[-1] == "cold"
+
+
+# ---------------------------------------------------------------------------
+# list_entities_with_tags — decision table 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_empty_returns_all(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    result = await storage.list_entities_with_tags("session", [], mode="and")
+    assert set(result) == {sid_a, sid_b}
+
+
+@pytest.mark.asyncio
+async def test_filter_single_tag(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    tid = await storage.create_tag("x")
+    await storage.attach_tag("session", sid_a, tid, user_id=None)
+    result = await storage.list_entities_with_tags("session", [tid], mode="and")
+    assert result == [sid_a]
+    assert sid_b not in result
+
+
+@pytest.mark.asyncio
+async def test_filter_and_requires_all_tags(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    t1 = await storage.create_tag("t1")
+    t2 = await storage.create_tag("t2")
+    await storage.attach_tag("session", sid_a, t1, user_id=None)
+    await storage.attach_tag("session", sid_a, t2, user_id=None)
+    await storage.attach_tag("session", sid_b, t1, user_id=None)
+    # sid_b has t1 only
+    result = await storage.list_entities_with_tags("session", [t1, t2], mode="and")
+    assert result == [sid_a]
+
+
+@pytest.mark.asyncio
+async def test_filter_or_matches_any(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    sid_c = await _session(storage, 3)
+    t1 = await storage.create_tag("t1")
+    t2 = await storage.create_tag("t2")
+    await storage.attach_tag("session", sid_a, t1, user_id=None)
+    await storage.attach_tag("session", sid_b, t2, user_id=None)
+    result = await storage.list_entities_with_tags("session", [t1, t2], mode="or")
+    assert set(result) == {sid_a, sid_b}
+    assert sid_c not in result
+
+
+@pytest.mark.asyncio
+async def test_filter_silently_drops_unknown_tag_ids(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("t")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    # 9999 doesn't exist — should behave as if only [tid] was passed
+    result = await storage.list_entities_with_tags("session", [tid, 9999], mode="and")
+    # AND with a missing tag: entity must have the missing tag too → no match
+    # Per spec: "silently dropped" → behave as [tid] only → entity matches
+    assert result == [sid]
+
+
+@pytest.mark.asyncio
+async def test_filter_invalid_mode_raises(storage: Storage) -> None:
+    with pytest.raises(ValueError, match="mode"):
+        await storage.list_entities_with_tags("session", [1], mode="xor")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# merge_tags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_moves_entities_to_target(storage: Storage) -> None:
+    sid = await _session(storage)
+    src = await storage.create_tag("src")
+    tgt = await storage.create_tag("tgt")
+    await storage.attach_tag("session", sid, src, user_id=None)
+
+    await storage.merge_tags(src, tgt)
+
+    assert await storage.list_tags_for_entity("session", sid) == [
+        {"id": tgt, "name": "tgt", "color": None}
+    ]
+    assert storage._db is not None
+    async with storage._db.execute("SELECT id FROM tags WHERE id=?", (src,)) as cur:
+        row = await cur.fetchone()
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_merge_deduplicates_when_entity_has_both(storage: Storage) -> None:
+    sid = await _session(storage)
+    src = await storage.create_tag("src")
+    tgt = await storage.create_tag("tgt")
+    await storage.attach_tag("session", sid, src, user_id=None)
+    await storage.attach_tag("session", sid, tgt, user_id=None)
+
+    await storage.merge_tags(src, tgt)
+
+    tags = await storage.list_tags_for_entity("session", sid)
+    assert len(tags) == 1
+    assert tags[0]["id"] == tgt
+
+
+@pytest.mark.asyncio
+async def test_merge_recomputes_usage_count(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    src = await storage.create_tag("src")
+    tgt = await storage.create_tag("tgt")
+    await storage.attach_tag("session", sid_a, src, user_id=None)
+    await storage.attach_tag("session", sid_b, tgt, user_id=None)
+
+    await storage.merge_tags(src, tgt)
+
+    assert storage._db is not None
+    async with storage._db.execute("SELECT usage_count FROM tags WHERE id=?", (tgt,)) as cur:
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["usage_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_merge_rejects_same_tag(storage: Storage) -> None:
+    tid = await storage.create_tag("same")
+    with pytest.raises(ValueError, match="itself"):
+        await storage.merge_tags(tid, tid)
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_source_raises(storage: Storage) -> None:
+    tgt = await storage.create_tag("tgt")
+    with pytest.raises(ValueError, match="source"):
+        await storage.merge_tags(9999, tgt)
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_target_raises(storage: Storage) -> None:
+    src = await storage.create_tag("src")
+    with pytest.raises(ValueError, match="target"):
+        await storage.merge_tags(src, 9999)
+
+
+# ---------------------------------------------------------------------------
+# delete_tag cascades via entity_tags FK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_cascades(storage: Storage) -> None:
+    sid = await _session(storage)
+    tid = await storage.create_tag("doomed")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    assert storage._db is not None
+    await storage._db.execute("PRAGMA foreign_keys = ON")
+
+    assert await storage.delete_tag(tid) is True
+    assert await storage.list_tags_for_entity("session", sid) == []

--- a/tests/test_storage_entity_tags.py
+++ b/tests/test_storage_entity_tags.py
@@ -332,6 +332,123 @@ async def test_merge_missing_target_raises(storage: Storage) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _maneuver(s: Storage, sid: int) -> int:
+    assert s._db is not None
+    cur = await s._db.execute(
+        "INSERT INTO maneuvers (session_id, type, ts) VALUES (?, 'tack', ?)",
+        (sid, _T0),
+    )
+    await s._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# sessions_matching_tags — broad filter across session + maneuver/bookmark/thread
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sessions_matching_tags_via_session_tag(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    tid = await storage.create_tag("x")
+    await storage.attach_tag("session", sid_a, tid, user_id=None)
+    result = await storage.sessions_matching_tags([tid], mode="and")
+    assert result == [sid_a]
+    assert sid_b not in result
+
+
+@pytest.mark.asyncio
+async def test_sessions_matching_tags_via_maneuver(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    mid = await _maneuver(storage, sid_a)
+    tid = await storage.create_tag("x")
+    await storage.attach_tag("maneuver", mid, tid, user_id=None)
+    result = await storage.sessions_matching_tags([tid], mode="and")
+    assert result == [sid_a]
+    assert sid_b not in result
+
+
+@pytest.mark.asyncio
+async def test_sessions_matching_tags_via_bookmark(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    bid = await storage.create_bookmark(
+        session_id=sid_a, user_id=None, name="b", note=None, t_start=_T0
+    )
+    tid = await storage.create_tag("x")
+    await storage.attach_tag("bookmark", bid, tid, user_id=None)
+    result = await storage.sessions_matching_tags([tid], mode="and")
+    assert result == [sid_a]
+    assert sid_b not in result
+
+
+@pytest.mark.asyncio
+async def test_sessions_matching_tags_and_requires_all(storage: Storage) -> None:
+    """AND semantics: every tag must appear somewhere under the session."""
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    mid = await _maneuver(storage, sid_a)
+    t1 = await storage.create_tag("t1")
+    t2 = await storage.create_tag("t2")
+    # Session A: t1 on the session, t2 on its maneuver → has both
+    await storage.attach_tag("session", sid_a, t1, user_id=None)
+    await storage.attach_tag("maneuver", mid, t2, user_id=None)
+    # Session B: only t1
+    await storage.attach_tag("session", sid_b, t1, user_id=None)
+    result = await storage.sessions_matching_tags([t1, t2], mode="and")
+    assert result == [sid_a]
+
+
+@pytest.mark.asyncio
+async def test_sessions_matching_tags_or_matches_any(storage: Storage) -> None:
+    sid_a = await _session(storage, 1)
+    sid_b = await _session(storage, 2)
+    sid_c = await _session(storage, 3)
+    t1 = await storage.create_tag("t1")
+    t2 = await storage.create_tag("t2")
+    await storage.attach_tag("session", sid_a, t1, user_id=None)
+    await storage.attach_tag("session", sid_b, t2, user_id=None)
+    result = await storage.sessions_matching_tags([t1, t2], mode="or")
+    assert set(result) == {sid_a, sid_b}
+    assert sid_c not in result
+
+
+# ---------------------------------------------------------------------------
+# list_session_tag_summary — grouped tag rows per session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_tag_summary_groups_by_entity_type(storage: Storage) -> None:
+    sid = await _session(storage, 1)
+    mid1 = await _maneuver(storage, sid)
+    mid2 = await _maneuver(storage, sid)
+    bid = await storage.create_bookmark(
+        session_id=sid, user_id=None, name="b", note=None, t_start=_T0
+    )
+    tid = await storage.create_tag("weather")
+    await storage.attach_tag("session", sid, tid, user_id=None)
+    await storage.attach_tag("maneuver", mid1, tid, user_id=None)
+    await storage.attach_tag("maneuver", mid2, tid, user_id=None)
+    await storage.attach_tag("bookmark", bid, tid, user_id=None)
+
+    summary = await storage.list_session_tag_summary([sid])
+    rows = summary[sid]
+    by_et = {r["entity_type"]: r["count"] for r in rows}
+    assert by_et == {"session": 1, "maneuver": 2, "bookmark": 1}
+
+
+@pytest.mark.asyncio
+async def test_session_tag_summary_empty_for_untagged_session(
+    storage: Storage,
+) -> None:
+    sid = await _session(storage, 1)
+    assert await storage.list_session_tag_summary([sid]) == {sid: []}
+
+
 @pytest.mark.asyncio
 async def test_delete_tag_cascades(storage: Storage) -> None:
     sid = await _session(storage)

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -314,12 +314,12 @@ async def test_bookmark_list_filters_by_tags_and(storage: Storage) -> None:
 
         # AND: only b1 has both
         resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags={t_red},{t_hot}")
-        ids = [b["id"] for b in resp.json()]
+        ids = [b["id"] for b in resp.json()["bookmarks"]]
         assert ids == [b1]
 
         # OR: both b1 and b2 carry red
         resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags={t_red},{t_hot}&tag_mode=or")
-        ids = sorted(b["id"] for b in resp.json())
+        ids = sorted(b["id"] for b in resp.json()["bookmarks"])
         assert ids == sorted([b1, b2])
 
 
@@ -336,7 +336,7 @@ async def test_thread_list_filters_by_tags(storage: Storage) -> None:
         await client.post(f"/api/entities/thread/{t1}/tags", json={"tag_id": tag})
 
         resp = await client.get(f"/api/sessions/{sid}/threads?tags={tag}")
-        ids = [t["id"] for t in resp.json()]
+        ids = [t["id"] for t in resp.json()["threads"]]
         assert ids == [t1]
         assert t2 not in ids
 

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -1,0 +1,381 @@
+"""API tests for the tag routes (#587)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+import helmlog.auth as auth_module
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _make_session(client: httpx.AsyncClient) -> int:
+    await client.post("/api/event", json={"event_name": "TagTest"})
+    resp = await client.post("/api/races/start")
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+async def _seed_session_direct(storage: Storage, idx: int = 1) -> int:
+    now = datetime.now(UTC).isoformat()
+    assert storage._db is not None
+    cur = await storage._db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"tag-{idx}", "E", idx, "2024-06-15", now),
+    )
+    await storage._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+def _viewer(user_id: int = 1) -> dict[str, Any]:
+    return {
+        "id": user_id,
+        "email": f"u{user_id}@e.com",
+        "name": f"u{user_id}",
+        "role": "viewer",
+        "is_developer": 0,
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "last_seen": None,
+        "is_active": 1,
+    }
+
+
+async def _seed_user(storage: Storage, user_id: int) -> None:
+    assert storage._db is not None
+    await storage._db.execute(
+        "INSERT OR IGNORE INTO users (id, email, role, created_at) "
+        "VALUES (?, ?, 'viewer', '2024-01-01T00:00:00+00:00')",
+        (user_id, f"u{user_id}@e.com"),
+    )
+    await storage._db.commit()
+
+
+# ---------------------------------------------------------------------------
+# /api/tags CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_tag(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/tags", json={"name": "weather"})
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "weather"
+
+        resp = await client.get("/api/tags")
+        assert resp.status_code == 200
+        names = [t["name"] for t in resp.json()]
+        assert "weather" in names
+
+
+@pytest.mark.asyncio
+async def test_create_tag_rejects_blank_name(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/tags", json={"name": "   "})
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_tag_rejects_duplicate(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.post("/api/tags", json={"name": "dupe"})
+        resp = await client.post("/api/tags", json={"name": "dupe"})
+        assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_list_tags_by_usage(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        hot = (await client.post("/api/tags", json={"name": "hot"})).json()["id"]
+        cold = (await client.post("/api/tags", json={"name": "cold"})).json()["id"]
+        warm = (await client.post("/api/tags", json={"name": "warm"})).json()["id"]
+        await client.post(f"/api/entities/session/{sid}/tags", json={"tag_id": hot})
+        await client.post(f"/api/entities/session/{sid}/tags", json={"tag_id": warm})
+        sid2 = await _seed_session_direct(storage, 2)
+        await client.post(f"/api/entities/session/{sid2}/tags", json={"tag_id": hot})
+
+        resp = await client.get("/api/tags?order_by=usage")
+        names = [t["name"] for t in resp.json()]
+        assert names[0] == "hot"
+        # warm (1) ranks above cold (0)
+        assert names.index("warm") < names.index("cold")
+        # cold has zero usage
+        cold_entry = next(t for t in resp.json() if t["id"] == cold)
+        assert cold_entry["usage_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_tags_invalid_order_by(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/tags?order_by=bogus")
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_tag_requires_admin(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    await _seed_user(storage, 1)
+    monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _viewer(1))
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/tags", json={"name": "renameme"})
+        tag_id = resp.json()["id"]
+
+        resp = await client.patch(f"/api/tags/{tag_id}", json={"name": "renamed"})
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_tag_admin_ok(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/tags", json={"name": "orig"})
+        tag_id = resp.json()["id"]
+        resp = await client.patch(f"/api/tags/{tag_id}", json={"name": "updated"})
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_requires_admin(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    await _seed_user(storage, 1)
+    monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _viewer(1))
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/tags", json={"name": "doomed"})
+        tag_id = resp.json()["id"]
+        resp = await client.delete(f"/api/tags/{tag_id}")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_tags_admin_ok(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        src = (await client.post("/api/tags", json={"name": "src"})).json()["id"]
+        tgt = (await client.post("/api/tags", json={"name": "tgt"})).json()["id"]
+        await client.post(f"/api/entities/session/{sid}/tags", json={"tag_id": src})
+
+        resp = await client.post(f"/api/tags/{src}/merge-into/{tgt}")
+        assert resp.status_code == 200
+
+        entity_tags = await client.get(f"/api/entities/session/{sid}/tags")
+        ids = [t["id"] for t in entity_tags.json()]
+        assert tgt in ids
+        assert src not in ids
+
+
+@pytest.mark.asyncio
+async def test_merge_tags_rejects_self(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        tid = (await client.post("/api/tags", json={"name": "same"})).json()["id"]
+        resp = await client.post(f"/api/tags/{tid}/merge-into/{tid}")
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Polymorphic entity attach/detach/list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_by_tag_id(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        tid = (await client.post("/api/tags", json={"name": "x"})).json()["id"]
+        resp = await client.post(f"/api/entities/session/{sid}/tags", json={"tag_id": tid})
+        assert resp.status_code == 201
+
+        resp = await client.get(f"/api/entities/session/{sid}/tags")
+        assert resp.status_code == 200
+        assert [t["name"] for t in resp.json()] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_attach_by_name_inline_creates(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(f"/api/entities/session/{sid}/tags", json={"name": "inline"})
+        assert resp.status_code == 201
+        # tag now exists
+        all_tags = await client.get("/api/tags")
+        assert "inline" in [t["name"] for t in all_tags.json()]
+
+
+@pytest.mark.asyncio
+async def test_detach(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        tid = (await client.post("/api/tags", json={"name": "x"})).json()["id"]
+        await client.post(f"/api/entities/session/{sid}/tags", json={"tag_id": tid})
+        resp = await client.delete(f"/api/entities/session/{sid}/tags/{tid}")
+        assert resp.status_code == 204
+        resp = await client.get(f"/api/entities/session/{sid}/tags")
+        assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_attach_rejects_unknown_entity_type(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/entities/bogus/1/tags", json={"name": "x"})
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_attach_requires_payload(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(f"/api/entities/session/{sid}/tags", json={})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Back-compat per-entity routes still work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bookmark_list_filters_by_tags_and(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        b1 = (
+            await client.post(
+                f"/api/sessions/{sid}/bookmarks",
+                json={"name": "b1", "t_start": "2024-06-15T12:00:00+00:00"},
+            )
+        ).json()["id"]
+        b2 = (
+            await client.post(
+                f"/api/sessions/{sid}/bookmarks",
+                json={"name": "b2", "t_start": "2024-06-15T12:01:00+00:00"},
+            )
+        ).json()["id"]
+        t_red = (await client.post("/api/tags", json={"name": "red"})).json()["id"]
+        t_hot = (await client.post("/api/tags", json={"name": "hot"})).json()["id"]
+        await client.post(f"/api/entities/bookmark/{b1}/tags", json={"tag_id": t_red})
+        await client.post(f"/api/entities/bookmark/{b1}/tags", json={"tag_id": t_hot})
+        await client.post(f"/api/entities/bookmark/{b2}/tags", json={"tag_id": t_red})
+
+        # AND: only b1 has both
+        resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags={t_red},{t_hot}")
+        ids = [b["id"] for b in resp.json()]
+        assert ids == [b1]
+
+        # OR: both b1 and b2 carry red
+        resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags={t_red},{t_hot}&tag_mode=or")
+        ids = sorted(b["id"] for b in resp.json())
+        assert ids == sorted([b1, b2])
+
+
+@pytest.mark.asyncio
+async def test_thread_list_filters_by_tags(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        t1 = (await client.post(f"/api/sessions/{sid}/threads", json={"title": "t1"})).json()["id"]
+        t2 = (await client.post(f"/api/sessions/{sid}/threads", json={"title": "t2"})).json()["id"]
+        tag = (await client.post("/api/tags", json={"name": "q"})).json()["id"]
+        await client.post(f"/api/entities/thread/{t1}/tags", json={"tag_id": tag})
+
+        resp = await client.get(f"/api/sessions/{sid}/threads?tags={tag}")
+        ids = [t["id"] for t in resp.json()]
+        assert ids == [t1]
+        assert t2 not in ids
+
+
+@pytest.mark.asyncio
+async def test_filter_accepts_empty_tags_param(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags=")
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_filter_invalid_tags_returns_400(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.get(f"/api/sessions/{sid}/bookmarks?tags=abc")
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_tag_routes(storage: Storage) -> None:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        sid = await _make_session(client)
+        resp = await client.post(f"/api/sessions/{sid}/tags", json={"tag_name": "legacy-route"})
+        assert resp.status_code == 201
+        tag_id = resp.json()["tag_id"]
+
+        resp = await client.get(f"/api/sessions/{sid}/tags")
+        assert any(t["id"] == tag_id for t in resp.json())
+
+        resp = await client.delete(f"/api/sessions/{sid}/tags/{tag_id}")
+        assert resp.status_code == 204

--- a/tests/test_threads_anchored_api.py
+++ b/tests/test_threads_anchored_api.py
@@ -196,7 +196,7 @@ async def test_list_threads_projects_anchor(storage: Storage) -> None:
         await client.post(f"/api/sessions/{sid}/threads", json={"title": "no anchor"})
         resp = await client.get(f"/api/sessions/{sid}/threads")
         assert resp.status_code == 200
-        threads = resp.json()
+        threads = resp.json()["threads"]
         anchors = [t["anchor"] for t in threads]
         assert {"kind": "timestamp", "t_start": _T0} in anchors
         assert None in anchors

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3363,7 +3363,7 @@ async def test_create_thread_and_list(storage: Storage) -> None:
 
         resp = await client.get(f"/api/sessions/{race_id}/threads")
         assert resp.status_code == 200
-        threads = resp.json()
+        threads = resp.json()["threads"]
         assert len(threads) == 1
         assert threads[0]["id"] == thread_id
         assert threads[0]["title"] == "Bad tack at weather mark"


### PR DESCRIPTION
## Summary

Final slice of the Moments epic (#588). Replaces the slice-1 per-entity
tag join tables with a single polymorphic `entity_tags` path, ships a
reusable tag picker, makes the tag chip functional, adds tag filters to
the main list endpoints, and lands an admin tag manager.

- **Migration v72** — folds `session_tags` + `note_tags` into
  `entity_tags`, backfills `tags.usage_count`, drops the legacy tables.
  Forward-only.
- **Storage** — generic `attach_tag` / `detach_tag` /
  `list_tags_for_entity` / `list_entities_with_tags` (AND/OR) /
  `merge_tags`. `ENTITY_TYPES` frozenset enforces five supported entity
  types: `session`, `maneuver`, `thread`, `bookmark`, `session_note`.
  `usage_count` and `last_used_at` maintained atomically with attach/detach.
- **Tag HTTP API** — `/api/tags` CRUD + merge;
  `/api/entities/{type}/{id}/tags` polymorphic attach/detach/list.
  Rename / delete / merge are admin-only; create is accessible to any
  authed user to support inline-create UX. Legacy per-entity routes
  (`/api/sessions/{id}/tags`, `/api/notes/{id}/tags`) remain as
  back-compat shims delegating to the generic path.
- **Filters** — `?tags=1,2&tag_mode=and|or` added to `/api/sessions`,
  `/api/sessions/{id}/bookmarks`, `/api/sessions/{id}/threads`. Unknown
  tag ids silently dropped per the /spec's stale-filter-tolerance rule.
- **UI** — `<tag-picker>` custom element with usage-ordered typeahead,
  keyboard nav (↑/↓/Enter/Esc), and inline-create when Enter is pressed
  on an empty match. Wired onto session detail, per-bookmark toggle, and
  thread detail views.
- **Admin tag manager** at `/admin/tags` — list, rename, recolor, merge,
  delete, usage counts.
- **`triggers.py`** note-tagging migrated to the new `attach_tag` path;
  legacy `add_session_tag` / `add_note_tag` / `get_session_tags` /
  `get_note_tags` removed from the storage API.

### Spec + decisions

- Spec: https://github.com/weaties/helmlog/issues/587#issuecomment-4270882085
- Data-license review: https://github.com/weaties/helmlog/issues/587#issuecomment-4273685014

Key decisions confirmed on the issue: four entity-type buckets in
storage (starts/roundings are `maneuvers` with `type` filter), clean
cutover in v72 (no column preservation), admin-gated rename/delete/merge,
AND as the default filter mode.

### Risk tier

**Critical** — migration v72 moves rows and drops tables. Data-license
review completed; full test suite + lint + types clean.

### Explicitly out of scope (tracked separately)

- Co-op replication of tags — combined Moments federation follow-up
- Tag-based ACLs / hierarchical tags / auto-tagging from classifiers

Closes #587

## Test plan

- [x] `uv run pytest` — 2127 passed, 2 skipped (full suite, ~8m)
- [x] `uv run ruff check .` / `format --check .` — clean
- [x] `uv run mypy src/` — clean
- [x] Decision table 2 (AND/OR filter) — 6 storage tests cover every row
- [x] Entity-scoping — unknown `entity_type` rejected with `ValueError` at
      storage and 400 at API
- [x] Merge semantics — de-duplicates on (entity_type, entity_id) and
      recomputes usage_count; rejects same-source-target
- [x] Cascade on delete — `entity_tags.tag_id ... ON DELETE CASCADE`
      exercised in both storage and triggers tests
- [x] Migration v72 — 6 tests assert session_tags and note_tags migrate
      correctly and the old tables are dropped
- [ ] **Browser smoke** — attach tags to a session / bookmark / thread,
      filter bookmark list by tag, open `/admin/tags` and exercise
      rename/merge/delete, confirm the tag chips render with correct
      colors. **Needs a human validation pass on the Pi before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)