### PR TITLE
feat: home surfaces latest race session; control panel moves to /control

### DIFF
--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -23,20 +23,47 @@ async def healthz(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
-@router.get("/", response_class=HTMLResponse, include_in_schema=False)
-async def index(request: Request) -> Response:
-    get_storage(request)
+def _render_control_panel(request: Request, active_page: str) -> Response:
+    """Render the home.html control panel (#635).
+
+    Shared by ``/control`` and by ``/`` when no races exist yet.
+    """
     return templates.TemplateResponse(
         request,
         "home.html",
         tpl_ctx(
             request,
-            "/",
+            active_page,
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             sk_port=request.app.state.race_config.sk_port,
         ),
     )
+
+
+@router.get("/control", response_class=HTMLResponse, include_in_schema=False)
+async def control_page(request: Request) -> Response:
+    """Control panel — start/stop races, crew, sails, instruments (#635)."""
+    get_storage(request)
+    return _render_control_panel(request, "/control")
+
+
+@router.get("/", response_class=HTMLResponse, include_in_schema=False)
+async def index(request: Request) -> Response:
+    """Home page — latest-race session view, or control panel fallback (#635).
+
+    * In-progress race (``end_utc IS NULL``) → live session view.
+    * Else most recent completed race (max ``end_utc``) → session view.
+    * Else (empty DB) → control panel, so a fresh install is usable.
+    """
+    storage = get_storage(request)
+    current = await storage.get_current_race()
+    if current is not None:
+        return await _render_session_page(request, current, live=True, active_page="/")
+    latest = await storage.get_latest_completed_race()
+    if latest is not None:
+        return await _render_session_page(request, latest, live=False, active_page="/")
+    return _render_control_panel(request, "/")
 
 
 @router.get("/history", response_class=HTMLResponse, include_in_schema=False)
@@ -63,8 +90,17 @@ def _canonical_session_url(race_id: int, slug: str | None) -> str:
 async def _render_session_page(
     request: Request,
     race: Any,  # helmlog.races.Race  # noqa: ANN401
+    *,
+    live: bool = False,
+    active_page: str = "/history",
 ) -> Response:
-    """Render the session detail template for a resolved race (#449)."""
+    """Render the session detail template for a resolved race (#449, #635).
+
+    ``live=True`` marks the page as live-updating (used when the home page
+    surfaces a race whose ``end_utc`` is still NULL). ``active_page``
+    controls the nav highlight — ``/`` when the session is served as the
+    home page, ``/history`` when it's the normal session detail URL.
+    """
     from datetime import UTC, datetime, timedelta
 
     storage = get_storage(request)
@@ -88,7 +124,7 @@ async def _render_session_page(
         "session.html",
         tpl_ctx(
             request,
-            "/history",
+            active_page,
             session_id=race.id,
             session_name=race.name,
             session_slug=race.slug,
@@ -97,6 +133,7 @@ async def _render_session_page(
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             user_role=user_role,
+            live=live,
         ),
     )
 
@@ -208,6 +245,7 @@ async def _render_debrief_page(request: Request, debrief: dict[str, Any]) -> Res
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             user_role=user_role,
+            live=False,
         ),
     )
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -300,6 +300,39 @@ async function init() {
   loadMatch();
   renderExports();
   renderDangerZone();
+  if (cfg.dataset.live === '1') _startLiveRefresh();
+}
+
+// ---------------------------------------------------------------------------
+// Live refresh — while a race is in progress and this session is served at /
+// (see #635). Reload the track + videos periodically so the map extends as
+// the boat moves and newly-uploaded clips appear. Connects to /ws/live as
+// a presence signal; falls back to polling if the socket is unavailable.
+// ---------------------------------------------------------------------------
+
+const _LIVE_REFRESH_MS = 15000;
+let _liveInterval = null;
+let _liveWs = null;
+let _liveLastRefresh = 0;
+
+async function _liveRefreshOnce() {
+  const now = Date.now();
+  if (now - _liveLastRefresh < _LIVE_REFRESH_MS - 500) return;
+  _liveLastRefresh = now;
+  try {
+    await Promise.all([loadTrack(), loadVideos()]);
+  } catch (e) { /* non-fatal */ }
+}
+
+function _startLiveRefresh() {
+  if (_liveInterval) return;
+  _liveInterval = setInterval(_liveRefreshOnce, _LIVE_REFRESH_MS);
+  try {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    _liveWs = new WebSocket(`${proto}//${location.host}/ws/live`);
+    _liveWs.onmessage = () => { _liveRefreshOnce(); };
+    _liveWs.onclose = () => { _liveWs = null; };
+  } catch (e) { /* polling covers the fallback */ }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -3556,6 +3556,23 @@ class Storage:
         row = await cur.fetchone()
         return self._row_to_race(row) if row else None
 
+    async def get_latest_completed_race(self) -> Race | None:
+        """Return the race with the most recent ``end_utc``, or None (#635).
+
+        Used by the home page to surface the last finished race when no race
+        is currently in progress. Excludes open races (``end_utc IS NULL``)
+        so the home view never shows a "completed" race that is actually
+        still running — ``get_current_race`` handles that case.
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            f"SELECT {self._RACE_COLS}"
+            " FROM races WHERE end_utc IS NOT NULL"
+            " ORDER BY end_utc DESC LIMIT 1"
+        )
+        row = await cur.fetchone()
+        return self._row_to_race(row) if row else None
+
     async def list_races_for_date(self, date_str: str) -> list[Race]:
         """Return all races for a UTC date string, ordered by start_utc ASC."""
         db = self._read_conn()

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -17,6 +17,7 @@
   <button id="nav-hamburger" class="nav-hamburger" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-links" onclick="toggleNav()">&#9776;</button>
   <div id="nav-links" class="nav-links">
     <a href="/"{% if active_page == "/" %} class="active"{% endif %}>Home</a>
+    <a href="/control" class="admin-link{% if active_page == "/control" %} active{% endif %}">Control</a>
     <a href="/history"{% if active_page == "/history" %} class="active"{% endif %}>History</a>
     <a href="/maneuvers"{% if active_page == "/maneuvers" %} class="active"{% endif %}>Maneuvers</a>
     <a href="/sails"{% if active_page == "/sails" %} class="active"{% endif %}>Sails</a>

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -87,6 +87,7 @@
   data-grafana-port="{{ grafana_port }}"
   data-grafana-uid="{{ grafana_uid }}"
   data-user-role="{{ user_role }}"
+  data-live="{{ '1' if live else '' }}"
   style="display:none"></div>
 
 <a href="/history" class="back-link">&larr; History</a>
@@ -116,6 +117,11 @@
     <div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:4px">Tags</div>
     <tag-picker entity-type="session" entity-id="{{ session_id }}"></tag-picker>
   </div>
+</div>
+
+<div id="video-container" class="card" style="display:none">
+  <div id="video-switcher" style="display:flex;gap:6px;margin-bottom:8px"></div>
+  <div id="yt-player" style="aspect-ratio:16/9;border-radius:8px;overflow:hidden"></div>
 </div>
 
 <div id="track-container" class="card" style="display:none">
@@ -241,11 +247,6 @@
     <ul id="bookmarks-list" style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px"></ul>
     <p id="bookmarks-empty" style="font-size:.78rem;color:var(--text-secondary);margin:0;display:none">No bookmarks on this session yet. Use the &#128278; Bookmark button in the replay controls to add one.</p>
   </div>
-</div>
-
-<div id="video-container" class="card" style="display:none">
-  <div id="video-switcher" style="display:flex;gap:6px;margin-bottom:8px"></div>
-  <div id="yt-player" style="aspect-ratio:16/9;border-radius:8px;overflow:hidden"></div>
 </div>
 
 <div id="wind-field-card" class="card" style="display:none">

--- a/tests/test_races.py
+++ b/tests/test_races.py
@@ -220,6 +220,35 @@ async def test_get_current_race_none_when_all_closed(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_latest_completed_race_none_when_empty(storage: Storage) -> None:
+    """No races in DB → get_latest_completed_race returns None (#635)."""
+    assert await storage.get_latest_completed_race() is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_completed_race_ignores_in_progress(storage: Storage) -> None:
+    """Open races (end_utc IS NULL) must not be returned (#635)."""
+    await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    assert await storage.get_latest_completed_race() is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_completed_race_picks_max_end_utc(storage: Storage) -> None:
+    """Returns the race with the most recent end_utc across dates (#635)."""
+    r1 = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+    await storage.end_race(r1.id, _END1)
+    earlier_date = "2025-08-09"
+    earlier_start = datetime(2025, 8, 9, 13, 45, 0, tzinfo=UTC)
+    earlier_end = datetime(2025, 8, 9, 14, 5, 0, tzinfo=UTC)
+    r0 = await storage.start_race("BallardCup", earlier_start, earlier_date, 1, "20250809-bc-1")
+    await storage.end_race(r0.id, earlier_end)
+
+    latest = await storage.get_latest_completed_race()
+    assert latest is not None
+    assert latest.id == r1.id
+
+
+@pytest.mark.asyncio
 async def test_list_races_for_date_ordered(storage: Storage) -> None:
     await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
     await storage.start_race("BallardCup", _START2, _DATE, 2, "20250810-BallardCup-2")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -398,6 +398,96 @@ async def test_nav_has_hamburger_menu(storage: Storage) -> None:
     assert 'href="/admin/boats"' in html
 
 
+# ---------------------------------------------------------------------------
+# Home routing: / redirects between control, live session, and latest completed
+# session depending on race state. See #635.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_control_renders_control_panel(storage: Storage) -> None:
+    """GET /control always renders the control-panel home template (#635)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/control")
+    assert resp.status_code == 200
+    assert 'id="setup-card"' in resp.text
+    assert "home.js" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_root_empty_db_falls_back_to_control_panel(storage: Storage) -> None:
+    """GET / with no races still serves the control panel (empty-state fallback, #635)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/")
+    assert resp.status_code == 200
+    assert 'id="setup-card"' in resp.text
+    assert "home.js" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_root_with_completed_race_renders_session(storage: Storage) -> None:
+    """GET / with a completed race renders that race's session view (#635)."""
+    start = datetime(2026, 4, 20, 19, 0, tzinfo=UTC)
+    end = datetime(2026, 4, 20, 19, 45, tzinfo=UTC)
+    race = await storage.start_race("Spring", start, "2026-04-20", 1, "spring-1")
+    await storage.end_race(race.id, end)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/")
+    assert resp.status_code == 200
+    # Session template markers
+    assert "session.js" in resp.text
+    assert f'data-session-id="{race.id}"' in resp.text
+    # Not live — completed
+    assert 'data-live="1"' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_root_with_in_progress_race_renders_live_session(storage: Storage) -> None:
+    """GET / with an open race renders the live session view (#635)."""
+    start = datetime(2026, 4, 21, 19, 0, tzinfo=UTC)
+    race = await storage.start_race("Spring", start, "2026-04-21", 2, "spring-2")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/")
+    assert resp.status_code == 200
+    assert "session.js" in resp.text
+    assert f'data-session-id="{race.id}"' in resp.text
+    assert 'data-live="1"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_root_in_progress_takes_precedence_over_completed(storage: Storage) -> None:
+    """An in-progress race beats the most-recent-completed for / (#635)."""
+    done_start = datetime(2026, 4, 20, 19, 0, tzinfo=UTC)
+    done_end = datetime(2026, 4, 20, 19, 45, tzinfo=UTC)
+    done = await storage.start_race("Spring", done_start, "2026-04-20", 1, "spring-1")
+    await storage.end_race(done.id, done_end)
+
+    open_start = datetime(2026, 4, 21, 19, 0, tzinfo=UTC)
+    open_race = await storage.start_race("Spring", open_start, "2026-04-21", 2, "spring-2")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/")
+    assert f'data-session-id="{open_race.id}"' in resp.text
+    assert 'data-live="1"' in resp.text
+
+
 @pytest.mark.asyncio
 async def test_grafana_annotations_cors_header(storage: Storage) -> None:
     """GET /api/grafana/annotations returns Access-Control-Allow-Origin: *."""


### PR DESCRIPTION
## Summary
- `/` now serves the latest-race session view — a live view when a race is in progress (`end_utc IS NULL`), the most recent completed race otherwise, and the control panel as an empty-state fallback on a fresh install
- `/control` always serves the control panel (start/stop race/practice/debrief, crew, sails, instruments). Keeps destructive actions off the default landing so an observer can't end a race by mistake
- Video section moves above the track; in-progress races live-update via `/ws/live` + a 15s refresh cadence
- `storage.get_latest_completed_race()` returns the race with the latest `end_utc` (excludes open rows)

Closes #635

## Test plan
- [x] `uv run pytest` — 2199 passed, 2 skipped
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] `uv run mypy src/` clean
- [x] Unit: `/` with empty DB → control panel; `/` with completed race → session view; `/` with open race → live session view; `/control` always → control panel
- [ ] Manual (Pi): open `/` mid-race, watch track extend and videos appear without manual refresh
- [ ] Manual (Pi): finish race, open `/`, confirm video + track render for the just-finished race

🤖 Generated with [Claude Code](https://claude.ai/code)