### PR TITLE
feat: T1 cache on session list + detail + tag-mutation hooks (#608)

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -38,6 +38,8 @@ class RaceCache(Protocol):
 
     async def invalidate(self, race_id: int) -> None: ...
 
+    def t1_invalidate_family(self, family: str) -> None: ...
+
 
 def compute_race_data_hash(
     *,
@@ -217,6 +219,10 @@ class WebCache:
         suffix = f"::race={race_id}"
         for key in [k for k in self._t1 if k.endswith(suffix)]:
             self._t1.pop(key, None)
+        # T1 — drop list-shaped families whose contents depend on the set of
+        # races (not on any single race_id). Any race insert/update/delete
+        # changes /api/sessions output, so its list-family entries must go.
+        self.t1_invalidate_family("sessions_list")
         # T2 — drop every row for this race
         try:
             db = self._storage._conn()  # noqa: SLF001

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -113,6 +113,36 @@ def get_web_cache(request: Request) -> WebCache | None:
 _CACHE_CONTROL = "private, max-age=0, must-revalidate"
 
 
+async def t1_cached_json_response(
+    request: Request,
+    *,
+    cache_key: str,
+    ttl_seconds: float,
+    compute: Callable[[], Awaitable[Any]],
+) -> Response:
+    """T1 (in-process dict + TTL) caching wrapper for JSON endpoints (#594/#608).
+
+    Unlike :func:`cached_json_response`, there's no ETag negotiation — T1 is
+    process-scoped and typical payloads are thin enough that a full-body
+    round-trip is acceptable. Used for list endpoints (the session list)
+    where the key space is large (many filter combinations) and correctness
+    beyond ``ttl_seconds`` is handled by explicit invalidation from the
+    race-mutation hook.
+
+    Cache failures degrade to un-cached behaviour — the request never fails
+    because of a cache problem.
+    """
+    cache = get_web_cache(request)
+    if cache is not None:
+        hit = cache.t1_get(cache_key)
+        if hit is not None:
+            return JSONResponse(hit)
+    payload = await compute()
+    if cache is not None:
+        cache.t1_put(cache_key, payload, ttl_seconds=ttl_seconds)
+    return JSONResponse(payload)
+
+
 async def cached_json_response(
     request: Request,
     *,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -14,7 +14,13 @@ from loguru import logger
 
 from helmlog.auth import require_auth, require_developer
 from helmlog.current import compute_set_drift
-from helmlog.routes._helpers import audit, cached_json_response, get_storage, limiter
+from helmlog.routes._helpers import (
+    audit,
+    cached_json_response,
+    get_storage,
+    limiter,
+    t1_cached_json_response,
+)
 
 router = APIRouter()
 
@@ -648,13 +654,33 @@ async def api_session_course_overlay(
     )
 
 
+_SESSION_DETAIL_TTL_S: float = 60.0
+
+
 @router.get("/api/sessions/{session_id}/detail")
 async def api_session_detail(
     request: Request,
     session_id: int,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
+) -> Response:
     """Return full metadata for a single session."""
+    # Race-mutation hook invalidates the race-keyed T1 entry directly; the
+    # 60s TTL guards against audio / wind-field / video-link changes that
+    # don't flow through the races-row invalidation hook.
+    cache_key = f"session_detail::race={session_id}"
+
+    async def _compute() -> dict[str, Any]:
+        return await _compute_session_detail(request, session_id)
+
+    return await t1_cached_json_response(
+        request,
+        cache_key=cache_key,
+        ttl_seconds=_SESSION_DETAIL_TTL_S,
+        compute=_compute,
+    )
+
+
+async def _compute_session_detail(request: Request, session_id: int) -> dict[str, Any]:
     storage = get_storage(request)
     db = storage._conn()
     cur = await db.execute(
@@ -733,38 +759,36 @@ async def api_session_detail(
     )
     has_wind_field = await wf_cur.fetchone() is not None
 
-    return JSONResponse(
-        {
-            "id": row["id"],
-            "type": row["session_type"],
-            "name": row["name"],
-            "event": row["event"],
-            "race_num": row["race_num"],
-            "date": row["date"],
-            "start_utc": start_utc.isoformat(),
-            "end_utc": end_utc.isoformat() if end_utc else None,
-            "duration_s": round(duration_s, 1) if duration_s is not None else None,
-            "has_track": bool(row["has_track"]),
-            "first_video_url": row["first_video_url"],
-            "has_audio": arow is not None,
-            "audio_session_id": arow["id"] if arow else None,
-            "audio_start_utc": (
-                datetime.fromisoformat(arow["start_utc"]).isoformat() if arow else None
-            ),
-            "audio_channels": (
-                len(audio_siblings) if audio_siblings else (arow["channels"] if arow else None)
-            ),
-            "audio_siblings": audio_siblings,
-            "debrief_audio": debrief_audio,
-            "peer_fingerprint": row["peer_fingerprint"],
-            "has_wind_field": has_wind_field,
-            "shared_name": row["shared_name"],
-            "match_group_id": row["match_group_id"],
-            "match_status": "confirmed"
-            if row["match_confirmed"]
-            else ("candidate" if row["match_group_id"] else "unmatched"),
-        }
-    )
+    return {
+        "id": row["id"],
+        "type": row["session_type"],
+        "name": row["name"],
+        "event": row["event"],
+        "race_num": row["race_num"],
+        "date": row["date"],
+        "start_utc": start_utc.isoformat(),
+        "end_utc": end_utc.isoformat() if end_utc else None,
+        "duration_s": round(duration_s, 1) if duration_s is not None else None,
+        "has_track": bool(row["has_track"]),
+        "first_video_url": row["first_video_url"],
+        "has_audio": arow is not None,
+        "audio_session_id": arow["id"] if arow else None,
+        "audio_start_utc": (
+            datetime.fromisoformat(arow["start_utc"]).isoformat() if arow else None
+        ),
+        "audio_channels": (
+            len(audio_siblings) if audio_siblings else (arow["channels"] if arow else None)
+        ),
+        "audio_siblings": audio_siblings,
+        "debrief_audio": debrief_audio,
+        "peer_fingerprint": row["peer_fingerprint"],
+        "has_wind_field": has_wind_field,
+        "shared_name": row["shared_name"],
+        "match_group_id": row["match_group_id"],
+        "match_status": "confirmed"
+        if row["match_confirmed"]
+        else ("candidate" if row["match_group_id"] else "unmatched"),
+    }
 
 
 @router.get("/api/sessions/{session_id}/wind-field")
@@ -2032,6 +2056,9 @@ async def api_detect_maneuvers(
     )
 
 
+_SESSIONS_LIST_TTL_S: float = 60.0
+
+
 @router.get("/api/sessions")
 async def api_sessions(
     request: Request,
@@ -2044,8 +2071,7 @@ async def api_sessions(
     limit: int = 25,
     offset: int = 0,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> JSONResponse:
-    storage = get_storage(request)
+) -> Response:
     if type is not None and type not in ("race", "practice", "debrief", "synthesized"):
         raise HTTPException(
             status_code=422,
@@ -2053,67 +2079,88 @@ async def api_sessions(
         )
     limit = max(1, min(limit, 200))
 
-    # Tag filter — if tag ids are supplied, narrow to sessions whose row OR
-    # any constituent entity (maneuver / bookmark / thread) carries the tags.
-    # We pre-compute the full matching-id set up front, then page through it
-    # after list_sessions applies the other filters, so total is accurate.
-    tag_filter_ids: set[int] | None = None
-    if tags:
-        try:
-            tag_ids = [int(s) for s in tags.split(",") if s.strip()]
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400, detail="tags must be comma-separated ints"
-            ) from exc
-        if tag_ids:
+    # Build a cache key from the filter tuple. 60s TTL keeps this bounded
+    # even across many filter combinations; race mutations also drop the
+    # whole `sessions_list` family via the invalidation hook in cache.py.
+    import hashlib
+
+    key_payload = f"q={q}|type={type}|from={from_date}|to={to_date}|tags={tags}|mode={tag_mode}|limit={limit}|offset={offset}"
+    key_hash = hashlib.sha256(key_payload.encode()).hexdigest()[:16]
+    cache_key = f"sessions_list:{key_hash}"
+
+    async def _compute() -> dict[str, Any]:
+        storage = get_storage(request)
+        # Tag filter — if tag ids are supplied, narrow to sessions whose row OR
+        # any constituent entity (maneuver / bookmark / thread) carries the
+        # tags. We pre-compute the full matching-id set up front, then page
+        # through it after list_sessions applies the other filters, so total
+        # is accurate.
+        tag_filter_ids: set[int] | None = None
+        if tags:
             try:
-                tag_filter_ids = set(await storage.sessions_matching_tags(tag_ids, mode=tag_mode))
+                tag_ids = [int(s) for s in tags.split(",") if s.strip()]
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            if not tag_filter_ids:
-                return JSONResponse({"total": 0, "sessions": []})
+                raise HTTPException(
+                    status_code=400, detail="tags must be comma-separated ints"
+                ) from exc
+            if tag_ids:
+                try:
+                    tag_filter_ids = set(
+                        await storage.sessions_matching_tags(tag_ids, mode=tag_mode)
+                    )
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                if not tag_filter_ids:
+                    return {"total": 0, "sessions": []}
 
-    # Pull the full set of sessions matching non-tag filters so we can
-    # compute available_tags across it. The chip row shows every tag
-    # reachable from the current non-tag filters — without this, selecting
-    # one tag would collapse the chip row down to just that tag and the
-    # user couldn't add a second one for AND/OR.
-    _all_total, all_non_tag_matches = await storage.list_sessions(
-        q=q or None,
-        session_type=type,
-        from_date=from_date,
-        to_date=to_date,
-        limit=10_000,
-        offset=0,
+        # Pull the full set of sessions matching non-tag filters so we can
+        # compute available_tags across it. The chip row shows every tag
+        # reachable from the current non-tag filters — without this,
+        # selecting one tag would collapse the chip row down to just that
+        # tag and the user couldn't add a second one for AND/OR.
+        _all_total, all_non_tag_matches = await storage.list_sessions(
+            q=q or None,
+            session_type=type,
+            from_date=from_date,
+            to_date=to_date,
+            limit=10_000,
+            offset=0,
+        )
+        if tag_filter_ids is not None:
+            filtered = [s for s in all_non_tag_matches if s["id"] in tag_filter_ids]
+            total = len(filtered)
+            sessions = filtered[offset : offset + limit]
+        else:
+            total = _all_total
+            sessions = all_non_tag_matches[offset : offset + limit]
+
+        # Aggregate available tags across ALL non-tag-filtered sessions so
+        # the chip row doesn't collapse when the user applies a tag filter.
+        all_ids = [s["id"] for s in all_non_tag_matches]
+        all_tag_summary = await storage.list_session_tag_summary(all_ids)
+        available_counts: dict[int, dict[str, Any]] = {}
+        for sid in all_ids:
+            for r in all_tag_summary.get(sid, []):
+                entry = available_counts.setdefault(
+                    r["id"],
+                    {"id": r["id"], "name": r["name"], "color": r["color"], "count": 0},
+                )
+                entry["count"] += r["count"]
+        available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
+
+        # Per-session tag summary only needed for the visible page.
+        page_tag_summary = await storage.list_session_tag_summary([s["id"] for s in sessions])
+        for s in sessions:
+            s["tag_summary"] = page_tag_summary.get(s["id"], [])
+
+        return {"total": total, "sessions": sessions, "available_tags": available_tags}
+
+    return await t1_cached_json_response(
+        request,
+        cache_key=cache_key,
+        ttl_seconds=_SESSIONS_LIST_TTL_S,
+        compute=_compute,
     )
-    if tag_filter_ids is not None:
-        filtered = [s for s in all_non_tag_matches if s["id"] in tag_filter_ids]
-        total = len(filtered)
-        sessions = filtered[offset : offset + limit]
-    else:
-        total = _all_total
-        sessions = all_non_tag_matches[offset : offset + limit]
-
-    # Aggregate available tags across ALL non-tag-filtered sessions so the
-    # chip row doesn't collapse when the user applies a tag filter.
-    all_ids = [s["id"] for s in all_non_tag_matches]
-    all_tag_summary = await storage.list_session_tag_summary(all_ids)
-    available_counts: dict[int, dict[str, Any]] = {}
-    for sid in all_ids:
-        for r in all_tag_summary.get(sid, []):
-            entry = available_counts.setdefault(
-                r["id"],
-                {"id": r["id"], "name": r["name"], "color": r["color"], "count": 0},
-            )
-            entry["count"] += r["count"]
-    available_tags = sorted(available_counts.values(), key=lambda t: t["name"])
-
-    # Per-session tag summary only needed for the visible page.
-    page_tag_summary = await storage.list_session_tag_summary([s["id"] for s in sessions])
-    for s in sessions:
-        s["tag_summary"] = page_tag_summary.get(s["id"], [])
-
-    return JSONResponse({"total": total, "sessions": sessions, "available_tags": available_tags})
 
 
 @router.get("/api/grafana/annotations")

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -1821,6 +1821,23 @@ class Storage:
         except Exception as exc:
             logger.warning("race cache invalidate failed id={}: {}", race_id, exc)
 
+    def _invalidate_sessions_list_cache(self) -> None:
+        """Drop T1 `sessions_list` family — used by tag-mutation paths (#608).
+
+        Tag writes (attach/detach/update/delete/merge) change the chip row
+        and per-session tag summary that the ``/api/sessions`` response
+        carries, but don't flow through the race-mutation path. Calling
+        this keeps the list cache coherent without the cost of touching
+        per-race T2 entries (which are unaffected by tag writes today).
+        """
+        cache = self._race_cache
+        if cache is None:
+            return
+        try:
+            cache.t1_invalidate_family("sessions_list")
+        except Exception as exc:
+            logger.warning("sessions_list cache invalidate failed: {}", exc)
+
     @property
     def session_active(self) -> bool:
         """True when a race or practice session is currently in progress."""
@@ -6168,12 +6185,15 @@ class Storage:
             "VALUES (?, ?, ?, ?, ?)",
             (tag_id, entity_type, entity_id, now, user_id),
         )
-        if cur.rowcount > 0:
+        changed = cur.rowcount > 0
+        if changed:
             await db.execute(
                 "UPDATE tags SET usage_count = usage_count + 1, last_used_at = ? WHERE id = ?",
                 (now, tag_id),
             )
         await db.commit()
+        if changed:
+            self._invalidate_sessions_list_cache()
 
     async def detach_tag(self, entity_type: str, entity_id: int, tag_id: int) -> bool:
         """Remove a tag from an entity. Returns True if a row was removed."""
@@ -6186,13 +6206,16 @@ class Storage:
             "DELETE FROM entity_tags WHERE tag_id = ? AND entity_type = ? AND entity_id = ?",
             (tag_id, entity_type, entity_id),
         )
-        if cur.rowcount > 0:
+        changed = cur.rowcount > 0
+        if changed:
             await db.execute(
                 "UPDATE tags SET usage_count = MAX(0, usage_count - 1) WHERE id = ?",
                 (tag_id,),
             )
         await db.commit()
-        return cur.rowcount > 0
+        if changed:
+            self._invalidate_sessions_list_cache()
+        return changed
 
     async def sessions_matching_tags(self, tag_ids: list[int], mode: str = "and") -> list[int]:
         """Return session ids whose session row OR any constituent entity
@@ -6430,6 +6453,7 @@ class Storage:
         )
         await db.execute("DELETE FROM tags WHERE id = ?", (source_id,))
         await db.commit()
+        self._invalidate_sessions_list_cache()
 
     async def get_or_create_tag(self, name: str, color: str | None = None) -> int:
         """Return the tag id for *name*, creating it if it doesn't exist."""
@@ -6470,7 +6494,10 @@ class Storage:
             params,  # noqa: S608
         )
         await db.commit()
-        return cur.rowcount > 0
+        changed = cur.rowcount > 0
+        if changed:
+            self._invalidate_sessions_list_cache()
+        return changed
 
     async def delete_tag(self, tag_id: int) -> bool:
         """Delete a tag. entity_tags.tag_id has ON DELETE CASCADE, so any
@@ -6481,7 +6508,10 @@ class Storage:
         db = self._conn()
         cur = await db.execute("DELETE FROM tags WHERE id = ?", (tag_id,))
         await db.commit()
-        return cur.rowcount > 0
+        changed = cur.rowcount > 0
+        if changed:
+            self._invalidate_sessions_list_cache()
+        return changed
 
     # ------------------------------------------------------------------
     # Bookmarks (#477 / #588 slice 1)

--- a/tests/test_web_cache_list_detail.py
+++ b/tests/test_web_cache_list_detail.py
@@ -1,0 +1,362 @@
+"""Tests for T1 caching on /api/sessions list + /detail and tag-mutation
+invalidation hooks (#608)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.cache import WebCache
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+_START = datetime(2026, 2, 26, 14, 0, 0, tzinfo=UTC)
+_END = datetime(2026, 2, 26, 14, 30, 0, tzinfo=UTC)
+
+
+async def _seed_completed_race(storage: Storage, race_num: int = 1) -> int:
+    race = await storage.start_race(
+        event="E",
+        start_utc=_START + timedelta(minutes=race_num),
+        date_str="2026-02-26",
+        race_num=race_num,
+        name=f"Race {race_num}",
+    )
+    db = storage._conn()
+    for i in range(3):
+        ts = (_START + timedelta(minutes=race_num, seconds=i * 30)).isoformat()
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (ts, 0, 37.7, -122.4, race.id),
+        )
+    await db.commit()
+    await storage.end_race(race.id, _END + timedelta(minutes=race_num))
+    return race.id
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t1_invalidate_family_drops_matching_entries(storage: Storage) -> None:
+    """`t1_invalidate_family("sessions_list")` must drop every entry in that
+    family (the matching used is prefix-based, see cache.t1_invalidate_family)."""
+    cache = WebCache(storage)
+    cache.t1_put("sessions_list:abc", {"v": 1}, ttl_seconds=60)
+    cache.t1_put("sessions_list:def", {"v": 2}, ttl_seconds=60)
+    cache.t1_put("other:keep", {"v": 3}, ttl_seconds=60)
+
+    cache.t1_invalidate_family("sessions_list")
+
+    assert cache.t1_get("sessions_list:abc") is None
+    assert cache.t1_get("sessions_list:def") is None
+    assert cache.t1_get("other:keep") == {"v": 3}
+
+
+@pytest.mark.asyncio
+async def test_race_invalidate_also_drops_sessions_list(storage: Storage) -> None:
+    """race-mutation hook must flush the sessions_list family, not just per-race."""
+    cache = WebCache(storage)
+    cache.t1_put("sessions_list:abc", {"v": 1}, ttl_seconds=60)
+    cache.t1_put_for_race("session_detail", race_id=42, value={"v": 2}, ttl_seconds=60)
+
+    await cache.invalidate(42)
+
+    assert cache.t1_get("sessions_list:abc") is None
+    assert cache.t1_get_for_race("session_detail", race_id=42) is None
+
+
+# ---------------------------------------------------------------------------
+# Route — session list T1 caching + invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_cache_hit_returns_same_body(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    await _seed_completed_race(storage, 1)
+    await _seed_completed_race(storage, 2)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        first = await client.get("/api/sessions")
+        hit = await client.get("/api/sessions")
+    assert first.status_code == 200
+    assert hit.status_code == 200
+    assert first.json() == hit.json()
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_writes_to_t1(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get("/api/sessions")
+
+    cache: WebCache = app.state.web_cache
+    # There should be at least one sessions_list entry after the request.
+    assert any(k.startswith("sessions_list:") for k in cache._t1)
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_different_filters_different_keys(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get("/api/sessions?type=race")
+        await client.get("/api/sessions?type=practice")
+
+    cache: WebCache = app.state.web_cache
+    list_keys = [k for k in cache._t1 if k.startswith("sessions_list:")]
+    assert len(list_keys) == 2  # distinct filter combos → distinct keys
+
+
+@pytest.mark.asyncio
+async def test_race_mutation_invalidates_sessions_list(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get("/api/sessions")
+        cache: WebCache = app.state.web_cache
+        assert any(k.startswith("sessions_list:") for k in cache._t1)
+
+        await storage.rename_race(race_id, new_name="Renamed")
+
+        assert not any(k.startswith("sessions_list:") for k in cache._t1)
+
+
+# ---------------------------------------------------------------------------
+# Route — session detail T1 caching + invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_detail_cache_hit_returns_same_body(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        first = await client.get(f"/api/sessions/{race_id}/detail")
+        hit = await client.get(f"/api/sessions/{race_id}/detail")
+    assert first.json() == hit.json()
+
+
+@pytest.mark.asyncio
+async def test_session_detail_404_bypasses_cache(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions/9999/detail")
+    assert resp.status_code == 404
+
+    cache: WebCache = app.state.web_cache
+    assert not any("session_detail" in k for k in cache._t1)
+
+
+@pytest.mark.asyncio
+async def test_session_detail_invalidates_on_race_mutation(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r1 = await client.get(f"/api/sessions/{race_id}/detail")
+        name_before = r1.json()["name"]
+
+        await storage.rename_race(race_id, new_name="After Rename")
+
+        r2 = await client.get(f"/api/sessions/{race_id}/detail")
+        name_after = r2.json()["name"]
+
+    assert name_before == "Race 1"
+    assert name_after == "After Rename"
+
+
+# ---------------------------------------------------------------------------
+# Tag-mutation invalidation hooks on storage (#608 core)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Mock cache that records invalidate + family-drop calls."""
+
+    def __init__(self) -> None:
+        self.invalidated_races: list[int] = []
+        self.families_dropped: list[str] = []
+
+    async def invalidate(self, race_id: int) -> None:
+        self.invalidated_races.append(race_id)
+
+    def t1_invalidate_family(self, family: str) -> None:
+        self.families_dropped.append(family)
+
+
+@pytest.mark.asyncio
+async def test_attach_tag_invalidates_sessions_list(storage: Storage) -> None:
+    race_id = await _seed_completed_race(storage, 1)
+    # Create a tag
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("foo", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("foo",))
+    tag_id = int((await cur.fetchone())["id"])
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    await storage.attach_tag("session", race_id, tag_id, user_id=None)
+
+    assert "sessions_list" in recorder.families_dropped
+
+
+@pytest.mark.asyncio
+async def test_attach_tag_noop_does_not_invalidate(storage: Storage) -> None:
+    """Re-attaching an existing tag is idempotent — no invalidation needed."""
+    race_id = await _seed_completed_race(storage, 1)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("foo", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("foo",))
+    tag_id = int((await cur.fetchone())["id"])
+
+    await storage.attach_tag("session", race_id, tag_id, user_id=None)
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    # Second attach is a no-op
+    await storage.attach_tag("session", race_id, tag_id, user_id=None)
+
+    assert recorder.families_dropped == []
+
+
+@pytest.mark.asyncio
+async def test_detach_tag_invalidates_sessions_list(storage: Storage) -> None:
+    race_id = await _seed_completed_race(storage, 1)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("foo", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("foo",))
+    tag_id = int((await cur.fetchone())["id"])
+    await storage.attach_tag("session", race_id, tag_id, user_id=None)
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    removed = await storage.detach_tag("session", race_id, tag_id)
+
+    assert removed is True
+    assert "sessions_list" in recorder.families_dropped
+
+
+@pytest.mark.asyncio
+async def test_update_tag_invalidates_sessions_list(storage: Storage) -> None:
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("foo", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("foo",))
+    tag_id = int((await cur.fetchone())["id"])
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    changed = await storage.update_tag(tag_id, name="bar")
+
+    assert changed is True
+    assert "sessions_list" in recorder.families_dropped
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_invalidates_sessions_list(storage: Storage) -> None:
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("foo", datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("foo",))
+    tag_id = int((await cur.fetchone())["id"])
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    removed = await storage.delete_tag(tag_id)
+
+    assert removed is True
+    assert "sessions_list" in recorder.families_dropped
+
+
+@pytest.mark.asyncio
+async def test_merge_tags_invalidates_sessions_list(storage: Storage) -> None:
+    db = storage._conn()
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("src", now),
+    )
+    await db.execute(
+        "INSERT INTO tags (name, created_at, usage_count) VALUES (?, ?, 0)",
+        ("tgt", now),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("src",))
+    src_id = int((await cur.fetchone())["id"])
+    cur = await db.execute("SELECT id FROM tags WHERE name = ?", ("tgt",))
+    tgt_id = int((await cur.fetchone())["id"])
+
+    recorder = _Recorder()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    await storage.merge_tags(src_id, tgt_id)
+
+    assert "sessions_list" in recorder.families_dropped


### PR DESCRIPTION
## Summary
Extends the #594 cache infrastructure to two more endpoints and wires tag writes into the invalidation path so the list cache stays coherent.

Closes #608.

## T1 caching
- **`/api/sessions`** (list) — 60s TTL. Cache key is a hash of the filter tuple (`q`, `type`, `from_date`, `to_date`, `tags`, `tag_mode`, `limit`, `offset`) so distinct filter combinations don't collide while still sharing a common invalidation family.
- **`/api/sessions/{id}/detail`** — 60s TTL, race-keyed. Race mutations drop the entry directly via the storage hook; the TTL is a safety net for audio / wind-field / video-link changes that don't flow through the races-row invalidation hook.

## Helper
- New `t1_cached_json_response()` in `routes/_helpers.py` — no ETag negotiation (T1 is process-scoped; thin payloads).
- `WebCache.invalidate(race_id)` now also calls `t1_invalidate_family("sessions_list")` so any race CRUD drops the list cache.

## Tag-mutation hooks in `storage.py`
`attach_tag`, `detach_tag`, `update_tag`, `delete_tag`, `merge_tags` now call `_invalidate_sessions_list_cache()` when they actually change state (idempotent no-ops skip the drop). The helper uses a new `t1_invalidate_family` method on the `RaceCache` Protocol — no per-race T2 eviction, because tag writes don't affect summary / track / wind-field / replay today.

## Test plan
- [x] 15 new tests in `tests/test_web_cache_list_detail.py` covering:
  - T1 helper family-drop semantics (prefix matching)
  - Race invalidation also drops the `sessions_list` family
  - `/api/sessions` cache hit returns same body as miss
  - `/api/sessions` writes to T1; different filters → different keys
  - Race mutation invalidates the list cache
  - `/detail` cache hit + invalidation via race rename
  - `/detail` 404 doesn't poison the cache
  - Every tag-mutation path fires the invalidation (attach/detach/update/delete/merge), idempotent no-op doesn't fire
- [x] Full suite: 2188 passed, 2 skipped, 0 failed
- [x] `ruff check` / `ruff format --check` / `mypy src/` — all clean
- [ ] Manually verify on corvopi-tst1 after deploy: history page first load populates `sessions_list:*` entries; adding a tag via the UI immediately invalidates (next reload is a miss)

## Follow-ups still tracked under #594
- #609 — peer-federation stale-while-revalidate + data-licensing (Critical)
- #610 — external API caching + polar baseline
- #611 — warm-on-complete + admin `/cache/stats`

Part of #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)