### PR TITLE
feat: capture heel and trim from Signal K navigation.attitude

### DIFF
--- a/src/helmlog/nmea2000.py
+++ b/src/helmlog/nmea2000.py
@@ -2,6 +2,7 @@
 
 Supported PGNs:
     127250 — Vessel Heading
+    127257 — Attitude (heel/trim)
     128259 — Speed Through Water
     128267 — Water Depth
     129025 — Position Rapid Update
@@ -27,6 +28,7 @@ from loguru import logger
 # ---------------------------------------------------------------------------
 
 PGN_VESSEL_HEADING: Final[int] = 127250
+PGN_ATTITUDE: Final[int] = 127257
 PGN_SPEED_THROUGH_WATER: Final[int] = 128259
 PGN_WATER_DEPTH: Final[int] = 128267
 PGN_POSITION_RAPID: Final[int] = 129025
@@ -38,6 +40,7 @@ PGN_RUDDER_ANGLE: Final[int] = 127245
 SUPPORTED_PGNS: Final[frozenset[int]] = frozenset(
     {
         PGN_VESSEL_HEADING,
+        PGN_ATTITUDE,
         PGN_SPEED_THROUGH_WATER,
         PGN_WATER_DEPTH,
         PGN_POSITION_RAPID,
@@ -168,6 +171,17 @@ class RudderRecord:
     rudder_angle_deg: float  # degrees (positive = starboard)
 
 
+@dataclass(frozen=True)
+class AttitudeRecord:
+    """PGN 127257 — Attitude (heel/trim)."""
+
+    pgn: int
+    source_addr: int
+    timestamp: datetime
+    heel_deg: float  # roll, degrees (positive = starboard down)
+    trim_deg: float  # pitch, degrees (positive = bow up)
+
+
 # Union type for all PGN record types
 PGNRecord = (
     HeadingRecord
@@ -178,6 +192,7 @@ PGNRecord = (
     | WindRecord
     | EnvironmentalRecord
     | RudderRecord
+    | AttitudeRecord
 )
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/sk_reader.py
+++ b/src/helmlog/sk_reader.py
@@ -19,6 +19,7 @@ from loguru import logger
 from websockets.asyncio.client import connect as _ws_connect
 
 from helmlog.nmea2000 import (
+    PGN_ATTITUDE,
     PGN_COG_SOG_RAPID,
     PGN_ENVIRONMENTAL,
     PGN_POSITION_RAPID,
@@ -27,6 +28,7 @@ from helmlog.nmea2000 import (
     PGN_VESSEL_HEADING,
     PGN_WATER_DEPTH,
     PGN_WIND_DATA,
+    AttitudeRecord,
     COGSOGRecord,
     DepthRecord,
     EnvironmentalRecord,
@@ -260,6 +262,32 @@ def process_delta(
                     )
                 except (KeyError, TypeError, ValueError) as exc:
                     logger.warning("SK: bad position value {!r}: {}", value, exc)
+                continue
+
+            if path == "navigation.attitude":
+                # Compound value {roll, pitch, yaw} in radians. Yaw is already
+                # covered by navigation.headingTrue; we only care about
+                # heel (roll) and trim (pitch).
+                try:
+                    roll = value.get("roll")
+                    pitch = value.get("pitch")
+                except AttributeError:
+                    logger.warning("SK: non-dict attitude value {!r}", value)
+                    continue
+                if roll is None or pitch is None:
+                    continue
+                try:
+                    records.append(
+                        AttitudeRecord(
+                            PGN_ATTITUDE,
+                            update_source_addr,
+                            ts,
+                            float(roll) * _RAD_TO_DEG,
+                            float(pitch) * _RAD_TO_DEG,
+                        )
+                    )
+                except (TypeError, ValueError) as exc:
+                    logger.warning("SK: bad attitude value {!r}: {}", value, exc)
                 continue
 
             if simple_fn := _SIMPLE.get(path):

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 from helmlog.anchors import Anchor, validate_anchor
 from helmlog.nmea2000 import (
+    AttitudeRecord,
     COGSOGRecord,
     DepthRecord,
     EnvironmentalRecord,
@@ -199,7 +200,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 73
+_CURRENT_VERSION: int = 74
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1732,6 +1733,20 @@ _MIGRATIONS: dict[int, str] = {
         CREATE INDEX IF NOT EXISTS idx_web_cache_race ON web_cache(race_id);
         CREATE INDEX IF NOT EXISTS idx_web_cache_created ON web_cache(created_utc);
     """,
+    74: """
+        -- #622: attitude (heel/trim) from PGN 127257 / SK navigation.attitude.
+        -- heel_deg = roll (positive = starboard down),
+        -- trim_deg = pitch (positive = bow up). Yaw is already covered by
+        -- headings (navigation.headingTrue) and not stored here.
+        CREATE TABLE IF NOT EXISTS attitudes (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT    NOT NULL,
+            source_addr INTEGER NOT NULL,
+            heel_deg    REAL    NOT NULL,
+            trim_deg    REAL    NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_attitudes_ts ON attitudes(ts);
+    """,
 }
 
 # Retention window for retired slugs (#449). Requests for a retired slug 301
@@ -1795,6 +1810,7 @@ class Storage:
         self._live_tw_angle_raw: float | None = None
         self._on_live_update: Callable[[dict[str, float | None]], None] | None = None
         self._last_rudder_write: float = 0.0
+        self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
         # instance after Storage is connected so any race mutation flows
         # through cache.invalidate(race_id) in-transaction.
@@ -1864,6 +1880,9 @@ class Storage:
                 self._recompute_true_wind()
             case RudderRecord():
                 self._live["rudder_deg"] = round(record.rudder_angle_deg, 1)
+            case AttitudeRecord():
+                self._live["heel_deg"] = round(record.heel_deg, 1)
+                self._live["trim_deg"] = round(record.trim_deg, 1)
         if self._on_live_update is not None:
             self._on_live_update(dict(self._live))
 
@@ -2399,6 +2418,8 @@ class Storage:
                 await self._write_environmental(record)
             case RudderRecord():
                 await self._write_rudder(record)
+            case AttitudeRecord():
+                await self._write_attitude(record)
         self._pending += 1
         await self._auto_flush()
 
@@ -2491,6 +2512,21 @@ class Storage:
             (_ts(r.timestamp), r.source_addr, r.rudder_angle_deg),
         )
 
+    async def _write_attitude(self, r: AttitudeRecord) -> None:
+        now = time.monotonic()
+        try:
+            hz = float(os.environ.get("ATTITUDE_STORAGE_HZ", "2"))
+        except ValueError:
+            hz = 2.0
+        if hz > 0 and (now - self._last_attitude_write) < (1.0 / hz):
+            return
+        self._last_attitude_write = now
+        db = self._conn()
+        await db.execute(
+            "INSERT INTO attitudes (ts, source_addr, heel_deg, trim_deg) VALUES (?, ?, ?, ?)",
+            (_ts(r.timestamp), r.source_addr, r.heel_deg, r.trim_deg),
+        )
+
     # ------------------------------------------------------------------
     # Query
     # ------------------------------------------------------------------
@@ -2521,6 +2557,7 @@ class Storage:
             "cogsog",
             "winds",
             "environmental",
+            "attitudes",
         }
         if table not in _ALLOWED_TABLES:
             raise ValueError(f"Unknown table: {table!r}")

--- a/tests/test_migration_v73.py
+++ b/tests/test_migration_v73.py
@@ -81,8 +81,8 @@ async def test_v73_web_cache_primary_key_is_family_plus_race() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_73_on_fresh_db() -> None:
-    from helmlog.storage import Storage, StorageConfig
+async def test_schema_version_tracks_current_on_fresh_db() -> None:
+    from helmlog.storage import _CURRENT_VERSION, Storage, StorageConfig
 
     s = Storage(StorageConfig(db_path=":memory:"))
     await s.connect()
@@ -91,6 +91,6 @@ async def test_schema_version_is_73_on_fresh_db() -> None:
         async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == 73
+        assert row[0] == _CURRENT_VERSION
     finally:
         await s.close()

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from helmlog.nmea2000 import (
+    AttitudeRecord,
     COGSOGRecord,
     DepthRecord,
     EnvironmentalRecord,
@@ -147,6 +148,34 @@ class TestPathConversions:
         assert abs(rec.rudder_angle_deg - 10.0) < 0.1
         assert rec.source_addr == SK_SOURCE_ADDR
         assert rec.timestamp == _TS_DT
+
+    def test_attitude_rad_to_deg(self) -> None:
+        buf: dict[str, float] = {}
+        # heel = 15°, trim = -2° (bow down)
+        value = {"roll": math.radians(15.0), "pitch": math.radians(-2.0), "yaw": 0.0}
+        records = process_delta(_delta("navigation.attitude", value), buf)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, AttitudeRecord)
+        assert abs(rec.heel_deg - 15.0) < 1e-6
+        assert abs(rec.trim_deg - -2.0) < 1e-6
+        assert rec.source_addr == SK_SOURCE_ADDR
+        assert rec.timestamp == _TS_DT
+
+    def test_attitude_missing_yaw_ok(self) -> None:
+        buf: dict[str, float] = {}
+        # Some SK sources omit yaw — should still emit a record
+        records = process_delta(_delta("navigation.attitude", {"roll": 0.1, "pitch": 0.05}), buf)
+        assert len(records) == 1
+        assert isinstance(records[0], AttitudeRecord)
+
+    def test_attitude_partial_dropped(self) -> None:
+        buf: dict[str, float] = {}
+        # Missing either roll or pitch → no record (avoid partial writes)
+        records = process_delta(_delta("navigation.attitude", {"roll": 0.1}), buf)
+        assert records == []
+        records = process_delta(_delta("navigation.attitude", {"pitch": 0.1}), buf)
+        assert records == []
 
     def test_true_wind_ref_zero(self) -> None:
         buf: dict[str, float] = {}

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from helmlog.nmea2000 import (
+    PGN_ATTITUDE,
     PGN_COG_SOG_RAPID,
     PGN_ENVIRONMENTAL,
     PGN_POSITION_RAPID,
@@ -15,6 +16,7 @@ from helmlog.nmea2000 import (
     PGN_VESSEL_HEADING,
     PGN_WATER_DEPTH,
     PGN_WIND_DATA,
+    AttitudeRecord,
     COGSOGRecord,
     DepthRecord,
     EnvironmentalRecord,
@@ -56,6 +58,7 @@ class TestMigration:
             "tides",
             "session_notes",
             "race_videos",
+            "attitudes",
         }:
             assert expected in names, f"Table {expected!r} not found"
 
@@ -290,6 +293,25 @@ class TestWriteQuery:
         rows = await storage.query_range("environmental", _TS, _TS + timedelta(seconds=1))
         assert len(rows) == 1
         assert abs(rows[0]["water_temp_c"] - 20.0) < 0.001
+
+    async def test_attitude_round_trip(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Disable the write-rate gate so every record lands in the table.
+        monkeypatch.setenv("ATTITUDE_STORAGE_HZ", "0")
+        record = AttitudeRecord(
+            pgn=PGN_ATTITUDE,
+            source_addr=5,
+            timestamp=_TS,
+            heel_deg=12.5,
+            trim_deg=-1.25,
+        )
+        await storage.write(record)
+        rows = await storage.query_range("attitudes", _TS, _TS + timedelta(seconds=1))
+        assert len(rows) == 1
+        assert abs(rows[0]["heel_deg"] - 12.5) < 0.001
+        assert abs(rows[0]["trim_deg"] - -1.25) < 0.001
+        assert rows[0]["source_addr"] == 5
 
     async def test_none_fields_stored_as_null(self, storage: Storage) -> None:
         record = HeadingRecord(


### PR DESCRIPTION
## Summary

- Adds `AttitudeRecord` + `PGN_ATTITUDE` (127257) and handles the SK `navigation.attitude` compound path (`{roll, pitch, yaw}` radians) in `sk_reader.py`
- New `attitudes` table via schema migration v74 with a ts index; write path is gated by `ATTITUDE_STORAGE_HZ` (default 2 Hz), mirroring the rudder pattern
- Live instrument cache now exposes `heel_deg` (roll) and `trim_deg` (pitch); yaw is already covered by `navigation.headingTrue` and is not stored

Urgent: requested for tonight's race so heel/trim are recorded during racing.

Closes #622

## Risk

- High (`sk_reader.py`) + Critical (storage migration). Migration is additive (CREATE TABLE + CREATE INDEX), no backfill, no column changes to existing tables.

## Test plan

- [x] `uv run pytest -q --no-cov` — 2177 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — clean
- [x] New unit tests cover the SK delta parse (heel/trim rad→deg, missing yaw, partial rejection) and the storage round-trip
- [ ] Post-merge: deploy to corvopi-tst1 and corvopi-prd1; confirm `attitudes` table is present and that rows land during a test session with the B&G bus connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)