### PR TITLE
feat: deep-link to a moment in a session via ?t= + Share button

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -301,6 +301,7 @@ async function init() {
   renderExports();
   renderDangerZone();
   if (cfg.dataset.live === '1') _startLiveRefresh();
+  _applyDeepLink();
 }
 
 // ---------------------------------------------------------------------------
@@ -1579,6 +1580,11 @@ function _onVideoReady() {
     }
     _videoSync.player.seekTo(offset, true);
   });
+  // If a deep-link was requested before the YT player was ready, re-apply
+  // it now so the video actually seeks. The scrubber / track have already
+  // been parked on the target by the earlier _applyDeepLink() call at the
+  // tail of init().
+  _applyDeepLink();
 }
 
 function switchVideo(idx) {
@@ -7847,6 +7853,128 @@ function _restartOverlayTick() {
 // Fire immediately on any producer event too, so scrubs + replay play feel
 // snappy instead of waiting up to 200ms for the poll.
 registerSurface('video-overlay', function(_utc) { _videoOverlayTick(); });
+
+// ---------------------------------------------------------------------------
+// Deep-link to a specific moment in the session via ?t= (#642).
+//
+// Accepts three formats to match YouTube share ergonomics:
+//   • seconds            ?t=125          ?t=125.5
+//   • readable           ?t=1m5s         ?t=2h10m         ?t=45s
+//   • clock              ?t=1:05         ?t=01:23:45
+//
+// Offsets are measured from the session's start_utc, not from any video's
+// own offset, since a session can have multiple linked videos. Out-of-range
+// values are clamped to the session window.
+// ---------------------------------------------------------------------------
+
+let _deepLinkTargetUtc = null;
+
+function _parseDeepLinkTime(raw) {
+  if (raw == null) return null;
+  const v = String(raw).trim();
+  if (!v) return null;
+  // Pure number → seconds
+  if (/^\d+(?:\.\d+)?$/.test(v)) return parseFloat(v);
+  // XhYmZs (any subset, at least one)
+  const readable = v.match(/^(?:(\d+(?:\.\d+)?)h)?(?:(\d+(?:\.\d+)?)m)?(?:(\d+(?:\.\d+)?)s)?$/);
+  if (readable && (readable[1] || readable[2] || readable[3])) {
+    const h = parseFloat(readable[1] || 0);
+    const mm = parseFloat(readable[2] || 0);
+    const ss = parseFloat(readable[3] || 0);
+    return h * 3600 + mm * 60 + ss;
+  }
+  // HH:MM:SS or MM:SS
+  const clock = v.match(/^(?:(\d+):)?(\d+):(\d+(?:\.\d+)?)$/);
+  if (clock) {
+    const h = parseFloat(clock[1] || 0);
+    const mm = parseFloat(clock[2]);
+    const ss = parseFloat(clock[3]);
+    return h * 3600 + mm * 60 + ss;
+  }
+  return null;
+}
+
+function _fmtDeepLinkTime(totalSec) {
+  const s = Math.max(0, Math.floor(totalSec));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  let out = '';
+  if (h) out += h + 'h';
+  if (m || h) out += m + 'm';
+  out += ss + 's';
+  return out;
+}
+
+function _applyDeepLink() {
+  if (!_session || !_session.start_utc) return;
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get('t');
+  if (!raw) return;
+  const seconds = _parseDeepLinkTime(raw);
+  if (seconds == null) return;
+  const sessionStart = new Date(_session.start_utc).getTime();
+  const sessionEnd = _session.end_utc
+    ? new Date(_session.end_utc).getTime()
+    : Date.now();
+  let targetMs = sessionStart + seconds * 1000;
+  if (targetMs < sessionStart) targetMs = sessionStart;
+  if (targetMs > sessionEnd) targetMs = sessionEnd;
+  _deepLinkTargetUtc = new Date(targetMs);
+  _seekTo(_deepLinkTargetUtc, 'deeplink');
+}
+
+async function shareVideoLink() {
+  if (!_session || !_session.start_utc) {
+    window.alert('Session data not loaded yet — try again in a moment.');
+    return;
+  }
+  // Prefer the YT player's position while it's playing; fall back to the
+  // shared clock so a user who only scrubbed the replay scrubber still
+  // gets a useful share link.
+  let utc = null;
+  try {
+    if (_videoSync && _videoSync.player && typeof _videoSync.player.getCurrentTime === 'function') {
+      const cur = _videoSync.player.getCurrentTime();
+      if (cur != null && !isNaN(cur) && typeof _videoOffsetToUtc === 'function') {
+        utc = _videoOffsetToUtc(cur);
+      }
+    }
+  } catch (e) { /* fall through */ }
+  if (!utc) utc = _playClock.positionUtc;
+  if (!utc) {
+    window.alert('Play or scrub first so there is a timestamp to anchor the share link to.');
+    return;
+  }
+  const sessionStart = new Date(_session.start_utc).getTime();
+  const offsetSec = (utc.getTime() - sessionStart) / 1000;
+  const t = _fmtDeepLinkTime(offsetSec);
+  const url = location.origin + location.pathname + '?t=' + t;
+  const btn = document.getElementById('video-share-btn');
+  try {
+    await navigator.clipboard.writeText(url);
+    _flashShareBtn(btn, 'Copied!');
+  } catch (e) {
+    // Browsers without clipboard perms → fall back to a prompt the user
+    // can copy from manually.
+    window.prompt('Copy share link', url);
+  }
+}
+
+function _flashShareBtn(btn, msg) {
+  if (!btn) return;
+  const orig = btn.textContent;
+  const origBg = btn.style.background;
+  const origColor = btn.style.color;
+  btn.textContent = msg;
+  btn.style.background = 'var(--success)';
+  btn.style.color = 'var(--bg-primary)';
+  setTimeout(() => {
+    btn.textContent = orig;
+    btn.style.background = origBg;
+    btn.style.color = origColor;
+  }, 1500);
+}
 
 // Hook into init() path without rewriting it: kick off replay load once the
 // DOM is ready, and wire controls immediately. _loadReplayData() waits on

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -134,6 +134,9 @@
     <button id="video-track-btn" type="button" onclick="toggleVideoTrack()"
       title="Show mini maneuver track over the video during maneuvers"
       style="background:var(--bg-input);color:var(--text-secondary);border:1px solid var(--border);border-radius:4px;padding:4px 10px;font-size:.78rem;cursor:pointer">Track</button>
+    <button id="video-share-btn" type="button" onclick="shareVideoLink()"
+      title="Copy a link to this exact moment"
+      style="background:var(--bg-input);color:var(--text-secondary);border:1px solid var(--border);border-radius:4px;padding:4px 10px;font-size:.78rem;cursor:pointer">Share</button>
   </div>
   <div id="yt-player-wrap" style="position:relative;aspect-ratio:16/9;border-radius:8px;overflow:hidden">
     <div id="yt-player" style="width:100%;height:100%"></div>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4262,6 +4262,47 @@ async def test_session_page_has_video_overlay_buttons(storage: Storage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Session deep-link via ?t= (#642) — the share button + URL parser need to
+# be present in the rendered page. Dynamic seek behaviour is JS-only and is
+# covered by manual verification.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_page_has_share_button(storage: Storage) -> None:
+    """Session page renders a Share button wired to shareVideoLink() (#642)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", follow_redirects=True
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        resp = await client.get(f"/session/{race_id}")
+    assert resp.status_code == 200
+    assert 'id="video-share-btn"' in resp.text
+    assert "shareVideoLink" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_session_js_has_deeplink_parser(storage: Storage) -> None:
+    """session.js ships the ?t= parser + share formatter (#642).
+
+    The parser itself is JS-only, but we can at least confirm the bundled
+    file contains the hook points so a refactor that accidentally strips
+    them will fail loudly here.
+    """
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/static/session.js")
+    assert resp.status_code == 200
+    assert "_parseDeepLinkTime" in resp.text
+    assert "_applyDeepLink" in resp.text
+    assert "_fmtDeepLinkTime" in resp.text
+
+
+# ---------------------------------------------------------------------------
 # Maneuver compare
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Session URL now accepts \`?t=<offset>\` to open at a specific moment. Parser takes three formats to match YouTube ergonomics:
  - seconds — \`?t=125\`, \`?t=125.5\`
  - readable — \`?t=1m5s\`, \`?t=2h10m\`, \`?t=45s\`
  - clock — \`?t=1:05\`, \`?t=01:23:45\`
- Offsets are measured from \`session.start_utc\` (a session can have multiple linked clips; YT-video-offset wouldn't be stable across clips) and are clamped to the session window so \`?t=99999\` just lands at end.
- New **Share** button next to the video switcher. Click copies \`.../session/{id}/{slug}?t=1h2m5s\` to the clipboard with a short "Copied!" flash on the button. Clipboard-blocked browsers fall back to a \`window.prompt\` the user can copy from.
- Deep-link seek lands paused (per the issue discussion) and fans out through \`_seekTo\` → \`_playClock\` so the scrubber, track cursor, and video all move together. Applied at the tail of \`init()\` and again inside \`_onVideoReady\` to catch the YT player once its consumer is registered.

Closes #642

## Test plan
- [x] \`uv run pytest --ignore=tests/integration\` — 2201 passed, 2 skipped
- [x] \`uv run ruff check .\` / \`ruff format --check .\` clean
- [x] \`uv run mypy src/\` clean
- [x] Unit: session page renders Share button; session.js bundle ships \`_parseDeepLinkTime\` / \`_applyDeepLink\` / \`_fmtDeepLinkTime\`
- [ ] Manual (Pi): open \`/session/{id}?t=125\` — video seeks to 2m5s, paused
- [ ] Manual (Pi): click Share mid-playback → URL copied, landing at same offset on paste
- [ ] Manual (Pi): try \`?t=1m5s\`, \`?t=01:23\`, and \`?t=99999\` (should land at end)

## Note on conflicts with #641

Open PR #641 (session video overlays) also restructures the \`#video-switcher\` container into a flex row with extra buttons. This PR does the same. Whichever merges first, the other is a ~4-line conflict — both adjustments cleanly merge the two button sets into one row.

🤖 Generated with [Claude Code](https://claude.ai/code)