### PR TITLE
fix: qualify imported race names with regatta source_id (#605)

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -81,7 +81,7 @@ async def import_results(
             )
             continue
 
-        race_id = await _upsert_race(db, race_data, regatta_id, reg.source)
+        race_id = await _upsert_race(db, race_data, regatta_id, reg)
 
         ranked = _assign_places(race_data.finishes)
         for place, finish in ranked:
@@ -281,20 +281,34 @@ async def _upsert_regatta(db: aiosqlite.Connection, reg: Regatta, now: str) -> i
     return cur.lastrowid  # type: ignore[return-value]
 
 
+def _imported_race_name(race: RaceData, reg: Regatta) -> str:  # noqa: F821
+    """Build the ``races.name`` value for an imported race.
+
+    The ``races.name`` column carries a global UNIQUE constraint that
+    pre-dates multi-source imports. Clubspot (and other providers) generate
+    the same human race number / class pair across regattas — e.g.
+    ``"Race 1 - J/105"`` — so the regatta's ``source_id`` is appended to
+    keep the name unique per regatta (#605).
+    """
+    base = f"{race.name} - {race.class_name}" if race.class_name else race.name
+    return f"{base} [{reg.source_id}]"
+
+
 async def _upsert_race(
     db: aiosqlite.Connection,
     race: RaceData,  # noqa: F821
     regatta_id: int,
-    source: str,
+    reg: Regatta,  # noqa: F821
 ) -> int:
     from helmlog.results.base import RaceData
 
     assert isinstance(race, RaceData)
     cur = await db.execute(
         "SELECT id, local_session_id FROM races WHERE source = ? AND source_id = ?",
-        (source, race.source_id),
+        (reg.source, race.source_id),
     )
     row = await cur.fetchone()
+    name = _imported_race_name(race, reg)
     if row:
         # Clear old results so the fresh set from the provider can be
         # re-inserted without UNIQUE constraint violations on (race_id, place).
@@ -314,7 +328,7 @@ async def _upsert_race(
             + (", local_session_id = NULL" if date_changed else "")
             + " WHERE id = ?",
             (
-                f"{race.name} - {race.class_name}" if race.class_name else race.name,
+                name,
                 race.race_number,
                 race.date,
                 placeholder_iso,
@@ -345,14 +359,14 @@ async def _upsert_race(
         "session_type, regatta_id, source, source_id) "
         "VALUES (?, ?, ?, ?, ?, ?, 'race', ?, ?, ?)",
         (
-            f"{race.name} - {race.class_name}" if race.class_name else race.name,
+            name,
             race.class_name,
             race.race_number,
             race.date,
             placeholder_iso,
             placeholder_iso,
             regatta_id,
-            source,
+            reg.source,
             race.source_id,
         ),
     )

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -526,3 +526,43 @@ async def test_race_with_no_date_skipped(storage: Storage) -> None:
     async with db.execute("SELECT COUNT(*) FROM races WHERE source_id = 'no_date_race'") as cur:
         (n,) = await cur.fetchone()  # type: ignore[misc]
     assert n == 0
+
+
+@pytest.mark.asyncio
+async def test_two_regattas_same_class_do_not_collide_on_name(storage: Storage) -> None:
+    """Regression for #605: races.name UNIQUE must not block a second regatta
+    that shares a class name (e.g. J/105) with a previously-imported regatta.
+
+    Before the fix, the importer generated name="Race 1 - J/105" for every
+    J/105 class race regardless of regatta, so the second regatta's INSERT
+    tripped the UNIQUE constraint on races.name.
+    """
+    from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults
+
+    def _make(source_id: str, reg_name: str) -> RegattaResults:
+        race = RaceData(
+            source_id=f"{source_id}_R1_J/105",
+            race_number=1,
+            name="Race 1",
+            date="2026-04-18",
+            class_name="J/105",
+            finishes=(BoatFinish(sail_number="105", place=1),),
+        )
+        return RegattaResults(
+            regatta=Regatta(source="clubspot", source_id=source_id, name=reg_name),
+            races=(race,),
+        )
+
+    counts_a = await import_results(storage, _make("regA", "Sound Wednesday"))
+    assert counts_a["races_upserted"] == 1
+
+    # Second regatta, same class, same race_number — must not raise.
+    counts_b = await import_results(storage, _make("regB", "CYC Spring"))
+    assert counts_b["races_upserted"] == 1
+
+    db = storage._conn()
+    async with db.execute(
+        "SELECT COUNT(*) FROM races WHERE source = 'clubspot' AND event = 'J/105'"
+    ) as cur:
+        (n,) = await cur.fetchone()  # type: ignore[misc]
+    assert n == 2


### PR DESCRIPTION
## Summary

- Imported race names now include the regatta's `source_id` as a suffix, so
  two regattas that share a class (e.g. J/105) no longer collide on the
  `races.name` UNIQUE constraint.
- Regression test added in `tests/test_results_importer.py`.

## Context

On corvopi-live today, fetching the newly-added "Racing: CYC Puget Sound
Spring Regatta - ORC/PHRF & Dinghies" 500'd with
`sqlite3.IntegrityError: UNIQUE constraint failed: races.name` because the
already-imported Sound Wednesday Night Series owned the name
`Race 1 - J/105`. The browser showed the downstream
`Unexpected token 'I', "Internal S"... is not valid JSON` error from trying
to `.json()` the 500 body.

Root cause: `_upsert_race` built the name as `f"{race.name} - {race.class_name}"`,
so every clubspot J/105 race anywhere was named `"Race 1 - J/105"`. Dedupe
is keyed on `(source, source_id)` — unique per regatta — but the INSERT
path still tripped the global name UNIQUE index.

## Behavior change

- New imported races are named e.g. `"Race 1 - J/105 [tCigjwehTt]"`.
- The admin UI's race nav already strips everything after the first ` - `,
  so the button label is unchanged.
- On the next fetch of an existing regatta, `_upsert_race` will UPDATE the
  `name` column in place for its races (dedupe hits on `(source, source_id)`).
  This is a one-shot, idempotent rename — no migration needed.

## Alternatives considered

Dropping the `races.name UNIQUE` constraint would be a cleaner long-term
fix, but `races` is Critical-tier and carries a number of FKs, so a table
rebuild migration deserves its own spec-reviewed change. Out of scope here.

Closes #605

## Test plan

- [x] `uv run pytest tests/test_results_importer.py` — 19/19 pass
- [x] `uv run pytest` — 2135 passed, 2 skipped
- [x] `uv run ruff check .` + `ruff format --check .` + `mypy src/` — clean
- [ ] Deploy to corvopi-live and confirm the CYC Puget Sound Spring Regatta
      fetch succeeds against the real Clubspot API

🤖 Generated with [Claude Code](https://claude.com/claude-code)