### PR TITLE
feat: warm-on-complete + /api/admin/cache/stats observability (#611)

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -130,18 +130,62 @@ class WebCache:
         self._storage = storage
         self._max_rows = max_rows
         self._t1: dict[str, _T1Entry] = {}
+        # Per-family hit/miss/invalidate counters (EARS Req. 18, #611).
+        # Exposed via /api/admin/cache/stats. Fine as a plain dict — the
+        # web stack is a single asyncio loop, no concurrent mutation.
+        self._counters: dict[str, dict[str, int]] = {}
+
+    # ------------------------------------------------------------------
+    # Stats (EARS Req. 18)
+    # ------------------------------------------------------------------
+
+    def _family_of(self, key: str) -> str:
+        """Extract the family prefix from a cache key.
+
+        ``sessions_list:abc`` → ``"sessions_list"``; ``session_detail::race=42``
+        → ``"session_detail"``. Any key without a separator is its own family.
+        """
+        race_idx = key.find("::race=")
+        colon_idx = key.find(":")
+        if race_idx == -1:
+            boundary = colon_idx
+        elif colon_idx == -1:
+            boundary = race_idx
+        else:
+            boundary = min(race_idx, colon_idx)
+        return key[:boundary] if boundary > 0 else key
+
+    def _bump(self, family: str, kind: str) -> None:
+        entry = self._counters.setdefault(family, {"hit": 0, "miss": 0, "invalidate": 0})
+        entry[kind] = entry.get(kind, 0) + 1
+
+    def stats(self) -> dict[str, dict[str, int]]:
+        """Return a snapshot of per-family hit/miss/invalidate counters."""
+        return {k: dict(v) for k, v in self._counters.items()}
+
+    def reset_stats(self) -> None:
+        """Zero all counters. Admin-visible via the stats endpoint."""
+        self._counters.clear()
+
+    def t1_size(self) -> int:
+        """Return the number of live T1 entries (includes expired-but-not-reaped)."""
+        return len(self._t1)
 
     # ------------------------------------------------------------------
     # T1 — process dict with TTL
     # ------------------------------------------------------------------
 
     def t1_get(self, key: str) -> object | None:
+        family = self._family_of(key)
         entry = self._t1.get(key)
         if entry is None:
+            self._bump(family, "miss")
             return None
         if entry.expires_at <= time.monotonic():
             self._t1.pop(key, None)
+            self._bump(family, "miss")
             return None
+        self._bump(family, "hit")
         return entry.value
 
     def t1_put(self, key: str, value: object, *, ttl_seconds: float) -> None:
@@ -159,8 +203,12 @@ class WebCache:
         """Drop every T1 entry whose key starts with ``family:`` or is race-keyed under it."""
         prefix_a = f"{family}:"
         prefix_b = f"{family}::race="
+        dropped = 0
         for key in [k for k in self._t1 if k.startswith(prefix_a) or k.startswith(prefix_b)]:
             self._t1.pop(key, None)
+            dropped += 1
+        if dropped:
+            self._bump(family, "invalidate")
 
     # ------------------------------------------------------------------
     # T2 — SQLite blob cache
@@ -171,13 +219,17 @@ class WebCache:
             row = await self._read_row(key_family, race_id)
         except Exception as exc:  # pragma: no cover - exercised via monkeypatch
             logger.warning("web cache read failed ({}): {}", key_family, exc)
+            self._bump(key_family, "miss")
             return None
         if row is None:
+            self._bump(key_family, "miss")
             return None
         if row["data_hash"] != data_hash:
+            self._bump(key_family, "miss")
             return None
         try:
             decoded: object = json.loads(row["blob"])
+            self._bump(key_family, "hit")
             return decoded
         except (json.JSONDecodeError, TypeError) as exc:
             logger.warning(
@@ -187,6 +239,7 @@ class WebCache:
                 exc,
             )
             await self._delete_row(key_family, race_id)
+            self._bump(key_family, "miss")
             return None
 
     async def t2_put(
@@ -215,19 +268,32 @@ class WebCache:
     # ------------------------------------------------------------------
 
     async def invalidate(self, race_id: int) -> None:
-        # T1 — drop any race-keyed entries for this id
+        # T1 — drop any race-keyed entries for this id, bumping a family
+        # counter for each distinct family we evict so /admin/cache/stats
+        # reflects per-family invalidation pressure.
         suffix = f"::race={race_id}"
+        dropped_families: set[str] = set()
         for key in [k for k in self._t1 if k.endswith(suffix)]:
+            dropped_families.add(self._family_of(key))
             self._t1.pop(key, None)
+        for family in dropped_families:
+            self._bump(family, "invalidate")
         # T1 — drop list-shaped families whose contents depend on the set of
         # races (not on any single race_id). Any race insert/update/delete
         # changes /api/sessions output, so its list-family entries must go.
         self.t1_invalidate_family("sessions_list")
-        # T2 — drop every row for this race
+        # T2 — drop every row for this race.
         try:
             db = self._storage._conn()  # noqa: SLF001
+            cur = await db.execute(
+                "SELECT DISTINCT key_family FROM web_cache WHERE race_id = ?",
+                (race_id,),
+            )
+            t2_families = [r["key_family"] for r in await cur.fetchall()]
             await db.execute("DELETE FROM web_cache WHERE race_id = ?", (race_id,))
             await db.commit()
+            for family in t2_families:
+                self._bump(family, "invalidate")
         except Exception as exc:
             logger.warning("web cache invalidate failed race={}: {}", race_id, exc)
 
@@ -290,9 +356,57 @@ class WebCache:
         await db.commit()
 
 
+async def warm_race_cache(storage: Storage, cache: WebCache, race_id: int) -> None:
+    """Pre-compute session_summary, session_track, and wind_field for a
+    freshly-ended race and store them in T2 (EARS Req. 16).
+
+    Designed to be fire-and-forget — any exception is logged and swallowed
+    so a warming failure can't affect the caller (Req. 17). Called from the
+    HTTP race-end route via ``asyncio.ensure_future``.
+    """
+    # Local import to avoid circular: routes.sessions imports from cache.
+    from helmlog.routes.sessions import (
+        _compute_session_summary,
+        _compute_session_track,
+        _compute_wind_field,
+    )
+
+    data_hash = await resolve_race_data_hash(storage, race_id)
+    if data_hash is None:
+        logger.debug("warm_race_cache: race {} missing, skipping", race_id)
+        return
+
+    async def _warm(family: str, coro: object) -> None:
+        try:
+            payload = await coro  # type: ignore[misc]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "warm_race_cache: compute failed family={} race={}: {}", family, race_id, exc
+            )
+            return
+        try:
+            await cache.t2_put(family, race_id=race_id, data_hash=data_hash, value=payload)
+        except Exception as exc:  # noqa: BLE001 — cache writes are best-effort
+            logger.warning(
+                "warm_race_cache: put failed family={} race={}: {}", family, race_id, exc
+            )
+
+    # Summary + track use a stable key_family; wind-field bakes the default
+    # UI parameters (grid_size=20, elapsed_s=0) into the family, matching
+    # the URL the history page will fetch first.
+    await _warm("session_summary", _compute_session_summary(storage, race_id))
+    await _warm("session_track", _compute_session_track(storage, race_id))
+    await _warm(
+        "wind_field:grid=20:t=0.000",
+        _compute_wind_field(storage, race_id, 0.0, 20),
+    )
+
+
 __all__ = [
     "MAX_CACHE_ROWS_DEFAULT",
     "RaceCache",
     "WebCache",
     "compute_race_data_hash",
+    "resolve_race_data_hash",
+    "warm_race_cache",
 ]

--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -8,7 +8,14 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from helmlog.auth import generate_token, invite_expires_at, require_auth
-from helmlog.routes._helpers import audit, get_storage, limiter, templates, tpl_ctx
+from helmlog.routes._helpers import (
+    audit,
+    get_storage,
+    get_web_cache,
+    limiter,
+    templates,
+    tpl_ctx,
+)
 
 router = APIRouter()
 
@@ -516,3 +523,52 @@ async def admin_tags_page(
 ) -> Response:
     get_storage(request)
     return templates.TemplateResponse(request, "admin/tags.html", tpl_ctx(request, "/admin/tags"))
+
+
+# ---------------------------------------------------------------------------
+# Web-cache observability (#594 / #611)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/admin/cache/stats", include_in_schema=False)
+async def admin_cache_stats(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Return per-family hit/miss/invalidate counters for the web response
+    cache (EARS Req. 18). Also surfaces cache row counts by tier so we can
+    spot unexpected growth on the test Pi.
+    """
+    cache = get_web_cache(request)
+    if cache is None:
+        return JSONResponse({"families": {}, "t1_entries": 0, "t2_rows": 0})
+
+    storage = get_storage(request)
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache")
+    t2_row = await cur.fetchone()
+    t2_rows = int(t2_row["n"]) if t2_row else 0
+
+    # Avoid touching protected attrs from the route layer: expose via
+    # small public helpers on WebCache.
+    return JSONResponse(
+        {
+            "families": cache.stats(),
+            "t1_entries": cache.t1_size(),
+            "t2_rows": t2_rows,
+        }
+    )
+
+
+@router.post("/api/admin/cache/stats/reset", status_code=204, include_in_schema=False)
+async def admin_cache_stats_reset(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Zero the per-family counters. Useful when measuring before/after a
+    specific user flow on the test Pi without restarting the service."""
+    cache = get_web_cache(request)
+    if cache is not None:
+        cache.reset_stats()
+    await audit(request, action="cache_stats_reset")
+    return Response(status_code=204)

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -505,6 +505,15 @@ async def api_end_race(
     asyncio.ensure_future(_network_auto_switch_end())
     asyncio.ensure_future(_auto_detect_maneuvers(race_id))
 
+    # Warm-on-complete (#594 / #611): pre-compute summary/track/wind-field
+    # in the background so the history page hits a warm T2 cache on first
+    # view. Failure logged but never surfaces.
+    _cache = getattr(request.app.state, "web_cache", None)
+    if _cache is not None:
+        from helmlog.cache import warm_race_cache
+
+        asyncio.ensure_future(warm_race_cache(storage, _cache, race_id))
+
     if request.app.state.recorder is not None and ss.audio_session_id is not None:
         from helmlog.audio import capture_stop
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
@@ -21,6 +21,9 @@ from helmlog.routes._helpers import (
     limiter,
     t1_cached_json_response,
 )
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
 
 router = APIRouter()
 
@@ -297,80 +300,90 @@ async def api_session_track(
     storage = get_storage(request)
 
     async def _compute() -> dict[str, Any]:
-        db = storage._conn()
-        cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
-        row = await cur.fetchone()
-        if row is None:
-            raise HTTPException(status_code=404, detail="Race not found")
-        start_utc = row["start_utc"]
-        end_utc = row["end_utc"] or start_utc
-
-        # Prefer race_id filter (exact match for synthesized sessions);
-        # fall back to time-range query for real instrument data.
-        rid_cur = await db.execute(
-            "SELECT COUNT(*) as cnt FROM positions WHERE race_id = ?", (session_id,)
-        )
-        rid_row = await rid_cur.fetchone()
-        has_race_id = rid_row["cnt"] > 0 if rid_row else False
-
-        if has_race_id:
-            pos_cur = await db.execute(
-                "SELECT latitude_deg, longitude_deg, ts FROM positions"
-                " WHERE race_id = ? ORDER BY ts",
-                (session_id,),
-            )
-        else:
-            pos_cur = await db.execute(
-                "SELECT latitude_deg, longitude_deg, ts FROM positions"
-                " WHERE ts >= ? AND ts <= ? ORDER BY ts",
-                (start_utc, end_utc),
-            )
-        positions = await pos_cur.fetchall()
-        if not positions:
-            return {"type": "FeatureCollection", "features": []}
-
-        # Per-second mean averaging. The SK reader currently records every fix
-        # with source_addr=0 even when Signal K is multiplexing two physical
-        # GPS antennas, so the raw rows zig-zag between antennas (~3m apart).
-        # Bucketing to 1Hz and averaging within the bucket collapses the
-        # zig-zag into a smooth single line midway between the antennas — what
-        # you'd get from a single GPS anyway. Also gives the frontend a
-        # naturally Vakaros-density polyline so its dash style reads cleanly.
-        buckets: dict[str, list[tuple[float, float]]] = {}
-        bucket_order: list[str] = []
-        for r in positions:
-            ts_raw = r["ts"]
-            if not ts_raw:
-                continue
-            key = str(ts_raw)[:19]  # truncate to whole-second precision
-            if key not in buckets:
-                buckets[key] = []
-                bucket_order.append(key)
-            buckets[key].append((float(r["latitude_deg"]), float(r["longitude_deg"])))
-
-        coords: list[list[float]] = []
-        timestamps: list[str] = []
-        for key in bucket_order:
-            rows = buckets[key]
-            avg_lat = sum(p[0] for p in rows) / len(rows)
-            avg_lng = sum(p[1] for p in rows) / len(rows)
-            coords.append([avg_lng, avg_lat])
-            timestamps.append(key + ("" if key.endswith("Z") or "+" in key else "Z"))
-
-        feature = {
-            "type": "Feature",
-            "geometry": {"type": "LineString", "coordinates": coords},
-            "properties": {
-                "session_id": session_id,
-                "points": len(coords),
-                "timestamps": timestamps,
-            },
-        }
-        return {"type": "FeatureCollection", "features": [feature]}
+        return await _compute_session_track(storage, session_id)
 
     return await cached_json_response(
         request, race_id=session_id, key_family="session_track", compute=_compute
     )
+
+
+async def _compute_session_track(storage: Storage, session_id: int) -> dict[str, Any]:
+    """Build the GeoJSON FeatureCollection for a session's GPS track.
+
+    Called by the HTTP endpoint and by the warm-on-complete hook in
+    ``cache.warm_race_cache`` (#611). Raises ``HTTPException(404)`` when
+    the race doesn't exist — the HTTP path surfaces that; the warmer
+    catches and logs it.
+    """
+    db = storage._conn()
+    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    row = await cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Race not found")
+    start_utc = row["start_utc"]
+    end_utc = row["end_utc"] or start_utc
+
+    # Prefer race_id filter (exact match for synthesized sessions);
+    # fall back to time-range query for real instrument data.
+    rid_cur = await db.execute(
+        "SELECT COUNT(*) as cnt FROM positions WHERE race_id = ?", (session_id,)
+    )
+    rid_row = await rid_cur.fetchone()
+    has_race_id = rid_row["cnt"] > 0 if rid_row else False
+
+    if has_race_id:
+        pos_cur = await db.execute(
+            "SELECT latitude_deg, longitude_deg, ts FROM positions WHERE race_id = ? ORDER BY ts",
+            (session_id,),
+        )
+    else:
+        pos_cur = await db.execute(
+            "SELECT latitude_deg, longitude_deg, ts FROM positions"
+            " WHERE ts >= ? AND ts <= ? ORDER BY ts",
+            (start_utc, end_utc),
+        )
+    positions = await pos_cur.fetchall()
+    if not positions:
+        return {"type": "FeatureCollection", "features": []}
+
+    # Per-second mean averaging. The SK reader currently records every fix
+    # with source_addr=0 even when Signal K is multiplexing two physical
+    # GPS antennas, so the raw rows zig-zag between antennas (~3m apart).
+    # Bucketing to 1Hz and averaging within the bucket collapses the
+    # zig-zag into a smooth single line midway between the antennas — what
+    # you'd get from a single GPS anyway. Also gives the frontend a
+    # naturally Vakaros-density polyline so its dash style reads cleanly.
+    buckets: dict[str, list[tuple[float, float]]] = {}
+    bucket_order: list[str] = []
+    for r in positions:
+        ts_raw = r["ts"]
+        if not ts_raw:
+            continue
+        key = str(ts_raw)[:19]  # truncate to whole-second precision
+        if key not in buckets:
+            buckets[key] = []
+            bucket_order.append(key)
+        buckets[key].append((float(r["latitude_deg"]), float(r["longitude_deg"])))
+
+    coords: list[list[float]] = []
+    timestamps: list[str] = []
+    for key in bucket_order:
+        rows = buckets[key]
+        avg_lat = sum(p[0] for p in rows) / len(rows)
+        avg_lng = sum(p[1] for p in rows) / len(rows)
+        coords.append([avg_lng, avg_lat])
+        timestamps.append(key + ("" if key.endswith("Z") or "+" in key else "Z"))
+
+    feature = {
+        "type": "Feature",
+        "geometry": {"type": "LineString", "coordinates": coords},
+        "properties": {
+            "session_id": session_id,
+            "points": len(coords),
+            "timestamps": timestamps,
+        },
+    }
+    return {"type": "FeatureCollection", "features": [feature]}
 
 
 @router.get("/api/sessions/{session_id}/summary")
@@ -387,19 +400,20 @@ async def api_session_summary(
     finishers. Designed to be cheap enough for per-row lazy fetch.
     """
 
+    storage = get_storage(request)
+
     async def _compute() -> dict[str, Any]:
-        return await _compute_session_summary(request, session_id)
+        return await _compute_session_summary(storage, session_id)
 
     return await cached_json_response(
         request, race_id=session_id, key_family="session_summary", compute=_compute
     )
 
 
-async def _compute_session_summary(request: Request, session_id: int) -> dict[str, Any]:
+async def _compute_session_summary(storage: Storage, session_id: int) -> dict[str, Any]:
     import math
     from bisect import bisect_left
 
-    storage = get_storage(request)
     db = storage._conn()
 
     cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
@@ -668,9 +682,10 @@ async def api_session_detail(
     # 60s TTL guards against audio / wind-field / video-link changes that
     # don't flow through the races-row invalidation hook.
     cache_key = f"session_detail::race={session_id}"
+    storage = get_storage(request)
 
     async def _compute() -> dict[str, Any]:
-        return await _compute_session_detail(request, session_id)
+        return await _compute_session_detail(storage, session_id)
 
     return await t1_cached_json_response(
         request,
@@ -680,8 +695,7 @@ async def api_session_detail(
     )
 
 
-async def _compute_session_detail(request: Request, session_id: int) -> dict[str, Any]:
-    storage = get_storage(request)
+async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str, Any]:
     db = storage._conn()
     cur = await db.execute(
         "SELECT r.id, r.name, r.event, r.race_num, r.date,"
@@ -806,9 +820,10 @@ async def api_session_wind_field(
     # invalidation works without bespoke hooks per parameter.
     clamped_grid = min(max(grid_size, 5), 40)
     key_family = f"wind_field:grid={clamped_grid}:t={elapsed_s:.3f}"
+    storage = get_storage(request)
 
     async def _compute() -> dict[str, Any]:
-        return await _compute_wind_field(request, session_id, elapsed_s, clamped_grid)
+        return await _compute_wind_field(storage, session_id, elapsed_s, clamped_grid)
 
     return await cached_json_response(
         request, race_id=session_id, key_family=key_family, compute=_compute
@@ -816,9 +831,8 @@ async def api_session_wind_field(
 
 
 async def _compute_wind_field(
-    request: Request, session_id: int, elapsed_s: float, grid_size: int
+    storage: Storage, session_id: int, elapsed_s: float, grid_size: int
 ) -> dict[str, Any]:
-    storage = get_storage(request)
     from helmlog.wind_field import WindField
 
     params = await storage.get_synth_wind_params(session_id)
@@ -1029,16 +1043,17 @@ async def api_session_replay(
     sensor had no reading for that second.
     """
 
+    storage = get_storage(request)
+
     async def _compute() -> dict[str, Any]:
-        return await _compute_session_replay(request, session_id)
+        return await _compute_session_replay(storage, session_id)
 
     return await cached_json_response(
         request, race_id=session_id, key_family="session_replay", compute=_compute
     )
 
 
-async def _compute_session_replay(request: Request, session_id: int) -> dict[str, Any]:
-    storage = get_storage(request)
+async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str, Any]:
     db = storage._conn()
     cur = await db.execute("SELECT id, start_utc, end_utc FROM races WHERE id = ?", (session_id,))
     row = await cur.fetchone()

--- a/tests/test_web_cache_stats_warm.py
+++ b/tests/test_web_cache_stats_warm.py
@@ -1,0 +1,290 @@
+"""Tests for /api/admin/cache/stats + warm-on-complete (#611)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.cache import WebCache, warm_race_cache
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+_START = datetime(2026, 2, 26, 14, 0, 0, tzinfo=UTC)
+_END = datetime(2026, 2, 26, 14, 30, 0, tzinfo=UTC)
+
+
+async def _seed_completed_race(storage: Storage, race_num: int = 1) -> int:
+    race = await storage.start_race(
+        event="E",
+        start_utc=_START + timedelta(minutes=race_num),
+        date_str="2026-02-26",
+        race_num=race_num,
+        name=f"Race {race_num}",
+    )
+    db = storage._conn()
+    for i in range(3):
+        ts = (_START + timedelta(minutes=race_num, seconds=i * 30)).isoformat()
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (ts, 0, 37.7, -122.4, race.id),
+        )
+    await db.commit()
+    await storage.end_race(race.id, _END + timedelta(minutes=race_num))
+    return race.id
+
+
+# ---------------------------------------------------------------------------
+# Counter unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_family_of_parses_list_and_race_keys(storage: Storage) -> None:
+    cache = WebCache(storage)
+    assert cache._family_of("sessions_list:abc123") == "sessions_list"
+    assert cache._family_of("session_detail::race=42") == "session_detail"
+    assert cache._family_of("wind_field:grid=20:t=0.000") == "wind_field"
+    assert cache._family_of("plain") == "plain"
+
+
+@pytest.mark.asyncio
+async def test_t1_hit_and_miss_bump_counters(storage: Storage) -> None:
+    cache = WebCache(storage)
+    # Miss
+    assert cache.t1_get("sessions_list:abc") is None
+    # Hit
+    cache.t1_put("sessions_list:abc", {"v": 1}, ttl_seconds=60)
+    assert cache.t1_get("sessions_list:abc") == {"v": 1}
+    # Another miss (different key, same family)
+    assert cache.t1_get("sessions_list:def") is None
+
+    stats = cache.stats()
+    assert stats["sessions_list"]["miss"] == 2
+    assert stats["sessions_list"]["hit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_t2_hit_and_miss_bump_counters(storage: Storage) -> None:
+    cache = WebCache(storage)
+    await cache.t2_put("session_track", race_id=1, data_hash="h", value={"v": 1})
+
+    # Hit
+    assert await cache.t2_get("session_track", race_id=1, data_hash="h") == {"v": 1}
+    # Miss — stale hash
+    assert await cache.t2_get("session_track", race_id=1, data_hash="WRONG") is None
+    # Miss — no row
+    assert await cache.t2_get("session_track", race_id=99, data_hash="h") is None
+
+    stats = cache.stats()
+    assert stats["session_track"]["hit"] == 1
+    assert stats["session_track"]["miss"] == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_bumps_counter_once_per_family(storage: Storage) -> None:
+    cache = WebCache(storage)
+    # Two entries in two families for the same race.
+    await cache.t2_put("session_summary", race_id=1, data_hash="h", value={"v": 1})
+    await cache.t2_put("session_track", race_id=1, data_hash="h", value={"v": 2})
+    # One T1 race-keyed entry too.
+    cache.t1_put_for_race("session_detail", race_id=1, value={"v": 3}, ttl_seconds=60)
+    # And a list-family entry.
+    cache.t1_put("sessions_list:abc", {"v": 4}, ttl_seconds=60)
+
+    await cache.invalidate(1)
+
+    stats = cache.stats()
+    # T2 invalidate: each distinct key_family once
+    assert stats["session_summary"]["invalidate"] == 1
+    assert stats["session_track"]["invalidate"] == 1
+    # T1 race-keyed invalidate
+    assert stats["session_detail"]["invalidate"] == 1
+    # T1 family-drop
+    assert stats["sessions_list"]["invalidate"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_stats_clears_counters(storage: Storage) -> None:
+    cache = WebCache(storage)
+    cache.t1_get("missing:key")
+    assert cache.stats() != {}
+    cache.reset_stats()
+    assert cache.stats() == {}
+
+
+# ---------------------------------------------------------------------------
+# /api/admin/cache/stats endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_endpoint_requires_admin(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")  # mock admin in test harness
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/admin/cache/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "families" in body
+    assert "t1_entries" in body
+    assert "t2_rows" in body
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_reflects_usage(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Miss, then hit
+        await client.get(f"/api/sessions/{race_id}/summary")
+        await client.get(f"/api/sessions/{race_id}/summary")
+
+        resp = await client.get("/api/admin/cache/stats")
+
+    body = resp.json()
+    assert "session_summary" in body["families"]
+    assert body["families"]["session_summary"]["miss"] >= 1
+    assert body["families"]["session_summary"]["hit"] >= 1
+    assert body["t2_rows"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_cache_stats_reset(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_completed_race(storage, 1)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await client.get(f"/api/sessions/{race_id}/summary")
+        before = (await client.get("/api/admin/cache/stats")).json()
+        assert before["families"] != {}
+
+        reset = await client.post("/api/admin/cache/stats/reset")
+        assert reset.status_code == 204
+
+        after = (await client.get("/api/admin/cache/stats")).json()
+        # The GET right after reset counts as one lookup; only session_list
+        # (from get_storage/ list path) should not appear yet. Everything
+        # else has been zeroed.
+        for fam, counters in after["families"].items():
+            assert counters["hit"] == 0, f"family {fam} should be zeroed"
+
+
+# ---------------------------------------------------------------------------
+# warm_race_cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warm_race_cache_populates_three_families(storage: Storage) -> None:
+    race_id = await _seed_completed_race(storage, 1)
+    cache = WebCache(storage)
+    storage.bind_race_cache(cache)
+
+    await warm_race_cache(storage, cache, race_id)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT key_family FROM web_cache WHERE race_id = ? ORDER BY key_family",
+        (race_id,),
+    )
+    families = [r["key_family"] for r in await cur.fetchall()]
+    # wind-field is only populated for synth sessions; real race won't warm it.
+    assert "session_summary" in families
+    assert "session_track" in families
+
+
+@pytest.mark.asyncio
+async def test_warm_race_cache_missing_race_is_noop(storage: Storage) -> None:
+    cache = WebCache(storage)
+    # Should not raise even though race 9999 doesn't exist.
+    await warm_race_cache(storage, cache, 9999)
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache")
+    assert (await cur.fetchone())["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_warm_race_cache_survives_compute_failure(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    race_id = await _seed_completed_race(storage, 1)
+    cache = WebCache(storage)
+
+    from helmlog.routes import sessions as sessions_mod
+
+    async def _boom(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sessions_mod, "_compute_session_track", _boom)
+
+    # Should still populate summary even though track fails.
+    await warm_race_cache(storage, cache, race_id)
+
+    db = storage._conn()
+    cur = await db.execute("SELECT key_family FROM web_cache WHERE race_id = ?", (race_id,))
+    families = [r["key_family"] for r in await cur.fetchall()]
+    assert "session_summary" in families
+    assert "session_track" not in families  # failed family skipped
+
+
+@pytest.mark.asyncio
+async def test_end_race_http_path_triggers_warm(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /api/races/{id}/end should fire warm_race_cache in background."""
+    import asyncio
+
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    # Start a race (cannot use _seed_completed_race since we want end_race via HTTP)
+    race = await storage.start_race(
+        event="E",
+        start_utc=_START,
+        date_str="2026-02-26",
+        race_num=1,
+        name="Race 1",
+    )
+    db = storage._conn()
+    for i in range(3):
+        ts = (_START + timedelta(seconds=i * 30)).isoformat()
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (ts, 0, 37.7, -122.4, race.id),
+        )
+    await db.commit()
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(f"/api/races/{race.id}/end")
+        assert resp.status_code == 204
+
+    # Let the background task finish.
+    for _ in range(20):
+        await asyncio.sleep(0.05)
+        cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ?", (race.id,))
+        if (await cur.fetchone())["n"] >= 2:
+            break
+
+    cur = await db.execute("SELECT key_family FROM web_cache WHERE race_id = ?", (race.id,))
+    families = [r["key_family"] for r in await cur.fetchall()]
+    assert "session_summary" in families
+    assert "session_track" in families


### PR DESCRIPTION
## Summary
Closes out the observability + pre-warming items from #594. **Stacked on #617** — retarget to \`main\` once that lands.

Closes #611.

## EARS requirements
- **16** — \`end_race\` HTTP route schedules a background warm task that pre-computes \`session_summary\`, \`session_track\`, and \`wind_field\` for the just-ended race. History page hits warm T2 cache on first view.
- **17** — Warm failure is logged but never blocks the end_race response.
- **18** — Per-family hit/miss/invalidate counters exposed via \`/api/admin/cache/stats\` (admin-only).

## Endpoints
- \`GET /api/admin/cache/stats\` → \`{"families": {...}, "t1_entries": N, "t2_rows": M}\`
- \`POST /api/admin/cache/stats/reset\` → 204 (+ audit log entry)

Both guarded by \`require_auth("admin")\`.

## Implementation
- \`WebCache._counters\` — dict[family, dict[hit/miss/invalidate]]. Hit/miss bumped on every \`t1_get\` and \`t2_get\`; invalidate bumped per family on \`t1_invalidate_family\` and on \`invalidate(race_id)\` (once per distinct T1 family dropped + once per distinct T2 \`key_family\` dropped).
- \`WebCache.stats()\`, \`reset_stats()\`, \`t1_size()\`.
- \`cache.warm_race_cache(storage, cache, race_id)\` fires after \`storage.end_race\` via \`asyncio.ensure_future\` — matches the existing pattern for camera-stop / maneuver-detection in that route.
- Refactored \`_compute_session_summary\`, \`_compute_session_track\`, \`_compute_session_detail\`, \`_compute_wind_field\`, \`_compute_session_replay\` to take \`storage\` directly (not \`Request\`) so the warmer can call them outside an HTTP context.

## Test plan
- [x] 12 new tests in \`tests/test_web_cache_stats_warm.py\`:
  - Counter bump on T1/T2 hit/miss (separately)
  - Invalidate bumps per-family once per dropped family
  - reset_stats clears counters
  - /api/admin/cache/stats returns populated stats after a miss+hit pair
  - /api/admin/cache/stats/reset zeroes counters
  - warm_race_cache populates summary + track for a seeded race
  - warm_race_cache on missing race is a silent no-op
  - warm_race_cache survives per-family compute failure (one family fails, others still warmed)
  - HTTP \`POST /api/races/{id}/end\` fires the warm task in background
- [x] Full suite: 2200 passed, 2 skipped
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src/\` — all clean
- [ ] Manually verify on corvopi-tst1 after deploy: open admin, hit \`/api/admin/cache/stats\`, confirm counters match browsing behaviour; end a race via UI and observe that \`/history\` served 304s immediately for the new row (warm cache kicked in)

Part of #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)