### PR TITLE
feat: surface heel and trim in session page gauges panel

### DIFF
--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1205,6 +1205,7 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
     app_winds_by_s = await _wind_series("reference = 2")
     hdgs_by_s = await _series("headings", ["heading_deg"])
     cogsog_by_s = await _series("cogsog", ["cog_deg", "sog_kts"])
+    attitudes_by_s = await _series("attitudes", ["heel_deg", "trim_deg"])
 
     keys = sorted(
         set(speeds_by_s.keys())
@@ -1212,6 +1213,7 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
         | set(app_winds_by_s.keys())
         | set(hdgs_by_s.keys())
         | set(cogsog_by_s.keys())
+        | set(attitudes_by_s.keys())
     )
 
     samples: list[dict[str, Any]] = []
@@ -1245,10 +1247,13 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
         sp = speeds_by_s.get(k)
         cs = cogsog_by_s.get(k)
         hd = hdgs_by_s.get(k)
+        at = attitudes_by_s.get(k)
         stw_v = float(sp["speed_kts"]) if sp else None
         sog_v = float(cs["sog_kts"]) if cs else None
         cog_v = float(cs["cog_deg"]) if cs else None
         hdg_v = float(hd["heading_deg"]) if hd else None
+        heel_v = float(at["heel_deg"]) if at and at["heel_deg"] is not None else None
+        trim_v = float(at["trim_deg"]) if at and at["trim_deg"] is not None else None
         sd = compute_set_drift(sog=sog_v, cog=cog_v, stw=stw_v, hdg=hdg_v)
         set_v: float | None = sd[0] if sd is not None else None
         drift_v: float | None = sd[1] if sd is not None else None
@@ -1264,6 +1269,8 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
                 "twd": twd,
                 "aws": aws,
                 "awa": awa,
+                "heel": heel_v,
+                "trim": trim_v,
                 "set": set_v,
                 "drift": drift_v,
             }

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1048,8 +1048,12 @@ async def api_session_replay(
     async def _compute() -> dict[str, Any]:
         return await _compute_session_replay(storage, session_id)
 
+    # v2: payload schema changed (heel, trim added in #645). The cache hash
+    # tracks source-data changes but not payload-shape changes, so bump the
+    # family suffix whenever fields are added/removed to force a recompute
+    # rather than serving a stale blob that lacks the new keys.
     return await cached_json_response(
-        request, race_id=session_id, key_family="session_replay", compute=_compute
+        request, race_id=session_id, key_family="session_replay_v2", compute=_compute
     )
 
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6750,7 +6750,11 @@ const _SPARK_LOOKBACK_MS = 5 * 60 * 1000;
 // and scale y to the slice's own min/max so small movements are still
 // visible. Returns without touching the canvas when the field is absent
 // so missing sensors fall back to a blank strip rather than a garbage line.
-function _drawSparkline(canvasId, field, cursorMs, color) {
+//
+// opts.zeroCentered: force the y-axis to be symmetric around 0 so signed
+// series (heel, trim) read as rail-angle gauges rather than auto-ranged
+// blobs. A faint baseline at y=0 is drawn in this mode.
+function _drawSparkline(canvasId, field, cursorMs, color, opts) {
   const c = document.getElementById(canvasId);
   if (!c || !_replaySamples || !_replaySamples.length) return;
   const ctx = c.getContext('2d');
@@ -6781,13 +6785,31 @@ function _drawSparkline(canvasId, field, cursorMs, color) {
 
   let vmin = Infinity, vmax = -Infinity;
   for (const [, v] of pts) { if (v < vmin) vmin = v; if (v > vmax) vmax = v; }
-  // Pad the range a touch so flat series don't sit on the edges
-  if (vmax - vmin < 1e-6) { vmax = vmin + 1; }
-  const pad = (vmax - vmin) * 0.1;
-  vmin -= pad; vmax += pad;
+  if (opts && opts.zeroCentered) {
+    // Symmetric range around 0, so +12° and -12° mirror each other and
+    // the zero line sits in the middle of the strip.
+    const r = Math.max(Math.abs(vmin), Math.abs(vmax), 1);
+    vmin = -r;
+    vmax = r;
+  } else {
+    // Pad the range a touch so flat series don't sit on the edges
+    if (vmax - vmin < 1e-6) { vmax = vmin + 1; }
+    const pad = (vmax - vmin) * 0.1;
+    vmin -= pad; vmax += pad;
+  }
 
   const xFor = t => ((t - t0) / (t1 - t0)) * (w - 2) + 1;
   const yFor = v => h - 1 - ((v - vmin) / (vmax - vmin)) * (h - 2);
+
+  if (opts && opts.zeroCentered) {
+    ctx.strokeStyle = 'rgba(255,255,255,0.12)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    const y0 = yFor(0);
+    ctx.moveTo(1, y0);
+    ctx.lineTo(w - 1, y0);
+    ctx.stroke();
+  }
 
   ctx.strokeStyle = color || 'rgba(120,180,255,0.9)';
   ctx.lineWidth = 1.2;
@@ -6821,6 +6843,15 @@ function _renderHud(utc) {
     const wrapped = ((Math.round(v) % 360) + 360) % 360;
     return wrapped + '\u00b0';
   };
+  // Signed-degree format: always shows +/- so heel and trim read as
+  // rail angle (+ = starboard down / bow up). Bare _fmtNum drops the sign
+  // for positives which would look ambiguous on a symmetric gauge.
+  const _fmtSignedDeg = (v, digits) => {
+    if (v == null || Number.isNaN(v)) return '—';
+    const rounded = Number(v).toFixed(digits);
+    const sign = Number(v) >= 0 ? '+' : '';
+    return sign + rounded + '°';
+  };
   setEl('hud-tws', _fmtNum(s && s.tws, 1));
   setEl('hud-twd', _fmtDeg(s && s.twd));
   setEl('hud-twa', _fmtDeg(s && s.twa));
@@ -6828,6 +6859,8 @@ function _renderHud(utc) {
   setEl('hud-awa', _fmtDeg(s && s.awa));
   setEl('hud-hdg', _fmtNum(s && s.hdg, 0));
   setEl('hud-cog', _fmtNum(s && s.cog, 0));
+  setEl('hud-heel', _fmtSignedDeg(s && s.heel, 1));
+  setEl('hud-trim', _fmtSignedDeg(s && s.trim, 1));
   setEl('hud-pct', g && g.pct != null ? _fmtPct(g.pct) : '—');
   setEl('hud-delta', g && g.delta != null ? (g.delta >= 0 ? '+' : '') + _fmtNum(g.delta, 2) : '—');
   setEl('hud-set', s && s.set != null && !Number.isNaN(s.set) ? _fmtDeg(s.set) : '—');
@@ -6842,6 +6875,8 @@ function _renderHud(utc) {
   _drawSparkline('spark-awa', 'awa', cursorMs, 'rgba(220,180,100,0.6)');
   _drawSparkline('spark-hdg', 'hdg', cursorMs, 'rgba(255,140,140,0.9)');
   _drawSparkline('spark-cog', 'cog', cursorMs, 'rgba(255,140,140,0.6)');
+  _drawSparkline('spark-heel', 'heel', cursorMs, 'rgba(180,140,220,0.9)', {zeroCentered: true});
+  _drawSparkline('spark-trim', 'trim', cursorMs, 'rgba(180,140,220,0.6)', {zeroCentered: true});
 }
 
 function _updateReplayControls() {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -7236,6 +7236,8 @@ async function _loadReplayData() {
       awa: s.awa,
       hdg: s.hdg,
       cog: s.cog,
+      heel: s.heel,
+      trim: s.trim,
       set: s.set,
       drift: s.drift,
     }));

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -214,6 +214,15 @@
         <canvas id="spark-hdg" width="300" height="26" style="width:100%;height:22px;display:block;margin-top:2px"></canvas>
         <canvas id="spark-cog" width="300" height="26" style="width:100%;height:22px;display:block"></canvas>
       </div>
+      <div class="replay-gauge" data-gauge="attitude" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Attitude</div>
+        <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">
+          <span><span style="color:var(--text-secondary);font-size:.7rem">HEEL</span> <span id="hud-heel" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+          <span><span style="color:var(--text-secondary);font-size:.7rem">TRIM</span> <span id="hud-trim" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
+        </div>
+        <canvas id="spark-heel" width="300" height="26" style="width:100%;height:22px;display:block;margin-top:2px"></canvas>
+        <canvas id="spark-trim" width="300" height="26" style="width:100%;height:22px;display:block"></canvas>
+      </div>
       <div class="replay-gauge" data-gauge="polar" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
         <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Polar</div>
         <div style="display:flex;gap:10px;align-items:baseline;font-family:monospace">

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4161,6 +4161,92 @@ async def test_replay_endpoint_returns_twd_when_heading_present(storage: Storage
 
 
 @pytest.mark.asyncio
+async def test_replay_endpoint_returns_heel_and_trim(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Attitude rows inside the session window surface as heel and trim on
+    every replay sample. Sign convention: heel positive = starboard down,
+    trim positive = bow up (see nmea2000.AttitudeRecord)."""
+    # _write_attitude rate-limits to 2 Hz by default; the test loop fires
+    # writes in microseconds so only the first would land. Disable it.
+    monkeypatch.setenv("ATTITUDE_STORAGE_HZ", "0")
+    from datetime import timedelta
+
+    from helmlog.nmea2000 import PGN_ATTITUDE, AttitudeRecord
+
+    start = datetime(2024, 8, 3, 12, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=5)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('Attitude', 'E', 1, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    race_id = int((await cur.fetchone())["id"])
+    for i in range(5):
+        ts = start + timedelta(seconds=i)
+        await storage.write(
+            AttitudeRecord(PGN_ATTITUDE, 5, ts, heel_deg=12.5 + i, trim_deg=-1.5 + i * 0.1)
+        )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/replay")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["samples"]) == 5
+    first = data["samples"][0]
+    assert first["heel"] == pytest.approx(12.5)
+    assert first["trim"] == pytest.approx(-1.5)
+    last = data["samples"][-1]
+    assert last["heel"] == pytest.approx(16.5)
+    assert last["trim"] == pytest.approx(-1.1)
+
+
+@pytest.mark.asyncio
+async def test_replay_endpoint_heel_trim_absent_when_no_attitude_rows(storage: Storage) -> None:
+    """Sessions recorded before schema v75 (no attitudes) still return the
+    heel/trim keys, set to None — the frontend relies on the key being
+    present so it can render em-dashes rather than crashing on undefined."""
+    from datetime import timedelta
+
+    from helmlog.nmea2000 import PGN_SPEED_THROUGH_WATER, SpeedRecord
+
+    start = datetime(2024, 8, 4, 12, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=3)
+    db = storage._conn()
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc)"
+        " VALUES ('NoAttitude', 'E', 1, ?, ?, ?)",
+        (start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+    race_id = int((await cur.fetchone())["id"])
+    for i in range(3):
+        ts = start + timedelta(seconds=i)
+        await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, 6.0))
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/replay")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["samples"]) == 3
+    for s in data["samples"]:
+        assert s["heel"] is None
+        assert s["trim"] is None
+
+
+@pytest.mark.asyncio
 async def test_course_overlay_unknown_session_returns_404(storage: Storage) -> None:
     app = create_app(storage)
     async with httpx.AsyncClient(

--- a/tests/test_web_cache_routes.py
+++ b/tests/test_web_cache_routes.py
@@ -213,7 +213,7 @@ async def test_replay_cache_blob_written_and_invalidated(
     db = storage._conn()
     cur = await db.execute(
         "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
-        (race_id, "session_replay"),
+        (race_id, "session_replay_v2"),
     )
     assert (await cur.fetchone())["n"] == 1
 
@@ -221,7 +221,7 @@ async def test_replay_cache_blob_written_and_invalidated(
     await storage.rename_race(race_id, new_name="After Rename")
     cur = await db.execute(
         "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
-        (race_id, "session_replay"),
+        (race_id, "session_replay_v2"),
     )
     assert (await cur.fetchone())["n"] == 0
 


### PR DESCRIPTION
## Summary

Adds an **Attitude** gauge group (HEEL / TRIM) to the session page replay HUD, following the existing numbers-plus-sparkline pattern used for speed, wind, and heading. Builds on the data capture landed in #624 (schema v75 `attitudes` table).

Closes #645

## Changes

- **`routes/sessions.py`** — `_compute_session_replay` now queries the `attitudes` table alongside speeds/winds/headings/cogsog and merges `heel` and `trim` onto every per-second sample. Keys absent from the attitude series surface as `null`, matching how other sensors behave when data is missing.
- **`templates/session.html`** — new `.replay-gauge[data-gauge=\"attitude\"]` block modeled on the Heading gauge: two-column HEEL / TRIM readout, two 300×26 sparkline canvases (`#spark-heel`, `#spark-trim`). Inserted between Heading and Polar so it sits with the other live vessel-state gauges.
- **`static/session.js`** —
  - `_drawSparkline` gains an optional `{zeroCentered: true}` mode that forces a symmetric range around 0 and draws a faint baseline through y=0. Signed series (heel, trim, and anything future) now read as rail-angle gauges rather than auto-ranged blobs.
  - `_renderHud` gains an inline `_fmtSignedDeg` helper and wires `s.heel` / `s.trim` into `#hud-heel` / `#hud-trim` with an explicit `+`/`−` so starboard-down (`+12.3°`) and bow-up (`+1.4°`) are unambiguous at a glance.
  - Heel/trim sparklines use a muted purple to visually separate from the existing speed/wind/heading palette.

## Sign conventions (from `nmea2000.AttitudeRecord`)

- **heel** = roll, positive = starboard rail down
- **trim** = pitch, positive = bow up

Both already stored in degrees by `sk_reader.py` on ingest, so no conversion in the replay path.

## Out of scope

- `export.py` CSV/GPX/JSON HEEL/TRIM columns — follow-up once naming is agreed.
- Polar heel-correction — larger piece, separate issue.
- B&G writeback — covered by IDX-011.

## Test plan

- [x] `uv run pytest tests/` — 2242 passed, 2 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/helmlog/routes/sessions.py src/helmlog/storage.py` — clean
- [x] New tests:
  - `test_replay_endpoint_returns_heel_and_trim` — attitude rows in the session window surface on every sample with correct signs.
  - `test_replay_endpoint_heel_trim_absent_when_no_attitude_rows` — pre-v75 sessions return `heel: null, trim: null` so the UI renders em-dashes instead of crashing.
- [ ] Manual smoke on an imported session with attitude data: gauge renders, signs match what the boat actually did, sparkline baseline sits mid-strip through zero.

## Risk tier

**Standard** — touches the replay endpoint join, template, and JS. No schema change, no auth change, no federation/peer API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)