### PR TITLE
feat: T2 cache on weather + tides with TTL support (#610)

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -227,6 +227,18 @@ class WebCache:
         if row["data_hash"] != data_hash:
             self._bump(key_family, "miss")
             return None
+        # v74+ schema: expires_utc is always present (NULL for race-keyed
+        # rows that rely on invalidation hooks rather than TTL).
+        expires = row["expires_utc"]
+        if expires is not None:
+            try:
+                exp_dt = datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
+            except ValueError:
+                exp_dt = None
+            if exp_dt is not None and exp_dt <= datetime.now(UTC):
+                await self._delete_row(key_family, race_id)
+                self._bump(key_family, "miss")
+                return None
         try:
             decoded: object = json.loads(row["blob"])
             self._bump(key_family, "hit")
@@ -249,6 +261,7 @@ class WebCache:
         race_id: int,
         data_hash: str,
         value: object,
+        ttl_seconds: float | None = None,
         _now: datetime | None = None,
     ) -> None:
         try:
@@ -256,12 +269,42 @@ class WebCache:
         except (TypeError, ValueError) as exc:
             logger.warning("web cache encode failed for {}: {}", key_family, exc)
             return
-        created = (_now or datetime.now(UTC)).isoformat()
+        now = _now or datetime.now(UTC)
+        created = now.isoformat()
+        expires_iso: str | None = None
+        if ttl_seconds is not None and ttl_seconds > 0:
+            from datetime import timedelta
+
+            expires_iso = (now + timedelta(seconds=ttl_seconds)).isoformat()
         try:
-            await self._write_row(key_family, race_id, data_hash, blob, created)
+            await self._write_row(key_family, race_id, data_hash, blob, created, expires_iso)
             await self._evict_over_cap()
         except Exception as exc:
             logger.warning("web cache write failed ({}): {}", key_family, exc)
+
+    # ------------------------------------------------------------------
+    # T2 — global (non-race-keyed) entries (#610)
+    # ------------------------------------------------------------------
+    #
+    # External API fetches (weather, tides) aren't tied to any race, so
+    # they share the T2 table via a race_id=0 sentinel. Invalidation of
+    # these entries is TTL-only — the race-mutation hook leaves them
+    # alone (race_id=0 never matches a real race).
+
+    async def t2_get_global(self, key_family: str, *, data_hash: str) -> object | None:
+        return await self.t2_get(key_family, race_id=0, data_hash=data_hash)
+
+    async def t2_put_global(
+        self,
+        key_family: str,
+        *,
+        data_hash: str,
+        value: object,
+        ttl_seconds: float | None,
+    ) -> None:
+        await self.t2_put(
+            key_family, race_id=0, data_hash=data_hash, value=value, ttl_seconds=ttl_seconds
+        )
 
     # ------------------------------------------------------------------
     # Invalidation — called by storage race-mutation paths
@@ -304,7 +347,8 @@ class WebCache:
     async def _read_row(self, key_family: str, race_id: int) -> aiosqlite.Row | None:
         db = self._storage._conn()  # noqa: SLF001
         cur = await db.execute(
-            "SELECT data_hash, blob FROM web_cache WHERE key_family = ? AND race_id = ?",
+            "SELECT data_hash, blob, expires_utc FROM web_cache"
+            " WHERE key_family = ? AND race_id = ?",
             (key_family, race_id),
         )
         return await cur.fetchone()
@@ -316,16 +360,18 @@ class WebCache:
         data_hash: str,
         blob: str,
         created_utc: str,
+        expires_utc: str | None,
     ) -> None:
         db = self._storage._conn()  # noqa: SLF001
         await db.execute(
-            "INSERT INTO web_cache (key_family, race_id, data_hash, blob, created_utc)"
-            " VALUES (?, ?, ?, ?, ?)"
+            "INSERT INTO web_cache (key_family, race_id, data_hash, blob,"
+            " created_utc, expires_utc) VALUES (?, ?, ?, ?, ?, ?)"
             " ON CONFLICT(key_family, race_id) DO UPDATE SET"
             "   data_hash = excluded.data_hash,"
             "   blob = excluded.blob,"
-            "   created_utc = excluded.created_utc",
-            (key_family, race_id, data_hash, blob, created_utc),
+            "   created_utc = excluded.created_utc,"
+            "   expires_utc = excluded.expires_utc",
+            (key_family, race_id, data_hash, blob, created_utc, expires_utc),
         )
         await db.commit()
 

--- a/src/helmlog/external.py
+++ b/src/helmlog/external.py
@@ -6,7 +6,7 @@ an async context manager to manage the shared HTTP client lifetime.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -14,6 +14,8 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from datetime import date, datetime
+
+    from helmlog.cache import WebCache
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -103,10 +105,14 @@ def _track_response(component: str, resp: httpx.Response) -> None:
 class ExternalFetcher:
     """Fetches external environmental data from web APIs."""
 
-    def __init__(self) -> None:
+    def __init__(self, cache: WebCache | None = None) -> None:
         self._client: httpx.AsyncClient | None = None
         # NOAA tide station list — fetched once and reused for the session
         self._stations_cache: list[dict[str, Any]] | None = None
+        # Optional T2 cache for successful API responses (#594 / #610).
+        # Weather entries expire after 1h; tides never expire (predictions
+        # for a given date are immutable once published).
+        self._cache: WebCache | None = cache
 
     async def __aenter__(self) -> ExternalFetcher:
         self._client = httpx.AsyncClient(timeout=10.0)
@@ -182,6 +188,28 @@ class ExternalFetcher:
         from datetime import UTC as _UTC
         from datetime import datetime as _datetime
 
+        # T2 cache lookup (#610). Predictions for a station+date are
+        # immutable once published, so there's no TTL — cache-forever is
+        # correct. Key by (lat, lon, date) rather than station id because
+        # the nearest-station lookup is the slow-moving input.
+        cache_hash = f"{_reduce_precision(lat)},{_reduce_precision(lon)}:{for_date.isoformat()}"
+        if self._cache is not None:
+            cached = await self._cache.t2_get_global("tides", data_hash=cache_hash)
+            if isinstance(cached, list):
+                try:
+                    return [
+                        TideReading(
+                            timestamp=_datetime.fromisoformat(r["timestamp"]),
+                            height_m=float(r["height_m"]),
+                            type=str(r["type"]),
+                            station_id=str(r["station_id"]),
+                            station_name=str(r["station_name"]),
+                        )
+                        for r in cached
+                    ]
+                except (KeyError, ValueError, TypeError) as exc:
+                    logger.warning("Tide cache decode failed, refetching: {}", exc)
+
         stations = await self._get_tide_stations()
         station = self._nearest_station(stations, lat, lon)
         if station is None:
@@ -253,6 +281,22 @@ class ExternalFetcher:
             station_name,
             station_id,
         )
+
+        if self._cache is not None and readings:
+            blob = [
+                {
+                    "timestamp": r.timestamp.isoformat(),
+                    "height_m": r.height_m,
+                    "type": r.type,
+                    "station_id": r.station_id,
+                    "station_name": r.station_name,
+                }
+                for r in readings
+            ]
+            await self._cache.t2_put_global(
+                "tides", data_hash=cache_hash, value=blob, ttl_seconds=None
+            )
+
         return readings
 
     async def fetch_tides(
@@ -311,6 +355,33 @@ class ExternalFetcher:
         lon = _reduce_precision(lon)
         logger.debug("fetch_weather: lat={:.2f} lon={:.2f} dt={}", lat, lon, dt)
 
+        # T2 cache lookup (#610). The data_hash encodes the location + hour
+        # so the cache naturally invalidates when the hour boundary is
+        # crossed (Open-Meteo's ``current`` block advances hourly). TTL 1h
+        # is a belt-and-suspenders safety net against clock skew or
+        # missed hour rollovers.
+        hour_key = dt.strftime("%Y-%m-%dT%H")
+        cache_hash = f"{lat:.2f},{lon:.2f}:{hour_key}"
+        if self._cache is not None:
+            cached = await self._cache.t2_get_global("weather", data_hash=cache_hash)
+            if cached is not None:
+                try:
+                    from datetime import datetime as _dt
+
+                    ts_iso = cached["timestamp"] if isinstance(cached, dict) else None
+                    if isinstance(cached, dict) and isinstance(ts_iso, str):
+                        return WeatherReading(
+                            timestamp=_dt.fromisoformat(ts_iso),
+                            lat=float(cached["lat"]),
+                            lon=float(cached["lon"]),
+                            wind_speed_kts=float(cached["wind_speed_kts"]),
+                            wind_direction_deg=float(cached["wind_direction_deg"]),
+                            air_temp_c=float(cached["air_temp_c"]),
+                            pressure_hpa=float(cached["pressure_hpa"]),
+                        )
+                except (KeyError, ValueError, TypeError) as exc:
+                    logger.warning("Weather cache decode failed, refetching: {}", exc)
+
         params: dict[str, Any] = {
             "latitude": lat,
             "longitude": lon,
@@ -353,4 +424,12 @@ class ExternalFetcher:
             reading.air_temp_c,
             reading.pressure_hpa,
         )
+
+        if self._cache is not None:
+            blob = asdict(reading)
+            blob["timestamp"] = reading.timestamp.isoformat()
+            await self._cache.t2_put_global(
+                "weather", data_hash=cache_hash, value=blob, ttl_seconds=3600.0
+            )
+
         return reading

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -436,7 +436,15 @@ async def _run() -> None:
         except Exception:  # noqa: BLE001
             pass
 
-    async with ExternalFetcher() as fetcher:
+    # Web response cache (#594). Created here so the ExternalFetcher and
+    # the web app share a single cache instance; web.py reuses the bound
+    # cache rather than creating its own.
+    from helmlog.cache import WebCache
+
+    web_cache = WebCache(storage)
+    storage.bind_race_cache(web_cache)
+
+    async with ExternalFetcher(cache=web_cache) as fetcher:
         if external_data_should_fetch():
             weather_task = asyncio.create_task(_weather_loop(storage, fetcher))
             tide_task = asyncio.create_task(_tide_loop(storage, fetcher))

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -199,7 +199,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 73
+_CURRENT_VERSION: int = 74
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1731,6 +1731,14 @@ _MIGRATIONS: dict[int, str] = {
         );
         CREATE INDEX IF NOT EXISTS idx_web_cache_race ON web_cache(race_id);
         CREATE INDEX IF NOT EXISTS idx_web_cache_created ON web_cache(created_utc);
+    """,
+    74: """
+        -- #610: TTL support for non-race-keyed T2 entries (external API
+        -- fetches). Existing race-keyed rows leave expires_utc NULL and
+        -- rely on the race-mutation invalidation hook as before. Global
+        -- entries use race_id=0 as a sentinel (no race ever has id 0).
+        ALTER TABLE web_cache ADD COLUMN expires_utc TEXT;
+        CREATE INDEX IF NOT EXISTS idx_web_cache_expires ON web_cache(expires_utc);
     """,
 }
 

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -88,10 +88,17 @@ def create_app(
     app.state.ws_clients = set()  # WebSocket client connections
 
     # -- Web response cache (#594) --
+    # Reuse a pre-bound cache if main.py already set one up (so background
+    # tasks like ExternalFetcher and the web routes share a single cache).
+    # Otherwise create a fresh one here — the test harness path.
     from helmlog.cache import WebCache
 
-    web_cache = WebCache(storage)
-    storage.bind_race_cache(web_cache)
+    existing = getattr(storage, "_race_cache", None)
+    if isinstance(existing, WebCache):
+        web_cache = existing
+    else:
+        web_cache = WebCache(storage)
+        storage.bind_race_cache(web_cache)
     app.state.web_cache = web_cache
 
     from helmlog.races import RaceConfig

--- a/tests/test_external_cache.py
+++ b/tests/test_external_cache.py
@@ -1,0 +1,277 @@
+"""Tests for T2 caching wrapped around fetch_weather + fetch_tide_predictions (#610)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from helmlog.cache import WebCache
+from helmlog.external import ExternalFetcher
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+_LAT = 41.79
+_LON = -71.87
+_DT = datetime(2026, 4, 20, 14, 0, 0, tzinfo=UTC)
+
+
+_OPEN_METEO_RESPONSE: dict[str, Any] = {
+    "current": {
+        "time": "2026-04-20T14:00",
+        "wind_speed_10m": 12.5,
+        "wind_direction_10m": 220.0,
+        "temperature_2m": 22.3,
+        "surface_pressure": 1013.2,
+    },
+}
+
+_NOAA_STATIONS: dict[str, Any] = {
+    "stations": [
+        {"id": "8461490", "name": "New London", "lat": 41.36, "lng": -72.09},
+    ]
+}
+
+_NOAA_PREDICTIONS: dict[str, Any] = {
+    "predictions": [
+        {"t": "2026-04-20 00:00", "v": "0.5"},
+        {"t": "2026-04-20 01:00", "v": "0.6"},
+        {"t": "2026-04-20 02:00", "v": "0.7"},
+    ]
+}
+
+
+def _mock_response(payload: dict[str, Any]) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# T2 global (race_id=0) primitives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t2_global_put_get_round_trip(storage: Storage) -> None:
+    cache = WebCache(storage)
+    await cache.t2_put_global("weather", data_hash="h1", value={"v": 1}, ttl_seconds=None)
+    assert await cache.t2_get_global("weather", data_hash="h1") == {"v": 1}
+
+
+@pytest.mark.asyncio
+async def test_t2_global_stale_hash_returns_none(storage: Storage) -> None:
+    cache = WebCache(storage)
+    await cache.t2_put_global("tides", data_hash="abc", value=[1, 2, 3], ttl_seconds=None)
+    assert await cache.t2_get_global("tides", data_hash="def") is None
+
+
+@pytest.mark.asyncio
+async def test_t2_ttl_expires_row(storage: Storage) -> None:
+    import asyncio
+
+    cache = WebCache(storage)
+    # 1ms TTL — guarantees expiry by the time the next await resolves.
+    await cache.t2_put_global("weather", data_hash="h", value={"v": 1}, ttl_seconds=0.001)
+    await asyncio.sleep(0.05)
+
+    assert await cache.t2_get_global("weather", data_hash="h") is None
+
+    # Row should be deleted by the lazy-eviction-on-read path.
+    db = storage._conn()
+    cur = await db.execute("SELECT COUNT(*) AS n FROM web_cache WHERE key_family = 'weather'")
+    assert (await cur.fetchone())["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_t2_null_ttl_persists(storage: Storage) -> None:
+    """Passing ttl_seconds=None stores with no expiry — tide predictions use this."""
+    cache = WebCache(storage)
+    await cache.t2_put_global("tides", data_hash="h", value=[1, 2], ttl_seconds=None)
+    assert await cache.t2_get_global("tides", data_hash="h") == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_t2_race_mutation_does_not_touch_global(storage: Storage) -> None:
+    """Global (race_id=0) entries must survive race invalidation hooks."""
+    cache = WebCache(storage)
+    await cache.t2_put_global("weather", data_hash="h", value={"v": 1}, ttl_seconds=None)
+
+    await cache.invalidate(race_id=42)
+
+    assert await cache.t2_get_global("weather", data_hash="h") == {"v": 1}
+
+
+# ---------------------------------------------------------------------------
+# Weather caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_weather_second_call_hits_cache(storage: Storage) -> None:
+    """Two successive weather fetches with the same (lat, lon, hour) → 1 HTTP call."""
+    cache = WebCache(storage)
+    mock_resp = _mock_response(_OPEN_METEO_RESPONSE)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        with patch.object(
+            fetcher._client, "get", new_callable=AsyncMock, return_value=mock_resp
+        ) as mget:
+            r1 = await fetcher.fetch_weather(_LAT, _LON, _DT)
+            r2 = await fetcher.fetch_weather(_LAT, _LON, _DT)
+
+    assert r1 is not None
+    assert r2 is not None
+    assert r1.wind_speed_kts == r2.wind_speed_kts
+    assert mget.call_count == 1, "second fetch should have hit the T2 cache"
+
+
+@pytest.mark.asyncio
+async def test_weather_hour_boundary_misses_cache(storage: Storage) -> None:
+    """Advancing the hour changes the cache key — second fetch should HTTP again."""
+    cache = WebCache(storage)
+    mock_resp = _mock_response(_OPEN_METEO_RESPONSE)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        with patch.object(
+            fetcher._client, "get", new_callable=AsyncMock, return_value=mock_resp
+        ) as mget:
+            await fetcher.fetch_weather(_LAT, _LON, _DT)
+            await fetcher.fetch_weather(_LAT, _LON, _DT.replace(hour=15))
+
+    assert mget.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_weather_error_is_not_cached(storage: Storage) -> None:
+    """A failed fetch must not poison the cache — the next call re-fetches."""
+    cache = WebCache(storage)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        # First call fails
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("boom"),
+        ):
+            assert await fetcher.fetch_weather(_LAT, _LON, _DT) is None
+
+        # Second call succeeds because the cache has no entry for this key
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response(_OPEN_METEO_RESPONSE),
+        ) as mget:
+            reading = await fetcher.fetch_weather(_LAT, _LON, _DT)
+
+    assert reading is not None
+    assert mget.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tide caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tides_second_call_hits_cache(storage: Storage) -> None:
+    """Same (lat, lon, date) tide fetches: second call must skip all HTTPs."""
+    cache = WebCache(storage)
+    for_date = date(2026, 4, 20)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        # Prime the station-list cache so both calls skip the /stations.json
+        # request and only the /datagetter request is interesting.
+        fetcher._stations_cache = _NOAA_STATIONS["stations"]
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response(_NOAA_PREDICTIONS),
+        ) as mget:
+            r1 = await fetcher.fetch_tide_predictions(_LAT, _LON, for_date)
+            r2 = await fetcher.fetch_tide_predictions(_LAT, _LON, for_date)
+
+    assert len(r1) == 3
+    assert len(r2) == 3
+    assert r1[0].height_m == r2[0].height_m
+    assert r1[0].station_id == r2[0].station_id
+    assert mget.call_count == 1, "tides cache should have served the second call"
+
+
+@pytest.mark.asyncio
+async def test_tides_different_date_misses(storage: Storage) -> None:
+    cache = WebCache(storage)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        fetcher._stations_cache = _NOAA_STATIONS["stations"]
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response(_NOAA_PREDICTIONS),
+        ) as mget:
+            await fetcher.fetch_tide_predictions(_LAT, _LON, date(2026, 4, 20))
+            await fetcher.fetch_tide_predictions(_LAT, _LON, date(2026, 4, 21))
+
+    assert mget.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tides_empty_result_is_not_cached(storage: Storage) -> None:
+    """An empty-result fetch (NOAA returned nothing usable) must not poison the cache."""
+    cache = WebCache(storage)
+    for_date = date(2026, 4, 20)
+
+    async with ExternalFetcher(cache=cache) as fetcher:
+        fetcher._stations_cache = _NOAA_STATIONS["stations"]
+        # First call: NOAA responds with an error body → empty list
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response({"error": {"message": "no data"}}),
+        ):
+            assert await fetcher.fetch_tide_predictions(_LAT, _LON, for_date) == []
+
+        # Second call: now the API works — cache shouldn't have poisoned us
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response(_NOAA_PREDICTIONS),
+        ) as mget:
+            good = await fetcher.fetch_tide_predictions(_LAT, _LON, for_date)
+
+    assert len(good) == 3
+    assert mget.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Fetcher without cache still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetcher_without_cache_still_works() -> None:
+    """ExternalFetcher() (no cache) degrades gracefully — every call hits HTTP."""
+    async with ExternalFetcher() as fetcher:
+        with patch.object(
+            fetcher._client,
+            "get",
+            new_callable=AsyncMock,
+            return_value=_mock_response(_OPEN_METEO_RESPONSE),
+        ) as mget:
+            await fetcher.fetch_weather(_LAT, _LON, _DT)
+            await fetcher.fetch_weather(_LAT, _LON, _DT)
+
+    assert mget.call_count == 2

--- a/tests/test_migration_v73.py
+++ b/tests/test_migration_v73.py
@@ -81,16 +81,19 @@ async def test_v73_web_cache_primary_key_is_family_plus_race() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_73_on_fresh_db() -> None:
+async def test_v73_migration_applied_on_fresh_db() -> None:
+    """Confirm v73 is applied on a fresh DB.
+
+    (Latest-version assertion lives in test_migration_v74.)
+    """
     from helmlog.storage import Storage, StorageConfig
 
     s = Storage(StorageConfig(db_path=":memory:"))
     await s.connect()
     try:
         assert s._db is not None
-        async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+        async with s._db.execute("SELECT 1 FROM schema_version WHERE version = 73") as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == 73
     finally:
         await s.close()

--- a/tests/test_migration_v74.py
+++ b/tests/test_migration_v74.py
@@ -1,0 +1,85 @@
+"""Tests for migration v74 — expires_utc column on web_cache (#610)."""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_v74_adds_expires_utc_column() -> None:
+    db = await _build_db_at(73)
+    try:
+        await _apply_migration(db, 74)
+        async with db.execute("PRAGMA table_info(web_cache)") as cur:
+            cols = {r[1] for r in await cur.fetchall()}
+        assert "expires_utc" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v74_allows_null_expires_utc() -> None:
+    """Existing race-keyed rows leave expires_utc NULL and rely on the
+    race-mutation invalidation hook — this is explicitly allowed."""
+    db = await _build_db_at(74)
+    try:
+        await db.execute(
+            "INSERT INTO web_cache (key_family, race_id, data_hash, blob, created_utc)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("session_summary", 1, "h", "{}", "2026-04-20T00:00:00+00:00"),
+        )
+        await db.commit()
+
+        async with db.execute(
+            "SELECT expires_utc FROM web_cache WHERE key_family = 'session_summary'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["expires_utc"] is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_version_is_74_on_fresh_db() -> None:
+    from helmlog.storage import Storage, StorageConfig
+
+    s = Storage(StorageConfig(db_path=":memory:"))
+    await s.connect()
+    try:
+        assert s._db is not None
+        async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 74
+    finally:
+        await s.close()


### PR DESCRIPTION
## Summary
Adds caching to the two external HTTP fetches the logger makes: hourly weather from Open-Meteo and daily tide predictions from NOAA CO-OPS. **Stacked on #623** (and transitively #617) — retarget to \`main\` once those land.

Closes #610.

## Schema
Migration v74 adds \`expires_utc TEXT NULL\` to \`web_cache\`. Race-keyed rows leave it NULL and rely on the invalidation hook as before; global (non-race) rows set it to gate TTL expiry.

## Cache API additions
- \`WebCache.t2_put\` now accepts optional \`ttl_seconds\`.
- \`t2_get_global\` / \`t2_put_global\` convenience methods using \`race_id=0\` as a sentinel for non-race-keyed entries.
- Expired rows are lazily evicted on read.

## External fetcher wiring
- \`ExternalFetcher(cache=WebCache | None)\` — cache is optional; without it, identical to prior behaviour.
- **Weather**: cached by \`(lat, lon, hour)\` with 1h TTL. Hour boundary naturally invalidates via data_hash mismatch.
- **Tides**: cached by \`(lat, lon, date)\` with no TTL — predictions for a given date are immutable once published.
- Errors (None / empty) are **not** cached — a transient failure doesn't poison the cache.
- \`main.py\` creates the WebCache standalone before the fetcher starts so background loops and the web app share a single cache; \`web.py\` now reuses a pre-bound cache when present.

## Scope note: polar baseline skipped
The issue also mentioned polar-baseline caching, but the baseline is already persisted to a dedicated \`polar_baseline\` table and only rebuilt via an admin endpoint / CLI — not on any hot read path. Adding a memory cache on top of disk-persisted results would be redundant. Left as a footnote; reopen if polar ever becomes a hot path.

## Test plan
- [x] 12 new tests in \`tests/test_external_cache.py\`: T2 global put/get, TTL expiry + null TTL, race-mutation doesn't touch globals, weather second-call hits cache, weather hour-boundary misses, weather errors aren't cached, tides second-call hits, tides different-date misses, tides empty-response isn't cached, fetcher-without-cache still works.
- [x] 3 new tests in \`tests/test_migration_v74.py\`: expires_utc column exists, NULL allowed for race-keyed rows, fresh-DB schema version is 74.
- [x] Full suite: 2215 passed, 2 skipped
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy src/\` — all clean
- [ ] Manually verify on corvopi-tst1 after deploy: check \`/api/admin/cache/stats\` after a full day — \`weather\` family should show hits each hour-boundary-miss + passive hits; \`tides\` family should show 1-2 misses per day + many hits across restarts. Weather table and tides table keep growing normally (cache layered on top, doesn't change DB writes).

Part of #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)