### PR TITLE
feat: time-aligned multi-maneuver overlay chart (#619)

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -988,6 +988,232 @@ async def enrich_maneuvers_for_ids(
 
 
 # ---------------------------------------------------------------------------
+# Multi-maneuver overlay series (#619)
+# ---------------------------------------------------------------------------
+
+# Window around head-to-wind (seconds). Covers the helm leading into the
+# turn plus the recovery phase for most tacks; gybes generally fit too.
+# Fixed length gives all selected maneuvers a common x-axis regardless of
+# their individual durations.
+_OVERLAY_PRE_S = 20
+_OVERLAY_POST_S = 30
+# Inclusive integer seconds from -PRE to +POST, one sample per second.
+_OVERLAY_AXIS: list[int] = list(range(-_OVERLAY_PRE_S, _OVERLAY_POST_S + 1))
+
+
+def _align_series_at_htw(series_by_sec: dict[str, float], htw_ts: datetime) -> list[float | None]:
+    """Resample a per-second series to the overlay axis relative to HTW.
+
+    ``series_by_sec`` is ``{iso_second: value}`` as built by the enrichment
+    loader (``setdefault`` keyed on ``ts.isoformat()[:19]``). For each
+    offset in the fixed overlay axis we compute the target absolute
+    second and look it up; misses are ``None``. No interpolation — the
+    detector already works on whole seconds so real data lands on the
+    grid naturally.
+    """
+    out: list[float | None] = []
+    for offset in _OVERLAY_AXIS:
+        target = (htw_ts + timedelta(seconds=offset)).isoformat()[:19]
+        v = series_by_sec.get(target)
+        out.append(float(v) if v is not None else None)
+    return out
+
+
+def _heading_rate_series(hdg_by_sec: dict[str, float], htw_ts: datetime) -> list[float | None]:
+    """First-difference of the heading series over the overlay window,
+    handling angular wrap (e.g. 359 → 1 → rate = +2°/s, not -358)."""
+    out: list[float | None] = []
+    prev: float | None = None
+    for offset in _OVERLAY_AXIS:
+        target = (htw_ts + timedelta(seconds=offset)).isoformat()[:19]
+        cur = hdg_by_sec.get(target)
+        if cur is None or prev is None:
+            out.append(None)
+        else:
+            out.append(round(_signed_heading_delta(prev, cur), 2))
+        prev = cur if cur is not None else prev
+    return out
+
+
+async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]) -> dict[str, Any]:
+    """Build the overlay payload for ``GET /api/maneuvers/overlay``.
+
+    Returns a dict shaped for the chart UI (#619):
+
+    ``{
+        "axis_s": [-20, -19, ..., 30],
+        "channels": ["bsp", "heading_rate_deg_s", "twa"],
+        "maneuvers": [
+            {
+                "session_id": 21,
+                "maneuver_id": 392,
+                "session_name": "...",
+                "session_slug": "...",
+                "type": "tack",
+                "rank": "avg",
+                "loss_percentile": 40,
+                "head_to_wind_ts": "...",
+                "bsp": [6.0, 6.0, ...],
+                "heading_rate_deg_s": [0.1, ...],
+                "twa": [40, ...],
+            },
+            ...
+        ],
+        "excluded_ids": ["21:393"],
+    }``
+
+    Maneuvers with ``head_to_wind_ts = None`` (roundings, stalled tacks,
+    missing TWA) are excluded and their ``"<sid>:<mid>"`` string appended
+    to ``excluded_ids`` so the UI can show a notice.
+
+    Per-session instrument data is loaded via ``enrich_session_maneuvers``
+    (cached), then aligned here to the fixed overlay axis. No new
+    storage round-trips for repeat calls on the same session ids.
+    """
+    if not pairs:
+        return {"axis_s": _OVERLAY_AXIS, "channels": [], "maneuvers": [], "excluded_ids": []}
+
+    by_session: dict[int, set[int]] = {}
+    for sid, mid in pairs:
+        by_session.setdefault(sid, set()).add(mid)
+
+    out: list[dict[str, Any]] = []
+    excluded: list[str] = []
+
+    for session_id, wanted_ids in by_session.items():
+        race = await storage.get_race(session_id)
+        if race is None:
+            for mid in wanted_ids:
+                excluded.append(f"{session_id}:{mid}")
+            continue
+
+        enriched, _video = await enrich_session_maneuvers(storage, session_id)
+        session_name = race.name
+        session_slug = race.slug or ""
+
+        # Load instrument series once per session for the overlay alignment.
+        series = await _load_session_instrument_series(storage, session_id)
+        hdg_by_sec = series["hdg"]
+        bsp_by_sec = series["bsp"]
+        twa_by_sec = series["twa"]
+
+        for m in enriched:
+            if m.get("id") not in wanted_ids:
+                continue
+            key = f"{session_id}:{m.get('id')}"
+            htw_raw = m.get("head_to_wind_ts")
+            if not htw_raw:
+                excluded.append(key)
+                continue
+            try:
+                htw_ts = _parse_iso(str(htw_raw))
+            except (ValueError, TypeError):
+                excluded.append(key)
+                continue
+
+            out.append(
+                {
+                    "session_id": session_id,
+                    "maneuver_id": m.get("id"),
+                    "session_name": session_name,
+                    "session_slug": session_slug,
+                    "type": m.get("type"),
+                    "rank": m.get("rank"),
+                    "loss_percentile": m.get("loss_percentile"),
+                    "head_to_wind_ts": m.get("head_to_wind_ts"),
+                    "entry_twa": m.get("entry_twa"),
+                    "entry_tws": m.get("entry_tws"),
+                    "bsp": _align_series_at_htw(bsp_by_sec, htw_ts),
+                    "heading_rate_deg_s": _heading_rate_series(hdg_by_sec, htw_ts),
+                    "twa": _align_series_at_htw(twa_by_sec, htw_ts),
+                }
+            )
+
+    return {
+        "axis_s": _OVERLAY_AXIS,
+        "channels": ["bsp", "heading_rate_deg_s", "twa"],
+        "maneuvers": out,
+        "excluded_ids": excluded,
+    }
+
+
+async def _load_session_instrument_series(
+    storage: Storage, session_id: int
+) -> dict[str, dict[str, float]]:
+    """Load per-second hdg / bsp / twa dicts for a session, keyed by
+    ``ts.isoformat()[:19]``. Uses the same race_id-scoped-with-fallback
+    pattern as ``enrich_session_maneuvers`` and builds the folded TWA
+    the same way."""
+    db = storage._conn()
+    race_cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    race_row = await race_cur.fetchone()
+    if race_row is None:
+        return {"hdg": {}, "bsp": {}, "twa": {}}
+
+    start = _parse_iso(race_row["start_utc"])
+    end = _parse_iso(race_row["end_utc"]) if race_row["end_utc"] else start + timedelta(hours=24)
+    start_pad = start - timedelta(seconds=_ENRICH_PAD_S)
+    end_pad = end + timedelta(seconds=_ENRICH_PAD_S)
+
+    async def _load(table: str) -> list[dict[str, Any]]:
+        data = await storage.query_range(table, start_pad, end_pad, race_id=session_id)
+        if not data:
+            data = await storage.query_range(table, start_pad, end_pad)
+        return data
+
+    headings_raw = await _load("headings")
+    speeds_raw = await _load("speeds")
+    winds_raw = await _load("winds")
+    cogsog_raw: list[dict[str, Any]] = []
+    if not headings_raw or not speeds_raw:
+        cogsog_raw = await _load("cogsog")
+
+    def _sec(ts_str: str) -> str:
+        return str(ts_str)[:19]
+
+    hdg_by_sec: dict[str, float] = {}
+    if headings_raw:
+        for r in headings_raw:
+            hdg_by_sec.setdefault(_sec(r["ts"]), float(r["heading_deg"]))
+    elif cogsog_raw:
+        for r in cogsog_raw:
+            hdg_by_sec.setdefault(_sec(r["ts"]), float(r["cog_deg"]))
+
+    bsp_by_sec: dict[str, float] = {}
+    if speeds_raw:
+        for r in speeds_raw:
+            bsp_by_sec.setdefault(_sec(r["ts"]), float(r["speed_kts"]))
+    elif cogsog_raw:
+        for r in cogsog_raw:
+            bsp_by_sec.setdefault(_sec(r["ts"]), float(r["sog_kts"]))
+
+    twa_by_sec: dict[str, float] = {}
+    for r in winds_raw:
+        ref_raw = r.get("reference")
+        if ref_raw is None:
+            continue
+        try:
+            ref = int(ref_raw)
+        except (TypeError, ValueError):
+            continue
+        if ref not in (0, 4):
+            continue
+        sec = _sec(r["ts"])
+        if ref == 0:
+            signed = float(r["wind_angle_deg"])
+            folded = abs(signed) % 360.0
+            twa_by_sec.setdefault(sec, folded if folded <= 180.0 else 360.0 - folded)
+        else:
+            twd_val = float(r["wind_angle_deg"]) % 360.0
+            hv = hdg_by_sec.get(sec)
+            if hv is not None:
+                raw = (twd_val - hv + 360.0) % 360.0
+                twa_by_sec.setdefault(sec, raw if raw <= 180.0 else 360.0 - raw)
+
+    return {"hdg": hdg_by_sec, "bsp": bsp_by_sec, "twa": twa_by_sec}
+
+
+# ---------------------------------------------------------------------------
 # Eager backfill worker (#613)
 # ---------------------------------------------------------------------------
 

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -205,6 +205,45 @@ async def maneuvers_browser_page(request: Request) -> Response:
     )
 
 
+@router.get("/maneuvers/overlay", response_class=HTMLResponse, include_in_schema=False)
+async def maneuvers_overlay_page(request: Request) -> Response:
+    """Time-aligned multi-maneuver overlay chart (#619).
+
+    One page serves both entry points. The ``ids`` query parameter
+    carries the ``<session_id>:<maneuver_id>`` pairs regardless of
+    whether the user arrived from the session detail page or the
+    cross-session maneuvers browser. A single session_id / name in
+    the URL (via a ``session`` query hint) gets rendered as a
+    breadcrumb so the user can return to the session page.
+    """
+    get_storage(request)
+    session_id_raw = request.query_params.get("session", "")
+    session_id: int | None = None
+    session_name = ""
+    session_slug = ""
+    try:
+        session_id = int(session_id_raw) if session_id_raw else None
+    except ValueError:
+        session_id = None
+    if session_id is not None:
+        storage = get_storage(request)
+        race = await storage.get_race(session_id)
+        if race is not None:
+            session_name = race.name
+            session_slug = race.slug or ""
+    return templates.TemplateResponse(
+        request,
+        "overlay.html",
+        tpl_ctx(
+            request,
+            "/maneuvers",
+            session_id=session_id,
+            session_name=session_name,
+            session_slug=session_slug,
+        ),
+    )
+
+
 @router.get(
     "/session/{session_id:int}/{slug}",
     response_class=HTMLResponse,

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -18,6 +20,7 @@ from helmlog.routes._helpers import (
     audit,
     cached_json_response,
     get_storage,
+    get_web_cache,
     limiter,
     t1_cached_json_response,
 )
@@ -1669,6 +1672,91 @@ async def api_cross_session_maneuvers_compare(
             "video_sync_by_session": {str(k): v for k, v in video_sync_by_session.items()},
         }
     )
+
+
+@router.get("/api/maneuvers/overlay")
+async def api_maneuvers_overlay(
+    request: Request,
+    ids: str = Query(..., description="Comma-separated <session_id>:<maneuver_id> pairs"),
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Time-aligned multi-maneuver overlay series (#619).
+
+    Takes ``<session_id>:<maneuver_id>`` pairs and returns per-maneuver
+    boatspeed, heading-rate, and TWA series resampled to 1 Hz over
+    ``[-20 s, +30 s]`` relative to each maneuver's ``head_to_wind_ts``
+    (#613). Maneuvers with no HTW (roundings, stalls) are excluded with
+    their ids listed in ``excluded_ids`` so the UI can show a notice.
+
+    Cached via the T2 global path (``race_id=0`` sentinel) with a
+    content-addressed ``data_hash`` that folds the sorted selection,
+    every touched session's current ``compute_race_data_hash`` (so any
+    race mutation changes the hash), and ``ENRICH_CACHE_VERSION`` (so
+    enrichment-code bumps self-invalidate). Orphaned entries age out
+    via TTL.
+    """
+    from helmlog.analysis.maneuvers import ENRICH_CACHE_VERSION, build_maneuvers_overlay
+    from helmlog.cache import resolve_race_data_hash
+
+    try:
+        parsed = _parse_cross_session_ids(ids)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="ids must be comma-separated <session_id>:<maneuver_id> pairs",
+        ) from exc
+
+    pairs: list[tuple[int, int]] = [(sid, mid) for sid, mid in parsed if isinstance(mid, int)]
+    if not pairs:
+        return JSONResponse(
+            {"axis_s": list(range(-20, 31)), "channels": [], "maneuvers": [], "excluded_ids": []}
+        )
+
+    storage = get_storage(request)
+    cache = get_web_cache(request)
+
+    sorted_pairs = sorted(pairs)
+    data_hash: str | None = None
+    if cache is not None:
+        try:
+            session_hashes: dict[int, str] = {}
+            for sid in sorted({sid for sid, _ in sorted_pairs}):
+                h = await resolve_race_data_hash(storage, sid)
+                if h:
+                    session_hashes[sid] = h
+            hash_input = json.dumps(
+                {
+                    "pairs": sorted_pairs,
+                    "session_hashes": session_hashes,
+                    "enrich_version": ENRICH_CACHE_VERSION,
+                },
+                sort_keys=True,
+            )
+            data_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+            hit = await cache.t2_get_global("maneuvers_overlay", data_hash=data_hash)
+            if hit is not None:
+                return JSONResponse(hit)
+        except Exception:  # noqa: BLE001 — cache must never fail a request
+            data_hash = None
+
+    payload = await build_maneuvers_overlay(storage, sorted_pairs)
+
+    if cache is not None and data_hash is not None:
+        # 24 h TTL — orphaned entries (from races that mutate and
+        # leave behind stale composite hashes) age out naturally.
+        # Cache writes are best-effort; any failure is logged by the
+        # cache layer and swallowed there.
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            await cache.t2_put_global(
+                "maneuvers_overlay",
+                data_hash=data_hash,
+                value=payload,
+                ttl_seconds=86400,
+            )
+
+    return JSONResponse(payload)
 
 
 @router.get("/api/maneuvers/sessions")

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -331,8 +331,10 @@ function updateSelectedCount() {
   const n = state.selected.size;
   const el = document.getElementById('mv-selected-count');
   el.textContent = n ? '(' + n + ' selected)' : '';
-  const btn = document.getElementById('mv-compare-btn');
-  btn.disabled = n === 0;
+  const cmp = document.getElementById('mv-compare-btn');
+  if (cmp) cmp.disabled = n === 0;
+  const ov = document.getElementById('mv-overlay-btn');
+  if (ov) ov.disabled = n === 0;
   const all = document.getElementById('mv-check-all');
   if (all) all.checked = n > 0 && n === state.maneuvers.length;
 }
@@ -345,6 +347,22 @@ function mvOpenCompare() {
     .filter(k => state.selected.has(k));
   if (!orderedKeys.length) return;
   window.open('/compare?ids=' + orderedKeys.join(','), '_blank');
+}
+
+function mvOpenOverlay() {
+  if (!state.selected.size) return;
+  // Overlay (#619) only makes sense for maneuvers with a head-to-wind
+  // alignment point — roundings have none, so pre-filter them client
+  // side to avoid the backend returning them all in excluded_ids.
+  const orderedKeys = state.maneuvers
+    .filter(m => m.type === 'tack' || m.type === 'gybe')
+    .map(m => m.session_id + ':' + m.id)
+    .filter(k => state.selected.has(k));
+  if (!orderedKeys.length) {
+    alert('Overlay requires tack or gybe maneuvers — roundings have no head-to-wind alignment.');
+    return;
+  }
+  window.open('/maneuvers/overlay?ids=' + orderedKeys.join(','), '_blank');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/helmlog/static/overlay.js
+++ b/src/helmlog/static/overlay.js
@@ -1,0 +1,410 @@
+/* Multi-maneuver time-aligned overlay chart (#619).
+ *
+ * Fetches /api/maneuvers/overlay?ids=sid:mid,... and renders stacked
+ * panels (BSP, heading rate, TWA) on a shared x-axis centred at t=0
+ * (head-to-wind). Each selected maneuver draws as a translucent line;
+ * the best (lowest loss_percentile) is highlighted green, the worst
+ * red, the rest grey. At >=15 maneuvers, auto-switches to a percentile
+ * band render (p10/p25/p50/p75/p90); the user can override via toggle.
+ *
+ * Hand-rolled canvas matches the existing compare.js style and avoids
+ * pulling in a chart library for a first landing — uPlot remains the
+ * recommended path if we outgrow this (issue #619).
+ */
+'use strict';
+
+const OV_AXIS_MIN = -20;
+const OV_AXIS_MAX = 30;
+const OV_BAND_AUTO_THRESHOLD = 15;
+
+const OV_CHANNELS = [
+  { key: 'bsp',                 label: 'Boat speed',    unit: 'kt',     decimals: 1 },
+  { key: 'heading_rate_deg_s',  label: 'Heading rate',  unit: '°/s',    decimals: 1 },
+  { key: 'twa',                 label: 'TWA',           unit: '°',      decimals: 0 },
+];
+
+const _ovState = {
+  data: null,
+  mode: 'auto',    // 'lines' | 'bands' | 'auto'
+  hoverId: null,   // "sid:mid" of the currently highlighted curve
+  panels: [],      // [{ channel, canvas, ctx, bbox }]
+};
+
+// ---------------------------------------------------------------------------
+// Fetch + bootstrap
+// ---------------------------------------------------------------------------
+
+function _ovIdsFromUrl() {
+  const params = new URLSearchParams(location.search);
+  return (params.get('ids') || '').trim();
+}
+
+async function ovInit() {
+  const ids = _ovIdsFromUrl();
+  const panelsEl = document.getElementById('ov-panels');
+  const emptyEl = document.getElementById('ov-empty');
+  const noticeEl = document.getElementById('ov-notice');
+  const legendEl = document.getElementById('ov-legend');
+  const subtitleEl = document.getElementById('ov-subtitle');
+
+  if (!ids) {
+    emptyEl.style.display = '';
+    return;
+  }
+
+  let payload;
+  try {
+    const r = await fetch('/api/maneuvers/overlay?ids=' + encodeURIComponent(ids));
+    if (!r.ok) {
+      noticeEl.textContent = 'Failed to load overlay: HTTP ' + r.status;
+      noticeEl.style.display = '';
+      return;
+    }
+    payload = await r.json();
+  } catch (e) {
+    noticeEl.textContent = 'Failed to load overlay: ' + e;
+    noticeEl.style.display = '';
+    return;
+  }
+
+  _ovState.data = payload;
+
+  if (!payload.maneuvers || payload.maneuvers.length === 0) {
+    emptyEl.style.display = '';
+    if (payload.excluded_ids && payload.excluded_ids.length) {
+      noticeEl.textContent =
+        'Excluded (no head-to-wind): ' + payload.excluded_ids.join(', ');
+      noticeEl.style.display = '';
+    }
+    return;
+  }
+
+  // Subtitle: count + session summary.
+  const uniqueSessions = new Set(payload.maneuvers.map(m => m.session_id));
+  subtitleEl.textContent =
+    payload.maneuvers.length + ' maneuver' + (payload.maneuvers.length === 1 ? '' : 's') +
+    ' across ' + uniqueSessions.size + ' session' + (uniqueSessions.size === 1 ? '' : 's');
+
+  if (payload.excluded_ids && payload.excluded_ids.length) {
+    noticeEl.textContent =
+      payload.excluded_ids.length + ' excluded (no head-to-wind): ' +
+      payload.excluded_ids.join(', ');
+    noticeEl.style.display = '';
+  }
+
+  // Build one canvas per channel.
+  panelsEl.innerHTML = '';
+  _ovState.panels = OV_CHANNELS.map(ch => {
+    const panel = document.createElement('div');
+    panel.className = 'ov-panel';
+    panel.innerHTML =
+      '<h4>' + ch.label + ' (' + ch.unit + ')</h4>' +
+      '<div class="ov-canvas-wrap"><canvas></canvas></div>';
+    panelsEl.appendChild(panel);
+    const canvas = panel.querySelector('canvas');
+    return { channel: ch, canvas, ctx: canvas.getContext('2d'), bbox: null };
+  });
+
+  legendEl.style.display = '';
+
+  // Hover tracking across all panels.
+  _ovState.panels.forEach(p => {
+    p.canvas.addEventListener('mousemove', evt => _ovOnHover(evt, p));
+    p.canvas.addEventListener('mouseleave', () => { _ovState.hoverId = null; _ovRender(); });
+  });
+
+  window.addEventListener('resize', _ovRender);
+  _ovRender();
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function _ovResolveMode() {
+  if (_ovState.mode !== 'auto') return _ovState.mode;
+  const n = (_ovState.data && _ovState.data.maneuvers.length) || 0;
+  return n >= OV_BAND_AUTO_THRESHOLD ? 'bands' : 'lines';
+}
+
+function _ovRender() {
+  if (!_ovState.data) return;
+  const mode = _ovResolveMode();
+  _ovState.panels.forEach(p => _ovRenderPanel(p, mode));
+}
+
+function _ovRenderPanel(panel, mode) {
+  const { canvas, ctx, channel } = panel;
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvas.clientWidth;
+  const cssH = canvas.clientHeight;
+  if (cssW === 0 || cssH === 0) return;
+  canvas.width = Math.round(cssW * dpr);
+  canvas.height = Math.round(cssH * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  const padL = 44, padR = 10, padT = 6, padB = 20;
+  const plotW = cssW - padL - padR;
+  const plotH = cssH - padT - padB;
+  panel.bbox = { padL, padR, padT, padB, plotW, plotH };
+
+  ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--bg-secondary') || '#1a1f26';
+  ctx.fillRect(0, 0, cssW, cssH);
+
+  const axis = _ovState.data.axis_s;
+  const maneuvers = _ovState.data.maneuvers;
+  const allValues = [];
+  maneuvers.forEach(m => {
+    const series = m[channel.key];
+    if (!series) return;
+    series.forEach(v => { if (v !== null && v !== undefined) allValues.push(v); });
+  });
+  if (!allValues.length) {
+    ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--text-secondary') || '#888';
+    ctx.font = '11px sans-serif';
+    ctx.fillText('(no data in window)', padL + 6, padT + 12);
+    return;
+  }
+
+  let yMin = Math.min(...allValues);
+  let yMax = Math.max(...allValues);
+  if (yMin === yMax) { yMin -= 1; yMax += 1; }
+  const yPad = (yMax - yMin) * 0.08;
+  yMin -= yPad; yMax += yPad;
+
+  const xToPx = x => padL + ((x - OV_AXIS_MIN) / (OV_AXIS_MAX - OV_AXIS_MIN)) * plotW;
+  const yToPx = y => padT + (1 - (y - yMin) / (yMax - yMin)) * plotH;
+
+  // Grid: vertical 0-line
+  ctx.strokeStyle = 'rgba(180,180,180,0.25)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(xToPx(0), padT);
+  ctx.lineTo(xToPx(0), padT + plotH);
+  ctx.stroke();
+
+  // Axis labels (x)
+  ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--text-secondary') || '#888';
+  ctx.font = '10px monospace';
+  ctx.textAlign = 'center';
+  [-20, -10, 0, 10, 20, 30].forEach(x => {
+    const lbl = x === 0 ? 'HTW' : (x > 0 ? '+' + x + 's' : x + 's');
+    ctx.fillText(lbl, xToPx(x), padT + plotH + 12);
+  });
+  ctx.textAlign = 'right';
+  [yMin + (yMax - yMin) * 0.0,
+   yMin + (yMax - yMin) * 0.5,
+   yMin + (yMax - yMin) * 1.0].forEach(y => {
+    ctx.fillText(y.toFixed(channel.decimals), padL - 4, yToPx(y) + 3);
+  });
+
+  if (mode === 'bands') {
+    _ovRenderBands(ctx, panel, axis, maneuvers, channel, xToPx, yToPx);
+  } else {
+    _ovRenderLines(ctx, panel, axis, maneuvers, channel, xToPx, yToPx);
+  }
+
+  // Panel border
+  ctx.strokeStyle = getComputedStyle(document.body).getPropertyValue('--border') || '#333';
+  ctx.strokeRect(padL, padT, plotW, plotH);
+}
+
+function _ovRenderLines(ctx, panel, axis, maneuvers, channel, xToPx, yToPx) {
+  if (!maneuvers.length) return;
+  // Rank by loss_percentile → best (lowest) green, worst (highest) red.
+  const pctls = maneuvers
+    .map(m => m.loss_percentile)
+    .filter(v => v !== null && v !== undefined);
+  const minP = pctls.length ? Math.min(...pctls) : null;
+  const maxP = pctls.length ? Math.max(...pctls) : null;
+
+  const isBest = m => m.loss_percentile === minP && m.rank !== 'consistent';
+  const isWorst = m => m.loss_percentile === maxP && m.rank !== 'consistent' && minP !== maxP;
+
+  // Grey lines first so the highlighted ones paint on top.
+  const greyFirst = maneuvers.slice().sort((a, b) => {
+    const aHi = isBest(a) || isWorst(a) ? 1 : 0;
+    const bHi = isBest(b) || isWorst(b) ? 1 : 0;
+    return aHi - bHi;
+  });
+
+  greyFirst.forEach(m => {
+    const series = m[channel.key];
+    if (!series) return;
+    const id = m.session_id + ':' + m.maneuver_id;
+    const hovered = _ovState.hoverId === id;
+    let color, alpha, width;
+    if (hovered) {
+      color = '#fff'; alpha = 1.0; width = 2.0;
+    } else if (isBest(m)) {
+      color = getComputedStyle(document.body).getPropertyValue('--success') || '#2a6';
+      alpha = 0.8; width = 1.8;
+    } else if (isWorst(m)) {
+      color = getComputedStyle(document.body).getPropertyValue('--error') || '#c44';
+      alpha = 0.8; width = 1.8;
+    } else {
+      color = getComputedStyle(document.body).getPropertyValue('--text-secondary') || '#888';
+      alpha = 0.45; width = 1.0;
+    }
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = width;
+    ctx.beginPath();
+    let started = false;
+    for (let i = 0; i < axis.length; i++) {
+      const v = series[i];
+      if (v === null || v === undefined) {
+        started = false; continue;
+      }
+      const x = xToPx(axis[i]);
+      const y = yToPx(v);
+      if (!started) { ctx.moveTo(x, y); started = true; }
+      else { ctx.lineTo(x, y); }
+    }
+    ctx.stroke();
+  });
+  ctx.globalAlpha = 1.0;
+}
+
+function _ovRenderBands(ctx, panel, axis, maneuvers, channel, xToPx, yToPx) {
+  // Compute p10/p25/p50/p75/p90 at each sample index across all maneuvers.
+  const qs = { p10: [], p25: [], p50: [], p75: [], p90: [] };
+  for (let i = 0; i < axis.length; i++) {
+    const col = [];
+    for (const m of maneuvers) {
+      const v = m[channel.key] ? m[channel.key][i] : null;
+      if (v !== null && v !== undefined) col.push(v);
+    }
+    if (col.length < 2) {
+      qs.p10.push(null); qs.p25.push(null); qs.p50.push(null); qs.p75.push(null); qs.p90.push(null);
+      continue;
+    }
+    col.sort((a, b) => a - b);
+    qs.p10.push(_ovPercentile(col, 0.10));
+    qs.p25.push(_ovPercentile(col, 0.25));
+    qs.p50.push(_ovPercentile(col, 0.50));
+    qs.p75.push(_ovPercentile(col, 0.75));
+    qs.p90.push(_ovPercentile(col, 0.90));
+  }
+
+  // Fill p25→p75 envelope
+  const accent = getComputedStyle(document.body).getPropertyValue('--accent') || '#4af';
+  ctx.fillStyle = accent;
+  ctx.globalAlpha = 0.25;
+  ctx.beginPath();
+  let started = false;
+  for (let i = 0; i < axis.length; i++) {
+    const v = qs.p25[i];
+    if (v === null || v === undefined) continue;
+    const x = xToPx(axis[i]);
+    const y = yToPx(v);
+    if (!started) { ctx.moveTo(x, y); started = true; } else { ctx.lineTo(x, y); }
+  }
+  for (let i = axis.length - 1; i >= 0; i--) {
+    const v = qs.p75[i];
+    if (v === null || v === undefined) continue;
+    const x = xToPx(axis[i]);
+    const y = yToPx(v);
+    ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fill();
+  ctx.globalAlpha = 1.0;
+
+  // p10 and p90 dashed outer lines
+  ctx.setLineDash([3, 3]);
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 1;
+  [qs.p10, qs.p90].forEach(arr => _ovStrokeSeries(ctx, axis, arr, xToPx, yToPx));
+  ctx.setLineDash([]);
+
+  // p50 solid median
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 2;
+  _ovStrokeSeries(ctx, axis, qs.p50, xToPx, yToPx);
+}
+
+function _ovPercentile(sortedCol, q) {
+  if (!sortedCol.length) return null;
+  const idx = q * (sortedCol.length - 1);
+  const lo = Math.floor(idx), hi = Math.ceil(idx);
+  if (lo === hi) return sortedCol[lo];
+  return sortedCol[lo] + (sortedCol[hi] - sortedCol[lo]) * (idx - lo);
+}
+
+function _ovStrokeSeries(ctx, axis, series, xToPx, yToPx) {
+  ctx.beginPath();
+  let started = false;
+  for (let i = 0; i < axis.length; i++) {
+    const v = series[i];
+    if (v === null || v === undefined) { started = false; continue; }
+    const x = xToPx(axis[i]);
+    const y = yToPx(v);
+    if (!started) { ctx.moveTo(x, y); started = true; } else { ctx.lineTo(x, y); }
+  }
+  ctx.stroke();
+}
+
+// ---------------------------------------------------------------------------
+// Hover
+// ---------------------------------------------------------------------------
+
+function _ovOnHover(evt, panel) {
+  if (!_ovState.data) return;
+  const rect = panel.canvas.getBoundingClientRect();
+  const x = evt.clientX - rect.left;
+  const y = evt.clientY - rect.top;
+  const { padL, padT, plotW, plotH } = panel.bbox || {};
+  if (padL === undefined) return;
+  if (x < padL || x > padL + plotW || y < padT || y > padT + plotH) {
+    _ovState.hoverId = null;
+    _ovRender();
+    return;
+  }
+  // Find the maneuver whose line is closest at this x.
+  const t = OV_AXIS_MIN + ((x - padL) / plotW) * (OV_AXIS_MAX - OV_AXIS_MIN);
+  const idx = Math.round(t - OV_AXIS_MIN);
+  if (idx < 0 || idx >= _ovState.data.axis_s.length) return;
+  const allValues = _ovState.data.maneuvers.map(m => m[panel.channel.key]?.[idx]).filter(v => v !== null && v !== undefined);
+  if (!allValues.length) return;
+  const yMin = Math.min(...allValues);
+  const yMax = Math.max(...allValues);
+  const range = yMax - yMin || 1;
+  let best = null, bestDist = Infinity;
+  _ovState.data.maneuvers.forEach(m => {
+    const v = m[panel.channel.key]?.[idx];
+    if (v === null || v === undefined) return;
+    const cy = padT + (1 - (v - yMin) / range) * plotH;
+    const d = Math.abs(cy - y);
+    if (d < bestDist) { bestDist = d; best = m; }
+  });
+  if (best && bestDist < 20) {
+    _ovState.hoverId = best.session_id + ':' + best.maneuver_id;
+  } else {
+    _ovState.hoverId = null;
+  }
+  _ovRender();
+}
+
+// ---------------------------------------------------------------------------
+// Mode toggle
+// ---------------------------------------------------------------------------
+
+function ovSetMode(mode) {
+  _ovState.mode = mode;
+  ['ov-mode-lines', 'ov-mode-bands', 'ov-mode-auto'].forEach(id => {
+    document.getElementById(id).classList.remove('active');
+  });
+  document.getElementById('ov-mode-' + mode).classList.add('active');
+  _ovRender();
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', ovInit);
+} else {
+  ovInit();
+}

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4271,6 +4271,34 @@ function openManeuverCompare() {
   window.open('/session/' + SESSION_ID + '/compare?ids=' + ids.join(','), '_blank');
 }
 
+function openManeuverOverlay() {
+  // Overlay (#619) — defaults to every tack/gybe in the session the first
+  // time it opens, then narrows via the same filter+selection state that
+  // drives Compare. Roundings have no head-to-wind alignment, so they're
+  // excluded from the URL regardless of selection.
+  const selectedIds = _maneuverRows()
+    .filter(m => _maneuverSelected.has(_manKey(m, _maneuvers.indexOf(m)))
+                  && typeof m.id === 'number'
+                  && (m.type === 'tack' || m.type === 'gybe'))
+    .map(m => SESSION_ID + ':' + m.id);
+  const ids = selectedIds.length
+    ? selectedIds
+    // Nothing selected (or only roundings selected) → fall back to every
+    // alignable maneuver in the session. Matches the issue's "default
+    // selection = every tack/gybe in that session" AC.
+    : _maneuvers
+        .filter(m => typeof m.id === 'number' && (m.type === 'tack' || m.type === 'gybe'))
+        .map(m => SESSION_ID + ':' + m.id);
+  if (!ids.length) {
+    alert('No tacks or gybes in this session — overlay requires a head-to-wind alignment point.');
+    return;
+  }
+  window.open(
+    '/maneuvers/overlay?session=' + SESSION_ID + '&ids=' + ids.join(','),
+    '_blank'
+  );
+}
+
 function _maneuverRows() {
   const items = _maneuvers.filter(_matchesManeuverFilter);
   const key = _maneuverSort.key, dir = _maneuverSort.dir;
@@ -4990,6 +5018,7 @@ function renderManeuverCard() {
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'all\')">all</button>'
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'none\')">none</button>'
     + '<button style="font-size:.68rem;padding:1px 6px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" onclick="setManeuverSelectAll(\'filtered\')">match filter</button>'
+    + '<button style="font-size:.7rem;padding:3px 10px;border:1px solid var(--accent);background:none;color:var(--accent);cursor:pointer;border-radius:4px;font-weight:600" onclick="openManeuverOverlay()" title="Time-aligned multi-maneuver chart at head-to-wind">Overlay Chart</button>'
     + '<button style="' + compareBtnStyle + '" onclick="openManeuverCompare()" title="Open synced video comparison for selected maneuvers">Compare Videos</button>'
     + '</div>';
 

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -102,6 +102,7 @@
     <strong id="mv-count">0 maneuvers</strong>
     <span id="mv-selected-count" style="font-size:.75rem;color:var(--text-secondary)"></span>
     <span class="spacer"></span>
+    <button id="mv-overlay-btn" onclick="mvOpenOverlay()" disabled>Overlay Selected</button>
     <button id="mv-compare-btn" onclick="mvOpenCompare()" disabled>Compare Selected</button>
   </div>
   <div id="mv-tag-filter" style="display:none"></div>

--- a/src/helmlog/templates/overlay.html
+++ b/src/helmlog/templates/overlay.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% block title %}Maneuver overlay — HelmLog{% endblock %}
+
+{% block extra_css %}
+<style>
+.page{max-width:100%!important;padding:4px 10px!important}
+.ov-header{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:4px;min-height:32px}
+.ov-header .back-link{font-size:.78rem;color:var(--text-secondary);text-decoration:none}
+.ov-header .back-link:hover{color:var(--accent)}
+.ov-header .title{font-size:.82rem;font-weight:600;color:var(--text-primary)}
+.ov-header .subtitle{font-size:.72rem;color:var(--text-secondary)}
+.ov-header .spacer{flex:1}
+.ov-controls{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.ov-controls button{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:3px;padding:3px 8px;font-size:.75rem;cursor:pointer}
+.ov-controls button.active{background:var(--accent-strong);color:var(--bg-primary);border-color:var(--accent-strong)}
+.ov-notice{font-size:.72rem;color:var(--warning);padding:4px 6px;background:rgba(255,180,0,.1);border:1px solid var(--warning);border-radius:3px;margin-bottom:4px}
+.ov-panel{background:var(--bg-secondary);border:1px solid var(--border);border-radius:4px;margin-bottom:6px;padding:4px}
+.ov-panel h4{font-size:.72rem;margin:0 0 2px 4px;color:var(--text-secondary);font-weight:500;letter-spacing:.04em;text-transform:uppercase}
+.ov-canvas-wrap{position:relative;width:100%;height:160px}
+.ov-canvas-wrap canvas{display:block;width:100%;height:100%}
+.ov-tooltip{position:absolute;pointer-events:none;background:rgba(18,22,28,.95);color:var(--text-primary);border:1px solid var(--border);border-radius:3px;padding:4px 6px;font-size:.68rem;font-family:monospace;white-space:nowrap;z-index:5}
+.ov-legend{font-size:.68rem;color:var(--text-secondary);padding:2px 4px}
+.ov-legend .best{color:var(--success)}
+.ov-legend .worst{color:var(--error)}
+.ov-empty{padding:30px 0;text-align:center;color:var(--text-secondary)}
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="ov-config"
+  data-session-id="{{ session_id or '' }}"
+  data-session-name="{{ session_name or '' }}"
+  data-session-slug="{{ session_slug or '' }}"
+  style="display:none"></div>
+
+<div class="ov-header">
+  {% if session_id %}
+  <a href="/session/{{ session_id }}/{{ session_slug or '' }}" class="back-link">&larr; {{ session_name }}</a>
+  {% else %}
+  <a href="/maneuvers" class="back-link">&larr; Maneuvers</a>
+  {% endif %}
+  <span class="title">Overlay</span>
+  <span class="subtitle" id="ov-subtitle"></span>
+  <span class="spacer"></span>
+  <div class="ov-controls">
+    <button type="button" id="ov-mode-lines" onclick="ovSetMode('lines')" class="active">Lines</button>
+    <button type="button" id="ov-mode-bands" onclick="ovSetMode('bands')">Bands</button>
+    <button type="button" id="ov-mode-auto" onclick="ovSetMode('auto')">Auto</button>
+  </div>
+</div>
+
+<div id="ov-notice" class="ov-notice" style="display:none"></div>
+
+<div id="ov-panels"></div>
+
+<div id="ov-legend" class="ov-legend" style="display:none">
+  <span class="best">\u25cf best</span>
+  <span style="margin-left:8px">\u25cf avg / consistent</span>
+  <span class="worst" style="margin-left:8px">\u25cf worst</span>
+  <span style="margin-left:16px">t=0 = head-to-wind</span>
+</div>
+
+<div id="ov-empty" class="ov-empty" style="display:none">
+  No maneuvers selected. Pick tacks or gybes from the session detail page or the maneuvers browser and try again.
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/shared.js?v={{ git_sha }}"></script>
+<script src="/static/overlay.js?v={{ git_sha }}"></script>
+{% endblock %}

--- a/tests/test_overlay_endpoint.py
+++ b/tests/test_overlay_endpoint.py
@@ -1,0 +1,261 @@
+"""Tests for the /api/maneuvers/overlay endpoint and its series builder (#619)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from helmlog.analysis.maneuvers import (
+    ENRICH_CACHE_VERSION,
+    build_maneuvers_overlay,
+)
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _seed_session(
+    storage: Storage,
+    *,
+    session_id: int,
+    name: str,
+    htw_offsets_s: list[int],
+    type_: str = "tack",
+) -> None:
+    """Seed a session with evenly-spaced maneuvers whose HTW timestamps
+    land at ``session_start + offset`` seconds for each entry in
+    ``htw_offsets_s``. Also seeds 180 s of 1 Hz headings/speeds/winds/
+    positions around each HTW so the overlay loader finds real data to
+    align.
+    """
+    db = storage._conn()
+    start = datetime(2026, 4, 20, 14, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=max(htw_offsets_s) + 120)
+
+    await db.execute(
+        "INSERT INTO races"
+        " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, 'e', ?, ?, 'race', ?, ?)",
+        (
+            session_id,
+            name,
+            session_id,
+            start.date().isoformat(),
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+
+    # Seed instruments across the whole window (1 Hz). We just write
+    # steady values — the overlay doesn't care about the *content*, it
+    # cares about alignment, length, and null handling.
+    total_s = max(htw_offsets_s) + 120
+    for i in range(total_s + 1):
+        ts = (start + timedelta(seconds=i)).isoformat()
+        await db.execute(
+            "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+            (ts, 0x05, 45.0 + i * 0.1),  # slowly changing hdg → non-zero rate
+        )
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 0x05, 6.0),
+        )
+        await db.execute(
+            "INSERT INTO winds"
+            " (ts, source_addr, wind_speed_kts, wind_angle_deg, reference) VALUES (?, ?, ?, ?, 0)",
+            (ts, 0x05, 12.0, 40.0),
+        )
+        await db.execute(
+            "INSERT INTO positions"
+            " (ts, source_addr, latitude_deg, longitude_deg) VALUES (?, ?, ?, ?)",
+            (ts, 0x05, 37.0 + i * 1e-5, -122.0),
+        )
+
+    # One maneuver per requested offset. head_to_wind_ts lands on that
+    # offset; ts and end_ts wrap it symmetrically so the enrichment
+    # payload passes its preconditions.
+    for mid, off in enumerate(htw_offsets_s, start=session_id * 100):
+        htw = start + timedelta(seconds=off)
+        await db.execute(
+            "INSERT INTO maneuvers"
+            " (id, session_id, type, ts, end_ts, head_to_wind_ts,"
+            "  duration_sec, loss_kts, vmg_loss_kts, tws_bin, twa_bin, details)"
+            " VALUES (?, ?, ?, ?, ?, ?, 10.0, 3.0, NULL, 12, 40, NULL)",
+            (
+                mid,
+                session_id,
+                type_,
+                (htw - timedelta(seconds=5)).isoformat(),
+                (htw + timedelta(seconds=5)).isoformat(),
+                htw.isoformat(),
+            ),
+        )
+    await db.commit()
+
+
+class TestBuildManeuversOverlay:
+    @pytest.mark.asyncio
+    async def test_three_maneuvers_return_length_51_series(self, storage: Storage) -> None:
+        await _seed_session(storage, session_id=1, name="s1", htw_offsets_s=[60, 120, 180])
+        pairs = [(1, 100), (1, 101), (1, 102)]
+        payload = await build_maneuvers_overlay(storage, pairs)
+
+        assert payload["channels"] == ["bsp", "heading_rate_deg_s", "twa"]
+        assert len(payload["axis_s"]) == 51
+        assert payload["axis_s"][0] == -20
+        assert payload["axis_s"][-1] == 30
+        assert len(payload["maneuvers"]) == 3
+        for m in payload["maneuvers"]:
+            assert len(m["bsp"]) == 51
+            assert len(m["heading_rate_deg_s"]) == 51
+            assert len(m["twa"]) == 51
+        assert payload["excluded_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_null_head_to_wind_excluded_with_notice(self, storage: Storage) -> None:
+        # Seed one tack and one rounding. Roundings get head_to_wind_ts
+        # = None from the enrichment pass (#613's contract), so they're
+        # the natural real-world case the exclusion branch catches.
+        await _seed_session(storage, session_id=2, name="s2", htw_offsets_s=[60])
+        db = storage._conn()
+        # Second maneuver: a rounding, which will not get a HTW
+        # assigned by enrichment even if signed TWA is present.
+        rounding_ts = (
+            datetime(2026, 4, 20, 14, 0, 0, tzinfo=UTC) + timedelta(seconds=120)
+        ).isoformat()
+        await db.execute(
+            "INSERT INTO maneuvers"
+            " (id, session_id, type, ts, end_ts, duration_sec, loss_kts,"
+            "  vmg_loss_kts, tws_bin, twa_bin, details)"
+            " VALUES (299, 2, 'rounding', ?, ?, 10.0, 3.0, NULL, 12, 40, NULL)",
+            (rounding_ts, rounding_ts),
+        )
+        await db.commit()
+        await storage.invalidate_session_maneuver_cache(2)
+
+        pairs = [(2, 200), (2, 299)]
+        payload = await build_maneuvers_overlay(storage, pairs)
+
+        assert len(payload["maneuvers"]) == 1
+        assert payload["maneuvers"][0]["maneuver_id"] == 200
+        assert "2:299" in payload["excluded_ids"]
+
+    @pytest.mark.asyncio
+    async def test_cross_session_selection_returns_all(self, storage: Storage) -> None:
+        await _seed_session(storage, session_id=3, name="a", htw_offsets_s=[60])
+        await _seed_session(storage, session_id=4, name="b", htw_offsets_s=[60])
+        pairs = [(3, 300), (4, 400)]
+        payload = await build_maneuvers_overlay(storage, pairs)
+        names = sorted(m["session_name"] for m in payload["maneuvers"])
+        assert names == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_empty_pairs_yields_empty_payload(self, storage: Storage) -> None:
+        payload = await build_maneuvers_overlay(storage, [])
+        assert payload["maneuvers"] == []
+        assert payload["excluded_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_series_values_align_at_zero(self, storage: Storage) -> None:
+        # The BSP series is steady 6.0 at every sample, so the overlay
+        # window should be fully populated (no nulls) for a maneuver
+        # whose HTW is well inside the seeded range.
+        await _seed_session(storage, session_id=5, name="s5", htw_offsets_s=[120])
+        payload = await build_maneuvers_overlay(storage, [(5, 500)])
+        assert len(payload["maneuvers"]) == 1
+        bsp = payload["maneuvers"][0]["bsp"]
+        # t=0 index is 20 (position of 0 in [-20..30]).
+        assert bsp[20] is not None
+        assert abs(bsp[20] - 6.0) < 0.01
+
+
+class TestOverlayEndpoint:
+    """HTTP-level tests going through the route + (disabled) cache."""
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_expected_shape(self, storage: Storage) -> None:
+        await _seed_session(storage, session_id=6, name="s6", htw_offsets_s=[60, 120])
+        from helmlog.web import create_app
+
+        # Auth is bypassed when this env is unset by tests; create_app
+        # wires a storage into app.state.storage from the arg.
+        app = create_app(storage)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/maneuvers/overlay", params={"ids": "6:600,6:601"})
+            assert r.status_code == 200
+            body = r.json()
+            assert body["channels"] == ["bsp", "heading_rate_deg_s", "twa"]
+            assert len(body["axis_s"]) == 51
+            assert len(body["maneuvers"]) == 2
+            assert body["excluded_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_endpoint_rejects_malformed_ids(self, storage: Storage) -> None:
+        from helmlog.web import create_app
+
+        app = create_app(storage)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/api/maneuvers/overlay", params={"ids": "garbage"})
+            assert r.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_single_session_and_cross_session_produce_same_shape(
+        self, storage: Storage
+    ) -> None:
+        """The AC requires that a single-session entry URL yields the same
+        JSON payload shape as a cross-session entry URL with equivalent
+        ids — one code path, one endpoint."""
+        await _seed_session(storage, session_id=7, name="ss", htw_offsets_s=[60, 120, 180])
+        await _seed_session(storage, session_id=8, name="xs", htw_offsets_s=[60])
+
+        from helmlog.web import create_app
+
+        app = create_app(storage)
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            ss = await c.get("/api/maneuvers/overlay", params={"ids": "7:700,7:701,7:702"})
+            xs = await c.get("/api/maneuvers/overlay", params={"ids": "7:700,7:701,7:702,8:800"})
+        # Same keys on every maneuver object regardless of entry-path.
+        ss_keys = {frozenset(m.keys()) for m in ss.json()["maneuvers"]}
+        xs_keys = {frozenset(m.keys()) for m in xs.json()["maneuvers"]}
+        assert ss_keys == xs_keys
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_identical_payload(self, storage: Storage) -> None:
+        from helmlog.cache import WebCache
+        from helmlog.web import create_app
+
+        app = create_app(storage)
+        app.state.web_cache = WebCache(storage)
+
+        await _seed_session(storage, session_id=9, name="cache", htw_offsets_s=[60])
+
+        transport = ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            first = await c.get("/api/maneuvers/overlay", params={"ids": "9:900"})
+            second = await c.get("/api/maneuvers/overlay", params={"ids": "9:900"})
+        assert first.status_code == 200 and second.status_code == 200
+        assert first.json() == second.json()
+
+    @pytest.mark.asyncio
+    async def test_enrich_version_in_cache_hash(self, storage: Storage) -> None:
+        """Sanity: ENRICH_CACHE_VERSION is referenced from the endpoint
+        (via build_maneuvers_overlay and the route's hash-input dict).
+        If it's ever dropped from the hash input, bumping versions
+        would show stale overlay payloads until TTL."""
+        # Import site verifies the endpoint's hash-input includes it.
+        import helmlog.routes.sessions as sessions_mod
+
+        src = sessions_mod.__file__ or ""
+        with open(src, encoding="utf-8") as f:
+            text = f.read()
+        assert "ENRICH_CACHE_VERSION" in text
+        assert "enrich_version" in text  # hash-input key name
+        # And the constant actually has a current value.
+        assert ENRICH_CACHE_VERSION >= 6


### PR DESCRIPTION
## Summary

One page, one chart, one endpoint, two entry points:

- **Session detail page**: new "Overlay Chart" button. Defaults to every tack/gybe in the session; respects overlay-selection checkboxes when any are active.
- **Cross-session maneuvers browser**: new "Overlay Selected" button next to "Compare Selected".

Both routes to ``/maneuvers/overlay?ids=sid:mid,...`` with an optional ``session=`` hint for the breadcrumb. URL is the only thing that differs between entries — template, JS, endpoint are all shared.

Closes #619 (epic: #612)

## Data & caching

- ``GET /api/maneuvers/overlay?ids=...`` returns per-maneuver series for bsp, heading_rate_deg_s, twa, resampled to 1 Hz on a fixed ``[-20..30]`` axis centred at ``head_to_wind_ts`` (#613). Maneuvers without HTW — roundings, stalled tacks — land in ``excluded_ids``.
- Cached via the T2 global path (``race_id=0`` sentinel). ``data_hash`` folds the sorted selection, every touched session's ``compute_race_data_hash``, and ``ENRICH_CACHE_VERSION``. Any race mutation or cache-version bump changes the hash and the overlay self-invalidates on the next request; orphaned entries age out on a 24 h TTL.

## Frontend choice

Hand-rolled canvas chart, matching the existing ``compare.js`` aesthetic (dark theme, minimal chrome, tabular-nums labels). The issue recommends **uPlot** but explicitly allows deviation; I went with the hand-rolled path to avoid adding a dependency for the first landing. If rendering budget or zoom/pan becomes an issue, uPlot is a straightforward swap — the data shape (per-maneuver aligned series) is uPlot-ready as-is.

## Tests

- 10 new backend tests in ``tests/test_overlay_endpoint.py`` covering series length, null-HTW exclusion, cross-session selection, value alignment at t=0, HTTP shape, malformed ids, single-vs-cross-session parity, cache hit, and hash-input integrity.
- Golden session test (#620) still passes — enrichment shape unchanged.

## Stacked on #633

Branched off ``feature/620-golden-session``. Once the upstream PRs (#626 → #630 → #631 → #632 → #633) merge, GitHub auto-retargets this to ``main``.

## Test plan

- [x] ``uv run pytest tests/test_overlay_endpoint.py -v`` — 10 passed
- [x] ``uv run pytest tests/test_golden_session.py`` — 2 passed (no snapshot drift)
- [x] Full suite: ``uv run pytest --no-cov`` — 2266 passed, 2 skipped
- [x] ``uv run ruff check . && ruff format --check .`` — clean
- [x] ``uv run mypy src/`` — clean
- [ ] Pi: deploy and verify the Overlay Chart button on a session page renders ten tack curves stacked at t=0; verify "Overlay Selected" on /maneuvers works with cross-session ids; check that a session with ≥15 tacks auto-switches to band mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)