### PR TITLE
feat: spread-aware ranking with numeric loss percentile (#616)

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -372,12 +372,37 @@ def enrich_maneuver(
     )
 
 
+# Spread-aware ranking thresholds (#616). When a session's loss spread
+# is too small to mean anything we label every maneuver ``consistent``
+# instead of manufacturing a good/bad distinction.
+#
+# - Relative: stdev / median ≥ 0.5 keeps the spread meaningful as a
+#   fraction of typical loss. In tight one-design fleets, mean tack
+#   loss varies session-to-session by ~3–6 m; half-median captures
+#   that without per-class calibration.
+# - Absolute floor: total range ≥ 3 m. Below that, we're inside the
+#   GPS positional-noise floor of the loss calc (SK multiplexed
+#   antennas bucket to ~2–3 m — see ``_bucket_positions_per_second``).
+# Both thresholds must pass for a quartile split to fire. If either
+# fails, every rankable item is labeled ``consistent``.
+_CONSISTENT_STDEV_FRAC = 0.5
+_CONSISTENT_ABS_SPREAD_M = 3.0
+
+
 def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Attach a ``rank`` label (``good`` / ``avg`` / ``bad``) in-place.
+    """Attach a ``rank`` label and ``loss_percentile`` in-place (#616).
 
     Ranking is by ``distance_loss_m`` when available, else ``loss_kts``.
-    Top quartile (lowest loss) → ``good``; bottom quartile → ``bad``;
-    middle half → ``avg``. Entries with no loss data get ``rank=None``.
+    When the set's loss spread is too small to be meaningful (low
+    relative stdev OR small absolute range), every rankable item gets
+    rank ``consistent`` instead of the quartile split. Otherwise top
+    quartile (lowest loss) → ``good``, bottom quartile → ``bad``,
+    middle half → ``avg``. Entries with no loss data get rank ``None``.
+
+    ``loss_percentile`` is the 0–100 within-set rank (lowest loss = 0)
+    on every rankable item, regardless of bucket. The UI renders it
+    as a tooltip number so a user can see the underlying ordering
+    even when the bucket label is ``consistent``.
     """
     if not items:
         return items
@@ -398,6 +423,32 @@ def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     sorted_items = sorted(ranked, key=lambda m: _key(m) or 0.0)
     n = len(sorted_items)
+
+    # Loss percentile per rankable item: 0 for the lowest loss, scaled
+    # to 100 across the set. Single-item sets get 0 to avoid div/0.
+    for i, m in enumerate(sorted_items):
+        m["loss_percentile"] = int(round(100 * i / n)) if n > 1 else 0
+
+    losses = [_key(m) or 0.0 for m in sorted_items]
+    spread = losses[-1] - losses[0]
+    median_loss = statistics.median(losses)
+    stdev_loss = statistics.pstdev(losses) if n > 1 else 0.0
+    relative_passes = median_loss > 0 and (stdev_loss / median_loss) >= _CONSISTENT_STDEV_FRAC
+    # The 3 m floor is unit-specific (GPS positional noise on
+    # ``distance_loss_m``). When falling back to ``loss_kts`` we can't
+    # apply it — knots aren't meters — so only the relative test gates
+    # the spread call on those rows.
+    using_distance = all(m.get("distance_loss_m") is not None for m in sorted_items)
+    absolute_passes = (not using_distance) or spread >= _CONSISTENT_ABS_SPREAD_M
+
+    if not (relative_passes and absolute_passes):
+        for m in ranked:
+            m["rank"] = "consistent"
+        for m in unranked:
+            m["rank"] = None
+            m.setdefault("loss_percentile", None)
+        return items
+
     q1 = max(1, n // 4)
     q3 = max(q1, n - n // 4)
     good = {id(m) for m in sorted_items[:q1]}
@@ -411,6 +462,7 @@ def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
             m["rank"] = "avg"
     for m in unranked:
         m["rank"] = None
+        m.setdefault("loss_percentile", None)
     return items
 
 
@@ -429,7 +481,9 @@ _ENRICH_PAD_S = 60  # seconds of instrument data to load beyond the session wind
 #     real recovery phase (HTW → exit), not a duration alias (#614).
 # v5: entry-window aggregates use median, not mean (#615). entry_bsp,
 #     entry_twa, entry_tws (and downstream distance_loss_m) shift.
-ENRICH_CACHE_VERSION = 5
+# v6: spread-aware ranking with new ``consistent`` label and numeric
+#     ``loss_percentile`` (#616).
+ENRICH_CACHE_VERSION = 6
 
 
 def _bucket_positions_per_second(

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -285,6 +285,9 @@ function renderResults() {
       ? '<span class="mv-video">&#9654;</span>'
       : '<span class="mv-no-video">\u2014</span>';
     const rank = m.rank ? m.rank : '';
+    const rankTitle = m.loss_percentile != null
+      ? 'loss percentile: ' + m.loss_percentile + ' (lower = less loss)'
+      : '';
     const tagCell = _renderRowTagChips(m.tags);
     return '<tr class="' + (sel ? 'selected' : '') + '" data-k="' + k + '" onclick="mvToggleRow(\'' + k + '\')">'
       + '<td><input type="checkbox" ' + (sel ? 'checked' : '') + ' onclick="event.stopPropagation();mvToggleRow(\'' + k + '\')"/></td>'
@@ -297,7 +300,7 @@ function renderResults() {
       + '<td class="mv-num">' + durTxt + '</td>'
       + '<td class="mv-num">' + turnPhaseTxt + '</td>'
       + '<td class="mv-num">' + recoverPhaseTxt + '</td>'
-      + '<td>' + _esc(rank) + '</td>'
+      + '<td' + (rankTitle ? ' title="' + _esc(rankTitle) + '"' : '') + '>' + _esc(rank) + '</td>'
       + '<td>' + video + '</td>'
       + '<td>' + tagCell + '</td>'
       + '</tr>';

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4181,7 +4181,12 @@ function _setPolarHighlightSegments(grades) {
 // ---------------------------------------------------------------------------
 
 const _MANEUVER_COLORS = { tack: cssVar('--accent-strong'), gybe: cssVar('--warning'), rounding: cssVar('--success'), start: cssVar('--success') };
-const _RANK_COLORS = { good: cssVar('--success'), bad: cssVar('--error'), avg: cssVar('--text-secondary') };
+const _RANK_COLORS = {
+  good: cssVar('--success'),
+  bad: cssVar('--error'),
+  avg: cssVar('--text-secondary'),
+  consistent: cssVar('--text-secondary'),
+};
 let _maneuverSort = { key: 'ts', dir: 1 };  // ts | type | duration_sec | distance_loss_m | loss_kts | turn_angle_deg
 // Active filter pills. Multi-select: combined with AND across dimensions
 // (type, rank, time) and OR within a dimension. Empty set == "all".
@@ -4631,9 +4636,10 @@ function showOverlayTip(ev, idx) {
     ['TWS', twsStr],
     ['TWD', m.twd_deg != null ? Math.round(m.twd_deg) + '°' : '—'],
   ];
+  const rankPctStr = m.loss_percentile != null ? ' (p' + m.loss_percentile + ')' : '';
   const header = '<div style="margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;gap:6px">'
     + '<span><span style="color:' + color + ';font-weight:600">' + esc(m.type) + '</span>'
-    + (m.rank ? ' <span style="color:' + rankColor + '">●' + esc(m.rank) + '</span>' : '') + '</span>'
+    + (m.rank ? ' <span style="color:' + rankColor + '" title="loss percentile (lower = less loss)">●' + esc(m.rank) + rankPctStr + '</span>' : '') + '</span>'
     + '<span style="color:var(--text-secondary);cursor:pointer;font-size:.8rem" onclick="hideOverlayTip()" title="Close">✕</span>'
     + '</div>';
   const grid = '<div style="display:grid;grid-template-columns:auto 1fr;gap:2px 8px">'

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -1081,6 +1081,78 @@ class TestBackfillStaleManeuverCache:
         assert processed == 0
 
 
+class TestSpreadAwareRanking:
+    """#616: rank_maneuvers labels everything 'consistent' when the spread
+    on distance_loss_m is too small to mean anything, and exposes a
+    numeric loss_percentile alongside the bucket label."""
+
+    def _mk(self, loss: float | None) -> dict:
+        return {"type": "tack", "ts": _BASE_TS.isoformat(), "distance_loss_m": loss}
+
+    def test_tight_session_all_labeled_consistent(self) -> None:
+        # 10 maneuvers losing 7.0–7.9 m. stdev≈0.3, median≈7.45 →
+        # stdev / median ≈ 0.04 (well under 0.5). max-min = 0.9 m
+        # (under 3.0). Both spread tests fail → all 'consistent'.
+        items = [self._mk(7.0 + i / 10.0) for i in range(10)]
+        ranked = rank_maneuvers(items)
+        assert all(m["rank"] == "consistent" for m in ranked)
+        # Percentiles still spread 0–90 (10 items, stride 10).
+        percentiles = sorted(m["loss_percentile"] for m in ranked)
+        assert percentiles == list(range(0, 100, 10))
+
+    def test_wide_session_uses_quartile_split(self) -> None:
+        # Losses 2..20 by 2s. median=11, sample stdev≈6.05, ratio≈0.55
+        # (passes 0.5 floor), spread=18 (passes 3 m floor). Quartile
+        # split active. NB: the issue example [3..12] doesn't satisfy
+        # its own relative threshold (ratio ≈ 0.40); using [2..20] keeps
+        # the test stable while leaving the constants tunable in code.
+        losses = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+        items = [self._mk(float(v)) for v in losses]
+        ranked = rank_maneuvers(items)
+        labels = [m["rank"] for m in ranked]
+        assert "good" in labels and "bad" in labels and "consistent" not in labels
+        lo = next(m for m in ranked if m["distance_loss_m"] == 2.0)
+        hi = next(m for m in ranked if m["distance_loss_m"] == 20.0)
+        assert lo["rank"] == "good" and lo["loss_percentile"] == 0
+        assert hi["rank"] == "bad" and hi["loss_percentile"] == 90
+
+    def test_absolute_floor_wins_when_relative_spread_high(self) -> None:
+        # 10 maneuvers losing 0.05, 0.10, 0.15, ..., 0.50 m. Big relative
+        # stdev (median ≈ 0.275, stdev ≈ 0.15 → ratio ≈ 0.55, *passes*
+        # the relative check), but max-min = 0.45 m → far under 3.0 m.
+        # Absolute floor must veto and return 'consistent'.
+        items = [self._mk(0.05 * (i + 1)) for i in range(10)]
+        ranked = rank_maneuvers(items)
+        assert all(m["rank"] == "consistent" for m in ranked)
+
+    def test_relative_threshold_wins_when_absolute_spread_passes(self) -> None:
+        # 10 maneuvers around a high baseline of 100m, total spread 30m
+        # (max=115, min=85). max-min = 30 ≥ 3 (passes absolute floor),
+        # but stdev ≈ 9–10 vs median ≈ 100 → ratio < 0.5. Relative
+        # threshold vetoes → 'consistent'. Boundary case in the AC.
+        losses = [85, 90, 95, 98, 100, 100, 102, 105, 110, 115]
+        items = [self._mk(float(v)) for v in losses]
+        ranked = rank_maneuvers(items)
+        assert all(m["rank"] == "consistent" for m in ranked)
+
+    def test_loss_percentile_present_even_when_consistent(self) -> None:
+        items = [self._mk(7.0 + i / 10.0) for i in range(5)]
+        ranked = rank_maneuvers(items)
+        for m in ranked:
+            assert isinstance(m["loss_percentile"], int)
+            assert 0 <= m["loss_percentile"] <= 100
+
+    def test_unrankable_items_stay_none(self) -> None:
+        items = [
+            {"type": "tack", "distance_loss_m": None, "loss_kts": None},
+            {"type": "tack", "distance_loss_m": None, "loss_kts": None},
+        ]
+        ranked = rank_maneuvers(items)
+        for m in ranked:
+            assert m["rank"] is None
+            assert m.get("loss_percentile") is None
+
+
 class TestRankManeuvers:
     def _mk(self, distance_loss: float | None, bsp_loss: float | None) -> dict:
         return {


### PR DESCRIPTION
## Summary

- ``rank_maneuvers`` now checks loss spread before splitting. When ``stdev/median < 0.5`` OR ``max − min < 3 m``, every rankable item gets ``consistent`` instead of the manufactured good/bad split. Otherwise the quartile logic fires as before.
- Every rankable item also gets a new ``loss_percentile`` (0–100, lowest loss = 0). Surfaced in both UIs as a tooltip number so users see the underlying ordering even when the bucket says ``consistent``.
- Thresholds exposed as module-level constants: ``_CONSISTENT_STDEV_FRAC = 0.5``, ``_CONSISTENT_ABS_SPREAD_M = 3.0``. Tunable in one place.
- ``ENRICH_CACHE_VERSION`` bumps 5 → 6 → backfill worker rebuilds on deploy.

Closes #616 (epic: #612)

## One small spec wrinkle

The issue's worked example ``[3, 4, 5, 6, 7, 8, 9, 10, 11, 12]`` actually fails its own ``stdev ≥ 0.5 × median`` test (sample stdev ≈ 3.03, half-median = 3.75 → ratio 0.40). I kept the constants per the resolved decision in #612 but adjusted the test to ``[2..20]`` which clearly clears both thresholds. If the locked thresholds turn out to be too aggressive in practice, lowering ``_CONSISTENT_STDEV_FRAC`` to ~0.3 in one place will catch tighter spreads. Calling it out explicitly so it can be revisited after first use.

## Loss-kts fallback exemption

The 3 m absolute floor is unit-specific (GPS positional noise on ``distance_loss_m``). When the legacy fallback path uses ``loss_kts`` instead, only the relative threshold gates the spread call — knots aren't meters.

## Stacked on #631

Branched off ``feature/615-median-baseline``. Once the upstream PRs (#626 → #630 → #631) merge, GitHub will auto-retarget this to ``main``.

## Test plan

- [x] ``uv run pytest tests/test_analysis_maneuvers.py`` — 45 passed (6 new spread-aware tests covering tight session, wide session, both boundary cases, percentile presence, and unrankable items)
- [x] Full suite: ``uv run pytest --no-cov`` — 2247 passed, 2 skipped
- [x] ``uv run ruff check . && ruff format --check .`` — clean
- [x] ``uv run mypy src/`` — clean
- [ ] Pi: deploy and verify a tight session shows ``consistent`` across the board, a wide session keeps good/bad, percentile tooltip renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)