### PR TITLE
fix: don't upload half-rendered Insta360 exports to YouTube

### DIFF
--- a/scripts/upload-stitched.sh
+++ b/scripts/upload-stitched.sh
@@ -10,8 +10,18 @@
 #
 # Skips files that:
 #   - aren't named in the X4 VID_*.mp4 / .insv pattern
-#   - are still being written (size still growing)
+#   - are still being written (size still growing, held open, or unparseable)
 #   - are already in the upload ledger
+#
+# Readiness check is defensive: the previous 30 s capped poll uploaded
+# half-rendered files whenever Insta360 Studio took longer than that to
+# finish exporting, which it always does for multi-GB 360° videos. The
+# current check waits until ALL of:
+#   1. no process holds the file open (lsof)
+#   2. size has been stable for $STABLE_WINDOW_S consecutive seconds
+#   3. ffprobe parses the container and reports a positive duration
+# before proceeding, with a generous $STABLE_MAX_WAIT_S ceiling so pathological
+# exports eventually fail loudly rather than silently uploading garbage.
 #
 # Required environment (same names as process-videos.sh):
 #   PI_API_URL              HelmLog API base URL, e.g. http://<pi-hostname>:3002
@@ -47,16 +57,116 @@ if ! [[ "$BASE" =~ ^(PRO_)?VID_([0-9]{8}_[0-9]{6}) ]]; then
 fi
 TS="${BASH_REMATCH[2]}"
 
-# Wait for the file to stop growing — Studio writes incrementally and we
-# don't want to upload a half-rendered file.
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] upload-stitched: $*"; }
+
+# ── Per-file lock ──────────────────────────────────────────────────────────
+#
+# fswatch may fire several events (Created + N × Updated + MovedTo) for one
+# export. Each fired event invokes this script, so without a lock a slow
+# readiness gate can be holding up one instance while follow-on events
+# queue up more. The lock turns those into no-ops.
+LOCKKEY=$(basename "$FILE" | tr -c 'A-Za-z0-9._-' '_')
+LOCKDIR="${TMPDIR:-/tmp}/helmlog-upload.${LOCKKEY}.lock"
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  log "another upload-stitched.sh is already processing ${BASE} — exiting"
+  exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+
+# ── Wait for the export to be fully written ────────────────────────────────
+#
+# Studio writes in place and can take tens of minutes on a big 360° file.
+# Uploading before Studio finishes produces corrupted videos on YouTube and
+# — worse — once the upload "succeeds" the script moves the broken file to
+# the backup volume, so the only recovery is to re-export from scratch. The
+# pre-flight gate below is deliberately paranoid to avoid that class of bug.
+
+STABLE_WINDOW_S="${HELMLOG_STABLE_WINDOW_S:-120}"   # required quiet interval
+STABLE_POLL_S="${HELMLOG_STABLE_POLL_S:-10}"        # poll cadence
+STABLE_MAX_WAIT_S="${HELMLOG_STABLE_MAX_WAIT_S:-14400}"  # 4 h hard ceiling
+
+file_has_writer() {
+  # Check whether any process holds the file open for writing. Read-only
+  # openers (Finder preview, Spotlight) do NOT indicate an in-progress
+  # export, so we filter on access mode rather than any open handle.
+  #
+  # lsof's ``-Fan`` emits one field per line — `a` = access mode (r/w/u),
+  # `n` = name. We only need the `a` records: if any one of them reports
+  # a writer mode the file is still being written.
+  lsof -w -Fan -- "$FILE" 2>/dev/null | awk '
+    /^a/ {
+      mode = substr($0, 2)
+      if (mode ~ /[wu]/) { found = 1; exit }
+    }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+ffprobe_ok() {
+  # Require ffprobe to (a) parse without error AND (b) return a positive
+  # container duration. A half-written MP4 often has a readable header but
+  # no moov atom, which makes `-show_format` fail with "Invalid data found
+  # when processing input". A fully-written file will not.
+  local dur
+  dur=$(ffprobe -v error -show_entries format=duration -of default=nk=1:nw=1 \
+        -- "$FILE" 2>/dev/null || true)
+  [ -n "$dur" ] && awk -v d="$dur" 'BEGIN { exit (d+0 > 0) ? 0 : 1 }'
+}
+
+if ! command -v ffprobe >/dev/null 2>&1; then
+  log "ERROR: ffprobe is required for readiness validation (brew install ffmpeg)" >&2
+  exit 1
+fi
+
+log "readiness gate: file=$FILE window=${STABLE_WINDOW_S}s max=${STABLE_MAX_WAIT_S}s"
+
+started_at=$(date +%s)
 prev_size=-1
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  cur=$(stat -f%z "$FILE" 2>/dev/null || echo 0)
-  if [ "$cur" -gt 0 ] && [ "$cur" -eq "$prev_size" ]; then
-    break
+stable_since=0
+
+while true; do
+  now=$(date +%s)
+  elapsed=$((now - started_at))
+
+  if [ "$elapsed" -ge "$STABLE_MAX_WAIT_S" ]; then
+    log "ERROR: file did not stabilize within ${STABLE_MAX_WAIT_S}s — aborting to avoid uploading a half-written export" >&2
+    exit 1
   fi
-  prev_size=$cur
-  sleep 3
+
+  if file_has_writer; then
+    [ "$((elapsed % 60))" -lt "$STABLE_POLL_S" ] && \
+      log "still being written (lsof shows a writer) — waiting… elapsed=${elapsed}s"
+    prev_size=-1
+    stable_since=0
+    sleep "$STABLE_POLL_S"
+    continue
+  fi
+
+  cur=$(stat -f%z "$FILE" 2>/dev/null || echo 0)
+  if [ "$cur" -le 0 ]; then
+    sleep "$STABLE_POLL_S"
+    continue
+  fi
+
+  if [ "$cur" = "$prev_size" ]; then
+    [ "$stable_since" = 0 ] && stable_since=$now
+    stable_for=$((now - stable_since))
+    if [ "$stable_for" -ge "$STABLE_WINDOW_S" ]; then
+      if ffprobe_ok; then
+        log "readiness gate: passed (size=${cur} stable_for=${stable_for}s)"
+        break
+      else
+        log "size stable but ffprobe rejected the container — resetting window" >&2
+        prev_size=-1
+        stable_since=0
+      fi
+    fi
+  else
+    prev_size=$cur
+    stable_since=0
+  fi
+
+  sleep "$STABLE_POLL_S"
 done
 
 # Default the camera label from the parent directory if not set explicitly,

--- a/scripts/watch-exports.sh
+++ b/scripts/watch-exports.sh
@@ -47,15 +47,24 @@ log "Upload script: $UPLOAD_SCRIPT"
 #               event, which is exactly what happens if you forget -E.
 #   -e          exclude regex (skip everything by default …)
 #   -i          … then include only VID_*.mp4 / .insv
-#   --event     only fire on Created / MovedTo (file appearance)
-#   --latency   small debounce
+#   --event     only fire on Created / MovedTo (file appearance). We
+#               deliberately DO NOT subscribe to Updated — during a
+#               multi-GB Studio export that event fires hundreds of times
+#               while data is still being written, and the downstream
+#               script used to get tricked into uploading a half-rendered
+#               file. Readiness is now validated inside upload-stitched.sh
+#               (lsof + size stability + ffprobe), so a single Created
+#               event is enough to kick things off.
+#   --latency   debounce window. Raised from 1 s to 10 s so a rename-on-
+#               create burst (Created immediately followed by MovedTo,
+#               which Studio does when renaming its temp export into the
+#               final path) coalesces into one event instead of two.
 fswatch \
   -0 \
   -r \
   -E \
-  --latency 1 \
+  --latency 10 \
   --event=Created \
-  --event=Updated \
   --event=MovedTo \
   -e ".*" \
   -i 'VID_[0-9]{8}_[0-9]{6}_[0-9]{2}_[0-9]+.*\.(mp4|insv)$' \
@@ -63,6 +72,8 @@ fswatch \
   while IFS= read -r -d '' f; do
     log "event: $f"
     # Run uploads sequentially — one big upload at a time keeps quota,
-    # bandwidth, and YouTube rate-limits sane.
+    # bandwidth, and YouTube rate-limits sane. upload-stitched.sh takes
+    # its own per-file lock so a follow-on event for the same export is
+    # a cheap no-op rather than a queued second attempt.
     "$UPLOAD_SCRIPT" "$f" || log "upload failed for $f"
   done

--- a/src/helmlog/youtube.py
+++ b/src/helmlog/youtube.py
@@ -14,7 +14,7 @@ import asyncio
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -22,6 +22,9 @@ from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-un
 from googleapiclient.discovery import build as _build_service  # type: ignore[import-untyped]
 from googleapiclient.http import MediaFileUpload  # type: ignore[import-untyped]
 from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _SCOPES = [
     "https://www.googleapis.com/auth/youtube.upload",
@@ -102,6 +105,15 @@ class ChannelMismatchError(RuntimeError):
     """Raised when the authenticated channel does not match the expected account."""
 
 
+class UploadVerificationError(RuntimeError):
+    """Raised when YouTube rejects or fails to process an uploaded video.
+
+    The pipeline treats this as a "do not archive the local file" signal —
+    the source MP4 stays in the exports dir so the user can investigate or
+    retry without having to re-export from Insta360 Studio.
+    """
+
+
 def verify_channel(service: object, expected_account: str) -> str:
     """Confirm the loaded credentials authenticate to the expected channel.
 
@@ -141,6 +153,108 @@ def verify_channel(service: object, expected_account: str) -> str:
         )
     logger.info("YouTube channel verified: {} ({})", title, custom_url or "no handle")
     return title
+
+
+# ---------------------------------------------------------------------------
+# Post-upload verification
+# ---------------------------------------------------------------------------
+
+
+# Terminal states reported by the YouTube Data API. A video that lands in one
+# of these has either been accepted (``processed``) or unambiguously refused
+# (``rejected`` / ``failed``). Anything else — notably ``uploaded`` —
+# means YouTube is still ingesting the bytes and may yet decide either way.
+_UPLOAD_STATUS_PROCESSED = "processed"
+_UPLOAD_STATUS_REJECTED = "rejected"
+_UPLOAD_STATUS_FAILED = "failed"
+_TERMINAL_UPLOAD_STATUSES = frozenset(
+    {_UPLOAD_STATUS_PROCESSED, _UPLOAD_STATUS_REJECTED, _UPLOAD_STATUS_FAILED}
+)
+
+
+def wait_for_upload_acceptance(
+    service: object,
+    video_id: str,
+    *,
+    timeout_s: float = 1800.0,
+    poll_interval_s: float = 20.0,
+    sleep: Callable[[float], None] | None = None,
+) -> dict[str, Any]:
+    """Poll YouTube until ``uploadStatus`` transitions out of ``uploaded``.
+
+    YouTube's initial response to ``videos.insert`` returns as soon as the
+    last byte is sent; the server still has to open the container,
+    remux / validate it, and mark the video as ``processed`` (success) or
+    ``rejected`` / ``failed`` (bad upload — typically truncated or corrupt).
+    This helper blocks until one of those terminal states is reported so the
+    caller can decide whether to archive the source file or keep it for a
+    retry.
+
+    Note this waits only for *upload acceptance* — deep transcoding (the
+    ``processingDetails.processingStatus`` field) can take many hours for
+    a multi-GB 360° video and isn't a reliable signal for "was the bitstream
+    coherent". If YouTube accepted the bitstream, it will eventually finish
+    transcoding on its own.
+
+    Args:
+        service: YouTube API service from :func:`build_service`.
+        video_id: The id returned by ``videos.insert``.
+        timeout_s: Hard ceiling — raises ``UploadVerificationError`` if we
+            never see a terminal status within this window.
+        poll_interval_s: Seconds between ``videos.list`` calls.
+        sleep: Optional injectable sleeper (tests use a no-op).
+
+    Returns:
+        The raw ``status`` dict for the video once it's in a terminal state.
+
+    Raises:
+        UploadVerificationError: If YouTube rejects the upload, marks it as
+            failed, or fails to return a terminal status inside ``timeout_s``.
+    """
+    import time
+
+    if sleep is None:
+        sleep = time.sleep
+
+    deadline = time.monotonic() + timeout_s
+    last_status: str | None = None
+
+    while True:
+        response = (
+            service.videos()  # type: ignore[attr-defined]
+            .list(part="status", id=video_id)
+            .execute()
+        )
+        items = response.get("items") or []
+        if not items:
+            # Fresh uploads occasionally return an empty list before the
+            # server fully registers the id — don't treat that as fatal
+            # on its own, just keep polling until the deadline.
+            logger.debug("videos.list returned no items yet for {}", video_id)
+        else:
+            status = items[0].get("status") or {}
+            upload_status = str(status.get("uploadStatus") or "")
+            if upload_status != last_status:
+                logger.info("YouTube uploadStatus for {}: {}", video_id, upload_status)
+                last_status = upload_status
+
+            if upload_status == _UPLOAD_STATUS_PROCESSED:
+                return status
+            if upload_status == _UPLOAD_STATUS_REJECTED:
+                reason = status.get("rejectionReason") or "unknown"
+                raise UploadVerificationError(f"YouTube rejected video {video_id}: {reason}")
+            if upload_status == _UPLOAD_STATUS_FAILED:
+                reason = status.get("failureReason") or "unknown"
+                raise UploadVerificationError(
+                    f"YouTube failed to process video {video_id}: {reason}"
+                )
+
+        if time.monotonic() >= deadline:
+            raise UploadVerificationError(
+                f"YouTube upload for {video_id} did not reach a terminal state "
+                f"within {timeout_s:.0f}s (last uploadStatus={last_status!r})"
+            )
+        sleep(poll_interval_s)
 
 
 # ---------------------------------------------------------------------------
@@ -339,5 +453,20 @@ async def upload_video(
     video_id: str = await asyncio.to_thread(_do_upload)
 
     youtube_url = f"https://youtu.be/{video_id}"
-    logger.info("Upload complete: {} → {}", title, youtube_url)
+    logger.info("Upload bytes complete, verifying YouTube accepted: {} → {}", title, youtube_url)
+
+    # Block until YouTube decides whether it could actually open the file.
+    # A truncated / corrupt source (the exact failure mode we used to hit when
+    # the readiness gate was too short) lands as ``rejected`` / ``failed``
+    # here; raising lets ``upload-stitched.sh`` skip the move-to-backup step
+    # and keep the source file in the exports dir for a retry.
+    verify_timeout = float(os.environ.get("HELMLOG_YT_VERIFY_TIMEOUT_S", "1800"))
+    await asyncio.to_thread(
+        wait_for_upload_acceptance,
+        service,
+        video_id,
+        timeout_s=verify_timeout,
+    )
+
+    logger.info("Upload accepted: {} → {}", title, youtube_url)
     return UploadResult(video_id=video_id, youtube_url=youtube_url, title=title)

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -13,10 +13,12 @@ import pytest
 
 from helmlog.youtube import (
     UploadResult,
+    UploadVerificationError,
     build_description,
     build_title,
     load_credentials,
     upload_video,
+    wait_for_upload_acceptance,
 )
 
 # ---------------------------------------------------------------------------
@@ -145,23 +147,35 @@ class TestLoadCredentials:
 # ---------------------------------------------------------------------------
 
 
+def _make_upload_service(video_id: str, upload_status: str = "processed") -> MagicMock:
+    """Build a mock YouTube service that completes upload + verification."""
+    insert_response = MagicMock()
+    insert_response.__getitem__ = lambda _, k: {"id": video_id}[k]
+
+    mock_insert = MagicMock()
+    mock_insert.next_chunk.return_value = (None, insert_response)
+
+    mock_list_request = MagicMock()
+    mock_list_request.execute.return_value = {
+        "items": [{"id": video_id, "status": {"uploadStatus": upload_status}}]
+    }
+
+    mock_videos = MagicMock()
+    mock_videos.insert.return_value = mock_insert
+    mock_videos.list.return_value = mock_list_request
+
+    mock_service = MagicMock()
+    mock_service.videos.return_value = mock_videos
+    return mock_service
+
+
 class TestUploadVideo:
     @pytest.mark.asyncio
     async def test_upload_returns_result(self, tmp_path: Path) -> None:
         video_file = tmp_path / "test.mp4"
         video_file.write_bytes(b"\x00" * 100)
 
-        mock_response = MagicMock()
-        mock_response.__getitem__ = lambda _, k: {"id": "dQw4w9WgXcQ"}[k]
-
-        mock_insert = MagicMock()
-        mock_insert.next_chunk.return_value = (None, mock_response)
-
-        mock_videos = MagicMock()
-        mock_videos.insert.return_value = mock_insert
-
-        mock_service = MagicMock()
-        mock_service.videos.return_value = mock_videos
+        mock_service = _make_upload_service("dQw4w9WgXcQ")
 
         with (
             patch("helmlog.youtube.load_credentials") as mock_load,
@@ -188,17 +202,8 @@ class TestUploadVideo:
         video_file = tmp_path / "test.mp4"
         video_file.write_bytes(b"\x00" * 100)
 
-        mock_response = MagicMock()
-        mock_response.__getitem__ = lambda _, k: {"id": "abc123"}[k]
-
-        mock_insert = MagicMock()
-        mock_insert.next_chunk.return_value = (None, mock_response)
-
-        mock_videos = MagicMock()
-        mock_videos.insert.return_value = mock_insert
-
-        mock_service = MagicMock()
-        mock_service.videos.return_value = mock_videos
+        mock_service = _make_upload_service("abc123")
+        mock_videos = mock_service.videos.return_value
 
         with (
             patch("helmlog.youtube.load_credentials") as mock_load,
@@ -218,3 +223,132 @@ class TestUploadVideo:
         call_kwargs = mock_videos.insert.call_args
         body = call_kwargs.kwargs.get("body") or call_kwargs[1].get("body")
         assert body["status"]["privacyStatus"] == "private"
+
+    @pytest.mark.asyncio
+    async def test_upload_raises_when_youtube_rejects(self, tmp_path: Path) -> None:
+        """A rejected upload must propagate so the caller leaves the file for retry."""
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"\x00" * 100)
+
+        insert_response = MagicMock()
+        insert_response.__getitem__ = lambda _, k: {"id": "rej123"}[k]
+        mock_insert = MagicMock()
+        mock_insert.next_chunk.return_value = (None, insert_response)
+
+        mock_list_request = MagicMock()
+        mock_list_request.execute.return_value = {
+            "items": [
+                {
+                    "id": "rej123",
+                    "status": {
+                        "uploadStatus": "rejected",
+                        "rejectionReason": "uploadAborted",
+                    },
+                }
+            ]
+        }
+
+        mock_videos = MagicMock()
+        mock_videos.insert.return_value = mock_insert
+        mock_videos.list.return_value = mock_list_request
+        mock_service = MagicMock()
+        mock_service.videos.return_value = mock_videos
+
+        with (
+            patch("helmlog.youtube.load_credentials") as mock_load,
+            patch("helmlog.youtube.build_service") as mock_build,
+        ):
+            mock_load.return_value = MagicMock()
+            mock_build.return_value = mock_service
+
+            with pytest.raises(UploadVerificationError, match="uploadAborted"):
+                await upload_video(
+                    file_path=video_file,
+                    title="Broken",
+                    description="Broken",
+                    privacy="unlisted",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Post-upload verification
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForUploadAcceptance:
+    def test_returns_when_processed(self) -> None:
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [{"id": "ok1", "status": {"uploadStatus": "processed"}}]
+        }
+
+        status = wait_for_upload_acceptance(service, "ok1", sleep=lambda _s: None)
+        assert status["uploadStatus"] == "processed"
+
+    def test_raises_on_rejected_with_reason(self) -> None:
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "id": "bad1",
+                    "status": {
+                        "uploadStatus": "rejected",
+                        "rejectionReason": "invalidFile",
+                    },
+                }
+            ]
+        }
+
+        with pytest.raises(UploadVerificationError, match="invalidFile"):
+            wait_for_upload_acceptance(service, "bad1", sleep=lambda _s: None)
+
+    def test_raises_on_failed_with_reason(self) -> None:
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "id": "bad2",
+                    "status": {
+                        "uploadStatus": "failed",
+                        "failureReason": "codec",
+                    },
+                }
+            ]
+        }
+
+        with pytest.raises(UploadVerificationError, match="codec"):
+            wait_for_upload_acceptance(service, "bad2", sleep=lambda _s: None)
+
+    def test_polls_until_terminal(self) -> None:
+        """Should keep polling while status remains ``uploaded``."""
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.side_effect = [
+            {"items": [{"id": "poll1", "status": {"uploadStatus": "uploaded"}}]},
+            {"items": [{"id": "poll1", "status": {"uploadStatus": "uploaded"}}]},
+            {"items": [{"id": "poll1", "status": {"uploadStatus": "processed"}}]},
+        ]
+
+        status = wait_for_upload_acceptance(service, "poll1", sleep=lambda _s: None)
+        assert status["uploadStatus"] == "processed"
+        assert service.videos.return_value.list.return_value.execute.call_count == 3
+
+    def test_raises_on_timeout(self) -> None:
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.return_value = {
+            "items": [{"id": "slow", "status": {"uploadStatus": "uploaded"}}]
+        }
+
+        with pytest.raises(UploadVerificationError, match="did not reach a terminal"):
+            # timeout_s=0 forces one poll then a timeout check.
+            wait_for_upload_acceptance(service, "slow", timeout_s=0.0, sleep=lambda _s: None)
+
+    def test_tolerates_empty_items_before_terminal(self) -> None:
+        """Fresh uploads sometimes return no items before the id propagates."""
+        service = MagicMock()
+        service.videos.return_value.list.return_value.execute.side_effect = [
+            {"items": []},
+            {"items": [{"id": "new1", "status": {"uploadStatus": "processed"}}]},
+        ]
+
+        status = wait_for_upload_acceptance(service, "new1", sleep=lambda _s: None)
+        assert status["uploadStatus"] == "processed"


### PR DESCRIPTION
## Summary

Insta360 Studio exports multi-GB 360° files over tens of minutes. The pre-flight stability poll in `upload-stitched.sh` was capped at 30 s (10 × 3 s) and would exit the loop regardless of whether the file had stopped growing, so any export that took longer than 30 s was getting uploaded mid-render. YouTube accepted the truncated byte stream, the script marked the upload successful, and the backup-move step shipped the broken source off the exports disk — leaving re-export from scratch as the only recovery. That happened on a ~39 GB file this week.

Fix is defense-in-depth so this class of bug can't recur even if one layer slips.

## What changed

**`scripts/upload-stitched.sh`** — readiness gate rewritten
- Waits for **all** of:
  1. No process holds the file open for writing (`lsof -w -Fan` + access-mode filter — distinguishes benign readers like Finder preview from an in-progress export)
  2. File size stable for `HELMLOG_STABLE_WINDOW_S` (default 120s) consecutive seconds
  3. `ffprobe` parses the container and returns a positive duration (catches a file that stopped growing but never got a valid moov atom)
- Unbounded poll, capped at `HELMLOG_STABLE_MAX_WAIT_S` (default 4h). Fails loudly on timeout instead of silently uploading garbage.
- Per-file lockdir (`/tmp/helmlog-upload.<key>.lock`, trap-cleaned) so repeat fswatch events on the same export become no-ops instead of queued retries.

**`scripts/watch-exports.sh`** — fewer, calmer events
- Dropped `--event=Updated`. During a live export that was firing hundreds of times per file; the first Created event is all we need now that readiness is validated downstream.
- Raised `--latency` from 1 s to 10 s so a rename-on-create burst coalesces.

**`src/helmlog/youtube.py`** — trust-but-verify on YouTube's end
- New `wait_for_upload_acceptance()` polls `videos.list(status)` after `videos.insert` completes and blocks until `uploadStatus` is `processed` (success), `rejected` / `failed` (→ `UploadVerificationError`), or the timeout (`HELMLOG_YT_VERIFY_TIMEOUT_S`, default 30 min) fires.
- Wired into `upload_video()` — a truncated / corrupt upload that somehow slipped past the bash gate now raises instead of returning a fake-success `UploadResult`, so `process_recording()` reports `uploaded=False` and `upload-stitched.sh` keeps the source file in place for retry.

## Test plan

- [x] `uv run pytest --no-cov` — 2229 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — clean
- [x] `bash -n` syntax check both scripts
- [x] Manually verified `file_has_writer` detects an open write fd and ignores read-only handles (the original version of the awk parser had `-Fn -Ffn` which lsof silently truncates — fixed to `-Fan`)
- [ ] Re-export a session in Studio and confirm the watcher no longer uploads until the file is complete

## Env knobs (all optional, sensible defaults)

- `HELMLOG_STABLE_WINDOW_S` — required quiet interval (default 120)
- `HELMLOG_STABLE_POLL_S` — poll cadence (default 10)
- `HELMLOG_STABLE_MAX_WAIT_S` — hard ceiling in seconds (default 14400 = 4 h)
- `HELMLOG_YT_VERIFY_TIMEOUT_S` — YouTube acceptance poll ceiling (default 1800 = 30 min)

Generated with [Claude Code](https://claude.ai/code)