### PR TITLE
docs: require worktrees for all file-editing work

### DIFF
--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -9,10 +9,13 @@ disable-model-invocation: true
 ## Steps
 
 ### 0. Enter a worktree
-Call `EnterWorktree` before touching `storage.py`. Migrations bump
-`_CURRENT_VERSION`, which is especially prone to conflicts when another agent
-is simultaneously adding a migration — the isolated worktree makes the version
-collision visible at merge time instead of silently overwriting.
+Before touching `storage.py`, make sure the session is in a git worktree.
+Check `git worktree list` — reuse an existing one via
+`EnterWorktree(path=...)` if it matches this task, otherwise create a new one
+via `EnterWorktree(name=...)`. Migrations bump `_CURRENT_VERSION`, which is
+especially prone to conflicts when another agent is simultaneously adding a
+migration — the isolated worktree makes the version collision visible at
+merge time instead of silently overwriting. See CLAUDE.md for the full rule.
 
 ### 1. Check current version
 Read `_CURRENT_VERSION` in `src/logger/storage.py`. Note the current value.

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 ## Steps
 
+### 0. Enter a worktree
+Call `EnterWorktree` before touching `storage.py`. Migrations bump
+`_CURRENT_VERSION`, which is especially prone to conflicts when another agent
+is simultaneously adding a migration — the isolated worktree makes the version
+collision visible at merge time instead of silently overwriting.
+
 ### 1. Check current version
 Read `_CURRENT_VERSION` in `src/logger/storage.py`. Note the current value.
 

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -12,9 +12,12 @@ for each step that involves code.
 ## Checklist
 
 ### 0. Enter a worktree
-Call `EnterWorktree` before any file edits. Scaffolding touches `tests/`,
-`src/logger/`, `main.py`, and often `web.py` and `storage.py` — exactly the
-kind of multi-file change that collides with other agents sharing the repo.
+Before any file edits, make sure the session is in a git worktree. Check
+`git worktree list` — reuse an existing one via `EnterWorktree(path=...)` if
+it matches this task, otherwise create a new one via `EnterWorktree(name=...)`.
+Scaffolding touches `tests/`, `src/logger/`, `main.py`, and often `web.py` and
+`storage.py` — exactly the kind of multi-file change that collides with other
+agents sharing the repo. See CLAUDE.md for the full rule.
 
 ### 1. Write tests first
 Create `tests/test_$ARGUMENTS.py` with tests for the module's public API.

--- a/.claude/skills/new-module/SKILL.md
+++ b/.claude/skills/new-module/SKILL.md
@@ -11,6 +11,11 @@ for each step that involves code.
 
 ## Checklist
 
+### 0. Enter a worktree
+Call `EnterWorktree` before any file edits. Scaffolding touches `tests/`,
+`src/logger/`, `main.py`, and often `web.py` and `storage.py` — exactly the
+kind of multi-file change that collides with other agents sharing the repo.
+
 ### 1. Write tests first
 Create `tests/test_$ARGUMENTS.py` with tests for the module's public API.
 Use the `storage` fixture from `conftest.py` and mock any external I/O.

--- a/.claude/skills/pr-checklist/SKILL.md
+++ b/.claude/skills/pr-checklist/SKILL.md
@@ -18,14 +18,23 @@ gh issue comment <number> --body "In progress on \`<branch-name>\` (Claude Code 
 
 ```
 
-## 1. Confirm feature branch
+## 1. Confirm worktree and feature branch
 
-You must be on a feature branch, **not `main`**. All changes to `main` come
-through merged PRs.
+You must be working inside a git worktree (per CLAUDE.md) and on a feature
+branch, **not `main`**. All changes to `main` come through merged PRs.
 
 ```bash
 git branch --show-current
 # Must NOT be "main"
+git rev-parse --show-toplevel
+# Should be under .claude/worktrees/<name> or a dedicated worktree path
+```
+
+If the current branch has the default `worktree-<name>` name from
+`EnterWorktree`, rename it to a conventional `feature/<topic>` before pushing:
+
+```bash
+git branch -m feature/<topic>
 ```
 
 ## 2. Determine risk tier

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -9,10 +9,11 @@ Always follow this cycle when implementing new functionality or fixing bugs.
 
 ## 0. Enter a worktree
 
-Before writing any test or code, call the `EnterWorktree` tool. Multiple
-Claude Code agents may share this repo on the same machine, and TDD inevitably
-produces uncommitted test+implementation changes that cannot safely coexist in
-a shared checkout. Skip only if the session is already in a worktree.
+Before writing any test or code, make sure the session is in a git worktree.
+Check `git worktree list` — if one already exists for this task, enter it via
+`EnterWorktree(path=...)`; otherwise create a new one via
+`EnterWorktree(name=...)`. See the "Always work in a git worktree" rule in
+CLAUDE.md for the why. Skip only if already in a worktree.
 
 ## 1. Red — Write a Failing Test
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -7,6 +7,13 @@ description: Use test-driven development when implementing new features or fixin
 
 Always follow this cycle when implementing new functionality or fixing bugs.
 
+## 0. Enter a worktree
+
+Before writing any test or code, call the `EnterWorktree` tool. Multiple
+Claude Code agents may share this repo on the same machine, and TDD inevitably
+produces uncommitted test+implementation changes that cannot safely coexist in
+a shared checkout. Skip only if the session is already in a worktree.
+
 ## 1. Red — Write a Failing Test
 
 Write the test **before** writing the implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,22 @@ branch switches reorder each other's files, and a deploy can easily pick up a
 half-finished hotfix from the wrong agent. Worktrees give each agent an
 isolated checkout on its own branch.
 
-Use the `EnterWorktree` tool at the start of any task that will touch files —
-feature work, bug fixes, migrations, doc edits, skill edits. It creates a
-worktree under `.claude/worktrees/<name>/` on a fresh branch off `HEAD`, and
-the session switches into it. When the session ends, you'll be prompted to
-keep or remove the worktree.
+**Always check for an existing worktree before creating a new one.** When
+resuming work on a PR or an issue, a worktree often already exists from the
+previous session.
+
+```bash
+git worktree list
+# Also check for leftover directories: ls .claude/worktrees/
+```
+
+If a worktree's branch matches the task (e.g., `feature/my-feature` for PR
+work, or a name containing the issue number), enter it with
+`EnterWorktree(path=<path>)` — do **not** create a second one. Only call
+`EnterWorktree(name=<name>)` to create a new worktree when none of the
+existing ones fit. The created worktree lives at `.claude/worktrees/<name>/`
+on a fresh branch off `HEAD`. When the session ends, you'll be prompted to
+keep or remove it.
 
 Read-only work (answering questions, exploring the codebase, running
 `/architecture`, `/diagnose`, `/domain`) does not need a worktree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,24 @@ helmlog --help          # full subcommand list
 
 ## Development Workflow
 
+### Always work in a git worktree
+
+**Before making any file edits, enter a git worktree.** Multiple Claude Code
+agents frequently run in this repo on the same machine at the same time. If
+two agents share a working directory, their uncommitted changes collide,
+branch switches reorder each other's files, and a deploy can easily pick up a
+half-finished hotfix from the wrong agent. Worktrees give each agent an
+isolated checkout on its own branch.
+
+Use the `EnterWorktree` tool at the start of any task that will touch files —
+feature work, bug fixes, migrations, doc edits, skill edits. It creates a
+worktree under `.claude/worktrees/<name>/` on a fresh branch off `HEAD`, and
+the session switches into it. When the session ends, you'll be prompted to
+keep or remove the worktree.
+
+Read-only work (answering questions, exploring the codebase, running
+`/architecture`, `/diagnose`, `/domain`) does not need a worktree.
+
 ### Mac setup (one time)
 
 ```bash
@@ -162,14 +180,19 @@ uv run mypy src/            # types clean
 
 When starting work on a GitHub issue:
 
-1. **Mark the issue in-progress**: apply the `in-progress` label and add a comment:
+1. **Enter a worktree first** — call `EnterWorktree` with a descriptive name
+   (e.g. `issue-332-polar-bug`) before any other setup. All subsequent steps
+   run inside the worktree.
+2. **Mark the issue in-progress**: apply the `in-progress` label and add a comment:
    ```bash
    gh issue edit <number> --add-label "in-progress"
    gh issue comment <number> --body "In progress on \`<branch-name>\` (Claude Code on <hostname>)"
    ```
-2. Branch off `main`: `git checkout -b feature/my-feature main`
-3. Develop with TDD until tests + lint + types pass
-4. Push and create PR with issue linking:
+3. Rename the worktree's branch to the conventional feature name if needed
+   (`git branch -m feature/my-feature`). The branch is already off `main` /
+   `HEAD`, so no `git checkout -b` is required.
+4. Develop with TDD until tests + lint + types pass
+5. Push and create PR with issue linking:
    ```bash
    git push -u origin feature/my-feature
    gh pr create --title "..." --body "$(cat <<'EOF'
@@ -184,12 +207,12 @@ When starting work on a GitHub issue:
    ```
    The PR body **must** include `Closes #<issue>` (or `Fixes #<issue>` for bugs) so GitHub
    auto-closes the issue on merge.
-5. On merge: GitHub auto-closes the linked issue via `Closes #N`. Remove `in-progress` label if
+6. On merge: GitHub auto-closes the linked issue via `Closes #N`. Remove `in-progress` label if
    it wasn't automatically cleared:
    ```bash
    gh issue edit <number> --remove-label "in-progress"
    ```
-6. If a PR is **closed without merge**, comment on the linked issue explaining the outcome:
+7. If a PR is **closed without merge**, comment on the linked issue explaining the outcome:
    - **Superseded** — link to the replacement PR/issue
    - **Deferred** — explain why, remove `in-progress` label
    - **Won't fix** — close the issue with `wontfix` label and explanation
@@ -267,6 +290,7 @@ Use `/data-license` to review code changes against the full policy.
 ## Dos and Don'ts
 
 **Do:**
+- **Always enter a git worktree before making file edits** (via the `EnterWorktree` tool). Multiple Claude Code agents may be running against this repo on the same machine — isolated worktrees prevent them from stepping on each other's branches and uncommitted changes.
 - **All changes to `main` must come through merged PRs** — never push directly to `main`
 - **Always include `Closes #N` in PR body** when the PR resolves an issue — this auto-closes the issue on merge and keeps the tracker clean. Use `Fixes #N` for bug fixes.
 - **Apply `in-progress` label when starting work** on an issue (`gh issue edit <N> --add-label "in-progress"`); remove it when the issue closes or work is deferred
@@ -281,6 +305,7 @@ Use `/data-license` to review code changes against the full policy.
 - Log every read error and decode failure with `loguru` at `WARNING` or above
 
 **Don't:**
+- **Never edit files in the primary checkout** (`/Users/dweatbrook/src/helmlog`) — enter a worktree first. Even "one-line" edits: another agent may already be on that branch.
 - **Never push directly to `main`** — `main` is sacrosanct. Always work on a feature branch and merge via PR. If on the Pi and a hotfix is needed, create or use an existing branch, commit and push there, then merge through GitHub.
 - Don't parse NMEA 2000 PGNs manually from scratch — use `canboat` or a library; only write custom decoders when necessary
 - Don't store data in memory across long runs — flush to SQLite frequently to survive crashes/reboots


### PR DESCRIPTION
## Summary

Codifies the "always enter a worktree first" rule across CLAUDE.md and the code-modifying skills so concurrent Claude Code agents in the same working directory stop stepping on each other's branches and uncommitted changes.

- **CLAUDE.md**
  - New "Always work in a git worktree" subsection at the top of Development Workflow, with the concurrent-agent rationale.
  - Issue → PR workflow: new step 1 (`EnterWorktree` first), remaining steps renumbered.
  - Do list: "Always enter a git worktree before making file edits".
  - Don't list: "Never edit files in the primary checkout".
- **Skills — step 0 preflight added:**
  - `tdd/SKILL.md` — worktree before the red-green-refactor cycle.
  - `new-module/SKILL.md` — worktree before scaffolding.
  - `new-migration/SKILL.md` — worktree before touching `_CURRENT_VERSION`.
- **`pr-checklist/SKILL.md`** — step 1 now checks both worktree location and feature branch, with guidance to rename the default `worktree-<name>` branch to `feature/<topic>` before pushing.

No code or runtime behavior changes — docs and skill definitions only.

## Test plan

- [ ] Skim the rendered CLAUDE.md section to confirm the rule reads clearly and the Issue → PR numbering is correct.
- [ ] Verify each updated skill still parses (frontmatter intact) by running `/tdd`, `/new-module`, `/new-migration`, `/pr-checklist` in a fresh session.
- [ ] Confirm a follow-up agent picks up the rule: start a new Claude session and ask for any edit — it should call `EnterWorktree` before touching files.

Generated with [Claude Code](https://claude.ai/code)