### PR TITLE
feat: ETag/304 + T2 cache on summary/track/wind-field (#594, PR 2/3)

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -63,6 +63,47 @@ def compute_race_data_hash(
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
+async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
+    """Read the race row + instrument row counts and return its data_hash.
+
+    Returns ``None`` when the race doesn't exist. Row count comes from
+    ``positions`` (the dominant data source for summary/track/wind-field)
+    filtered by ``race_id`` if tagged, else by the race time window. A
+    completed race's hash is stable; an open race's hash changes as data
+    streams in, which keeps ETag revalidation meaningful for the home page.
+    """
+    db = storage._conn()
+    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (race_id,))
+    race = await cur.fetchone()
+    if race is None:
+        return None
+    start_iso = str(race["start_utc"])
+    end_iso = str(race["end_utc"]) if race["end_utc"] is not None else None
+
+    # Row count: prefer race_id tagging, fall back to time window.
+    rid_cur = await db.execute(
+        "SELECT COUNT(*) AS cnt FROM positions WHERE race_id = ?", (race_id,)
+    )
+    rid_row = await rid_cur.fetchone()
+    n_tagged = int(rid_row["cnt"]) if rid_row else 0
+    if n_tagged > 0:
+        row_count = n_tagged
+    else:
+        window_end = end_iso or start_iso
+        win_cur = await db.execute(
+            "SELECT COUNT(*) AS cnt FROM positions WHERE ts >= ? AND ts <= ?",
+            (start_iso, window_end),
+        )
+        win_row = await win_cur.fetchone()
+        row_count = int(win_row["cnt"]) if win_row else 0
+
+    start_dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
+    end_dt = datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else None
+    return compute_race_data_hash(
+        race_id=race_id, start_utc=start_dt, end_utc=end_dt, row_count=row_count
+    )
+
+
 class _T1Entry:
     __slots__ = ("expires_at", "value")
 

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from fastapi import Response
+from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 from slowapi import Limiter
@@ -16,10 +18,12 @@ from slowapi.util import get_remote_address
 
 if TYPE_CHECKING:
     import asyncio
+    from collections.abc import Awaitable, Callable
     from datetime import datetime
 
     from fastapi import Request
 
+    from helmlog.cache import WebCache
     from helmlog.storage import Storage
 
 # ---------------------------------------------------------------------------
@@ -99,6 +103,74 @@ except Exception:  # noqa: BLE001
 def get_storage(request: Request) -> Storage:
     """Return the Storage instance from the app state."""
     return request.app.state.storage  # type: ignore[no-any-return]
+
+
+def get_web_cache(request: Request) -> WebCache | None:
+    """Return the WebCache bound to the app, or None if not configured."""
+    return getattr(request.app.state, "web_cache", None)
+
+
+_CACHE_CONTROL = "private, max-age=0, must-revalidate"
+
+
+async def cached_json_response(
+    request: Request,
+    *,
+    race_id: int,
+    key_family: str,
+    compute: Callable[[], Awaitable[Any]],
+) -> Response:
+    """ETag + 304 + T2 caching wrapper for per-race JSON endpoints (#594).
+
+    Flow:
+      1. Resolve the race's ``data_hash``. If the race doesn't exist, let
+         ``compute`` run so it can raise the correct 404.
+      2. If ``If-None-Match`` matches ``data_hash``, return 304 immediately.
+      3. If the T2 cache has an entry for ``(key_family, race_id)`` with
+         matching hash, return it as JSON.
+      4. Otherwise call ``compute``, store the result in T2, emit the
+         ``ETag`` + ``Cache-Control`` headers, and return JSON.
+
+    Cache failures never fail the request — a missing ``WebCache`` or any
+    raise from cache read/write degrades to un-cached behaviour.
+    """
+    from helmlog.cache import resolve_race_data_hash
+
+    cache = get_web_cache(request)
+    storage = get_storage(request)
+
+    data_hash: str | None = None
+    if cache is not None:
+        try:
+            data_hash = await resolve_race_data_hash(storage, race_id)
+        except Exception:  # noqa: BLE001 — cache failures must never fail a request
+            data_hash = None
+
+    if data_hash is not None:
+        if_none_match = request.headers.get("if-none-match", "").strip().strip('"')
+        if if_none_match == data_hash:
+            return Response(
+                status_code=304,
+                headers={"ETag": f'"{data_hash}"', "Cache-Control": _CACHE_CONTROL},
+            )
+        cached = None
+        if cache is not None:
+            cached = await cache.t2_get(key_family, race_id=race_id, data_hash=data_hash)
+        if cached is not None:
+            return JSONResponse(
+                cached,
+                headers={"ETag": f'"{data_hash}"', "Cache-Control": _CACHE_CONTROL},
+            )
+
+    payload = await compute()
+
+    if cache is not None and data_hash is not None:
+        await cache.t2_put(key_family, race_id=race_id, data_hash=data_hash, value=payload)
+
+    headers = (
+        {"ETag": f'"{data_hash}"', "Cache-Control": _CACHE_CONTROL} if data_hash is not None else {}
+    )
+    return JSONResponse(payload, headers=headers)
 
 
 def tpl_ctx(request: Request, page: str, **extra: Any) -> dict[str, Any]:  # noqa: ANN401

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -995,7 +995,7 @@ async def api_session_replay(
     request: Request,
     session_id: int,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
+) -> Response:
     """Return the payload the replay UI needs: session bounds, a per-second
     instrument series for the HUD, and per-segment polar grades (#464/#469).
 
@@ -1004,6 +1004,16 @@ async def api_session_replay(
     without loading the full raw tables. Fields are nulled out when a given
     sensor had no reading for that second.
     """
+
+    async def _compute() -> dict[str, Any]:
+        return await _compute_session_replay(request, session_id)
+
+    return await cached_json_response(
+        request, race_id=session_id, key_family="session_replay", compute=_compute
+    )
+
+
+async def _compute_session_replay(request: Request, session_id: int) -> dict[str, Any]:
     storage = get_storage(request)
     db = storage._conn()
     cur = await db.execute("SELECT id, start_utc, end_utc FROM races WHERE id = ?", (session_id,))
@@ -1220,28 +1230,26 @@ async def api_session_replay(
             }
         )
 
-    return JSONResponse(
-        {
-            "session_id": session_id,
-            # Normalize for the JS Date() parser: if the row already carries a
-            # timezone indicator (isoformat on an aware UTC datetime produces
-            # "...+00:00") leave it alone, otherwise append "Z". The previous
-            # unconditional-append produced the invalid "...+00:00Z" that made
-            # new Date() return Invalid Date and silently broke the scrubber,
-            # time label, and YT sync.
-            "start_utc": (start_utc if ("Z" in start_utc or "+" in start_utc) else start_utc + "Z"),
-            "end_utc": end_utc if ("Z" in end_utc or "+" in end_utc) else end_utc + "Z",
-            # Effective race gun (prefers the latest Vakaros race_start
-            # event inside the race window). Frontend uses this to filter
-            # pre-gun "roundings" out of the replay laylines.
-            "race_gun_utc": (
-                race_gun_utc if ("Z" in race_gun_utc or "+" in race_gun_utc) else race_gun_utc + "Z"
-            ),
-            "segment_seconds": _polar.POLAR_SEGMENT_SECONDS,
-            "grades": grades_out,
-            "samples": samples,
-        }
-    )
+    return {
+        "session_id": session_id,
+        # Normalize for the JS Date() parser: if the row already carries a
+        # timezone indicator (isoformat on an aware UTC datetime produces
+        # "...+00:00") leave it alone, otherwise append "Z". The previous
+        # unconditional-append produced the invalid "...+00:00Z" that made
+        # new Date() return Invalid Date and silently broke the scrubber,
+        # time label, and YT sync.
+        "start_utc": (start_utc if ("Z" in start_utc or "+" in start_utc) else start_utc + "Z"),
+        "end_utc": end_utc if ("Z" in end_utc or "+" in end_utc) else end_utc + "Z",
+        # Effective race gun (prefers the latest Vakaros race_start
+        # event inside the race window). Frontend uses this to filter
+        # pre-gun "roundings" out of the replay laylines.
+        "race_gun_utc": (
+            race_gun_utc if ("Z" in race_gun_utc or "+" in race_gun_utc) else race_gun_utc + "Z"
+        ),
+        "segment_seconds": _polar.POLAR_SEGMENT_SECONDS,
+        "grades": grades_out,
+        "samples": samples,
+    }
 
 
 @router.get("/api/sessions/{session_id}/maneuvers")

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from helmlog.auth import require_auth, require_developer
 from helmlog.current import compute_set_drift
-from helmlog.routes._helpers import audit, get_storage, limiter
+from helmlog.routes._helpers import audit, cached_json_response, get_storage, limiter
 
 router = APIRouter()
 
@@ -286,78 +286,85 @@ async def api_session_track(
     request: Request,
     session_id: int,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
+) -> Response:
     """Return GPS track as GeoJSON for map display."""
     storage = get_storage(request)
-    db = storage._conn()
-    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
-    row = await cur.fetchone()
-    if row is None:
-        raise HTTPException(status_code=404, detail="Race not found")
-    start_utc = row["start_utc"]
-    end_utc = row["end_utc"] or start_utc
 
-    # Prefer race_id filter (exact match for synthesized sessions);
-    # fall back to time-range query for real instrument data.
-    rid_cur = await db.execute(
-        "SELECT COUNT(*) as cnt FROM positions WHERE race_id = ?", (session_id,)
+    async def _compute() -> dict[str, Any]:
+        db = storage._conn()
+        cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+        row = await cur.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Race not found")
+        start_utc = row["start_utc"]
+        end_utc = row["end_utc"] or start_utc
+
+        # Prefer race_id filter (exact match for synthesized sessions);
+        # fall back to time-range query for real instrument data.
+        rid_cur = await db.execute(
+            "SELECT COUNT(*) as cnt FROM positions WHERE race_id = ?", (session_id,)
+        )
+        rid_row = await rid_cur.fetchone()
+        has_race_id = rid_row["cnt"] > 0 if rid_row else False
+
+        if has_race_id:
+            pos_cur = await db.execute(
+                "SELECT latitude_deg, longitude_deg, ts FROM positions"
+                " WHERE race_id = ? ORDER BY ts",
+                (session_id,),
+            )
+        else:
+            pos_cur = await db.execute(
+                "SELECT latitude_deg, longitude_deg, ts FROM positions"
+                " WHERE ts >= ? AND ts <= ? ORDER BY ts",
+                (start_utc, end_utc),
+            )
+        positions = await pos_cur.fetchall()
+        if not positions:
+            return {"type": "FeatureCollection", "features": []}
+
+        # Per-second mean averaging. The SK reader currently records every fix
+        # with source_addr=0 even when Signal K is multiplexing two physical
+        # GPS antennas, so the raw rows zig-zag between antennas (~3m apart).
+        # Bucketing to 1Hz and averaging within the bucket collapses the
+        # zig-zag into a smooth single line midway between the antennas — what
+        # you'd get from a single GPS anyway. Also gives the frontend a
+        # naturally Vakaros-density polyline so its dash style reads cleanly.
+        buckets: dict[str, list[tuple[float, float]]] = {}
+        bucket_order: list[str] = []
+        for r in positions:
+            ts_raw = r["ts"]
+            if not ts_raw:
+                continue
+            key = str(ts_raw)[:19]  # truncate to whole-second precision
+            if key not in buckets:
+                buckets[key] = []
+                bucket_order.append(key)
+            buckets[key].append((float(r["latitude_deg"]), float(r["longitude_deg"])))
+
+        coords: list[list[float]] = []
+        timestamps: list[str] = []
+        for key in bucket_order:
+            rows = buckets[key]
+            avg_lat = sum(p[0] for p in rows) / len(rows)
+            avg_lng = sum(p[1] for p in rows) / len(rows)
+            coords.append([avg_lng, avg_lat])
+            timestamps.append(key + ("" if key.endswith("Z") or "+" in key else "Z"))
+
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "LineString", "coordinates": coords},
+            "properties": {
+                "session_id": session_id,
+                "points": len(coords),
+                "timestamps": timestamps,
+            },
+        }
+        return {"type": "FeatureCollection", "features": [feature]}
+
+    return await cached_json_response(
+        request, race_id=session_id, key_family="session_track", compute=_compute
     )
-    rid_row = await rid_cur.fetchone()
-    has_race_id = rid_row["cnt"] > 0 if rid_row else False
-
-    if has_race_id:
-        pos_cur = await db.execute(
-            "SELECT latitude_deg, longitude_deg, ts FROM positions WHERE race_id = ? ORDER BY ts",
-            (session_id,),
-        )
-    else:
-        pos_cur = await db.execute(
-            "SELECT latitude_deg, longitude_deg, ts FROM positions"
-            " WHERE ts >= ? AND ts <= ? ORDER BY ts",
-            (start_utc, end_utc),
-        )
-    positions = await pos_cur.fetchall()
-    if not positions:
-        return JSONResponse({"type": "FeatureCollection", "features": []})
-
-    # Per-second mean averaging. The SK reader currently records every fix
-    # with source_addr=0 even when Signal K is multiplexing two physical
-    # GPS antennas, so the raw rows zig-zag between antennas (~3m apart).
-    # Bucketing to 1Hz and averaging within the bucket collapses the
-    # zig-zag into a smooth single line midway between the antennas — what
-    # you'd get from a single GPS anyway. Also gives the frontend a
-    # naturally Vakaros-density polyline so its dash style reads cleanly.
-    buckets: dict[str, list[tuple[float, float]]] = {}
-    bucket_order: list[str] = []
-    for r in positions:
-        ts_raw = r["ts"]
-        if not ts_raw:
-            continue
-        key = str(ts_raw)[:19]  # truncate to whole-second precision
-        if key not in buckets:
-            buckets[key] = []
-            bucket_order.append(key)
-        buckets[key].append((float(r["latitude_deg"]), float(r["longitude_deg"])))
-
-    coords: list[list[float]] = []
-    timestamps: list[str] = []
-    for key in bucket_order:
-        rows = buckets[key]
-        avg_lat = sum(p[0] for p in rows) / len(rows)
-        avg_lng = sum(p[1] for p in rows) / len(rows)
-        coords.append([avg_lng, avg_lat])
-        timestamps.append(key + ("" if key.endswith("Z") or "+" in key else "Z"))
-
-    feature = {
-        "type": "Feature",
-        "geometry": {"type": "LineString", "coordinates": coords},
-        "properties": {
-            "session_id": session_id,
-            "points": len(coords),
-            "timestamps": timestamps,
-        },
-    }
-    return JSONResponse({"type": "FeatureCollection", "features": [feature]})
 
 
 @router.get("/api/sessions/{session_id}/summary")
@@ -366,13 +373,23 @@ async def api_session_summary(
     request: Request,
     session_id: int,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
+) -> Response:
     """Compact per-race summary for the history page thumbnails.
 
     Returns a downsampled track, event markers (tacks, gybes, roundings,
     start, finish) indexed into that track, average wind, and top-3
     finishers. Designed to be cheap enough for per-row lazy fetch.
     """
+
+    async def _compute() -> dict[str, Any]:
+        return await _compute_session_summary(request, session_id)
+
+    return await cached_json_response(
+        request, race_id=session_id, key_family="session_summary", compute=_compute
+    )
+
+
+async def _compute_session_summary(request: Request, session_id: int) -> dict[str, Any]:
     import math
     from bisect import bisect_left
 
@@ -532,14 +549,12 @@ async def api_session_summary(
     if own_result and not any(str(row.get("sail_number") or "") == str(own_sail) for row in top3):
         results.append(own_result)
 
-    return JSONResponse(
-        {
-            "track": track,
-            "events": events,
-            "wind": wind,
-            "results": results,
-        }
-    )
+    return {
+        "track": track,
+        "events": events,
+        "wind": wind,
+        "results": results,
+    }
 
 
 @router.get("/api/sessions/{session_id}/vakaros-overlay")
@@ -759,12 +774,29 @@ async def api_session_wind_field(
     elapsed_s: float = 0.0,
     grid_size: int = 20,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
+) -> Response:
     """Return a spatial grid of TWD/TWS values and course marks."""
+    # The wind field is a function of (session_id, elapsed_s, grid_size). Bake
+    # the non-race parameters into the T2 key_family so distinct query shapes
+    # don't collide. data_hash still comes from the race row so race-mutation
+    # invalidation works without bespoke hooks per parameter.
+    clamped_grid = min(max(grid_size, 5), 40)
+    key_family = f"wind_field:grid={clamped_grid}:t={elapsed_s:.3f}"
+
+    async def _compute() -> dict[str, Any]:
+        return await _compute_wind_field(request, session_id, elapsed_s, clamped_grid)
+
+    return await cached_json_response(
+        request, race_id=session_id, key_family=key_family, compute=_compute
+    )
+
+
+async def _compute_wind_field(
+    request: Request, session_id: int, elapsed_s: float, grid_size: int
+) -> dict[str, Any]:
     storage = get_storage(request)
     from helmlog.wind_field import WindField
 
-    grid_size = min(max(grid_size, 5), 40)
     params = await storage.get_synth_wind_params(session_id)
     if params is None:
         raise HTTPException(status_code=404, detail="No wind field for this session")
@@ -827,25 +859,23 @@ async def api_session_wind_field(
 
     cells = await asyncio.to_thread(_compute)
 
-    return JSONResponse(
-        {
-            "elapsed_s": elapsed_s,
-            "duration_s": params["duration_s"],
-            "base_twd": params["base_twd"],
-            "tws_low": params["tws_low"],
-            "tws_high": params["tws_high"],
-            "grid": {
-                "rows": grid_size,
-                "cols": grid_size,
-                "lat_min": round(lat_min, 6),
-                "lat_max": round(lat_max, 6),
-                "lon_min": round(lon_min, 6),
-                "lon_max": round(lon_max, 6),
-                "cells": cells,
-            },
-            "marks": marks,
-        }
-    )
+    return {
+        "elapsed_s": elapsed_s,
+        "duration_s": params["duration_s"],
+        "base_twd": params["base_twd"],
+        "tws_low": params["tws_low"],
+        "tws_high": params["tws_high"],
+        "grid": {
+            "rows": grid_size,
+            "cols": grid_size,
+            "lat_min": round(lat_min, 6),
+            "lat_max": round(lat_max, 6),
+            "lon_min": round(lon_min, 6),
+            "lon_max": round(lon_max, 6),
+            "cells": cells,
+        },
+        "marks": marks,
+    }
 
 
 @router.get("/api/sessions/{session_id}/wind-timeseries")

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -87,6 +87,13 @@ def create_app(
     app.state.startup_sha = STARTUP_SHA
     app.state.ws_clients = set()  # WebSocket client connections
 
+    # -- Web response cache (#594) --
+    from helmlog.cache import WebCache
+
+    web_cache = WebCache(storage)
+    storage.bind_race_cache(web_cache)
+    app.state.web_cache = web_cache
+
     from helmlog.races import RaceConfig
 
     app.state.race_config = RaceConfig()

--- a/tests/test_web_cache_routes.py
+++ b/tests/test_web_cache_routes.py
@@ -178,6 +178,55 @@ async def test_track_emits_etag_and_304(storage: Storage, monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_replay_emits_etag_and_304(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    """/api/sessions/{id}/replay rolls up set/drift + polar grades + instrument
+    series. Same caching semantics as summary/track.
+    """
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get(f"/api/sessions/{race_id}/replay")
+        assert r1.status_code == 200
+        payload = r1.json()
+        assert "samples" in payload
+        etag = r1.headers["etag"]
+        assert etag
+        r2 = await client.get(f"/api/sessions/{race_id}/replay", headers={"If-None-Match": etag})
+    assert r2.status_code == 304
+
+
+@pytest.mark.asyncio
+async def test_replay_cache_blob_written_and_invalidated(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get(f"/api/sessions/{race_id}/replay")
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (race_id, "session_replay"),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+    # rename fires the invalidation hook — replay blob must be dropped.
+    await storage.rename_race(race_id, new_name="After Rename")
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (race_id, "session_replay"),
+    )
+    assert (await cur.fetchone())["n"] == 0
+
+
+@pytest.mark.asyncio
 async def test_t2_blob_written_on_summary_miss(
     storage: Storage, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_web_cache_routes.py
+++ b/tests/test_web_cache_routes.py
@@ -1,0 +1,222 @@
+"""Tests for ETag/304 + T2 caching on session summary/track/wind-field (#594, PR 2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+_START = datetime(2026, 2, 26, 14, 0, 0, tzinfo=UTC)
+_END = datetime(2026, 2, 26, 14, 30, 0, tzinfo=UTC)
+
+
+async def _seed_completed_race(storage: Storage) -> int:
+    """Insert a completed race with a handful of position rows. Returns race_id."""
+    race = await storage.start_race(
+        event="E",
+        start_utc=_START,
+        date_str="2026-02-26",
+        race_num=1,
+        name="Race 1",
+    )
+    # Seed a few positions inside the window, tagged with race_id.
+    db = storage._conn()
+    for i in range(5):
+        ts = (_START + timedelta(seconds=i * 30)).isoformat()
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (ts, 0, 37.7 + i * 0.001, -122.4 + i * 0.001, race.id),
+        )
+    await db.commit()
+    await storage.end_race(race.id, _END)
+    return race.id
+
+
+@pytest.mark.asyncio
+async def test_summary_emits_etag_and_cache_control(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/summary")
+    assert resp.status_code == 200
+    etag = resp.headers.get("etag")
+    assert etag, f"expected ETag header, got: {dict(resp.headers)}"
+    assert etag.startswith('"') and etag.endswith('"')
+    assert len(etag.strip('"')) == 16  # 16-char hex digest
+    assert "must-revalidate" in resp.headers.get("cache-control", "")
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_304_on_if_none_match(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get(f"/api/sessions/{race_id}/summary")
+        etag = r1.headers["etag"]
+        r2 = await client.get(f"/api/sessions/{race_id}/summary", headers={"If-None-Match": etag})
+    assert r2.status_code == 304
+    assert r2.content == b""
+    assert r2.headers.get("etag") == etag
+
+
+@pytest.mark.asyncio
+async def test_summary_returns_200_when_if_none_match_stale(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(
+            f"/api/sessions/{race_id}/summary",
+            headers={"If-None-Match": '"deadbeefcafebabe"'},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["track"]  # body regenerated
+
+
+@pytest.mark.asyncio
+async def test_summary_cache_hit_returns_same_body_as_miss(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        miss = await client.get(f"/api/sessions/{race_id}/summary")
+        hit = await client.get(f"/api/sessions/{race_id}/summary")
+    assert miss.status_code == 200
+    assert hit.status_code == 200
+    assert miss.headers["etag"] == hit.headers["etag"]
+    assert miss.json() == hit.json()
+
+
+@pytest.mark.asyncio
+async def test_summary_etag_changes_after_race_mutation(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rename_race → _invalidate_race_cache hook → new data_hash on next request."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get(f"/api/sessions/{race_id}/summary")
+        etag1 = r1.headers["etag"]
+
+        # end_utc doesn't change under rename, so data_hash is stable — we
+        # need a race-row field the hash depends on. Add more position rows
+        # instead so row_count changes, exercising the same hook path because
+        # start/end_utc are the canonical fields. Either way, rename_race
+        # fires the invalidation hook and drops the blob.
+        db = storage._conn()
+        for i in range(5, 10):
+            ts = (_START + timedelta(seconds=i * 30)).isoformat()
+            await db.execute(
+                "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (ts, 0, 37.7, -122.4, race_id),
+            )
+        await db.commit()
+        await storage.rename_race(race_id, new_name="Race 1 Renamed")
+
+        r2 = await client.get(f"/api/sessions/{race_id}/summary")
+        etag2 = r2.headers["etag"]
+    assert etag1 != etag2
+
+
+@pytest.mark.asyncio
+async def test_summary_404_on_missing_race(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions/9999/summary")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_track_emits_etag_and_304(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get(f"/api/sessions/{race_id}/track")
+        assert r1.status_code == 200
+        etag = r1.headers["etag"]
+        r2 = await client.get(f"/api/sessions/{race_id}/track", headers={"If-None-Match": etag})
+    assert r2.status_code == 304
+
+
+@pytest.mark.asyncio
+async def test_t2_blob_written_on_summary_miss(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After a summary request, web_cache must contain the corresponding blob."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get(f"/api/sessions/{race_id}/summary")
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (race_id, "session_summary"),
+    )
+    row = await cur.fetchone()
+    assert row["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_race_end_invalidation_clears_summary_blob(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get(f"/api/sessions/{race_id}/summary")
+
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ?", (race_id,))
+    assert (await cur.fetchone())["n"] >= 1
+
+    # rename_race goes through the invalidation hook
+    await storage.rename_race(race_id, new_name="Post Rename")
+
+    cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ?", (race_id,))
+    assert (await cur.fetchone())["n"] == 0


### PR DESCRIPTION
## Summary
Wires the cache infrastructure from PR #596 into the three hottest per-session endpoints.

**Stacked on #596** — base this PR against `feature/web-cache-594-pr1`. Switch base to `main` once #596 merges.

## Endpoints affected
- `/api/sessions/{id}/summary` — 6-parallel fetch on session detail page
- `/api/sessions/{id}/track` — GPS GeoJSON, lazy-loaded per history row
- `/api/sessions/{id}/wind-field` — synthesized wind grid (baked `grid_size`+`elapsed_s` into T2 key_family)

## How it works
- `resolve_race_data_hash(storage, race_id)` hashes `(race_id, start_utc, end_utc, positions_row_count)`. Completed races get a stable hash; active races see it change as data streams in (keeps revalidation meaningful for the home page).
- Shared `cached_json_response(...)` helper in `routes/_helpers.py` does the full flow: resolve hash → 304 on `If-None-Match` match → T2 hit → compute + store + emit `ETag` + `Cache-Control: private, max-age=0, must-revalidate`.
- `web.py` lifespan instantiates a single `WebCache` and binds it via `storage.bind_race_cache()` so every `races` mutation fires the invalidation hook from PR 1.
- Cache failures degrade to un-cached behaviour (EARS Req. 3).

## EARS requirements covered
- **10** — ETag = `data_hash` on summary/track/wind-field ✅
- **11** — 304 round-trip with no body, no regeneration ✅
- **12** — `Cache-Control: private, max-age=0, must-revalidate` ✅

## Deferred to PR 3
- **16–17** — warm-on-complete background task
- **13–15** — peer-federation stale-while-revalidate + external API caching

## Test plan
- [x] 9 new route tests in `tests/test_web_cache_routes.py` covering ETag emission, 304 round-trip, stale ETag → 200, cache-hit parity with miss, ETag flip after race mutation, 404 on missing race, T2 blob written on miss, invalidation on rename_race.
- [x] Existing 24 cache unit + 3 v73 migration tests still pass.
- [x] Full suite: 2170 passing locally.
- [x] `uv run ruff check .` + `ruff format --check` + `mypy src/` all clean.
- [ ] Manually verify on the test Pi that history-page scrolling now serves 304s for previously-fetched thumbnails.

## Tag-invalidation follow-up (from caching review)
Neither `/summary` nor `/track` nor `/wind-field` includes tag data today, so the tagging landing (#595) doesn't require changes here. The `/api/sessions` list and `/bookmarks`/`/threads`/`/maneuvers` endpoints *do* include tags — those will be addressed in a follow-up alongside PR 3 where T1 caching actually lands.

Part of #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)