### PR TITLE
style: apply ruff format to unblock CI lint

### DIFF
--- a/src/helmlog/routes/bookmarks.py
+++ b/src/helmlog/routes/bookmarks.py
@@ -127,18 +127,14 @@ async def api_list_bookmarks(
         if tag_ids:
             try:
                 allowed = set(
-                    await storage.list_entities_with_tags(
-                        "bookmark", tag_ids, mode=tag_mode
-                    )
+                    await storage.list_entities_with_tags("bookmark", tag_ids, mode=tag_mode)
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             rows = [r for r in rows if r["id"] in allowed]
 
     serialized = [{**_serialize(r), "tags": r.get("tags") or []} for r in rows]
-    return JSONResponse(
-        {"bookmarks": serialized, "available_tags": available_tags}
-    )
+    return JSONResponse({"bookmarks": serialized, "available_tags": available_tags})
 
 
 def _may_modify(user: dict[str, Any], bm: dict[str, Any]) -> bool:

--- a/src/helmlog/routes/comments.py
+++ b/src/helmlog/routes/comments.py
@@ -130,9 +130,7 @@ async def api_list_threads(
         if tag_ids:
             try:
                 allowed = set(
-                    await storage.list_entities_with_tags(
-                        "thread", tag_ids, mode=tag_mode
-                    )
+                    await storage.list_entities_with_tags("thread", tag_ids, mode=tag_mode)
                 )
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1766,9 +1766,7 @@ async def api_maneuver_browse(
         else:
             resolved_session_ids = ids_in
     elif regatta_id is not None:
-        sql = (
-            "SELECT id FROM races  WHERE regatta_id = ?    AND (source IS NULL OR source IN ('live', 'synthesized')) "
-        )
+        sql = "SELECT id FROM races  WHERE regatta_id = ?    AND (source IS NULL OR source IN ('live', 'synthesized')) "
         qparams: list[Any] = [regatta_id]
         if session_type is not None:
             sql += "   AND session_type = ? "
@@ -1943,9 +1941,7 @@ async def api_maneuver_browse(
                 status_code=400, detail="tags must be comma-separated ints"
             ) from exc
         if tag_mode not in {"and", "or"}:
-            raise HTTPException(
-                status_code=400, detail="tag_mode must be 'and' or 'or'"
-            )
+            raise HTTPException(status_code=400, detail="tag_mode must be 'and' or 'or'")
         if tag_ids:
             wanted = set(tag_ids)
 
@@ -2033,9 +2029,7 @@ async def api_sessions(
             ) from exc
         if tag_ids:
             try:
-                tag_filter_ids = set(
-                    await storage.sessions_matching_tags(tag_ids, mode=tag_mode)
-                )
+                tag_filter_ids = set(await storage.sessions_matching_tags(tag_ids, mode=tag_mode))
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             if not tag_filter_ids:
@@ -2077,15 +2071,11 @@ async def api_sessions(
     available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
 
     # Per-session tag summary only needed for the visible page.
-    page_tag_summary = await storage.list_session_tag_summary(
-        [s["id"] for s in sessions]
-    )
+    page_tag_summary = await storage.list_session_tag_summary([s["id"] for s in sessions])
     for s in sessions:
         s["tag_summary"] = page_tag_summary.get(s["id"], [])
 
-    return JSONResponse(
-        {"total": total, "sessions": sessions, "available_tags": available_tags}
-    )
+    return JSONResponse({"total": total, "sessions": sessions, "available_tags": available_tags})
 
 
 @router.get("/api/grafana/annotations")

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -6145,9 +6145,7 @@ class Storage:
         await db.commit()
         return cur.rowcount > 0
 
-    async def sessions_matching_tags(
-        self, tag_ids: list[int], mode: str = "and"
-    ) -> list[int]:
+    async def sessions_matching_tags(self, tag_ids: list[int], mode: str = "and") -> list[int]:
         """Return session ids whose session row OR any constituent entity
         (maneuver / bookmark / thread) carries the given tag set.
 

--- a/tests/test_migration_v71.py
+++ b/tests/test_migration_v71.py
@@ -185,9 +185,7 @@ async def test_v71_migration_applied_on_fresh_db() -> None:
     await s.connect()
     try:
         assert s._db is not None
-        async with s._db.execute(
-            "SELECT 1 FROM schema_version WHERE version = 71"
-        ) as cur:
+        async with s._db.execute("SELECT 1 FROM schema_version WHERE version = 71") as cur:
             row = await cur.fetchone()
         assert row is not None
     finally:


### PR DESCRIPTION
## Summary

- `ruff format --check .` was failing on `main`, turning the `lint` job red on every open PR (including dependabot PRs that only touch workflow files).
- Five files merged in the recent Moments slices (#589, #592, #595) had multi-line call sites that the installed `ruff==0.15.10` would collapse.
- Pure cosmetic change — no behavior touched.

Files reformatted:
- `src/helmlog/routes/bookmarks.py`
- `src/helmlog/routes/comments.py`
- `src/helmlog/routes/sessions.py`
- `src/helmlog/storage.py`
- `tests/test_migration_v71.py`

## Test plan

- [x] `uv run ruff format --check .` → 221 files already formatted
- [x] `uv run ruff check .` → All checks passed
- [ ] CI `lint` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)