### PR TITLE
fix: debrief multi-channel parity + USB device-set change warning (#648 Part 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ AUDIO_CHANNELS=1
 # (2 × 480 MB PCM → ~4 GB Float32 decoded). Lower if you see "Loading audio…"
 # hangs on shorter sessions.
 # AUDIO_STREAM_THRESHOLD_MINUTES=45
+# Number of distinct speakers on each sibling-mode mono WAV (one USB receiver
+# that mixes N mics into one stream). Default 2. Set to 0 to let pyannote pick
+# the count, which can over-split on noisy race audio. Only used in sibling mode.
+# AUDIO_SPEAKERS_PER_CHANNEL=2
 # Audio transcription
 WHISPER_MODEL=base
 # Speaker diarisation — requires free HF account + accepted model terms

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ SK_PORT=3000
 AUDIO_DIR=data/audio
 AUDIO_SAMPLE_RATE=48000
 AUDIO_CHANNELS=1
+# Session length (minutes) at or above which the session page streams audio via
+# <audio> elements instead of decoding the whole WAV into memory. decodeAudioData
+# on multi-sibling sessions longer than ~45 min blows the browser's memory budget
+# (2 × 480 MB PCM → ~4 GB Float32 decoded). Lower if you see "Loading audio…"
+# hangs on shorter sessions.
+# AUDIO_STREAM_THRESHOLD_MINUTES=45
 # Audio transcription
 WHISPER_MODEL=base
 # Speaker diarisation — requires free HF account + accepted model terms

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/*.sqlite
 data/*.csv
 data/audio/
 data/notes/
+data/vakaros-inbox/
 
 # Claude Code project directory (except shared skills and evals)
 .claude/*

--- a/scripts/transcribe_worker.py
+++ b/scripts/transcribe_worker.py
@@ -33,8 +33,15 @@ async def transcribe(
     file: UploadFile,
     model_size: str = Query(default="base"),
     diarize: str = Query(default="true"),
+    num_speakers: int | None = Query(default=None),
 ) -> JSONResponse:
-    """Accept a WAV upload, run whisper + optional diarisation, return JSON."""
+    """Accept a WAV upload, run whisper + optional diarisation, return JSON.
+
+    ``num_speakers`` (optional) constrains pyannote to exactly N speakers —
+    useful when the caller knows each mono WAV has a fixed number of voices
+    (e.g. a wireless receiver mixing 2 mics into 1 mono stream). Unset lets
+    pyannote pick the count, which can over-split on noisy race audio.
+    """
     want_diarize = diarize.lower() in {"true", "1", "yes"}
 
     # Save the uploaded WAV to a temp file (whisper needs a file path)
@@ -46,11 +53,12 @@ async def transcribe(
 
     try:
         logger.info(
-            "Transcribing: {} ({:.1f} MB) model={} diarize={}",
+            "Transcribing: {} ({:.1f} MB) model={} diarize={} num_speakers={}",
             file.filename,
             len(content) / 1_048_576,
             model_size,
             want_diarize,
+            num_speakers,
         )
 
         from helmlog.transcribe import (
@@ -72,7 +80,7 @@ async def transcribe(
 
         if use_diarize:
             text, segments_json_str = _run_with_diarization(
-                file_path=tmp_path, model_size=model_size
+                file_path=tmp_path, model_size=model_size, num_speakers=num_speakers
             )
             segments: list[dict[str, Any]] = json.loads(segments_json_str)
         else:

--- a/src/helmlog/audio.py
+++ b/src/helmlog/audio.py
@@ -457,6 +457,7 @@ async def capture_start(
     name: str | None,
     race_id: int | None,
     session_type: str,
+    prev_capture_group_id: str | None = None,
 ) -> int:
     """Start an audio capture and persist every resulting session.
 
@@ -464,11 +465,23 @@ async def capture_start(
     ``AudioRecorder`` or a sibling-card ``AudioRecorderGroup``. Returns
     the *primary* session id (ordinal 0) so the caller can keep tracking
     the capture with a single scalar in ``session_state``.
+
+    ``prev_capture_group_id`` is the race's sibling capture group, passed at
+    debrief-start time. If set and the USB identity set we detect now differs
+    from the one the race saw, log a WARNING (#648 C5) and continue with the
+    current topology — debrief is not blocked by the change.
     """
     if isinstance(recorder, AudioRecorderGroup):
         from helmlog.usb_audio import detect_all_capture_devices
 
         devices = detect_all_capture_devices(min_channels=1)
+
+        if prev_capture_group_id is not None:
+            await _warn_if_device_set_changed(
+                storage,
+                prev_capture_group_id=prev_capture_group_id,
+                current_devices=devices,
+            )
         sessions = await recorder.start(config, devices=devices, name=name)
     else:
         sessions = [await recorder.start(config, name=name)]
@@ -528,6 +541,58 @@ async def capture_stop(
     assert completed_single.end_utc is not None
     await storage.update_audio_session_end(primary_session_id, completed_single.end_utc)
     return completed_single
+
+
+async def _warn_if_device_set_changed(
+    storage: Any,  # noqa: ANN401 — Storage
+    *,
+    prev_capture_group_id: str,
+    current_devices: list[Any],  # list[DetectedDevice]
+) -> None:
+    """Compare the USB identity set of a previous capture group to the set of
+    devices detected now. Log a WARNING when they differ (#648 C5).
+
+    Used at debrief-start to surface hot-unplug / re-enumeration between the
+    race and the debrief. Never raises — debrief must not be blocked.
+    """
+    try:
+        prev_siblings = await storage.list_capture_group_siblings(prev_capture_group_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("capture_start: sibling lookup for {} failed: {}", prev_capture_group_id, exc)
+        return
+    if not prev_siblings:
+        return
+
+    prev_identities: set[tuple[int, int, str, str]] = {
+        (
+            int(s.get("vendor_id") or 0),
+            int(s.get("product_id") or 0),
+            s.get("serial") or "",
+            s.get("usb_port_path") or "",
+        )
+        for s in prev_siblings
+    }
+    current_identities: set[tuple[int, int, str, str]] = {
+        (
+            int(getattr(d, "vendor_id", 0) or 0),
+            int(getattr(d, "product_id", 0) or 0),
+            getattr(d, "serial", "") or "",
+            getattr(d, "usb_port_path", "") or "",
+        )
+        for d in current_devices
+    }
+    if prev_identities != current_identities:
+        dropped = prev_identities - current_identities
+        added = current_identities - prev_identities
+        logger.warning(
+            "Debrief USB device set changed since race (#648 C5): "
+            "race_siblings={} detected_now={} dropped={} added={} — "
+            "recording with current topology",
+            len(prev_identities),
+            len(current_identities),
+            sorted(dropped),
+            sorted(added),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -413,6 +413,19 @@ SETTINGS_DEFS: tuple[SettingDef, ...] = (
             "Takes effect on the next session page load."
         ),
     ),
+    SettingDef(
+        key="AUDIO_SPEAKERS_PER_CHANNEL",
+        label="Expected speakers per sibling mic",
+        input_type="number",
+        default="2",
+        help_text=(
+            "Number of crew voices sharing each sibling-mode mono WAV (one USB "
+            "receiver mixing N mics into one stream). Passed to pyannote as a "
+            "num_speakers hint so it doesn't over-split noisy audio into 5–9 "
+            "spurious labels. 0 lets pyannote pick the count automatically. "
+            "Only used for sibling captures; takes effect on retranscribe."
+        ),
+    ),
 )
 
 SETTINGS_BY_KEY: dict[str, SettingDef] = {s.key: s for s in SETTINGS_DEFS}

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -400,6 +400,19 @@ SETTINGS_DEFS: tuple[SettingDef, ...] = (
         default="pit",
         help_text="Crew position assigned to audio channel 4.",
     ),
+    SettingDef(
+        key="AUDIO_STREAM_THRESHOLD_MINUTES",
+        label="Audio streaming threshold (minutes)",
+        input_type="number",
+        default="45",
+        help_text=(
+            "Sibling-mode sessions at or above this length stream audio via HTTP "
+            "range requests on the session page instead of decoding the whole WAV "
+            "into memory. Lower this if long sessions hang on ‘Loading audio…’; "
+            "raise it if sample-accurate scrubbing matters more than memory. "
+            "Takes effect on the next session page load."
+        ),
+    ),
 )
 
 SETTINGS_BY_KEY: dict[str, SettingDef] = {s.key: s for s in SETTINGS_DEFS}

--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -227,18 +227,38 @@ async def api_get_transcript(
     row = await storage.get_audio_session_row(session_id)
     group_id = row.get("capture_group_id") if row else None
     merged_speaker_map: dict[str, Any] = {}
+
+    # Collect per-segment overrides keyed on (audio_session_id, segment_index)
+    # so the merged response can carry override metadata for each segment.
+    # Stored in transcript_segments.override_user_id (#648).
+    override_maps: dict[int, dict[int, dict[str, Any]]] = {}
+
+    def _tag_segments(asid: int, segs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        ov = override_maps.get(asid, {})
+        for idx, seg in enumerate(segs):
+            seg["audio_session_id"] = asid
+            seg["segment_index"] = idx
+            hit = ov.get(idx)
+            if hit:
+                seg["override_user_id"] = hit["user_id"]
+                seg["override_name"] = hit["name"]
+        return segs
+
     if group_id:
         merged: list[dict[str, Any]] = []
         siblings = await storage.list_capture_group_siblings(str(group_id))
         for sr in siblings:
-            st = await storage.get_transcript_with_anon(int(sr["id"]))
+            sid = int(sr["id"])
+            st = await storage.get_transcript_with_anon(sid)
             if st is None:
                 continue
+            if st.get("id") is not None:
+                override_maps[sid] = await storage.get_segment_overrides(int(st["id"]))
             sj = st.get("segments_json")
             if sj:
                 try:
                     segs = _json.loads(sj)
-                    merged.extend(segs)
+                    merged.extend(_tag_segments(sid, segs))
                 except (_json.JSONDecodeError, TypeError):
                     pass
             sm = st.get("speaker_map")
@@ -250,7 +270,12 @@ async def api_get_transcript(
         merged.sort(key=lambda s: float(s.get("start", 0.0)))
         t["segments"] = merged
     elif t.get("segments_json"):
-        t["segments"] = _json.loads(t["segments_json"])
+        overrides = (
+            await storage.get_segment_overrides(int(t["id"])) if t.get("id") is not None else {}
+        )
+        override_maps[session_id] = overrides
+        segs = _json.loads(t["segments_json"])
+        t["segments"] = _tag_segments(session_id, segs)
     t.pop("segments_json", None)
     # Remove internal anon map from response
     t.pop("speaker_anon_map", None)
@@ -339,6 +364,52 @@ async def api_assign_speaker(
 
     asyncio.create_task(maybe_build_voice_profile(storage, user_id))
     return JSONResponse({"speaker_label": speaker_label, "user_id": user_id, "name": name})
+
+
+@router.post(
+    "/api/audio/{session_id}/transcript/segments/{segment_index}/speaker-override",
+    status_code=200,
+)
+@limiter.limit("60/minute")
+async def api_override_segment_speaker(
+    request: Request,
+    session_id: int,
+    segment_index: int,
+    _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> JSONResponse:
+    """Override the speaker for a single transcript segment (#648).
+
+    Unlike ``/transcript/assign-speaker`` (label-wide), this updates just
+    one segment so a misattributed utterance can be corrected without
+    re-labelling every other segment that shares the label. Pass
+    ``{"user_id": null}`` to clear the override.
+    """
+    storage = get_storage(request)
+    body = await request.json()
+    user_id = body.get("user_id")
+    if user_id is not None and not isinstance(user_id, int):
+        raise HTTPException(status_code=422, detail="user_id must be an integer or null")
+
+    t = await storage.get_transcript(session_id)
+    if t is None:
+        raise HTTPException(status_code=404, detail="Transcript not found")
+    found, name = await storage.set_segment_speaker_override(int(t["id"]), segment_index, user_id)
+    if not found:
+        raise HTTPException(status_code=404, detail="Segment not found")
+    await audit(
+        request,
+        "transcript.override_segment_speaker",
+        detail=f"session={session_id} segment={segment_index} user={user_id}",
+        user=_user,
+    )
+    return JSONResponse(
+        {
+            "audio_session_id": session_id,
+            "segment_index": segment_index,
+            "user_id": user_id,
+            "name": name,
+        }
+    )
 
 
 @router.post("/api/audio/{session_id}/transcript/anonymize-speaker", status_code=200)

--- a/src/helmlog/routes/audio.py
+++ b/src/helmlog/routes/audio.py
@@ -220,9 +220,13 @@ async def api_get_transcript(
         raise HTTPException(status_code=404, detail="No transcript job found for this session")
 
     # Sibling merge: if this session has a capture_group_id, union the
-    # segments from every sibling's transcript into a single sorted array.
+    # segments from every sibling's transcript into a single sorted array,
+    # AND union their speaker_maps (#648) so assignments on any sibling are
+    # visible in the merged view. Labels are globally unique because we
+    # prefix with position_name in _persist_sibling_segments.
     row = await storage.get_audio_session_row(session_id)
     group_id = row.get("capture_group_id") if row else None
+    merged_speaker_map: dict[str, Any] = {}
     if group_id:
         merged: list[dict[str, Any]] = []
         siblings = await storage.list_capture_group_siblings(str(group_id))
@@ -231,13 +235,18 @@ async def api_get_transcript(
             if st is None:
                 continue
             sj = st.get("segments_json")
-            if not sj:
-                continue
-            try:
-                segs = _json.loads(sj)
-            except (_json.JSONDecodeError, TypeError):
-                continue
-            merged.extend(segs)
+            if sj:
+                try:
+                    segs = _json.loads(sj)
+                    merged.extend(segs)
+                except (_json.JSONDecodeError, TypeError):
+                    pass
+            sm = st.get("speaker_map")
+            if sm:
+                import contextlib
+
+                with contextlib.suppress(_json.JSONDecodeError, TypeError):
+                    merged_speaker_map.update(_json.loads(sm))
         merged.sort(key=lambda s: float(s.get("start", 0.0)))
         t["segments"] = merged
     elif t.get("segments_json"):
@@ -247,7 +256,10 @@ async def api_get_transcript(
     t.pop("speaker_anon_map", None)
     # Expose speaker_map for UI (crew labels, auto-match info)
     raw_map = t.pop("speaker_map", None)
-    t["speaker_map"] = _json.loads(raw_map) if raw_map else {}
+    if group_id:
+        t["speaker_map"] = merged_speaker_map
+    else:
+        t["speaker_map"] = _json.loads(raw_map) if raw_map else {}
     return JSONResponse(t)
 
 
@@ -295,8 +307,26 @@ async def api_assign_speaker(
     if row is None:
         raise HTTPException(status_code=404, detail="User not found")
     name = row["name"] or f"User {user_id}"
-    found = await storage.assign_speaker_crew(t["id"], speaker_label, user_id, name)
-    if not found:
+    # #648: fan out across siblings so the merged transcript's speaker_map
+    # gets updated regardless of which sibling's primary we POSTed against.
+    # Speaker labels are globally unique (prefixed with position_name) so
+    # writing the same label across every sibling's speaker_map is safe.
+    asession = await storage.get_audio_session_row(session_id)
+    group_id = asession.get("capture_group_id") if asession else None
+    targets: list[int] = []
+    if group_id:
+        siblings = await storage.list_capture_group_siblings(str(group_id))
+        for sr in siblings:
+            st = await storage.get_transcript(int(sr["id"]))
+            if st is not None:
+                targets.append(int(st["id"]))
+    if not targets:
+        targets = [int(t["id"])]
+    any_found = False
+    for tid in targets:
+        if await storage.assign_speaker_crew(tid, speaker_label, user_id, name):
+            any_found = True
+    if not any_found:
         raise HTTPException(status_code=404, detail="Transcript not found")
     await audit(
         request,

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -570,6 +570,10 @@ async def api_start_debrief(
 
     debrief_name = f"{row['name']}-debrief"
     now = datetime.now(UTC)
+    # Hand capture_start the race's sibling group so it can warn when the USB
+    # device set has changed between race-end and debrief-start (#648 C5).
+    prev_audio = await storage.get_race_primary_audio_session(race_id)
+    prev_group_id = prev_audio["capture_group_id"] if prev_audio else None
     ss.debrief_audio_session_id = await capture_start(
         request.app.state.recorder,
         request.app.state.audio_config,
@@ -577,6 +581,7 @@ async def api_start_debrief(
         name=debrief_name,
         race_id=race_id,
         session_type="debrief",
+        prev_capture_group_id=prev_group_id,
     )
     ss.debrief_race_id = race_id
     ss.debrief_race_name = row["name"]

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -750,7 +750,7 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
         group_rows = await storage.list_capture_group_siblings(str(arow["capture_group_id"]))
         for sr in group_rows:
             cmap = await storage.get_channel_map_for_audio_session(int(sr["id"]))
-            position_name = cmap.get(0, f"sib{sr['capture_ordinal']}")
+            position_name = cmap.get(0, f"R{int(sr['capture_ordinal']) + 1}")
             audio_siblings.append(
                 {
                     "audio_session_id": int(sr["id"]),
@@ -789,7 +789,7 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
             )
             for sr in debrief_group_rows:
                 cmap = await storage.get_channel_map_for_audio_session(int(sr["id"]))
-                position_name = cmap.get(0, f"sib{sr['capture_ordinal']}")
+                position_name = cmap.get(0, f"R{int(sr['capture_ordinal']) + 1}")
                 debrief_siblings.append(
                     {
                         "audio_session_id": int(sr["id"]),

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -698,6 +699,15 @@ async def api_session_detail(
     )
 
 
+def _audio_stream_threshold_minutes() -> int:
+    """Minutes of session length at/above which the session page streams audio
+    instead of decoding (#648). Tunable via the admin settings page or env."""
+    try:
+        return int(os.environ.get("AUDIO_STREAM_THRESHOLD_MINUTES", "45"))
+    except ValueError:
+        return 45
+
+
 async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str, Any]:
     db = storage._conn()
     cur = await db.execute(
@@ -756,9 +766,10 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
     # block the session page can render alongside the main audio card.
     debrief_audio: dict[str, Any] | None = None
     dcur = await db.execute(
-        "SELECT id, start_utc FROM audio_sessions"
+        "SELECT id, start_utc, end_utc, capture_group_id, capture_ordinal"
+        " FROM audio_sessions"
         " WHERE race_id = ? AND session_type = 'debrief'"
-        " ORDER BY id ASC LIMIT 1",
+        " ORDER BY capture_ordinal ASC, id ASC LIMIT 1",
         (session_id,),
     )
     drow = await dcur.fetchone()
@@ -768,6 +779,40 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
             "start_utc": datetime.fromisoformat(drow["start_utc"]).isoformat(),
             "stream_url": f"/api/audio/{int(drow['id'])}/stream",
         }
+        # #648: surface debrief siblings so the session page can render a
+        # multi-sibling player (sticky isolation + channel mixing) for
+        # debriefs, just like the race player.
+        debrief_siblings: list[dict[str, Any]] = []
+        if drow["capture_group_id"]:
+            debrief_group_rows = await storage.list_capture_group_siblings(
+                str(drow["capture_group_id"])
+            )
+            for sr in debrief_group_rows:
+                cmap = await storage.get_channel_map_for_audio_session(int(sr["id"]))
+                position_name = cmap.get(0, f"sib{sr['capture_ordinal']}")
+                debrief_siblings.append(
+                    {
+                        "audio_session_id": int(sr["id"]),
+                        "ordinal": int(sr["capture_ordinal"]),
+                        "position_name": position_name,
+                        "stream_url": f"/api/audio/{int(sr['id'])}/stream",
+                    }
+                )
+        debrief_audio["siblings"] = debrief_siblings
+        # Decide streaming vs decode for the debrief based on its own duration.
+        debrief_duration_s: float | None = None
+        if drow["end_utc"]:
+            try:
+                deb_start = datetime.fromisoformat(drow["start_utc"])
+                deb_end = datetime.fromisoformat(drow["end_utc"])
+                debrief_duration_s = (deb_end - deb_start).total_seconds()
+            except (TypeError, ValueError):
+                debrief_duration_s = None
+        debrief_audio["use_streaming_audio"] = bool(
+            len(debrief_siblings) > 1
+            and debrief_duration_s is not None
+            and debrief_duration_s >= _audio_stream_threshold_minutes() * 60
+        )
 
     # Check for wind field params (synthesized sessions)
     wf_cur = await db.execute(
@@ -780,14 +825,10 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
     # instead of decoding each sibling into a memory buffer. Long multi-sibling
     # sessions (>~45 min × 2 siblings) blow Chrome's per-tab memory budget when
     # decodeAudioData expands PCM s16 into Float32 per channel.
-    import os as _os
-
-    try:
-        threshold_min = int(_os.environ.get("AUDIO_STREAM_THRESHOLD_MINUTES", "45"))
-    except ValueError:
-        threshold_min = 45
     use_streaming_audio = bool(
-        audio_siblings and duration_s is not None and duration_s >= threshold_min * 60
+        audio_siblings
+        and duration_s is not None
+        and duration_s >= _audio_stream_threshold_minutes() * 60
     )
 
     return {

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -776,6 +776,20 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
     )
     has_wind_field = await wf_cur.fetchone() is not None
 
+    # #648: hint the session page whether to stream audio via <audio> elements
+    # instead of decoding each sibling into a memory buffer. Long multi-sibling
+    # sessions (>~45 min × 2 siblings) blow Chrome's per-tab memory budget when
+    # decodeAudioData expands PCM s16 into Float32 per channel.
+    import os as _os
+
+    try:
+        threshold_min = int(_os.environ.get("AUDIO_STREAM_THRESHOLD_MINUTES", "45"))
+    except ValueError:
+        threshold_min = 45
+    use_streaming_audio = bool(
+        audio_siblings and duration_s is not None and duration_s >= threshold_min * 60
+    )
+
     return {
         "id": row["id"],
         "type": row["session_type"],
@@ -797,6 +811,7 @@ async def _compute_session_detail(storage: Storage, session_id: int) -> dict[str
             len(audio_siblings) if audio_siblings else (arow["channels"] if arow else None)
         ),
         "audio_siblings": audio_siblings,
+        "use_streaming_audio": use_streaming_audio,
         "debrief_audio": debrief_audio,
         "peer_fingerprint": row["peer_fingerprint"],
         "has_wind_field": has_wind_field,

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -196,28 +196,42 @@ function _vakarosBoatIcon(color, opacity) {
   return L.divIcon({className: 'vakaros-boat', html: html, iconSize: [28, 22], iconAnchor: [14, 12]});
 }
 
-// Transcript auto-follow state. The transcript container scrolls itself to
-// keep the active segment visible, but if the user scrolls manually we
-// disable that until they click a segment (which re-anchors).
-let _transcriptFollow = true;
-let _lastTranscriptProgrammaticScrollAt = 0;
-
-// Scroll the transcript container so the active segment is visible — without
-// ever calling scrollIntoView() (which can jerk the whole page when the
-// container itself isn't fully in view). Returns true if a scroll happened.
+// Per-pane transcript state (#648). Both race and debrief transcripts use
+// the same rendering pipeline; each pane gets its own slot so follow state,
+// active-segment highlight, and block storage stay isolated.
 //
-// Uses getBoundingClientRect (#648) instead of offsetTop because offsetTop is
-// relative to the nearest *positioned* ancestor, which is not always the
-// scroll container — when it isn't, assigning the raw offsetTop to
-// container.scrollTop lands at a wildly wrong position (the symptom the user
-// reported as "transcript jumps to god only knows where").
-function _scrollTranscriptSegmentIntoView(container, el) {
-  if (!_transcriptFollow) return false;
+//   _transcriptPanes[paneKey] = {
+//     containerId, followBtnId, surfaceName,
+//     audioSessionId,      // primary audio_session_id for this pane
+//     audioStartUtc,       // Date anchor for clock math
+//     onPlay(block),       // click-to-play handler
+//     onOpenOverride(block), // pencil-click handler
+//     speakerMap,          // label → crew entry
+//     blocks,              // merged display blocks
+//     follow,              // auto-scroll enabled
+//     lastActiveIdx,       // last-rendered active block
+//     surfaceRegistered,   // registerSurface called once per pane
+//     lastProgrammaticScrollAt,  // timestamp of our last scroll — used to
+//                                // ignore our own scroll events
+//   }
+const _transcriptPanes = {};
+
+// Back-compat alias so legacy code keeps working until all call sites move
+// off the global (#648).
+let _transcriptFollow = true;
+
+function _scrollTranscriptSegmentIntoView(container, el, paneKey) {
+  // Uses getBoundingClientRect (#648) instead of offsetTop because offsetTop
+  // is relative to the nearest *positioned* ancestor, which is not always
+  // the scroll container — when it isn't, assigning the raw offsetTop to
+  // container.scrollTop lands at a wildly wrong position (the symptom the
+  // user reported as "transcript jumps to god only knows where").
+  const pane = paneKey ? _transcriptPanes[paneKey] : null;
+  const follow = pane ? pane.follow : _transcriptFollow;
+  if (!follow) return false;
   const margin = 4;
   const cRect = container.getBoundingClientRect();
   const eRect = el.getBoundingClientRect();
-  // Position of the segment relative to the container's *content*, regardless
-  // of offsetParent topology.
   const relTop = eRect.top - cRect.top + container.scrollTop;
   const relBottom = relTop + el.offsetHeight;
   const top = relTop - margin;
@@ -229,29 +243,35 @@ function _scrollTranscriptSegmentIntoView(container, el) {
     target = bottom - container.clientHeight;
   }
   if (target == null) return false;
-  _lastTranscriptProgrammaticScrollAt = Date.now();
+  const now = Date.now();
+  if (pane) pane.lastProgrammaticScrollAt = now;
   container.scrollTop = Math.max(0, target);
   return true;
 }
 
-function _wireTranscriptScrollListener() {
-  const container = document.getElementById('transcript-segments');
+function _wireTranscriptScrollListener(paneKey) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane) return;
+  const container = document.getElementById(pane.containerId);
   if (!container || container._scrollWired) return;
   container._scrollWired = true;
   container.addEventListener('scroll', function() {
-    // Ignore the scroll events we triggered ourselves.
-    if (Date.now() - _lastTranscriptProgrammaticScrollAt < 400) return;
-    if (_transcriptFollow) {
-      _transcriptFollow = false;
-      _renderTranscriptFollowBadge();
+    // Ignore the scroll events we triggered ourselves (400 ms window).
+    if (Date.now() - (pane.lastProgrammaticScrollAt || 0) < 400) return;
+    if (pane.follow) {
+      pane.follow = false;
+      if (paneKey === 'race') _transcriptFollow = false;
+      _renderTranscriptFollowBadge(paneKey);
     }
   });
 }
 
-function _renderTranscriptFollowBadge() {
-  const btn = document.getElementById('transcript-follow-btn');
+function _renderTranscriptFollowBadge(paneKey) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane) return;
+  const btn = document.getElementById(pane.followBtnId);
   if (!btn) return;
-  if (_transcriptFollow) {
+  if (pane.follow) {
     btn.textContent = '\u25C9 Follow';
     btn.style.opacity = '1';
     btn.title = 'Auto-scrolling to active segment. Click to pause.';
@@ -262,9 +282,13 @@ function _renderTranscriptFollowBadge() {
   }
 }
 
-function toggleTranscriptFollow() {
-  _transcriptFollow = !_transcriptFollow;
-  _renderTranscriptFollowBadge();
+function toggleTranscriptFollow(paneKey) {
+  const key = paneKey || 'race';
+  const pane = _transcriptPanes[key];
+  if (!pane) return;
+  pane.follow = !pane.follow;
+  if (key === 'race') _transcriptFollow = pane.follow;
+  _renderTranscriptFollowBadge(key);
 }
 let _transcriptId = null; // transcript ID for tuning extraction
 let _tuningSegmentAudio = null; // shared <audio> for segment playback
@@ -2422,7 +2446,46 @@ async function loadTranscript() {
   }
 }
 
+// Race transcript entry point — thin trampoline into the shared pane
+// renderer (#648). Both race and debrief go through _renderTranscriptPane
+// so layout, follow button, pencils, and auto-scroll behave identically.
 function _renderDiarizedTranscript(body, t) {
+  _renderTranscriptPane('race', body, t, {
+    containerId: 'transcript-segments',
+    followBtnId: 'transcript-follow-btn',
+    surfaceName: 'transcript',
+    segClass: 'transcript-seg',
+    speakerClass: 'transcript-speaker',
+    audioStartUtcRaw: _session && _session.audio_start_utc,
+    onClickSegment: 'playTranscriptSegment',
+    onClickSpeaker: (escLabel) => "openSpeakerPicker('" + escLabel + "')",
+    onClickOverride: 'openSegmentOverridePicker',
+    onToggleFollow: "toggleTranscriptFollow('race')",
+    speakerMap: _speakerMap,
+  });
+}
+
+// Shared renderer driven by pane state (#648). Keeps race + debrief in
+// lock-step on layout, click affordances, follow behaviour, and scroll
+// math. Pane state lives in _transcriptPanes[paneKey] so multiple panes
+// can coexist on the same page without trampling each other.
+function _renderTranscriptPane(paneKey, body, t, opts) {
+  const prev = _transcriptPanes[paneKey] || {};
+  const pane = _transcriptPanes[paneKey] = {
+    ...prev,
+    containerId: opts.containerId,
+    followBtnId: opts.followBtnId,
+    surfaceName: opts.surfaceName,
+    audioStartUtcRaw: opts.audioStartUtcRaw,
+    segClass: opts.segClass,
+    speakerMap: opts.speakerMap || {},
+    blocks: [],
+    follow: prev.follow !== undefined ? prev.follow : true,
+    lastActiveIdx: -1,
+    surfaceRegistered: prev.surfaceRegistered || false,
+    lastProgrammaticScrollAt: prev.lastProgrammaticScrollAt || 0,
+  };
+
   const blocks = [];
   for (const seg of t.segments) {
     const last = blocks[blocks.length - 1];
@@ -2449,16 +2512,21 @@ function _renderDiarizedTranscript(body, t) {
       blocks.push(block);
     }
   }
-  _transcriptBlocks = blocks;
+  pane.blocks = blocks;
+  // Keep legacy race-only globals in sync until every call site migrates.
+  if (paneKey === 'race') {
+    _transcriptBlocks = blocks;
+    _speakerMap = pane.speakerMap;
+  }
+
   const rawSpeakers = [...new Set(t.segments.map(s => s.speaker))];
   const speakers = [...new Set(blocks.map(b => b.speaker))];
   const palette = [cssVar('--accent'), cssVar('--success'), cssVar('--warning'), cssVar('--danger'), '#c4b5fd', '#f9a8d4'];
   const color = s => palette[rawSpeakers.indexOf(s) >= 0 ? rawSpeakers.indexOf(s) % palette.length : speakers.indexOf(s) % palette.length];
   const fmt = s => { const m = Math.floor(s / 60); return m + ':' + String(Math.floor(s % 60)).padStart(2, '0'); };
 
-  // Display name for a speaker (crew name from speaker_map, or raw label)
   const displayName = (rawLabel) => {
-    const entry = _speakerMap[rawLabel];
+    const entry = pane.speakerMap[rawLabel];
     if (entry && entry.name) {
       if (entry.type === 'auto' && entry.confidence != null) {
         return entry.name + ' (' + Math.round(entry.confidence * 100) + '%)';
@@ -2470,60 +2538,63 @@ function _renderDiarizedTranscript(body, t) {
 
   body.innerHTML = ''
     + '<div style="display:flex;justify-content:flex-end;align-items:center;margin-bottom:6px;gap:8px">'
-    + (_session.audio_channels > 1 ? _renderIsolationToggle() : '')
-    + '<button id="transcript-follow-btn" type="button" onclick="toggleTranscriptFollow()" '
+    + '<button id="' + opts.followBtnId + '" type="button" '
+    + 'onclick="' + opts.onToggleFollow + '" '
     + 'style="font-size:.7rem;padding:2px 8px;border:1px solid var(--border);background:transparent;color:var(--text-secondary);cursor:pointer;border-radius:3px" '
     + 'title="Auto-scrolling to active segment. Click to pause.">\u25C9 Follow</button>'
     + '</div>'
-    + '<div id="transcript-segments" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
+    + '<div id="' + opts.containerId + '" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
     + blocks.map((b, i) => {
       const speakerHtml = b.override_user_id
-        ? '<span class="transcript-speaker" data-speaker="' + esc(b.speaker)
+        ? '<span class="' + opts.speakerClass + '" data-speaker="' + esc(b.speaker)
           + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;'
           + 'font-style:italic" title="Overridden from ' + esc(displayName(b.speaker))
           + ' — click ✎ to change">'
           + esc(b.override_name || '') + '</span>'
-        : '<span class="transcript-speaker" data-speaker="' + esc(b.speaker)
+        : '<span class="' + opts.speakerClass + '" data-speaker="' + esc(b.speaker)
           + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;'
           + 'cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" '
-          + 'onclick="event.stopPropagation();openSpeakerPicker(\'' + esc(b.speaker) + '\')" '
+          + 'onclick="event.stopPropagation();' + opts.onClickSpeaker(esc(b.speaker)) + '" '
           + 'title="Click to assign crew">'
           + esc(displayName(b.speaker)) + '</span>';
-      return '<div class="transcript-seg" data-idx="' + i + '" '
+      return '<div class="' + opts.segClass + '" data-idx="' + i + '" '
         + 'style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;'
-        + 'transition:background .15s" onclick="playTranscriptSegment(' + i + ')">'
+        + 'transition:background .15s" onclick="' + opts.onClickSegment + '(' + i + ')">'
         + speakerHtml
         + '<span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">['
         + fmt(b.start) + ']</span>'
         + ' <span class="transcript-seg-override" title="Override this segment only" '
         + 'style="font-size:.7rem;cursor:pointer;color:var(--text-secondary);margin-left:4px" '
-        + 'onclick="event.stopPropagation();openSegmentOverridePicker(' + i + ')">&#9998;</span>'
+        + 'onclick="event.stopPropagation();' + opts.onClickOverride + '(' + i + ')">&#9998;</span>'
         + '<div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">'
         + esc(b.text.trim()) + '</div>'
         + '</div>';
     }).join('')
     + '</div>';
 
-  // Register the diarized transcript as a playback-clock surface so it
-  // highlights the active segment in sync with audio/video/map (#446).
-  _registerTranscriptSurface();
-  _wireTranscriptScrollListener();
-  _renderTranscriptFollowBadge();
+  _registerTranscriptSurface(paneKey);
+  _wireTranscriptScrollListener(paneKey);
+  _renderTranscriptFollowBadge(paneKey);
 }
 
+// Legacy back-compat globals. Race pane now lives in _transcriptPanes.race,
+// but some older code still reads/writes these. Kept until full migration.
 let _transcriptSurfaceRegistered = false;
 let _lastActiveTranscriptIdx = -1;
-function _registerTranscriptSurface() {
-  if (!_session || !_session.audio_start_utc) return;
-  if (_transcriptSurfaceRegistered) return; // idempotent — transcript may re-render on poll
-  _transcriptSurfaceRegistered = true;
+
+function _registerTranscriptSurface(paneKey) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane || !pane.audioStartUtcRaw) return;
+  if (pane.surfaceRegistered) return;  // idempotent — transcript polls every 3s
+  pane.surfaceRegistered = true;
+  if (paneKey === 'race') _transcriptSurfaceRegistered = true;
+  const raw = pane.audioStartUtcRaw;
   const audioStart = new Date(
-    _session.audio_start_utc.endsWith('Z') || _session.audio_start_utc.includes('+')
-      ? _session.audio_start_utc
-      : _session.audio_start_utc + 'Z'
+    raw.endsWith('Z') || raw.includes('+') ? raw : raw + 'Z'
   );
-  registerSurface('transcript', function(utc) {
-    if (!_transcriptBlocks.length) return;
+  registerSurface(pane.surfaceName, function(utc) {
+    const p = _transcriptPanes[paneKey];
+    if (!p || !p.blocks.length) return;
     const local = (utc.getTime() - audioStart.getTime()) / 1000;
 
     // Pick a single best-match block (#648): with merged sibling transcripts
@@ -2534,15 +2605,16 @@ function _registerTranscriptSurface() {
     // recently — what a listener would expect to see in the auto-follow view.
     let activeIdx = -1;
     let bestStart = -Infinity;
-    for (let i = 0; i < _transcriptBlocks.length; i++) {
-      const b = _transcriptBlocks[i];
+    for (let i = 0; i < p.blocks.length; i++) {
+      const b = p.blocks[i];
       if (local >= b.start && local <= b.end && b.start > bestStart) {
         activeIdx = i;
         bestStart = b.start;
       }
     }
 
-    const segs = document.querySelectorAll('.transcript-seg');
+    const container = document.getElementById(p.containerId);
+    const segs = container ? container.querySelectorAll('.' + p.segClass) : [];
     for (let i = 0; i < segs.length; i++) {
       const el = segs[i];
       if (!el) continue;
@@ -2555,41 +2627,50 @@ function _registerTranscriptSurface() {
     // tick while the same block is playing caused the "transcript drifts away
     // from playhead" jitter, because co-active blocks flipped the scroll
     // target back and forth between their DOM positions.
-    if (activeIdx !== -1 && activeIdx !== _lastActiveTranscriptIdx) {
-      _lastActiveTranscriptIdx = activeIdx;
-      const container = document.getElementById('transcript-segments');
+    if (activeIdx !== -1 && activeIdx !== p.lastActiveIdx) {
+      p.lastActiveIdx = activeIdx;
+      if (paneKey === 'race') _lastActiveTranscriptIdx = activeIdx;
       const el = segs[activeIdx];
-      if (container && el) _scrollTranscriptSegmentIntoView(container, el);
+      if (container && el) _scrollTranscriptSegmentIntoView(container, el, paneKey);
     } else if (activeIdx === -1) {
-      _lastActiveTranscriptIdx = -1;
+      p.lastActiveIdx = -1;
+      if (paneKey === 'race') _lastActiveTranscriptIdx = -1;
     }
   });
 }
 
-function playTranscriptSegment(idx) {
-  const b = _transcriptBlocks[idx];
+// Click-to-play for a transcript block. Re-enables auto-scroll, seeks the
+// playback clock (video/map follow), and dispatches to the right audio
+// player based on the pane (#648). Race pane drives the race mc player;
+// debrief pane drives the debrief dmc player.
+function _playTranscriptBlock(paneKey, idx) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane) return;
+  const b = pane.blocks[idx];
   if (!b) return;
   // Clicking a segment is a strong "I want to follow this" signal —
   // re-enable auto-scroll if the user had paused it.
-  if (!_transcriptFollow) {
-    _transcriptFollow = true;
-    _renderTranscriptFollowBadge();
+  if (!pane.follow) {
+    pane.follow = true;
+    if (paneKey === 'race') _transcriptFollow = true;
+    _renderTranscriptFollowBadge(paneKey);
   }
-  // Route through the playback clock so video and map follow too.
-  if (_session && _session.audio_start_utc) {
+  if (pane.audioStartUtcRaw) {
+    const raw = pane.audioStartUtcRaw;
     const audioStart = new Date(
-      _session.audio_start_utc.endsWith('Z') || _session.audio_start_utc.includes('+')
-        ? _session.audio_start_utc
-        : _session.audio_start_utc + 'Z'
+      raw.endsWith('Z') || raw.includes('+') ? raw : raw + 'Z'
     );
-    setPosition(new Date(audioStart.getTime() + b.start * 1000), {source: 'transcript'});
+    setPosition(new Date(audioStart.getTime() + b.start * 1000), {source: pane.surfaceName});
   }
-  // Multi-channel sessions use the Web Audio path; route the click through
-  // _mcOnSegmentClick so the listener gets channel isolation for the segment.
+  const ch = (b.channel_index !== undefined && b.channel_index !== null)
+    ? b.channel_index : null;
+  if (paneKey === 'debrief') {
+    _dmcOnSegmentClick(ch === null ? -1 : ch, b.start, b.end);
+    return;
+  }
+  // Race pane — multi-channel via mc player if configured, else fall back
+  // to the legacy single-<audio> element.
   if ((_session.audio_channels || 1) > 1) {
-    const ch = (b.channel_index !== undefined && b.channel_index !== null)
-      ? b.channel_index
-      : null;
     _mcOnSegmentClick(ch, b.start, b.end);
     return;
   }
@@ -2602,11 +2683,17 @@ function playTranscriptSegment(idx) {
   }
 }
 
+// Back-compat thin trampolines — keep old inline onclicks resolving.
+function playTranscriptSegment(idx) { _playTranscriptBlock('race', idx); }
+function playDebriefTranscriptSegment(idx) { _playTranscriptBlock('debrief', idx); }
+
 // Open a picker to override the speaker for just this one block — covers
-// every underlying transcript_segments row in the block (#648). Called from
-// the ✎ pencil icon on each race transcript block.
-async function openSegmentOverridePicker(blockIdx) {
-  const block = _transcriptBlocks[blockIdx];
+// every underlying transcript_segments row in the block (#648). Pane-aware
+// so the race pencil and the debrief pencil both use this one picker.
+async function _openBlockOverridePicker(paneKey, blockIdx) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane) return;
+  const block = pane.blocks[blockIdx];
   if (!block || !Array.isArray(block._segRefs) || !block._segRefs.length) return;
   let users;
   try {
@@ -2638,13 +2725,13 @@ async function openSegmentOverridePicker(blockIdx) {
         + 'style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" '
         + 'onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" '
         + 'onmouseout="this.style.background=\'\'" '
-        + 'onclick="applySegmentOverride(' + blockIdx + ',' + u.id + ')">'
+        + 'onclick="_applyBlockOverride(\'' + paneKey + '\',' + blockIdx + ',' + u.id + ')">'
         + esc(u.name || u.email) + '</div>';
     }
   }
   html += '<div style="display:flex;gap:6px;justify-content:flex-end;margin-top:8px">'
     + '<button class="btn-export" style="font-size:.72rem" '
-    + 'onclick="applySegmentOverride(' + blockIdx + ',null)">Clear override</button>'
+    + 'onclick="_applyBlockOverride(\'' + paneKey + '\',' + blockIdx + ',null)">Clear override</button>'
     + '<button class="btn-export" style="font-size:.72rem" '
     + 'onclick="document.getElementById(\'speaker-picker\').remove();'
     + 'document.getElementById(\'speaker-picker-backdrop\').remove()">Cancel</button>'
@@ -2660,8 +2747,14 @@ async function openSegmentOverridePicker(blockIdx) {
   document.body.appendChild(picker);
 }
 
-async function applySegmentOverride(blockIdx, userId) {
-  const block = _transcriptBlocks[blockIdx];
+// Back-compat trampolines for inline onclick handlers on existing segments.
+function openSegmentOverridePicker(idx) { return _openBlockOverridePicker('race', idx); }
+function openDebriefBlockOverridePicker(idx) { return _openBlockOverridePicker('debrief', idx); }
+
+async function _applyBlockOverride(paneKey, blockIdx, userId) {
+  const pane = _transcriptPanes[paneKey];
+  if (!pane) return;
+  const block = pane.blocks[blockIdx];
   if (!block || !Array.isArray(block._segRefs)) return;
   const picker = document.getElementById('speaker-picker');
   const backdrop = document.getElementById('speaker-picker-backdrop');
@@ -2697,7 +2790,17 @@ async function applySegmentOverride(blockIdx, userId) {
   }
   // Cheap path — re-run the transcript loader so the block splits update
   // correctly (override status is part of the grouping key).
-  loadTranscript();
+  if (paneKey === 'race') {
+    loadTranscript();
+  } else {
+    const deb = _session && _session.debrief_audio;
+    if (deb) _loadDebriefTranscript(deb.audio_session_id);
+  }
+}
+
+// Back-compat trampoline for the previous global name.
+function applySegmentOverride(blockIdx, userId) {
+  return _applyBlockOverride('race', blockIdx, userId);
 }
 
 async function openSpeakerPicker(speakerLabel, audioSessionId) {
@@ -2855,7 +2958,7 @@ function _renderDebriefMultiChannel(wrap, deb, siblings) {
   _dmcIsolated = null;
   _dmcSticky = false;
   _dmcDurationS = 0;
-  const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`);
+  const labels = siblings.map(s => s.position_name || `R${(Number(s.ordinal) || 0) + 1}`);
   const downloadHref = '/api/audio/' + deb.audio_session_id + '/download';
   wrap.innerHTML =
     '<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:4px">'
@@ -2914,12 +3017,35 @@ function _dmcInit() {
   const primary = _dmcEls[0];
   if (!primary._dmcPrimaryWired) {
     primary._dmcPrimaryWired = true;
+    let dmcFanoutLast = 0;
     primary.addEventListener('timeupdate', () => {
       _dmcUpdateProgress();
       const t = primary.currentTime;
       for (let i = 1; i < _dmcEls.length; i++) {
         if (Math.abs(_dmcEls[i].currentTime - t) > 0.2) {
           try { _dmcEls[i].currentTime = t; } catch (e) { /* swallow */ }
+        }
+      }
+      // Fan out to the playback clock so the debrief transcript's auto-scroll
+      // (and any other consumer) keeps up with playback (#648). Throttle to
+      // 5 Hz — matches the existing audio fanout cadence. Uses source
+      // 'debrief-mc' so the debrief transcript consumer is NOT the one we
+      // skip in setPosition's same-source filter.
+      const deb = _session && _session.debrief_audio;
+      if (deb && deb.start_utc) {
+        const now = (typeof _clockNowMs === 'function') ? _clockNowMs() : Date.now();
+        if (now - dmcFanoutLast >= 200) {
+          dmcFanoutLast = now;
+          const raw = deb.start_utc;
+          const startUtc = new Date(
+            raw.endsWith('Z') || raw.includes('+') ? raw : raw + 'Z'
+          );
+          if (!isNaN(startUtc.getTime())) {
+            setPosition(
+              new Date(startUtc.getTime() + t * 1000),
+              {source: 'debrief-mc'},
+            );
+          }
         }
       }
     });
@@ -2974,7 +3100,7 @@ function _dmcSetIsolation(idx) {
     if (idx === null) {
       ind.textContent = 'mixed';
     } else {
-      const label = (_dmcSiblings[idx] && _dmcSiblings[idx].position_name) || `sib${idx}`;
+      const label = (_dmcSiblings[idx] && _dmcSiblings[idx].position_name) || `R${idx + 1}`;
       ind.textContent = 'isolated: ' + label;
     }
   }
@@ -3070,70 +3196,46 @@ async function _loadDebriefTranscript(audioSessionId) {
     return;
   }
   const segs = Array.isArray(t.segments) ? t.segments : [];
-  const fmt = s => {
-    const m = Math.floor(s / 60);
-    return m + ':' + String(Math.floor(s % 60)).padStart(2, '0');
-  };
-  const speakerMap = t.speaker_map || {};
-  const displayName = raw => {
-    const entry = speakerMap[raw];
-    if (entry && entry.name) return entry.name;
-    return raw || '';
-  };
-  // Segments are clickable — clicking seeks the debrief <audio> element to
-  // the segment start and starts playback. Use inline onclick with the raw
-  // start seconds so the handler stays self-contained.
-  const segStyle =
-    'margin-bottom:3px;cursor:pointer;padding:2px 4px;border-radius:3px';
-  let html = '';
-  // Resolve the per-segment channel index (#648) so transcript clicks can
-  // isolate the right mic on the multi-sibling debrief player.
-  const chOf = s => (s.channel_index !== undefined && s.channel_index !== null)
-    ? Number(s.channel_index) : -1;
-  if (segs.length && segs.some(s => s.speaker)) {
-    html = segs.map(s => {
-      const start = Number(s.start) || 0;
-      const ch = chOf(s);
-      // Override (#648): if a per-segment override is set, show that name
-      // italicized instead of the label's crew assignment; otherwise the
-      // speaker name opens the crew picker (label-wide) like before.
-      let who = '';
-      if (s.override_user_id && s.override_name) {
-        who = '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
-          + '" style="color:var(--accent);font-style:italic" '
-          + 'title="Overridden from ' + esc(displayName(s.speaker))
-          + ' — click ✎ to change">'
-          + esc(s.override_name) + ':</span> ';
-      } else if (s.speaker) {
-        who = '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
-          + '" style="color:var(--accent);cursor:pointer;text-decoration:underline dotted;'
-          + 'text-underline-offset:2px" '
-          + 'onclick="event.stopPropagation();openSpeakerPicker(\''
-          + esc(s.speaker) + '\',' + audioSessionId + ')" '
-          + 'title="Click to assign crew">'
-          + esc(displayName(s.speaker)) + ':</span> ';
-      }
-      const ovAsid = s.audio_session_id || audioSessionId;
-      const ovIdx = (s.segment_index !== undefined && s.segment_index !== null)
-        ? s.segment_index : -1;
-      const pencil = ovIdx >= 0
-        ? ' <span class="transcript-seg-override" title="Override this segment only" '
-          + 'style="font-size:.7rem;cursor:pointer;color:var(--text-secondary);margin-left:4px" '
-          + 'onclick="event.stopPropagation();'
-          + 'openDebriefSegmentOverridePicker(' + ovAsid + ',' + ovIdx + ')">&#9998;</span>'
-        : '';
-      return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
-        + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
-        + 'onmouseout="this.style.background=\'transparent\'" '
-        + 'title="Click to play from here">'
-        + '<span style="color:var(--text-secondary);font-family:monospace">['
-        + fmt(start) + ']</span> '
-        + who + esc(s.text || '') + pencil + '</div>';
-    }).join('');
+  const hasDiarized = segs.length > 0 && segs.some(s => s.speaker);
+
+  // #648: debrief transcript now uses the same shared renderer as the race
+  // transcript — block grouping, follow button, per-segment override pencil,
+  // speaker-click crew picker, auto-scroll synced to the debrief player.
+  // Non-diarized fallback keeps the simple text view + retranscribe button.
+  if (hasDiarized) {
+    // Retranscribe button sits above the shared render; the shared renderer
+    // owns everything from the follow button down.
+    body.innerHTML =
+      '<div style="display:flex;justify-content:flex-end;margin-bottom:4px">'
+      + '<button class="btn-export" style="font-size:.7rem" '
+      + 'onclick="retranscribeDebrief(' + audioSessionId + ')" '
+      + 'title="Re-run transcription with diarization so crew sharing a mic get separate speaker labels">'
+      + '&#8635; Retranscribe with diarization</button>'
+      + '</div>'
+      + '<div id="debrief-transcript-shared"></div>';
+    const shared = document.getElementById('debrief-transcript-shared');
+    const debAudio = _session && _session.debrief_audio;
+    _renderTranscriptPane('debrief', shared, t, {
+      containerId: 'debrief-transcript-segments',
+      followBtnId: 'debrief-transcript-follow-btn',
+      surfaceName: 'debrief-transcript',
+      segClass: 'debrief-transcript-seg',
+      speakerClass: 'debrief-transcript-speaker',
+      audioStartUtcRaw: debAudio && debAudio.start_utc,
+      onClickSegment: 'playDebriefTranscriptSegment',
+      onClickSpeaker: (escLabel) => "openSpeakerPicker('" + escLabel + "'," + audioSessionId + ")",
+      onClickOverride: 'openDebriefBlockOverridePicker',
+      onToggleFollow: "toggleTranscriptFollow('debrief')",
+      speakerMap: t.speaker_map || {},
+    });
   } else if (segs.length) {
-    html = segs.map(s => {
+    // Non-diarized fallback — short untimed list + retranscribe CTA.
+    const fmt = s => { const m = Math.floor(s / 60); return m + ':' + String(Math.floor(s % 60)).padStart(2, '0'); };
+    const segStyle = 'margin-bottom:3px;cursor:pointer;padding:2px 4px;border-radius:3px';
+    const html = segs.map(s => {
       const start = Number(s.start) || 0;
-      const ch = chOf(s);
+      const ch = (s.channel_index !== undefined && s.channel_index !== null)
+        ? Number(s.channel_index) : -1;
       return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
         + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
         + 'onmouseout="this.style.background=\'transparent\'" '
@@ -3141,20 +3243,19 @@ async function _loadDebriefTranscript(audioSessionId) {
         + '<span style="color:var(--text-secondary);font-family:monospace">['
         + fmt(start) + ']</span> ' + esc(s.text || '') + '</div>';
     }).join('');
+    body.innerHTML =
+      '<div style="display:flex;justify-content:flex-end;margin-bottom:4px">'
+      + '<button class="btn-export" style="font-size:.7rem" '
+      + 'onclick="retranscribeDebrief(' + audioSessionId + ')">'
+      + '&#8635; Retranscribe with diarization</button>'
+      + '</div>'
+      + '<div style="max-height:260px;overflow-y:auto;background:var(--bg-secondary);'
+      + 'border-radius:6px;padding:8px;color:var(--text-primary)">' + html + '</div>';
   } else if (t.text) {
-    html = '<div style="white-space:pre-wrap">' + esc(t.text) + '</div>';
+    body.innerHTML = '<div style="white-space:pre-wrap">' + esc(t.text) + '</div>';
   } else {
-    html = '<span style="color:var(--text-secondary)">(empty)</span>';
+    body.innerHTML = '<span style="color:var(--text-secondary)">(empty)</span>';
   }
-  body.innerHTML =
-    '<div style="display:flex;justify-content:flex-end;margin-bottom:4px">'
-    + '<button class="btn-export" style="font-size:.7rem" '
-    + 'onclick="retranscribeDebrief(' + audioSessionId + ')" '
-    + 'title="Re-run transcription with diarization so crew sharing a mic get separate speaker labels">'
-    + '&#8635; Retranscribe with diarization</button>'
-    + '</div>'
-    + '<div style="max-height:260px;overflow-y:auto;background:var(--bg-secondary);'
-    + 'border-radius:6px;padding:8px;color:var(--text-primary)">' + html + '</div>';
 }
 
 // Debrief-transcript per-segment override picker (#648). Same flow as the
@@ -3721,7 +3822,7 @@ async function loadMultiChannelAudio() {
           _mcStopProgressTick();
         }
       });
-      const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`).join(', ');
+      const labels = siblings.map(s => s.position_name || `R${(Number(s.ordinal) || 0) + 1}`).join(', ');
       document.getElementById('mc-status').textContent =
         `${siblings.length} receivers (${labels}) — streaming mode — click a transcript segment to isolate that mic.`;
       _mcUpdateProgress();
@@ -3752,7 +3853,7 @@ async function loadMultiChannelAudio() {
         return g;
       });
       _mcMerger.connect(_mcCtx.destination);
-      const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`).join(', ');
+      const labels = siblings.map(s => s.position_name || `R${(Number(s.ordinal) || 0) + 1}`).join(', ');
       document.getElementById('mc-status').textContent =
         `${siblings.length} receivers (${labels}) — click a transcript segment to isolate that mic.`;
       _mcUpdateProgress();

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2976,8 +2976,33 @@ async function _loadDebriefTranscript(audioSessionId) {
     html = '<span style="color:var(--text-secondary)">(empty)</span>';
   }
   body.innerHTML =
-    '<div style="max-height:260px;overflow-y:auto;background:var(--bg-secondary);'
+    '<div style="display:flex;justify-content:flex-end;margin-bottom:4px">'
+    + '<button class="btn-export" style="font-size:.7rem" '
+    + 'onclick="retranscribeDebrief(' + audioSessionId + ')" '
+    + 'title="Re-run transcription with diarization so crew sharing a mic get separate speaker labels">'
+    + '&#8635; Retranscribe with diarization</button>'
+    + '</div>'
+    + '<div style="max-height:260px;overflow-y:auto;background:var(--bg-secondary);'
     + 'border-radius:6px;padding:8px;color:var(--text-primary)">' + html + '</div>';
+}
+
+async function retranscribeDebrief(audioSessionId) {
+  if (!confirm(
+    'Re-run transcription with diarization? The existing debrief transcript will be replaced. '
+    + 'This takes a few minutes on the remote worker.'
+  )) return;
+  const body = document.getElementById('debrief-transcript-body');
+  if (body) {
+    body.innerHTML = '<span style="color:var(--warning)">Starting retranscription…</span>';
+  }
+  const r = await fetch('/api/audio/' + audioSessionId + '/retranscribe', { method: 'POST' });
+  if (!r.ok) {
+    if (body) {
+      body.innerHTML = '<span style="color:var(--danger)">Failed to start retranscription</span>';
+    }
+    return;
+  }
+  _loadDebriefTranscript(audioSessionId);
 }
 
 async function startDebriefTranscript(audioSessionId) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -205,11 +205,23 @@ let _lastTranscriptProgrammaticScrollAt = 0;
 // Scroll the transcript container so the active segment is visible — without
 // ever calling scrollIntoView() (which can jerk the whole page when the
 // container itself isn't fully in view). Returns true if a scroll happened.
+//
+// Uses getBoundingClientRect (#648) instead of offsetTop because offsetTop is
+// relative to the nearest *positioned* ancestor, which is not always the
+// scroll container — when it isn't, assigning the raw offsetTop to
+// container.scrollTop lands at a wildly wrong position (the symptom the user
+// reported as "transcript jumps to god only knows where").
 function _scrollTranscriptSegmentIntoView(container, el) {
   if (!_transcriptFollow) return false;
   const margin = 4;
-  const top = el.offsetTop - margin;
-  const bottom = el.offsetTop + el.offsetHeight + margin;
+  const cRect = container.getBoundingClientRect();
+  const eRect = el.getBoundingClientRect();
+  // Position of the segment relative to the container's *content*, regardless
+  // of offsetParent topology.
+  const relTop = eRect.top - cRect.top + container.scrollTop;
+  const relBottom = relTop + el.offsetHeight;
+  const top = relTop - margin;
+  const bottom = relBottom + margin;
   let target = null;
   if (top < container.scrollTop) {
     target = top;
@@ -2651,28 +2663,230 @@ function _renderDebriefPlayer() {
   const wrap = document.createElement('div');
   wrap.id = 'debrief-player';
   wrap.style.marginTop = '10px';
+  const siblings = Array.isArray(deb.siblings) ? deb.siblings : [];
+  if (siblings.length > 1) {
+    _renderDebriefMultiChannel(wrap, deb, siblings);
+  } else {
+    wrap.innerHTML =
+      '<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:4px">'
+      + 'Debrief</div>'
+      + '<div style="display:flex;align-items:center;gap:8px">'
+      + '<audio id="debrief-audio" controls preload="metadata" style="flex:1;min-width:0">'
+      + '<source src="' + deb.stream_url + '" type="audio/wav"></audio>'
+      + '<a class="btn-sm" href="/api/audio/' + deb.audio_session_id + '/download" '
+      + 'style="font-size:.72rem;text-decoration:none" title="Download debrief WAV">&#8595;</a>'
+      + '</div>'
+      + '<div class="section-title" style="margin-top:12px;cursor:pointer" '
+      + 'onclick="toggleSection(\'debrief-transcript\')">'
+      + 'Transcript <span id="debrief-transcript-toggle">&#9660;</span></div>'
+      + '<div class="section-body" id="debrief-transcript-body" style="font-size:.78rem">'
+      + '<span style="color:var(--text-secondary)">Loading transcript\u2026</span>'
+      + '</div>';
+  }
+  card.appendChild(wrap);
+  _loadDebriefTranscript(deb.audio_session_id);
+}
+
+// ---------------------------------------------------------------------------
+// Debrief multi-channel player (#648)
+//
+// Mirrors the race multi-channel player but uses plain <audio> elements
+// (one per sibling) + .muted for isolation, instead of the Web Audio
+// decodeAudioData path. Plenty for the debrief UX -- sticky isolation +
+// channel mixing -- and works for any length without memory ballooning.
+// ---------------------------------------------------------------------------
+
+let _dmcEls = [];
+let _dmcIsolated = null;
+let _dmcSticky = false;
+let _dmcIsolationTimer = null;
+let _dmcDurationS = 0;
+let _dmcSiblings = [];
+
+function _renderDebriefMultiChannel(wrap, deb, siblings) {
+  _dmcSiblings = siblings;
+  _dmcEls = [];
+  _dmcIsolated = null;
+  _dmcSticky = false;
+  _dmcDurationS = 0;
+  const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`);
+  const downloadHref = '/api/audio/' + deb.audio_session_id + '/download';
   wrap.innerHTML =
     '<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:4px">'
-    + 'Debrief</div>'
-    + '<div style="display:flex;align-items:center;gap:8px">'
-    + '<audio id="debrief-audio" controls preload="metadata" style="flex:1;min-width:0">'
-    + '<source src="' + deb.stream_url + '" type="audio/wav"></audio>'
-    + '<a class="btn-sm" href="/api/audio/' + deb.audio_session_id + '/download" '
-    + 'style="font-size:.72rem;text-decoration:none" title="Download debrief WAV">&#8595;</a>'
+    + 'Debrief \u2014 ' + siblings.length + ' receivers (' + labels.map(esc).join(', ') + ')'
     + '</div>'
+    + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">'
+    + '<button id="dmc-playpause" class="btn-sm" onclick="_dmcTogglePlay()" '
+    + 'style="font-size:1.1rem;padding:4px 12px">&#9654;</button>'
+    + '<input id="dmc-seek" type="range" min="0" max="1000" value="0" '
+    + 'style="flex:1;min-width:160px" oninput="_dmcSeekFromSlider(this.value)">'
+    + '<span id="dmc-time" style="font-size:.78rem;color:var(--text-secondary);'
+    + 'min-width:80px;text-align:right">0:00 / 0:00</span>'
+    + '<a class="btn-sm" href="' + downloadHref + '" '
+    + 'style="font-size:.72rem;text-decoration:none" title="Download debrief primary WAV">&#8595;</a>'
+    + '</div>'
+    + '<div style="display:flex;align-items:center;gap:10px;margin-top:6px;'
+    + 'font-size:.78rem;color:var(--text-secondary);flex-wrap:wrap">'
+    + '<label><input id="dmc-sticky" type="checkbox" onchange="_dmcToggleSticky(this.checked)"> '
+    + 'Sticky isolation</label>'
+    + '<button class="btn-sm" onclick="_dmcSetIsolation(null)">All channels</button>'
+    + siblings.map((s, i) =>
+      '<button class="btn-sm" onclick="_dmcSetIsolation(' + i + ')">' + esc(labels[i]) + '</button>'
+    ).join('')
+    + '<span id="dmc-isolation-indicator">mixed</span>'
+    + '</div>'
+    // Hidden <audio> elements, one per sibling -- driven in parallel.
+    + siblings.map(s =>
+      '<audio id="dmc-sib-' + s.ordinal + '" preload="metadata" src="' + esc(s.stream_url)
+      + '" style="display:none"></audio>'
+    ).join('')
     + '<div class="section-title" style="margin-top:12px;cursor:pointer" '
     + 'onclick="toggleSection(\'debrief-transcript\')">'
     + 'Transcript <span id="debrief-transcript-toggle">&#9660;</span></div>'
     + '<div class="section-body" id="debrief-transcript-body" style="font-size:.78rem">'
     + '<span style="color:var(--text-secondary)">Loading transcript\u2026</span>'
     + '</div>';
-  card.appendChild(wrap);
-  _loadDebriefTranscript(deb.audio_session_id);
 }
 
-// Seek the debrief <audio> element to `t` seconds and start playback.
-// Used as the onclick target for transcript segments in the debrief panel.
-function seekDebriefAudio(t) {
+function _dmcInit() {
+  // Resolve element handles + wire listeners. Safe to re-call; each element
+  // is wired at most once via a property flag. Returns true when all
+  // siblings have been resolved in the DOM.
+  if (!_dmcSiblings.length) return false;
+  _dmcEls = _dmcSiblings.map(s => document.getElementById('dmc-sib-' + s.ordinal));
+  if (_dmcEls.some(e => !e)) return false;
+  _dmcEls.forEach(el => {
+    if (el._dmcWired) return;
+    el._dmcWired = true;
+    el.addEventListener('loadedmetadata', () => {
+      if (isFinite(el.duration) && el.duration > _dmcDurationS) {
+        _dmcDurationS = el.duration;
+        _dmcUpdateProgress();
+      }
+    });
+  });
+  const primary = _dmcEls[0];
+  if (!primary._dmcPrimaryWired) {
+    primary._dmcPrimaryWired = true;
+    primary.addEventListener('timeupdate', () => {
+      _dmcUpdateProgress();
+      const t = primary.currentTime;
+      for (let i = 1; i < _dmcEls.length; i++) {
+        if (Math.abs(_dmcEls[i].currentTime - t) > 0.2) {
+          try { _dmcEls[i].currentTime = t; } catch (e) { /* swallow */ }
+        }
+      }
+    });
+    primary.addEventListener('ended', () => {
+      _dmcEls.forEach(el => { try { el.pause(); } catch (e) { /* swallow */ } });
+      const btn = document.getElementById('dmc-playpause');
+      if (btn) btn.innerHTML = '&#9654;';
+    });
+  }
+  return true;
+}
+
+function _dmcTogglePlay() {
+  if (!_dmcInit()) return;
+  const btn = document.getElementById('dmc-playpause');
+  if (_dmcEls[0].paused) {
+    _dmcEls.forEach(el => {
+      const p = el.play();
+      if (p && typeof p.catch === 'function') p.catch(() => { /* autoplay blocked */ });
+    });
+    if (btn) btn.innerHTML = '&#9208;';
+  } else {
+    _dmcEls.forEach(el => { try { el.pause(); } catch (e) { /* swallow */ } });
+    if (btn) btn.innerHTML = '&#9654;';
+  }
+}
+
+function _dmcSeekFromSlider(val) {
+  if (!_dmcInit() || !_dmcDurationS) return;
+  const t = (Number(val) / 1000) * _dmcDurationS;
+  _dmcEls.forEach(el => { try { el.currentTime = t; } catch (e) { /* swallow */ } });
+}
+
+function _dmcUpdateProgress() {
+  const seek = document.getElementById('dmc-seek');
+  const time = document.getElementById('dmc-time');
+  if (!seek || !time || !_dmcEls.length) return;
+  const t = _dmcEls[0].currentTime || 0;
+  if (_dmcDurationS > 0) seek.value = String((t / _dmcDurationS) * 1000);
+  const fmt = s => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+  time.textContent = `${fmt(t)} / ${fmt(_dmcDurationS)}`;
+}
+
+function _dmcSetIsolation(idx) {
+  if (!_dmcInit()) return;
+  _dmcIsolated = idx;
+  _dmcEls.forEach((el, i) => {
+    el.muted = idx !== null && i !== idx;
+  });
+  const ind = document.getElementById('dmc-isolation-indicator');
+  if (ind) {
+    if (idx === null) {
+      ind.textContent = 'mixed';
+    } else {
+      const label = (_dmcSiblings[idx] && _dmcSiblings[idx].position_name) || `sib${idx}`;
+      ind.textContent = 'isolated: ' + label;
+    }
+  }
+}
+
+function _dmcToggleSticky(on) {
+  _dmcSticky = !!on;
+  if (!_dmcSticky) {
+    if (_dmcIsolationTimer) {
+      clearTimeout(_dmcIsolationTimer);
+      _dmcIsolationTimer = null;
+    }
+    _dmcSetIsolation(null);
+  }
+}
+
+// Called by debrief transcript segment clicks -- seeks all <audio> els to
+// startSec, starts playback, optionally isolates a channel for the segment's
+// duration (or permanently when sticky).
+function _dmcOnSegmentClick(channelIdx, startSec, endSec) {
+  if (!_dmcInit()) return;
+  const t = Math.max(0, Number(startSec) || 0);
+  _dmcEls.forEach(el => { try { el.currentTime = t; } catch (e) { /* swallow */ } });
+  _dmcEls.forEach(el => {
+    const p = el.play();
+    if (p && typeof p.catch === 'function') p.catch(() => { /* swallow */ });
+  });
+  const btn = document.getElementById('dmc-playpause');
+  if (btn) btn.innerHTML = '&#9208;';
+  if (typeof channelIdx === 'number' && channelIdx >= 0) {
+    if (_dmcIsolationTimer) {
+      clearTimeout(_dmcIsolationTimer);
+      _dmcIsolationTimer = null;
+    }
+    _dmcSetIsolation(channelIdx);
+    if (!_dmcSticky) {
+      const durMs = Math.max(500, ((Number(endSec) || 0) - t) * 1000);
+      _dmcIsolationTimer = setTimeout(() => {
+        _dmcSetIsolation(null);
+        _dmcIsolationTimer = null;
+      }, durMs);
+    }
+  }
+}
+
+// Seek the debrief audio to `t` seconds and start playback. When the debrief
+// is multi-sibling (#648), hand off to the sibling coordinator so isolation +
+// sticky apply on transcript clicks. Single-stream debriefs drop through to
+// the plain <audio> element.
+function seekDebriefAudio(t, channelIdx) {
+  if (_dmcSiblings && _dmcSiblings.length > 1) {
+    _dmcOnSegmentClick(
+      typeof channelIdx === 'number' ? channelIdx : -1,
+      t,
+      t,
+    );
+    return;
+  }
   const el = document.getElementById('debrief-audio');
   if (!el) return;
   try {
@@ -2726,13 +2940,18 @@ async function _loadDebriefTranscript(audioSessionId) {
   const segStyle =
     'margin-bottom:3px;cursor:pointer;padding:2px 4px;border-radius:3px';
   let html = '';
+  // Resolve the per-segment channel index (#648) so transcript clicks can
+  // isolate the right mic on the multi-sibling debrief player.
+  const chOf = s => (s.channel_index !== undefined && s.channel_index !== null)
+    ? Number(s.channel_index) : -1;
   if (segs.length && segs.some(s => s.speaker)) {
     html = segs.map(s => {
       const start = Number(s.start) || 0;
+      const ch = chOf(s);
       const who = s.speaker
         ? '<span style="color:var(--accent)">' + esc(displayName(s.speaker)) + ':</span> '
         : '';
-      return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ')" '
+      return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
         + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
         + 'onmouseout="this.style.background=\'transparent\'" '
         + 'title="Click to play from here">'
@@ -2743,7 +2962,8 @@ async function _loadDebriefTranscript(audioSessionId) {
   } else if (segs.length) {
     html = segs.map(s => {
       const start = Number(s.start) || 0;
-      return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ')" '
+      const ch = chOf(s);
+      return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
         + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
         + 'onmouseout="this.style.background=\'transparent\'" '
         + 'title="Click to play from here">'
@@ -2905,9 +3125,27 @@ let _mcRafHandle = null;
 let _mcStreamMode = false;
 let _mcAudioEls = [];
 let _mcMediaSources = [];
+// Target of a just-issued seek in streaming mode. Reads of
+// _mcAudioEls[0].currentTime can be briefly stale during the Chrome seek
+// cycle (we've seen reads return the pre-seek time for ~50 ms after a click),
+// which shipped the transcript consumer a stale `local` and caused the
+// auto-scroll to jump to the wrong place. While a seek is in flight we hand
+// out the authoritative target instead.
+let _mcPendingSeekTarget = null;
+let _mcPendingSeekClearAt = 0;
 
 function _mcCurrentTime() {
   if (_mcStreamMode) {
+    // During an in-flight seek, primary.currentTime can briefly report stale
+    // values — prefer the pending target so the transcript scroll lands at
+    // the clicked segment instead of the pre-click playhead (#648).
+    if (_mcPendingSeekTarget !== null) {
+      if (_clockNowMs() >= _mcPendingSeekClearAt) {
+        _mcPendingSeekTarget = null;
+      } else {
+        return _mcPendingSeekTarget;
+      }
+    }
     const el = _mcAudioEls[0];
     return el ? el.currentTime : _mcStartOffset;
   }
@@ -2942,6 +3180,8 @@ function _mcRebuildSource(offsetSeconds) {
   // Streaming mode (#648): seek every <audio> element and start playback
   // on all. Drift correction happens in the progress tick.
   if (_mcStreamMode) {
+    _mcPendingSeekTarget = offsetSeconds;
+    _mcPendingSeekClearAt = _clockNowMs() + 500;
     _mcAudioEls.forEach(el => {
       try { el.currentTime = offsetSeconds; } catch (e) { /* not seekable yet */ }
     });
@@ -3049,11 +3289,17 @@ function _mcSeek(toSeconds) {
   if (!_mcCtx || !_mcBuffer) return;
   const clamped = Math.max(0, Math.min(_mcBuffer.duration, toSeconds));
   if (_mcStreamMode) {
+    _mcPendingSeekTarget = clamped;
+    _mcPendingSeekClearAt = _clockNowMs() + 500;  // clear within one RAF batch
     _mcAudioEls.forEach(el => {
       try { el.currentTime = clamped; } catch (e) { /* not seekable yet */ }
     });
     if (!_mcIsPlaying) _mcStartOffset = clamped;
     _mcUpdateProgress();
+    // Force the transcript consumer to re-pick an active block on the next
+    // tick, even if we happen to pick the same DOM index — guarantees the
+    // scroll lands at the clicked target.
+    _lastActiveTranscriptIdx = -1;
     return;
   }
   if (_mcIsPlaying) {
@@ -3062,6 +3308,7 @@ function _mcSeek(toSeconds) {
     _mcStartOffset = clamped;
   }
   _mcUpdateProgress();
+  _lastActiveTranscriptIdx = -1;
 }
 
 function _mcUpdateButtons() {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2914,36 +2914,46 @@ function _renderDebriefPlayer() {
   const deb = _session && _session.debrief_audio;
   if (!deb) return;
   // Anchor to #audio-card (not #audio-body) so the debrief subsection lands
-  // after the race transcript that now lives inside the same card. Otherwise
-  // the debrief gets sandwiched between the race player and its transcript.
+  // after the race transcript that now lives inside the same card.
   const card = document.getElementById('audio-card');
   if (!card) return;
   const existing = document.getElementById('debrief-player');
   if (existing) existing.remove();
   const wrap = document.createElement('div');
   wrap.id = 'debrief-player';
-  wrap.style.marginTop = '10px';
+
+  // #648: collapsible "Debrief Audio" header matches the "Race Audio" section
+  // above so the two audio blocks read as peer sections at the same visual
+  // weight. Player + transcript both live inside the body so they collapse
+  // together.
+  wrap.innerHTML =
+    '<div class="section-title" style="margin-top:14px;cursor:pointer" '
+    + 'onclick="toggleSection(\'debrief-audio\')">'
+    + 'Debrief Audio <span id="debrief-audio-toggle">&#9660;</span></div>'
+    + '<div class="section-body" id="debrief-audio-body">'
+    + '<div id="debrief-audio-inner"></div>'
+    + '<div class="section-title" style="margin-top:12px;cursor:pointer" '
+    + 'onclick="toggleSection(\'debrief-transcript\')">'
+    + 'Transcript <span id="debrief-transcript-toggle">&#9660;</span></div>'
+    + '<div class="section-body" id="debrief-transcript-body" style="font-size:.78rem">'
+    + '<span style="color:var(--text-secondary)">Loading transcript\u2026</span>'
+    + '</div>'
+    + '</div>';
+  card.appendChild(wrap);
+
+  const inner = document.getElementById('debrief-audio-inner');
   const siblings = Array.isArray(deb.siblings) ? deb.siblings : [];
   if (siblings.length > 1) {
-    _renderDebriefMultiChannel(wrap, deb, siblings);
+    _renderDebriefMultiChannel(inner, deb, siblings);
   } else {
-    wrap.innerHTML =
-      '<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:4px">'
-      + 'Debrief</div>'
-      + '<div style="display:flex;align-items:center;gap:8px">'
+    inner.innerHTML =
+      '<div style="display:flex;align-items:center;gap:8px">'
       + '<audio id="debrief-audio" controls preload="metadata" style="flex:1;min-width:0">'
       + '<source src="' + deb.stream_url + '" type="audio/wav"></audio>'
       + '<a class="btn-sm" href="/api/audio/' + deb.audio_session_id + '/download" '
       + 'style="font-size:.72rem;text-decoration:none" title="Download debrief WAV">&#8595;</a>'
-      + '</div>'
-      + '<div class="section-title" style="margin-top:12px;cursor:pointer" '
-      + 'onclick="toggleSection(\'debrief-transcript\')">'
-      + 'Transcript <span id="debrief-transcript-toggle">&#9660;</span></div>'
-      + '<div class="section-body" id="debrief-transcript-body" style="font-size:.78rem">'
-      + '<span style="color:var(--text-secondary)">Loading transcript\u2026</span>'
       + '</div>';
   }
-  card.appendChild(wrap);
   _loadDebriefTranscript(deb.audio_session_id);
 }
 
@@ -2972,10 +2982,7 @@ function _renderDebriefMultiChannel(wrap, deb, siblings) {
   const labels = siblings.map(s => s.position_name || `R${(Number(s.ordinal) || 0) + 1}`);
   const downloadHref = '/api/audio/' + deb.audio_session_id + '/download';
   wrap.innerHTML =
-    '<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:4px">'
-    + 'Debrief \u2014 ' + siblings.length + ' receivers (' + labels.map(esc).join(', ') + ')'
-    + '</div>'
-    + '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">'
+    '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">'
     + '<button id="dmc-playpause" class="btn-sm" onclick="_dmcTogglePlay()" '
     + 'style="font-size:1.1rem;padding:4px 12px">&#9654;</button>'
     + '<input id="dmc-seek" type="range" min="0" max="1000" value="0" '
@@ -2999,13 +3006,7 @@ function _renderDebriefMultiChannel(wrap, deb, siblings) {
     + siblings.map(s =>
       '<audio id="dmc-sib-' + s.ordinal + '" preload="metadata" src="' + esc(s.stream_url)
       + '" style="display:none"></audio>'
-    ).join('')
-    + '<div class="section-title" style="margin-top:12px;cursor:pointer" '
-    + 'onclick="toggleSection(\'debrief-transcript\')">'
-    + 'Transcript <span id="debrief-transcript-toggle">&#9660;</span></div>'
-    + '<div class="section-body" id="debrief-transcript-body" style="font-size:.78rem">'
-    + '<span style="color:var(--text-secondary)">Loading transcript\u2026</span>'
-    + '</div>';
+    ).join('');
 }
 
 function _dmcInit() {
@@ -3549,9 +3550,17 @@ function _mcSetIsolation(channelIndex) {
   });
   const ind = document.getElementById('mc-isolation-indicator');
   if (ind) {
-    ind.textContent = channelIndex === null
-      ? 'mixed'
-      : `isolated: CH${channelIndex}`;
+    if (channelIndex === null) {
+      ind.textContent = 'mixed';
+    } else {
+      // Prefer the configured position_name (R1 / R2 / "helm pair" / …) —
+      // matches the debrief's isolation indicator format (#648).
+      const sib = _session
+        && Array.isArray(_session.audio_siblings)
+        && _session.audio_siblings[channelIndex];
+      const label = (sib && sib.position_name) || ('R' + (channelIndex + 1));
+      ind.textContent = 'isolated: ' + label;
+    }
   }
 }
 
@@ -3770,6 +3779,12 @@ async function loadMultiChannelAudio() {
     '<div style="display:flex;align-items:center;gap:10px;margin-top:6px;font-size:.78rem;color:var(--text-secondary)">' +
     '<label><input id="mc-sticky" type="checkbox" onchange="_mcToggleSticky(this.checked)"> Sticky isolation</label>' +
     '<button class="btn-sm" onclick="_mcSetIsolation(null)">All channels</button>' +
+    ((_session && Array.isArray(_session.audio_siblings) && _session.audio_siblings.length > 1)
+      ? _session.audio_siblings.map((s, i) =>
+          '<button class="btn-sm" onclick="_mcSetIsolation(' + i + ')">'
+          + esc(s.position_name || ('R' + (i + 1))) + '</button>'
+        ).join('')
+      : '') +
     '<span id="mc-isolation-indicator">mixed</span>' +
     '</div>' +
     '<div id="mc-status" style="font-size:.78rem;color:var(--text-secondary);margin-top:4px">Loading audio…</div>';

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2426,14 +2426,28 @@ function _renderDiarizedTranscript(body, t) {
   const blocks = [];
   for (const seg of t.segments) {
     const last = blocks[blocks.length - 1];
-    // Group by both speaker and channel so multi-channel sessions don't
-    // collapse adjacent same-speaker utterances from different mics.
+    // Group by speaker, channel, AND override status so a single segment
+    // override (#648) visually breaks out of its block instead of being
+    // hidden under the parent speaker's label.
     const sameBlock = last
       && last.speaker === seg.speaker
-      && last.channel_index === seg.channel_index;
+      && last.channel_index === seg.channel_index
+      && (last.override_user_id || null) === (seg.override_user_id || null);
     if (sameBlock) {
-      last.text += ' ' + seg.text; last.end = seg.end;
-    } else { blocks.push({...seg}); }
+      last.text += ' ' + seg.text;
+      last.end = seg.end;
+      last._segRefs.push({
+        audio_session_id: seg.audio_session_id,
+        segment_index: seg.segment_index,
+      });
+    } else {
+      const block = {...seg};
+      block._segRefs = [{
+        audio_session_id: seg.audio_session_id,
+        segment_index: seg.segment_index,
+      }];
+      blocks.push(block);
+    }
   }
   _transcriptBlocks = blocks;
   const rawSpeakers = [...new Set(t.segments.map(s => s.speaker))];
@@ -2462,13 +2476,32 @@ function _renderDiarizedTranscript(body, t) {
     + 'title="Auto-scrolling to active segment. Click to pause.">\u25C9 Follow</button>'
     + '</div>'
     + '<div id="transcript-segments" style="max-height:400px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">'
-    + blocks.map((b, i) =>
-      '<div class="transcript-seg" data-idx="' + i + '" style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;transition:background .15s" onclick="playTranscriptSegment(' + i + ')">'
-      + '<span class="transcript-speaker" data-speaker="' + esc(b.speaker) + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" onclick="event.stopPropagation();openSpeakerPicker(\'' + esc(b.speaker) + '\')" title="Click to assign crew">' + esc(displayName(b.speaker)) + '</span>'
-      + '<span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">[' + fmt(b.start) + ']</span>'
-      + '<div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">' + esc(b.text.trim()) + '</div>'
-      + '</div>'
-    ).join('')
+    + blocks.map((b, i) => {
+      const speakerHtml = b.override_user_id
+        ? '<span class="transcript-speaker" data-speaker="' + esc(b.speaker)
+          + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;'
+          + 'font-style:italic" title="Overridden from ' + esc(displayName(b.speaker))
+          + ' — click ✎ to change">'
+          + esc(b.override_name || '') + '</span>'
+        : '<span class="transcript-speaker" data-speaker="' + esc(b.speaker)
+          + '" style="color:' + color(b.speaker) + ';font-weight:600;font-size:.75rem;'
+          + 'cursor:pointer;text-decoration:underline dotted;text-underline-offset:2px" '
+          + 'onclick="event.stopPropagation();openSpeakerPicker(\'' + esc(b.speaker) + '\')" '
+          + 'title="Click to assign crew">'
+          + esc(displayName(b.speaker)) + '</span>';
+      return '<div class="transcript-seg" data-idx="' + i + '" '
+        + 'style="margin-bottom:8px;padding:4px 6px;border-radius:4px;cursor:pointer;'
+        + 'transition:background .15s" onclick="playTranscriptSegment(' + i + ')">'
+        + speakerHtml
+        + '<span style="color:var(--text-secondary);font-size:.7rem;margin-left:4px">['
+        + fmt(b.start) + ']</span>'
+        + ' <span class="transcript-seg-override" title="Override this segment only" '
+        + 'style="font-size:.7rem;cursor:pointer;color:var(--text-secondary);margin-left:4px" '
+        + 'onclick="event.stopPropagation();openSegmentOverridePicker(' + i + ')">&#9998;</span>'
+        + '<div style="color:var(--text-primary);font-size:.8rem;margin-top:2px">'
+        + esc(b.text.trim()) + '</div>'
+        + '</div>';
+    }).join('')
     + '</div>';
 
   // Register the diarized transcript as a playback-clock surface so it
@@ -2567,6 +2600,104 @@ function playTranscriptSegment(idx) {
     audioEl.currentTime = b.start;
     audioEl.play();
   }
+}
+
+// Open a picker to override the speaker for just this one block — covers
+// every underlying transcript_segments row in the block (#648). Called from
+// the ✎ pencil icon on each race transcript block.
+async function openSegmentOverridePicker(blockIdx) {
+  const block = _transcriptBlocks[blockIdx];
+  if (!block || !Array.isArray(block._segRefs) || !block._segRefs.length) return;
+  let users;
+  try {
+    const r = await fetch('/api/crew/users');
+    if (!r.ok) return;
+    users = (await r.json()).users || [];
+  } catch { return; }
+
+  const old = document.getElementById('speaker-picker');
+  if (old) old.remove();
+
+  const picker = document.createElement('div');
+  picker.id = 'speaker-picker';
+  picker.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);'
+    + 'background:var(--bg-primary);border:1px solid var(--border);border-radius:8px;'
+    + 'padding:16px;z-index:1000;box-shadow:0 4px 20px rgba(0,0,0,0.3);min-width:220px;'
+    + 'max-height:320px;overflow-y:auto';
+  let html =
+    '<div style="font-weight:600;margin-bottom:4px;font-size:.85rem">'
+    + 'Override speaker for this segment</div>'
+    + '<div style="color:var(--text-secondary);font-size:.72rem;margin-bottom:8px">'
+    + 'Only this one utterance — other segments with the same speaker are unchanged.'
+    + '</div>';
+  if (!users || !users.length) {
+    html += '<div style="color:var(--text-secondary);font-size:.8rem">No crew members found</div>';
+  } else {
+    for (const u of users) {
+      html += '<div class="speaker-pick-option" '
+        + 'style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" '
+        + 'onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" '
+        + 'onmouseout="this.style.background=\'\'" '
+        + 'onclick="applySegmentOverride(' + blockIdx + ',' + u.id + ')">'
+        + esc(u.name || u.email) + '</div>';
+    }
+  }
+  html += '<div style="display:flex;gap:6px;justify-content:flex-end;margin-top:8px">'
+    + '<button class="btn-export" style="font-size:.72rem" '
+    + 'onclick="applySegmentOverride(' + blockIdx + ',null)">Clear override</button>'
+    + '<button class="btn-export" style="font-size:.72rem" '
+    + 'onclick="document.getElementById(\'speaker-picker\').remove();'
+    + 'document.getElementById(\'speaker-picker-backdrop\').remove()">Cancel</button>'
+    + '</div>';
+  picker.innerHTML = html;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'speaker-picker-backdrop';
+  backdrop.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;'
+    + 'background:rgba(0,0,0,0.4);z-index:999';
+  backdrop.onclick = () => { picker.remove(); backdrop.remove(); };
+  document.body.appendChild(backdrop);
+  document.body.appendChild(picker);
+}
+
+async function applySegmentOverride(blockIdx, userId) {
+  const block = _transcriptBlocks[blockIdx];
+  if (!block || !Array.isArray(block._segRefs)) return;
+  const picker = document.getElementById('speaker-picker');
+  const backdrop = document.getElementById('speaker-picker-backdrop');
+  if (picker) picker.remove();
+  if (backdrop) backdrop.remove();
+
+  // Fire one POST per underlying segment. Same response on every call.
+  let lastName = null;
+  for (const ref of block._segRefs) {
+    try {
+      const r = await fetch(
+        '/api/audio/' + ref.audio_session_id
+        + '/transcript/segments/' + ref.segment_index + '/speaker-override',
+        {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({user_id: userId}),
+        },
+      );
+      if (r.ok) {
+        const data = await r.json();
+        lastName = data && data.name;
+      }
+    } catch (e) { /* keep going */ }
+  }
+  // Update block state in place so render reflects without a full reload.
+  if (userId === null) {
+    delete block.override_user_id;
+    delete block.override_name;
+  } else {
+    block.override_user_id = userId;
+    block.override_name = lastName;
+  }
+  // Cheap path — re-run the transcript loader so the block splits update
+  // correctly (override status is part of the grouping key).
+  loadTranscript();
 }
 
 async function openSpeakerPicker(speakerLabel, audioSessionId) {
@@ -2963,16 +3094,33 @@ async function _loadDebriefTranscript(audioSessionId) {
     html = segs.map(s => {
       const start = Number(s.start) || 0;
       const ch = chOf(s);
-      // Speaker name is clickable — opens the crew picker and routes the
-      // eventual POST to the debrief's audio_session_id (#648).
-      const who = s.speaker
-        ? '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
+      // Override (#648): if a per-segment override is set, show that name
+      // italicized instead of the label's crew assignment; otherwise the
+      // speaker name opens the crew picker (label-wide) like before.
+      let who = '';
+      if (s.override_user_id && s.override_name) {
+        who = '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
+          + '" style="color:var(--accent);font-style:italic" '
+          + 'title="Overridden from ' + esc(displayName(s.speaker))
+          + ' — click ✎ to change">'
+          + esc(s.override_name) + ':</span> ';
+      } else if (s.speaker) {
+        who = '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
           + '" style="color:var(--accent);cursor:pointer;text-decoration:underline dotted;'
           + 'text-underline-offset:2px" '
           + 'onclick="event.stopPropagation();openSpeakerPicker(\''
           + esc(s.speaker) + '\',' + audioSessionId + ')" '
           + 'title="Click to assign crew">'
-          + esc(displayName(s.speaker)) + ':</span> '
+          + esc(displayName(s.speaker)) + ':</span> ';
+      }
+      const ovAsid = s.audio_session_id || audioSessionId;
+      const ovIdx = (s.segment_index !== undefined && s.segment_index !== null)
+        ? s.segment_index : -1;
+      const pencil = ovIdx >= 0
+        ? ' <span class="transcript-seg-override" title="Override this segment only" '
+          + 'style="font-size:.7rem;cursor:pointer;color:var(--text-secondary);margin-left:4px" '
+          + 'onclick="event.stopPropagation();'
+          + 'openDebriefSegmentOverridePicker(' + ovAsid + ',' + ovIdx + ')">&#9998;</span>'
         : '';
       return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
         + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
@@ -2980,7 +3128,7 @@ async function _loadDebriefTranscript(audioSessionId) {
         + 'title="Click to play from here">'
         + '<span style="color:var(--text-secondary);font-family:monospace">['
         + fmt(start) + ']</span> '
-        + who + esc(s.text || '') + '</div>';
+        + who + esc(s.text || '') + pencil + '</div>';
     }).join('');
   } else if (segs.length) {
     html = segs.map(s => {
@@ -3007,6 +3155,84 @@ async function _loadDebriefTranscript(audioSessionId) {
     + '</div>'
     + '<div style="max-height:260px;overflow-y:auto;background:var(--bg-secondary);'
     + 'border-radius:6px;padding:8px;color:var(--text-primary)">' + html + '</div>';
+}
+
+// Debrief-transcript per-segment override picker (#648). Same flow as the
+// race-transcript openSegmentOverridePicker but targets one debrief segment
+// directly (debrief renders per-segment, no grouping).
+async function openDebriefSegmentOverridePicker(audioSessionId, segmentIndex) {
+  let users;
+  try {
+    const r = await fetch('/api/crew/users');
+    if (!r.ok) return;
+    users = (await r.json()).users || [];
+  } catch { return; }
+
+  const old = document.getElementById('speaker-picker');
+  if (old) old.remove();
+
+  const picker = document.createElement('div');
+  picker.id = 'speaker-picker';
+  picker.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);'
+    + 'background:var(--bg-primary);border:1px solid var(--border);border-radius:8px;'
+    + 'padding:16px;z-index:1000;box-shadow:0 4px 20px rgba(0,0,0,0.3);min-width:220px;'
+    + 'max-height:320px;overflow-y:auto';
+  let html =
+    '<div style="font-weight:600;margin-bottom:4px;font-size:.85rem">'
+    + 'Override speaker for this segment</div>'
+    + '<div style="color:var(--text-secondary);font-size:.72rem;margin-bottom:8px">'
+    + 'Only this one utterance — other segments with the same speaker are unchanged.'
+    + '</div>';
+  if (!users || !users.length) {
+    html += '<div style="color:var(--text-secondary);font-size:.8rem">No crew members found</div>';
+  } else {
+    for (const u of users) {
+      html += '<div class="speaker-pick-option" '
+        + 'style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" '
+        + 'onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" '
+        + 'onmouseout="this.style.background=\'\'" '
+        + 'onclick="applyDebriefSegmentOverride('
+        + audioSessionId + ',' + segmentIndex + ',' + u.id + ')">'
+        + esc(u.name || u.email) + '</div>';
+    }
+  }
+  html += '<div style="display:flex;gap:6px;justify-content:flex-end;margin-top:8px">'
+    + '<button class="btn-export" style="font-size:.72rem" '
+    + 'onclick="applyDebriefSegmentOverride('
+    + audioSessionId + ',' + segmentIndex + ',null)">Clear override</button>'
+    + '<button class="btn-export" style="font-size:.72rem" '
+    + 'onclick="document.getElementById(\'speaker-picker\').remove();'
+    + 'document.getElementById(\'speaker-picker-backdrop\').remove()">Cancel</button>'
+    + '</div>';
+  picker.innerHTML = html;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'speaker-picker-backdrop';
+  backdrop.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;'
+    + 'background:rgba(0,0,0,0.4);z-index:999';
+  backdrop.onclick = () => { picker.remove(); backdrop.remove(); };
+  document.body.appendChild(backdrop);
+  document.body.appendChild(picker);
+}
+
+async function applyDebriefSegmentOverride(audioSessionId, segmentIndex, userId) {
+  const picker = document.getElementById('speaker-picker');
+  const backdrop = document.getElementById('speaker-picker-backdrop');
+  if (picker) picker.remove();
+  if (backdrop) backdrop.remove();
+  try {
+    await fetch(
+      '/api/audio/' + audioSessionId
+      + '/transcript/segments/' + segmentIndex + '/speaker-override',
+      {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({user_id: userId}),
+      },
+    );
+  } catch (e) { /* swallow */ }
+  const deb = _session && _session.debrief_audio;
+  if (deb) _loadDebriefTranscript(deb.audio_session_id);
 }
 
 async function retranscribeDebrief(audioSessionId) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2467,6 +2467,7 @@ function _renderDiarizedTranscript(body, t) {
 }
 
 let _transcriptSurfaceRegistered = false;
+let _lastActiveTranscriptIdx = -1;
 function _registerTranscriptSurface() {
   if (!_session || !_session.audio_start_utc) return;
   if (_transcriptSurfaceRegistered) return; // idempotent — transcript may re-render on poll
@@ -2479,18 +2480,43 @@ function _registerTranscriptSurface() {
   registerSurface('transcript', function(utc) {
     if (!_transcriptBlocks.length) return;
     const local = (utc.getTime() - audioStart.getTime()) / 1000;
-    const segs = document.querySelectorAll('.transcript-seg');
+
+    // Pick a single best-match block (#648): with merged sibling transcripts
+    // multiple blocks can cover the same instant, and highlighting + scrolling
+    // to every match yanked the scroll position to whichever one ran last in
+    // the loop. The "most recently started block that contains local" is
+    // stable and follows the speaker whose utterance actually started most
+    // recently — what a listener would expect to see in the auto-follow view.
+    let activeIdx = -1;
+    let bestStart = -Infinity;
     for (let i = 0; i < _transcriptBlocks.length; i++) {
       const b = _transcriptBlocks[i];
+      if (local >= b.start && local <= b.end && b.start > bestStart) {
+        activeIdx = i;
+        bestStart = b.start;
+      }
+    }
+
+    const segs = document.querySelectorAll('.transcript-seg');
+    for (let i = 0; i < segs.length; i++) {
       const el = segs[i];
       if (!el) continue;
-      if (local >= b.start && local <= b.end) {
-        el.style.background = 'var(--bg-hover, rgba(255,255,255,0.08))';
-        const container = document.getElementById('transcript-segments');
-        if (container) _scrollTranscriptSegmentIntoView(container, el);
-      } else {
-        el.style.background = '';
-      }
+      el.style.background = i === activeIdx
+        ? 'var(--bg-hover, rgba(255,255,255,0.08))'
+        : '';
+    }
+
+    // Only scroll when the active segment actually changes — scrolling every
+    // tick while the same block is playing caused the "transcript drifts away
+    // from playhead" jitter, because co-active blocks flipped the scroll
+    // target back and forth between their DOM positions.
+    if (activeIdx !== -1 && activeIdx !== _lastActiveTranscriptIdx) {
+      _lastActiveTranscriptIdx = activeIdx;
+      const container = document.getElementById('transcript-segments');
+      const el = segs[activeIdx];
+      if (container && el) _scrollTranscriptSegmentIntoView(container, el);
+    } else if (activeIdx === -1) {
+      _lastActiveTranscriptIdx = -1;
     }
   });
 }

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2871,8 +2871,20 @@ let _mcBuffers = [];
 let _mcSources = [];
 let _mcSticky = false;
 let _mcRafHandle = null;
+// Streaming mode (#648): for sessions over AUDIO_STREAM_THRESHOLD_MINUTES we
+// play each sibling through an HTMLAudioElement + MediaElementAudioSourceNode
+// instead of decodeAudioData, so memory stays flat regardless of session
+// length. Sync is approximate (browser nudges, not sample-accurate), which is
+// fine for lavalier mic audio but would be wrong for music.
+let _mcStreamMode = false;
+let _mcAudioEls = [];
+let _mcMediaSources = [];
 
 function _mcCurrentTime() {
+  if (_mcStreamMode) {
+    const el = _mcAudioEls[0];
+    return el ? el.currentTime : _mcStartOffset;
+  }
   if (!_mcCtx || !_mcBuffer) return 0;
   if (!_mcIsPlaying) return _mcStartOffset;
   return _mcStartOffset + (_mcCtx.currentTime - _mcStartTime);
@@ -2901,6 +2913,22 @@ function _mcClearTimer() {
 }
 
 function _mcRebuildSource(offsetSeconds) {
+  // Streaming mode (#648): seek every <audio> element and start playback
+  // on all. Drift correction happens in the progress tick.
+  if (_mcStreamMode) {
+    _mcAudioEls.forEach(el => {
+      try { el.currentTime = offsetSeconds; } catch (e) { /* not seekable yet */ }
+    });
+    _mcAudioEls.forEach(el => {
+      const p = el.play();
+      if (p && typeof p.catch === 'function') p.catch(() => { /* autoplay blocked */ });
+    });
+    _mcStartOffset = offsetSeconds;
+    _mcIsPlaying = true;
+    _mcUpdateButtons();
+    return;
+  }
+
   // Sibling-card mode: rebuild N BufferSources in parallel, started at the
   // same AudioContext time so all receivers stay sample-aligned (#509).
   if (_mcSiblings) {
@@ -2967,6 +2995,14 @@ function _mcPlay() {
 
 function _mcPause() {
   if (!_mcIsPlaying) return;
+  if (_mcStreamMode) {
+    _mcStartOffset = _mcCurrentTime();
+    _mcAudioEls.forEach(el => { try { el.pause(); } catch (e) { /* swallow */ } });
+    _mcIsPlaying = false;
+    _mcUpdateButtons();
+    _mcStopProgressTick();
+    return;
+  }
   if (_mcSiblings) {
     _mcStartOffset = _mcCurrentTime();
     _mcSources.forEach(s => { try { s.stop(); } catch (e) { /* swallow */ } });
@@ -2986,6 +3022,14 @@ function _mcPause() {
 function _mcSeek(toSeconds) {
   if (!_mcCtx || !_mcBuffer) return;
   const clamped = Math.max(0, Math.min(_mcBuffer.duration, toSeconds));
+  if (_mcStreamMode) {
+    _mcAudioEls.forEach(el => {
+      try { el.currentTime = clamped; } catch (e) { /* not seekable yet */ }
+    });
+    if (!_mcIsPlaying) _mcStartOffset = clamped;
+    _mcUpdateProgress();
+    return;
+  }
   if (_mcIsPlaying) {
     _mcRebuildSource(clamped);
   } else {
@@ -3010,15 +3054,30 @@ function _mcUpdateProgress() {
 }
 
 let _mcFanoutLast = 0;
+let _mcDriftCheckLast = 0;
 function _mcStartProgressTick() {
   _mcStopProgressTick();
   const tick = () => {
     _mcUpdateProgress();
+    // Streaming-mode drift correction (#648): HTMLAudioElements don't stay
+    // sample-accurate across siblings; nudge non-primary elements back in
+    // line with primary every 500 ms if drift exceeds 150 ms.
+    const now = _clockNowMs();
+    if (_mcStreamMode && _mcIsPlaying && _mcAudioEls.length > 1
+        && now - _mcDriftCheckLast >= 500) {
+      _mcDriftCheckLast = now;
+      const primaryT = _mcAudioEls[0].currentTime;
+      for (let i = 1; i < _mcAudioEls.length; i++) {
+        const el = _mcAudioEls[i];
+        if (Math.abs(el.currentTime - primaryT) > 0.15) {
+          try { el.currentTime = primaryT; } catch (e) { /* swallow */ }
+        }
+      }
+    }
     // Throttled producer fanout: while mc is playing, push the current
     // playhead out as a source='mc' update so the map cursor, gauges, and
     // replay scrubber track along. 150 ms matches the existing audio
     // fanout cadence.
-    const now = _clockNowMs();
     if (_mcIsPlaying && now - _mcFanoutLast >= 150) {
       _mcFanoutLast = now;
       const anchor = _mcSessionStart();
@@ -3056,6 +3115,10 @@ async function loadMultiChannelAudio() {
     '</div>' +
     '<div id="mc-status" style="font-size:.78rem;color:var(--text-secondary);margin-top:4px">Loading audio…</div>';
 
+  // Render the debrief player up front so a stuck / failed race-audio decode
+  // never hides a perfectly good debrief (#648).
+  _renderDebriefPlayer();
+
   try {
     const Ctx = window.AudioContext || window.webkitAudioContext;
     if (!Ctx) {
@@ -3065,9 +3128,61 @@ async function loadMultiChannelAudio() {
     }
     _mcCtx = new Ctx();
 
+    const siblings = _session && _session.audio_siblings;
+
+    // Streaming path (#648): for sessions at/above the server-configured
+    // threshold (AUDIO_STREAM_THRESHOLD_MINUTES), play each sibling through
+    // an HTMLAudioElement + MediaElementAudioSourceNode instead of
+    // decodeAudioData. Memory stays flat; seeking is byte-range-driven.
+    if (_session && _session.use_streaming_audio && siblings && siblings.length > 1) {
+      _mcStreamMode = true;
+      _mcSiblings = true;
+      _mcAudioEls = siblings.map(s => {
+        const el = new Audio();
+        el.preload = 'auto';
+        el.src = s.stream_url;
+        return el;
+      });
+      _mcMerger = _mcCtx.createChannelMerger(1);
+      _mcGains = _mcAudioEls.map(() => {
+        const g = _mcCtx.createGain();
+        g.gain.value = 1;
+        g.connect(_mcMerger, 0, 0);
+        return g;
+      });
+      _mcMerger.connect(_mcCtx.destination);
+      _mcMediaSources = _mcAudioEls.map((el, i) => {
+        const src = _mcCtx.createMediaElementSource(el);
+        src.connect(_mcGains[i]);
+        return src;
+      });
+      // Wait for metadata so we know the longest duration for the seek bar.
+      const durations = await Promise.all(_mcAudioEls.map(el => new Promise((resolve, reject) => {
+        if (el.readyState >= 1 && isFinite(el.duration)) return resolve(el.duration);
+        el.addEventListener('loadedmetadata', () => resolve(el.duration), {once: true});
+        el.addEventListener('error', () => reject(new Error('metadata load failed')), {once: true});
+      })));
+      const longest = durations.reduce((a, b) => (b > a ? b : a), 0);
+      _mcBuffer = {duration: longest};
+      // End detection on primary — mirrors the buffer-path ended handler.
+      _mcAudioEls[0].addEventListener('ended', () => {
+        if (!_mcIsPlaying) return;
+        if (_mcCurrentTime() >= _mcBuffer.duration - 0.1) {
+          _mcIsPlaying = false;
+          _mcStartOffset = 0;
+          _mcUpdateButtons();
+          _mcStopProgressTick();
+        }
+      });
+      const labels = siblings.map(s => s.position_name || `sib${s.ordinal}`).join(', ');
+      document.getElementById('mc-status').textContent =
+        `${siblings.length} receivers (${labels}) — streaming mode — click a transcript segment to isolate that mic.`;
+      _mcUpdateProgress();
+      return;
+    }
+
     // Sibling-card capture (#509): N mono WAVs, one BufferSource per
     // receiver, routed through per-source gains to a common mono merger.
-    const siblings = _session && _session.audio_siblings;
     if (siblings && siblings.length > 1) {
       _mcSiblings = true;
       const decoded = await Promise.all(siblings.map(async s => {
@@ -3094,7 +3209,6 @@ async function loadMultiChannelAudio() {
       document.getElementById('mc-status').textContent =
         `${siblings.length} receivers (${labels}) — click a transcript segment to isolate that mic.`;
       _mcUpdateProgress();
-      _renderDebriefPlayer();
       return;
     }
 
@@ -3120,7 +3234,6 @@ async function loadMultiChannelAudio() {
     document.getElementById('mc-status').textContent =
       `${channels}-channel session — click a transcript segment to isolate that channel.`;
     _mcUpdateProgress();
-    _renderDebriefPlayer();
   } catch (e) {
     console.error('multi-channel audio load failed', e);
     document.getElementById('mc-status').textContent = 'Error: ' + e.message;

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2438,7 +2438,18 @@ async function loadTranscript() {
   const hasDiarizedSegments = t.segments && t.segments.length > 0
     && t.segments.some(s => s.speaker);
   if (hasDiarizedSegments) {
-    _renderDiarizedTranscript(body, t);
+    // #648: render the retranscribe button above the shared pane render so
+    // the race transcript gets the same affordance the debrief has —
+    // there's always a way to re-run diarization from the transcript view.
+    body.innerHTML =
+      '<div style="display:flex;justify-content:flex-end;margin-bottom:4px">'
+      + '<button class="btn-export" style="font-size:.7rem" onclick="retranscribe()" '
+      + 'title="Re-run transcription with diarization so crew sharing a mic get separate speaker labels">'
+      + '&#8635; Retranscribe with diarization</button>'
+      + '</div>'
+      + '<div id="race-transcript-shared"></div>';
+    const shared = document.getElementById('race-transcript-shared');
+    _renderDiarizedTranscript(shared, t);
   } else {
     const text = t.text ? esc(t.text) : '(empty)';
     body.innerHTML = '<div style="font-size:.8rem;color:var(--text-primary);white-space:pre-wrap;max-height:300px;overflow-y:auto;background:var(--bg-secondary);border-radius:6px;padding:8px">' + text + '</div>'

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -2569,7 +2569,9 @@ function playTranscriptSegment(idx) {
   }
 }
 
-async function openSpeakerPicker(speakerLabel) {
+async function openSpeakerPicker(speakerLabel, audioSessionId) {
+  // audioSessionId routes the eventual POST to the right transcript when
+  // clicking on a debrief segment (#648). Omitted → defaults to the race.
   // Fetch crew list for the picker
   let users;
   try {
@@ -2587,12 +2589,13 @@ async function openSpeakerPicker(speakerLabel) {
   picker.id = 'speaker-picker';
   picker.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--bg-primary);border:1px solid var(--border);border-radius:8px;padding:16px;z-index:1000;box-shadow:0 4px 20px rgba(0,0,0,0.3);min-width:200px;max-height:300px;overflow-y:auto';
 
+  const sidArg = audioSessionId ? (',' + audioSessionId) : '';
   let html = '<div style="font-weight:600;margin-bottom:8px;font-size:.85rem">Assign ' + esc(speakerLabel) + ' to:</div>';
   if (!users || !users.length) {
     html += '<div style="color:var(--text-secondary);font-size:.8rem">No crew members found</div>';
   } else {
     for (const u of users) {
-      html += '<div class="speaker-pick-option" style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" onmouseout="this.style.background=\'\'" onclick="assignSpeaker(\'' + esc(speakerLabel) + '\',' + u.id + ')">' + esc(u.name || u.email) + '</div>';
+      html += '<div class="speaker-pick-option" style="padding:6px 8px;cursor:pointer;border-radius:4px;font-size:.8rem" onmouseover="this.style.background=\'var(--bg-hover, rgba(255,255,255,0.08))\'" onmouseout="this.style.background=\'\'" onclick="assignSpeaker(\'' + esc(speakerLabel) + '\',' + u.id + sidArg + ')">' + esc(u.name || u.email) + '</div>';
     }
   }
   html += '<div style="text-align:right;margin-top:8px"><button class="btn-export" style="font-size:.75rem" onclick="document.getElementById(\'speaker-picker\').remove()">Cancel</button></div>';
@@ -2607,8 +2610,11 @@ async function openSpeakerPicker(speakerLabel) {
   document.body.appendChild(picker);
 }
 
-async function assignSpeaker(speakerLabel, userId) {
-  const r = await fetch('/api/audio/' + _session.audio_session_id + '/transcript/assign-speaker', {
+async function assignSpeaker(speakerLabel, userId, audioSessionId) {
+  // audioSessionId defaults to the race primary so existing race-transcript
+  // calls keep working; the debrief transcript passes its own id (#648).
+  const sid = audioSessionId || _session.audio_session_id;
+  const r = await fetch('/api/audio/' + sid + '/transcript/assign-speaker', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({speaker_label: speakerLabel, user_id: userId})
@@ -2623,10 +2629,19 @@ async function assignSpeaker(speakerLabel, userId) {
   const data = await r.json();
   // Update speaker_map locally and re-render labels
   _speakerMap[speakerLabel] = {type: 'crew', user_id: data.user_id, name: data.name};
-  // Update all speaker labels in the transcript
-  document.querySelectorAll('.transcript-speaker[data-speaker="' + speakerLabel + '"]').forEach(el => {
+  // Update all speaker labels in the transcript(s). The race transcript uses
+  // .transcript-speaker spans; the debrief uses .debrief-transcript-speaker.
+  document.querySelectorAll(
+    '.transcript-speaker[data-speaker="' + speakerLabel + '"],' +
+    ' .debrief-transcript-speaker[data-speaker="' + speakerLabel + '"]'
+  ).forEach(el => {
     el.textContent = data.name;
   });
+  // Reload the debrief transcript so its own speakerMap updates too.
+  const debAudio = _session && _session.debrief_audio;
+  if (debAudio && typeof _loadDebriefTranscript === 'function') {
+    _loadDebriefTranscript(debAudio.audio_session_id);
+  }
 }
 
 async function startTranscript() {
@@ -2948,8 +2963,16 @@ async function _loadDebriefTranscript(audioSessionId) {
     html = segs.map(s => {
       const start = Number(s.start) || 0;
       const ch = chOf(s);
+      // Speaker name is clickable — opens the crew picker and routes the
+      // eventual POST to the debrief's audio_session_id (#648).
       const who = s.speaker
-        ? '<span style="color:var(--accent)">' + esc(displayName(s.speaker)) + ':</span> '
+        ? '<span class="debrief-transcript-speaker" data-speaker="' + esc(s.speaker)
+          + '" style="color:var(--accent);cursor:pointer;text-decoration:underline dotted;'
+          + 'text-underline-offset:2px" '
+          + 'onclick="event.stopPropagation();openSpeakerPicker(\''
+          + esc(s.speaker) + '\',' + audioSessionId + ')" '
+          + 'title="Click to assign crew">'
+          + esc(displayName(s.speaker)) + ':</span> '
         : '';
       return '<div style="' + segStyle + '" onclick="seekDebriefAudio(' + start + ',' + ch + ')" '
         + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -7430,30 +7430,30 @@ class Storage:
         return True
 
     async def get_transcript_with_anon(self, audio_session_id: int) -> dict[str, Any] | None:
-        """Get transcript with speaker_map and anonymization applied to segments.
+        """Get transcript with anonymization applied to segments.
 
-        Priority: anonymization (speaker_anon_map) > crew assignment (speaker_map).
+        Anonymization rewrites the raw speaker label + redacts text for
+        consent-revoked crew (PII concern). Crew-name substitution is
+        *NOT* applied here — it happens client-side via the speaker_map
+        the client already receives, so the server can keep the raw
+        ``sib0:SPEAKER_01``-style labels visible. That lets click-to-
+        assign round-trip cleanly: the label the UI posts back is the
+        same key the speaker_map is stored under (#648).
         """
         t = await self.get_transcript(audio_session_id)
         if t is None:
             return None
         anon_map: dict[str, str] = json.loads(t.get("speaker_anon_map") or "{}")
-        crew_map: dict[str, Any] = json.loads(t.get("speaker_map") or "{}")
-        if (anon_map or crew_map) and t.get("segments_json"):
+        if anon_map and t.get("segments_json"):
             segments = json.loads(t["segments_json"])
             for seg in segments:
                 speaker = seg.get("speaker", "")
                 if speaker in anon_map:
-                    # Anonymization takes priority
                     seg["speaker"] = anon_map[speaker]
                     seg["text"] = "[REDACTED]"
-                elif speaker in crew_map:
-                    entry = crew_map[speaker]
-                    if isinstance(entry, dict):
-                        seg["speaker"] = entry.get("name", speaker)
             t["segments_json"] = json.dumps(segments)
             # Also redact the plain text for anonymized speakers
-            if t.get("text") and anon_map:
+            if t.get("text"):
                 lines = t["text"].split("\n")
                 redacted_lines = []
                 for line in lines:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -200,7 +200,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 76
+_CURRENT_VERSION: int = 77
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1534,7 +1534,8 @@ _MIGRATIONS: dict[int, str] = {
             text          TEXT    NOT NULL,
             speaker       TEXT,
             channel_index INTEGER,
-            position_name TEXT
+            position_name TEXT,
+            override_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
         );
         CREATE INDEX IF NOT EXISTS idx_transcript_segments_transcript
             ON transcript_segments(transcript_id);
@@ -1761,6 +1762,15 @@ _MIGRATIONS: dict[int, str] = {
         -- Populated by enrichment (analysis/maneuvers.py), not by the
         -- detector. Null for rounding and other types.
         ALTER TABLE maneuvers ADD COLUMN head_to_wind_ts TEXT;
+    """,
+    77: """
+        -- #648: per-segment speaker override. Label-wide assignments via
+        -- speaker_map re-label every segment that shares the label. This
+        -- column lets a single segment point at a different crew member
+        -- without mutating the label or touching other segments. Null
+        -- means "use the label-wide speaker_map lookup".
+        ALTER TABLE transcript_segments ADD COLUMN override_user_id INTEGER
+            REFERENCES users(id) ON DELETE SET NULL;
     """,
 }
 
@@ -6120,12 +6130,58 @@ class Storage:
         """Return relational transcript segments for a transcript, ordered."""
         cur = await self._read_conn().execute(
             "SELECT id, transcript_id, segment_index, start_time, end_time,"
-            " text, speaker, channel_index, position_name"
+            " text, speaker, channel_index, position_name, override_user_id"
             " FROM transcript_segments WHERE transcript_id=?"
             " ORDER BY segment_index",
             (transcript_id,),
         )
         return [dict(r) for r in await cur.fetchall()]
+
+    async def set_segment_speaker_override(
+        self, transcript_id: int, segment_index: int, user_id: int | None
+    ) -> tuple[bool, str | None]:
+        """Set or clear the per-segment speaker override (#648).
+
+        Returns ``(found, name)`` — ``found`` is True if a segment row was
+        matched; ``name`` is the user's display name if ``user_id`` is set and
+        valid, else None (clearing the override). Passing ``user_id=None``
+        clears the override.
+        """
+        db = self._conn()
+        name: str | None = None
+        if user_id is not None:
+            ucur = await db.execute("SELECT name FROM users WHERE id = ?", (user_id,))
+            urow = await ucur.fetchone()
+            if urow is None:
+                return (False, None)
+            name = urow["name"] or f"User {user_id}"
+        cur = await db.execute(
+            "UPDATE transcript_segments SET override_user_id = ?"
+            " WHERE transcript_id = ? AND segment_index = ?",
+            (user_id, transcript_id, segment_index),
+        )
+        await db.commit()
+        return ((cur.rowcount or 0) > 0, name)
+
+    async def get_segment_overrides(self, transcript_id: int) -> dict[int, dict[str, Any]]:
+        """Return {segment_index: {"user_id", "name"}} for every segment in a
+        transcript that has an override set. Used by the transcript endpoint
+        to attach override info to the merged response (#648).
+        """
+        cur = await self._read_conn().execute(
+            "SELECT ts.segment_index, ts.override_user_id, u.name"
+            " FROM transcript_segments ts"
+            " LEFT JOIN users u ON u.id = ts.override_user_id"
+            " WHERE ts.transcript_id = ? AND ts.override_user_id IS NOT NULL",
+            (transcript_id,),
+        )
+        result: dict[int, dict[str, Any]] = {}
+        for r in await cur.fetchall():
+            result[int(r["segment_index"])] = {
+                "user_id": int(r["override_user_id"]),
+                "name": r["name"] or f"User {r['override_user_id']}",
+            }
+        return result
 
     async def log_voice_consent_ack(
         self,

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2950,6 +2950,23 @@ class Storage:
                 pass
         return res
 
+    async def get_race_primary_audio_session(self, race_id: int) -> dict[str, Any] | None:
+        """Return the race/practice primary audio_session row for a race, if any.
+
+        Used at debrief-start to recover the race's ``capture_group_id`` so
+        the debrief can detect whether the USB device set has changed (#648).
+        """
+        cur = await self._read_conn().execute(
+            "SELECT id, channels, channel_map, capture_group_id, capture_ordinal,"
+            " vendor_id, product_id, serial, usb_port_path"
+            " FROM audio_sessions"
+            " WHERE race_id = ? AND session_type IN ('race', 'practice')"
+            " ORDER BY capture_ordinal ASC, id ASC LIMIT 1",
+            (race_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
     async def list_capture_group_siblings(self, capture_group_id: str) -> list[dict[str, Any]]:
         """Return all audio_sessions rows sharing a capture_group_id, in ordinal order.
 

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -397,10 +397,12 @@
 </div>
 
 <div id="audio-card" class="card" style="display:none">
-  <div class="section-title">Audio</div>
-  <div id="audio-body"></div>
-  <div class="section-title" style="margin-top:12px" onclick="toggleSection('transcript')">Transcript <span id="transcript-toggle">&#9660;</span></div>
-  <div class="section-body" id="transcript-body"></div>
+  <div class="section-title" onclick="toggleSection('race-audio')">Race Audio <span id="race-audio-toggle">&#9660;</span></div>
+  <div class="section-body" id="race-audio-body">
+    <div id="audio-body"></div>
+    <div class="section-title" style="margin-top:12px" onclick="toggleSection('transcript')">Transcript <span id="transcript-toggle">&#9660;</span></div>
+    <div class="section-body" id="transcript-body"></div>
+  </div>
 </div>
 
 <div class="card" id="tuning-extraction-card" style="display:none">

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -186,6 +186,7 @@ async def _persist_sibling_segments(
     *,
     ordinal: int,
     position_name: str,
+    preserve_diarized_speaker: bool = False,
 ) -> None:
     """Tag mono-sibling segments with channel_index/position and persist relationally.
 
@@ -193,20 +194,28 @@ async def _persist_sibling_segments(
     WAV is already a single-channel file — but the downstream merge (chunk 3)
     needs the same ``channel_index``/``position_name``/``speaker`` tags that
     pt.4's multi-channel path provides, so we annotate and bulk-insert here.
+
+    When ``preserve_diarized_speaker=True`` (debrief audio, #648), keep the
+    pyannote-assigned speaker label (SPEAKER_01, …) instead of overriding it
+    with the mic's ``position_name``. The race-audio default relies on
+    hardware isolation (one mic per person) which breaks during debrief when
+    crew gather around and share mics.
     """
     if not segments:
         return
     for seg in segments:
         seg["channel_index"] = ordinal
         seg["position_name"] = position_name
-        seg["speaker"] = position_name
+        if not preserve_diarized_speaker or not seg.get("speaker"):
+            # Race default, or fallback when pyannote didn't emit a speaker.
+            seg["speaker"] = position_name
     relational = [
         {
             "segment_index": idx,
             "start_time": float(seg.get("start", 0.0)),  # type: ignore[arg-type]
             "end_time": float(seg.get("end", 0.0)),  # type: ignore[arg-type]
             "text": str(seg.get("text", "")),
-            "speaker": position_name,
+            "speaker": str(seg.get("speaker") or position_name),
             "channel_index": ordinal,
             "position_name": position_name,
         }
@@ -249,6 +258,11 @@ async def transcribe_session(
     await storage.update_transcript(transcript_id, status="running")
     file_path: str = row["file_path"]
     channels: int = row.get("channels", 1)
+    # Debrief audio breaks the "one mic == one person" hardware-isolation
+    # assumption that lets race audio collapse speaker labels onto the mic's
+    # position_name. For debriefs, keep the pyannote-diarized speaker labels
+    # so people who share a mic are still distinguishable (#648).
+    preserve_diarized_speaker: bool = row.get("session_type") == "debrief"
 
     # Sibling-card capture (#509): when the session is one of N parallel
     # mono USB cards, tag its segments with the ordinal + configured
@@ -320,6 +334,7 @@ async def transcribe_session(
                     segments,
                     ordinal=sibling_tag[0],
                     position_name=sibling_tag[1],
+                    preserve_diarized_speaker=preserve_diarized_speaker,
                 )
             segments_json_str = json.dumps(segments) if segments else None
             await storage.update_transcript(

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -48,11 +48,16 @@ async def _try_remote_transcribe(
     diarize: bool,
     *,
     transcribe_url: str = "",
+    num_speakers: int | None = None,
 ) -> tuple[str, list[dict[str, object]]] | None:
     """POST the WAV file to a remote worker and return (text, segments).
 
     *transcribe_url* is the base URL of the worker (e.g. ``http://mac:8321``).
     Falls back to ``TRANSCRIBE_URL`` env var if not provided.
+
+    *num_speakers* optionally constrains pyannote to exactly N speakers —
+    important for sibling captures that mix 2 people onto one mono WAV.
+    Unset = pyannote picks automatically (may over-split on noisy audio).
 
     Returns *None* when no URL is configured or the remote is unreachable,
     signalling the caller to fall back to local processing.
@@ -73,13 +78,16 @@ async def _try_remote_transcribe(
 
     endpoint = f"{url}/transcribe"
     logger.info("Remote transcribe: uploading {} to {}", file_path, endpoint)
+    params: dict[str, str] = {"model_size": model_size, "diarize": str(diarize).lower()}
+    if num_speakers is not None:
+        params["num_speakers"] = str(int(num_speakers))
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(_REMOTE_TIMEOUT_S)) as client:
             with open(file_path, "rb") as f:
                 resp = await client.post(
                     endpoint,
                     files={"file": ("audio.wav", f, "audio/wav")},
-                    params={"model_size": model_size, "diarize": str(diarize).lower()},
+                    params=params,
                 )
             resp.raise_for_status()
         data = resp.json()
@@ -98,11 +106,16 @@ async def _transcribe_one_channel(
     diarize: bool,
     *,
     transcribe_url: str = "",
+    num_speakers: int | None = None,
 ) -> tuple[str, list[dict[str, object]]]:
     """Helper: transcribe a single channel (local or remote)."""
     # 1. Try remote
     remote = await _try_remote_transcribe(
-        file_path, model_size, diarize, transcribe_url=transcribe_url
+        file_path,
+        model_size,
+        diarize,
+        transcribe_url=transcribe_url,
+        num_speakers=num_speakers,
     )
     if remote is not None:
         return remote
@@ -110,7 +123,10 @@ async def _transcribe_one_channel(
     # 2. Try local
     if diarize and _pyannote_available() and bool(os.environ.get("HF_TOKEN")):
         text, segments_json_str = await asyncio.to_thread(
-            _run_with_diarization, file_path=file_path, model_size=model_size
+            _run_with_diarization,
+            file_path=file_path,
+            model_size=model_size,
+            num_speakers=num_speakers,
         )
         return text, json.loads(segments_json_str)
     else:
@@ -264,10 +280,21 @@ async def transcribe_session(
     # mono USB cards, tag its segments with the ordinal + configured
     # position_name so the downstream merge can stitch them back together.
     sibling_tag: tuple[int, str] | None = None
+    num_speakers_hint: int | None = None
     if row.get("capture_group_id") and channels == 1:
         cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
         position = cmap.get(0, f"sib{row.get('capture_ordinal', 0)}")
         sibling_tag = (int(row.get("capture_ordinal") or 0), position)
+        # #648: common sibling-mode setup has multiple crew sharing one
+        # wireless receiver (2 mics → one mono WAV). Tell pyannote how many
+        # voices to expect so it doesn't over-split noisy race audio into
+        # 5–9 spurious labels. Configurable via env; default 2.
+        try:
+            num_speakers_hint = int(os.environ.get("AUDIO_SPEAKERS_PER_CHANNEL", "2"))
+        except ValueError:
+            num_speakers_hint = 2
+        if num_speakers_hint <= 0:
+            num_speakers_hint = None
 
     segments_json_str: str | None = None
     try:
@@ -319,7 +346,11 @@ async def transcribe_session(
 
         # ----- Remote offload (preferred when TRANSCRIBE_URL is set) -----
         remote = await _try_remote_transcribe(
-            file_path, model_size, diarize, transcribe_url=transcribe_url
+            file_path,
+            model_size,
+            diarize,
+            transcribe_url=transcribe_url,
+            num_speakers=num_speakers_hint,
         )
         if remote is not None:
             text, segments = remote
@@ -349,7 +380,10 @@ async def transcribe_session(
         # ----- Local processing (fallback) -----
         if use_diarize:
             text, segments_json_str = await asyncio.to_thread(
-                _run_with_diarization, file_path=file_path, model_size=model_size
+                _run_with_diarization,
+                file_path=file_path,
+                model_size=model_size,
+                num_speakers=num_speakers_hint,
             )
             await storage.update_transcript(
                 transcript_id, status="done", text=text, segments_json=segments_json_str
@@ -477,12 +511,18 @@ def _run_whisper_segments(*, file_path: str, model_size: str) -> list[tuple[floa
     return [(s.start, s.end, s.text) for s in segments]
 
 
-def _run_diarizer(file_path: str) -> list[tuple[float, float, str]]:
+def _run_diarizer(
+    file_path: str, *, num_speakers: int | None = None
+) -> list[tuple[float, float, str]]:
     """Return [(start, end, speaker_label)] from pyannote diarisation.
 
     Audio is pre-loaded via soundfile and converted to a torch tensor to bypass
     pyannote's built-in audio decoder which depends on torchcodec (unavailable
     on aarch64).
+
+    *num_speakers* (optional) constrains pyannote to exactly N speakers —
+    critical for sibling captures that mix 2 crew onto one mono WAV, where
+    otherwise pyannote over-splits into 5–9 labels on noisy race audio.
     """
     import soundfile as sf
     import torch
@@ -504,7 +544,10 @@ def _run_diarizer(file_path: str) -> list[tuple[float, float, str]]:
     data, sample_rate = sf.read(file_path, dtype="float32")
     waveform = torch.from_numpy(data).unsqueeze(0) if data.ndim == 1 else torch.from_numpy(data).T
     audio_input: dict[str, object] = {"waveform": waveform, "sample_rate": sample_rate}
-    result = pipeline(audio_input)
+    if num_speakers is not None and num_speakers > 0:
+        result = pipeline(audio_input, num_speakers=int(num_speakers))
+    else:
+        result = pipeline(audio_input)
 
     # pyannote 4.x returns DiarizeOutput; 3.x returns Annotation directly.
     annotation = getattr(result, "speaker_diarization", result)
@@ -542,10 +585,12 @@ def _merge(
     ]
 
 
-def _run_with_diarization(*, file_path: str, model_size: str) -> tuple[str, str]:
+def _run_with_diarization(
+    *, file_path: str, model_size: str, num_speakers: int | None = None
+) -> tuple[str, str]:
     """Run whisper + diarisation and return (plain_text, segments_json)."""
     whisper_segs = _run_whisper_segments(file_path=file_path, model_size=model_size)
-    diar_segs = _run_diarizer(file_path)
+    diar_segs = _run_diarizer(file_path, num_speakers=num_speakers)
     segments = _merge(whisper_segs, diar_segs)
     plain = "\n".join(f"{seg['speaker']}: {str(seg['text']).strip()}" for seg in segments)
     return plain, json.dumps(segments)
@@ -596,8 +641,11 @@ def _extract_speaker_embeddings(
     Uses the pyannote embedding model to compute a centroid embedding for each
     speaker by averaging embeddings across their segments.
 
-    Returns a dict mapping normalised speaker labels (SPEAKER_00, etc.) to
-    serialised float32 embedding bytes.
+    Returns a dict mapping raw speaker labels (whatever the caller passed —
+    e.g. ``sib0:SPEAKER_00`` for sibling captures, #648) to serialised
+    float32 embedding bytes. The labels are preserved end-to-end so
+    cross-session auto-match can key on the same globally-unique label the
+    segments store.
     """
     try:
         import numpy as np
@@ -626,18 +674,11 @@ def _extract_speaker_embeddings(
     if data.ndim == 1:
         data = data.reshape(-1, 1)
 
-    # Normalise speaker labels same as _merge
-    unique: list[str] = []
-    for _, _, label in diar_segs:
-        if label not in unique:
-            unique.append(label)
-    label_map = {lbl: f"SPEAKER_{i:02d}" for i, lbl in enumerate(unique)}
-
-    # Group segments by speaker
+    # Group segments by raw speaker label — no renumbering, so the keys
+    # match what's stored in transcript_segments.speaker (#648).
     speaker_segs: dict[str, list[tuple[float, float]]] = {}
     for s, e, lbl in diar_segs:
-        norm = label_map[lbl]
-        speaker_segs.setdefault(norm, []).append((s, e))
+        speaker_segs.setdefault(lbl, []).append((s, e))
 
     embeddings: dict[str, bytes] = {}
     for speaker, segs in speaker_segs.items():

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -186,7 +186,6 @@ async def _persist_sibling_segments(
     *,
     ordinal: int,
     position_name: str,
-    preserve_diarized_speaker: bool = False,
 ) -> None:
     """Tag mono-sibling segments with channel_index/position and persist relationally.
 
@@ -195,20 +194,22 @@ async def _persist_sibling_segments(
     needs the same ``channel_index``/``position_name``/``speaker`` tags that
     pt.4's multi-channel path provides, so we annotate and bulk-insert here.
 
-    When ``preserve_diarized_speaker=True`` (debrief audio, #648), keep the
-    pyannote-assigned speaker label (SPEAKER_01, …) instead of overriding it
-    with the mic's ``position_name``. The race-audio default relies on
-    hardware isolation (one mic per person) which breaks during debrief when
-    crew gather around and share mics.
+    Speaker labels (#648): always keep the pyannote-diarized label when one
+    was emitted so cross-mic speakers are distinguishable — the hardware-
+    isolation "one mic = one person" shortcut breaks both in debrief (crew
+    share mics) and in the race itself (someone talks into a neighbor's mic
+    during a maneuver). We prefix each label with ``position_name`` so
+    ``sib0:SPEAKER_00`` stays distinct from ``sib1:SPEAKER_00`` (pyannote
+    labels are per-WAV, not correlated across siblings). Segments without a
+    speaker fall back to the bare ``position_name``.
     """
     if not segments:
         return
     for seg in segments:
         seg["channel_index"] = ordinal
         seg["position_name"] = position_name
-        if not preserve_diarized_speaker or not seg.get("speaker"):
-            # Race default, or fallback when pyannote didn't emit a speaker.
-            seg["speaker"] = position_name
+        raw_speaker = seg.get("speaker")
+        seg["speaker"] = f"{position_name}:{raw_speaker}" if raw_speaker else position_name
     relational = [
         {
             "segment_index": idx,
@@ -258,11 +259,6 @@ async def transcribe_session(
     await storage.update_transcript(transcript_id, status="running")
     file_path: str = row["file_path"]
     channels: int = row.get("channels", 1)
-    # Debrief audio breaks the "one mic == one person" hardware-isolation
-    # assumption that lets race audio collapse speaker labels onto the mic's
-    # position_name. For debriefs, keep the pyannote-diarized speaker labels
-    # so people who share a mic are still distinguishable (#648).
-    preserve_diarized_speaker: bool = row.get("session_type") == "debrief"
 
     # Sibling-card capture (#509): when the session is one of N parallel
     # mono USB cards, tag its segments with the ordinal + configured
@@ -334,7 +330,6 @@ async def transcribe_session(
                     segments,
                     ordinal=sibling_tag[0],
                     position_name=sibling_tag[1],
-                    preserve_diarized_speaker=preserve_diarized_speaker,
                 )
             segments_json_str = json.dumps(segments) if segments else None
             await storage.update_transcript(

--- a/src/helmlog/transcribe.py
+++ b/src/helmlog/transcribe.py
@@ -283,8 +283,12 @@ async def transcribe_session(
     num_speakers_hint: int | None = None
     if row.get("capture_group_id") and channels == 1:
         cmap = await storage.get_channel_map_for_audio_session(audio_session_id)
-        position = cmap.get(0, f"sib{row.get('capture_ordinal', 0)}")
-        sibling_tag = (int(row.get("capture_ordinal") or 0), position)
+        # Fallback label (#648): user-facing "R1" / "R2" etc. when no admin
+        # channel_map is configured. Maps to the receiver number from the
+        # common 2-mic-per-receiver setup, 1-indexed for humans.
+        ordinal = int(row.get("capture_ordinal") or 0)
+        position = cmap.get(0, f"R{ordinal + 1}")
+        sibling_tag = (ordinal, position)
         # #648: common sibling-mode setup has multiple crew sharing one
         # wireless receiver (2 mics → one mono WAV). Tell pyannote how many
         # voices to expect so it doesn't over-split noisy race audio into

--- a/tests/test_audio_streaming_threshold.py
+++ b/tests/test_audio_streaming_threshold.py
@@ -1,0 +1,198 @@
+"""Session detail returns ``use_streaming_audio`` hint for long sibling sessions (#648).
+
+Session pages with two or more sibling WAVs longer than
+``AUDIO_STREAM_THRESHOLD_MINUTES`` (default 45) must stream via
+``<audio>`` + ``MediaElementAudioSourceNode`` instead of ``decodeAudioData``;
+the detail endpoint surfaces the per-session verdict so the frontend can
+branch without knowing the threshold.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.audio import AudioSession
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_race_with_siblings(
+    storage: Storage, tmp_path: Path, *, duration_minutes: int, n_siblings: int = 2
+) -> int:
+    """Create a race with N sibling audio sessions of the given duration."""
+    start = datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=duration_minutes)
+
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            f"LongRace-{duration_minutes}min",
+            "Bench",
+            1,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+
+    for ordinal in range(n_siblings):
+        wav = tmp_path / f"sib{ordinal}.wav"
+        wav.write_bytes(b"RIFF0000WAVEfmt ")
+        await storage.write_audio_session(
+            AudioSession(
+                file_path=str(wav),
+                device_name=f"Fake sib{ordinal}",
+                start_utc=start,
+                end_utc=end,
+                sample_rate=48000,
+                channels=1,
+                vendor_id=0x1234,
+                product_id=0x5678,
+                serial=f"sn{ordinal}",
+                usb_port_path=f"1-{ordinal + 1}",
+                capture_group_id="grp-648",
+                capture_ordinal=ordinal,
+            ),
+            race_id=race_id,
+            session_type="race",
+            name=f"LongRace-{duration_minutes}min",
+        )
+    return race_id
+
+
+async def _seed_single_audio_race(
+    storage: Storage, tmp_path: Path, *, duration_minutes: int
+) -> int:
+    """Race with a single (non-sibling) audio session — long but single-device."""
+    start = datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=duration_minutes)
+    db = storage._conn()
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            f"SingleLong-{duration_minutes}min",
+            "Bench",
+            2,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+
+    wav = tmp_path / "single.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    await storage.write_audio_session(
+        AudioSession(
+            file_path=str(wav),
+            device_name="Single multichannel",
+            start_utc=start,
+            end_utc=end,
+            sample_rate=48000,
+            channels=4,  # multi-channel on one device; no sibling group
+        ),
+        race_id=race_id,
+        session_type="race",
+        name=f"SingleLong-{duration_minutes}min",
+    )
+    return race_id
+
+
+async def _get_detail(storage: Storage, race_id: int) -> dict:
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/sessions/{race_id}/detail")
+    assert resp.status_code == 200
+    return resp.json()
+
+
+async def test_short_sibling_session_uses_buffer_mode(storage: Storage, tmp_path: Path) -> None:
+    """30-min session < 45-min default → use_streaming_audio is False."""
+    race_id = await _seed_race_with_siblings(storage, tmp_path, duration_minutes=30)
+    data = await _get_detail(storage, race_id)
+    assert data["audio_channels"] == 2
+    assert data["use_streaming_audio"] is False
+
+
+async def test_long_sibling_session_triggers_streaming(storage: Storage, tmp_path: Path) -> None:
+    """82-min session (like the #648 repro race) ≥ 45-min default → streaming mode."""
+    race_id = await _seed_race_with_siblings(storage, tmp_path, duration_minutes=82)
+    data = await _get_detail(storage, race_id)
+    assert data["audio_channels"] == 2
+    assert data["use_streaming_audio"] is True
+
+
+async def test_threshold_override_via_env(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Custom AUDIO_STREAM_THRESHOLD_MINUTES=20 → 25-min session flips to streaming."""
+    monkeypatch.setenv("AUDIO_STREAM_THRESHOLD_MINUTES", "20")
+    race_id = await _seed_race_with_siblings(storage, tmp_path, duration_minutes=25)
+    data = await _get_detail(storage, race_id)
+    assert data["use_streaming_audio"] is True
+
+
+async def test_invalid_threshold_falls_back_to_default(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-integer env var → fall back to 45-min default, 30-min stays buffer."""
+    monkeypatch.setenv("AUDIO_STREAM_THRESHOLD_MINUTES", "not-a-number")
+    race_id = await _seed_race_with_siblings(storage, tmp_path, duration_minutes=30)
+    data = await _get_detail(storage, race_id)
+    assert data["use_streaming_audio"] is False
+
+
+async def test_single_device_long_session_does_not_stream(storage: Storage, tmp_path: Path) -> None:
+    """Streaming path only applies to sibling captures; single-device multi-channel
+    sessions stay on the decodeAudioData path regardless of duration because the
+    channel splitter that drives isolation only works with a decoded AudioBuffer."""
+    race_id = await _seed_single_audio_race(storage, tmp_path, duration_minutes=90)
+    data = await _get_detail(storage, race_id)
+    assert data["use_streaming_audio"] is False
+
+
+async def test_no_audio_session_use_streaming_false(storage: Storage) -> None:
+    """Race with no audio rows at all → use_streaming_audio is False."""
+    db = storage._conn()
+    start = datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=90)
+    cur = await db.execute(
+        "INSERT INTO races (name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "NoAudio",
+            "Bench",
+            3,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    await db.commit()
+    race_id = cur.lastrowid
+    assert race_id is not None
+    data = await _get_detail(storage, race_id)
+    assert data["has_audio"] is False
+    assert data["use_streaming_audio"] is False

--- a/tests/test_debrief_parity.py
+++ b/tests/test_debrief_parity.py
@@ -1,0 +1,379 @@
+"""Debrief multi-channel parity with race audio (#648 Part 1, C1–C6).
+
+Validates the capture-topology invariants from the structured spec:
+
+- C1: same recorder + audio_config instance used for race start and debrief start
+- C2: debrief audio_sessions row has same ``channels`` as race
+- C3: sibling mode creates a new ``capture_group_id`` for debrief with the
+      same number of ordinals (0..N-1) as the race
+- C4: channel_map resolves identically for race and debrief audio sessions
+- C5: USB device-set change between race-end and debrief-start logs a
+      WARNING; debrief is NOT blocked and records with current topology
+- C6: integration-level smoke test — /api/races/start → /end → debrief/start
+      produces audio_sessions rows with matching topology
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+from helmlog.audio import AudioConfig, AudioSession
+from helmlog.usb_audio import DetectedDevice
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from helmlog.storage import Storage
+
+
+# ---------------------------------------------------------------------------
+# Fakes — a more realistic AudioRecorderGroup stand-in that:
+#   * generates a fresh capture_group_id on every start() call (like the real
+#     AudioRecorderGroup does via uuid.uuid4())
+#   * propagates vendor_id/product_id/serial/usb_port_path from the devices arg
+#     onto each sibling AudioSession so the C5 identity comparison has data
+# ---------------------------------------------------------------------------
+
+
+class FakeGroupRecorder:
+    """Quacks like AudioRecorderGroup — fresh group_id per start(), devices
+    passed through to sibling sessions as USB identity."""
+
+    def __init__(self) -> None:
+        self._sessions: list[AudioSession] = []
+
+    async def start(
+        self,
+        config: AudioConfig,  # noqa: ARG002
+        *,
+        devices: list[DetectedDevice],
+        name: str | None = None,
+    ) -> list[AudioSession]:
+        group_id = uuid.uuid4().hex
+        sessions: list[AudioSession] = []
+        for ordinal, dev in enumerate(devices):
+            fname = f"{name}-sib{ordinal}.wav" if name else f"fake-{ordinal}.wav"
+            sessions.append(
+                AudioSession(
+                    file_path=f"/tmp/{fname}",
+                    device_name=dev.name,
+                    start_utc=datetime.now(UTC),
+                    end_utc=None,
+                    sample_rate=48000,
+                    channels=1,
+                    vendor_id=dev.vendor_id,
+                    product_id=dev.product_id,
+                    serial=dev.serial,
+                    usb_port_path=dev.usb_port_path,
+                    capture_group_id=group_id,
+                    capture_ordinal=ordinal,
+                )
+            )
+        self._sessions = sessions
+        return sessions
+
+    async def stop(self) -> list[AudioSession]:
+        completed: list[AudioSession] = []
+        for s in self._sessions:
+            s.end_utc = datetime.now(UTC)
+            completed.append(s)
+        self._sessions = []
+        return completed
+
+
+def _dev(vendor: int, product: int, serial: str, port: str, idx: int) -> DetectedDevice:
+    return DetectedDevice(
+        vendor_id=vendor,
+        product_id=product,
+        serial=serial,
+        usb_port_path=port,
+        max_channels=1,
+        sounddevice_index=idx,
+        name=f"Fake card {idx}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _set_event(client: httpx.AsyncClient, name: str = "TestRegatta") -> None:
+    resp = await client.post("/api/event", json={"event_name": name})
+    assert resp.status_code == 204
+
+
+def _patch_group_isinstance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make capture_start/stop treat FakeGroupRecorder as an AudioRecorderGroup."""
+    monkeypatch.setattr(
+        "helmlog.audio.AudioRecorderGroup",
+        FakeGroupRecorder,
+        raising=True,
+    )
+
+
+async def _race_then_debrief(
+    storage: Storage,
+    tmp_path: Path,
+    *,
+    devices_race: list[DetectedDevice],
+    devices_debrief: list[DetectedDevice] | None = None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, Any], dict[str, Any] | None, int, FakeGroupRecorder]:
+    """Drive race-start → end → debrief-start in sibling mode and return the
+    race's primary audio_session row, the debrief's primary row, the race id,
+    and the recorder instance used."""
+    _patch_group_isinstance(monkeypatch)
+    recorder = FakeGroupRecorder()
+    config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+    app = create_app(storage, recorder=recorder, audio_config=config)  # type: ignore[arg-type]
+
+    calls: list[list[DetectedDevice]] = [devices_race]
+    if devices_debrief is not None:
+        calls.append(devices_debrief)
+    else:
+        calls.append(devices_race)
+
+    call_iter = iter(calls)
+
+    def _fake_detect(*, min_channels: int = 1) -> list[DetectedDevice]:  # noqa: ARG001
+        return next(call_iter)
+
+    monkeypatch.setattr("helmlog.usb_audio.detect_all_capture_devices", _fake_detect)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        await client.post(f"/api/races/{race_id}/end")
+        await client.post(f"/api/races/{race_id}/debrief/start")
+
+    race_row = None
+    async for r in _iter_audio_sessions(storage, race_id, "race", "practice"):
+        race_row = r
+        break
+    debrief_row = None
+    async for r in _iter_audio_sessions(storage, race_id, "debrief"):
+        debrief_row = r
+        break
+    assert race_row is not None
+    return race_row, debrief_row, race_id, recorder
+
+
+async def _iter_audio_sessions(
+    storage: Storage, race_id: int, *types: str
+) -> AsyncIterator[dict[str, Any]]:
+    placeholders = ",".join("?" * len(types))
+    cur = await storage._read_conn().execute(
+        "SELECT id, file_path, channels, channel_map, capture_group_id,"
+        " capture_ordinal, vendor_id, product_id, serial, usb_port_path,"
+        " session_type, race_id"
+        f" FROM audio_sessions WHERE race_id = ? AND session_type IN ({placeholders})"
+        " ORDER BY capture_ordinal ASC, id ASC",
+        (race_id, *types),
+    )
+    rows = await cur.fetchall()
+    for row in rows:
+        yield dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_c1_same_recorder_and_config_reused_for_debrief(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C1: race and debrief share the app.state.recorder / audio_config instance."""
+    devs = [_dev(0x1234, 0x5678, "A", "1-1", 1), _dev(0x1234, 0x5678, "B", "1-2", 2)]
+    race_row, debrief_row, _race_id, _rec = await _race_then_debrief(
+        storage, tmp_path, devices_race=devs, monkeypatch=monkeypatch
+    )
+    assert race_row is not None and debrief_row is not None
+    # Same recorder → same USB identities captured on the primary row
+    assert (race_row["vendor_id"], race_row["product_id"], race_row["serial"]) == (
+        debrief_row["vendor_id"],
+        debrief_row["product_id"],
+        debrief_row["serial"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_c2_debrief_channels_match_race_sibling(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C2: debrief audio_sessions row has the same ``channels`` as race."""
+    devs = [_dev(0x1111, 0x2222, "S0", "1-1", 1), _dev(0x1111, 0x2222, "S1", "1-2", 2)]
+    race_row, debrief_row, _race_id, _rec = await _race_then_debrief(
+        storage, tmp_path, devices_race=devs, monkeypatch=monkeypatch
+    )
+    assert race_row is not None and debrief_row is not None
+    assert debrief_row["channels"] == race_row["channels"]
+
+
+@pytest.mark.asyncio
+async def test_c3_debrief_has_new_group_id_same_ordinal_count(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C3: new capture_group_id with same sibling ordinal count (0..N-1)."""
+    devs = [
+        _dev(0xAAAA, 0xBBBB, f"sn{i}", f"1-{i}", i)
+        for i in range(1, 4)  # 3 siblings
+    ]
+    race_row, debrief_row, race_id, _rec = await _race_then_debrief(
+        storage, tmp_path, devices_race=devs, monkeypatch=monkeypatch
+    )
+    assert race_row is not None and debrief_row is not None
+    race_group = race_row["capture_group_id"]
+    debrief_group = debrief_row["capture_group_id"]
+    assert race_group is not None and debrief_group is not None
+    assert race_group != debrief_group, "debrief must get a fresh capture_group_id"
+
+    race_sibs = await storage.list_capture_group_siblings(race_group)
+    debrief_sibs = await storage.list_capture_group_siblings(debrief_group)
+    assert len(race_sibs) == len(debrief_sibs) == 3
+    assert [s["capture_ordinal"] for s in race_sibs] == [0, 1, 2]
+    assert [s["capture_ordinal"] for s in debrief_sibs] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_c4_channel_map_resolves_identically_for_race_and_debrief(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C4: channel_map resolution via USB identity + ordinal is stable across
+    race and debrief. Uses the admin-default channel_map table."""
+    devs = [
+        _dev(0xCAFE, 0xBEEF, "helm-sn", "usb1-1", 1),
+        _dev(0xCAFE, 0xBEEF, "main-sn", "usb1-2", 2),
+    ]
+    # Seed an admin-default map for each device (channel 0 → position).
+    for dev, position in ((devs[0], "helm"), (devs[1], "main")):
+        await storage.set_channel_map(
+            vendor_id=dev.vendor_id,
+            product_id=dev.product_id,
+            serial=dev.serial,
+            usb_port_path=dev.usb_port_path,
+            mapping={0: position},
+        )
+
+    race_row, debrief_row, _race_id, _rec = await _race_then_debrief(
+        storage, tmp_path, devices_race=devs, monkeypatch=monkeypatch
+    )
+    assert race_row is not None and debrief_row is not None
+
+    race_map = await storage.get_channel_map_for_audio_session(int(race_row["id"]))
+    debrief_map = await storage.get_channel_map_for_audio_session(int(debrief_row["id"]))
+    assert race_map == debrief_map
+    assert race_map == {0: "helm"}  # sanity — first sibling is the helm card
+
+
+@pytest.mark.asyncio
+async def test_c5_usb_set_change_logs_warning_does_not_block(
+    storage: Storage,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """C5: if detection at debrief-start returns a different device set than
+    the race saw, log a WARNING; debrief is NOT blocked."""
+    import logging
+
+    from loguru import logger as _loguru
+
+    # Route loguru → caplog so pytest can inspect warnings.
+    handler_id = _loguru.add(
+        lambda msg: caplog.handler.emit(
+            logging.LogRecord(
+                name="loguru",
+                level=msg.record["level"].no,
+                pathname="",
+                lineno=0,
+                msg=msg.record["message"],
+                args=(),
+                exc_info=None,
+            )
+        ),
+        level="WARNING",
+    )
+    try:
+        caplog.set_level("WARNING")
+        race_devs = [
+            _dev(0xDEAD, 0xBEEF, "A", "1-1", 1),
+            _dev(0xDEAD, 0xBEEF, "B", "1-2", 2),
+        ]
+        # Debrief detects one fewer device (simulates hot-unplug).
+        debrief_devs = [_dev(0xDEAD, 0xBEEF, "A", "1-1", 1)]
+        _race_row, debrief_row, race_id, _rec = await _race_then_debrief(
+            storage,
+            tmp_path,
+            devices_race=race_devs,
+            devices_debrief=debrief_devs,
+            monkeypatch=monkeypatch,
+        )
+        # Debrief must still have been created, just with fewer siblings.
+        assert debrief_row is not None
+        assert race_id is not None
+        debrief_sibs = await storage.list_capture_group_siblings(
+            str(debrief_row["capture_group_id"])
+        )
+        assert len(debrief_sibs) == 1
+
+        # Warning was emitted.
+        assert any(
+            "device set" in r.message.lower() or "#648" in r.message
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ), f"expected a C5 device-set-changed warning; got records: {caplog.records}"
+    finally:
+        _loguru.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_c6_race_then_debrief_topology_integration(
+    storage: Storage, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """C6: end-to-end smoke — race start → end → debrief start produces two
+    audio_sessions rows with matching topology in sibling mode."""
+    devs = [
+        _dev(0x1357, 0x2468, "port", "usb-1", 1),
+        _dev(0x1357, 0x2468, "stbd", "usb-2", 2),
+    ]
+    race_row, debrief_row, race_id, rec = await _race_then_debrief(
+        storage, tmp_path, devices_race=devs, monkeypatch=monkeypatch
+    )
+    assert race_row is not None, "race primary audio_session row missing"
+    assert debrief_row is not None, "debrief primary audio_session row missing"
+    assert race_row["race_id"] == race_id
+    assert debrief_row["race_id"] == race_id
+    assert debrief_row["session_type"] == "debrief"
+
+    # Channel count per row matches (1 per sibling in sibling mode).
+    assert race_row["channels"] == debrief_row["channels"]
+
+    # Sibling-group shape matches — same ordinal count, fresh group_id.
+    race_sibs = await storage.list_capture_group_siblings(str(race_row["capture_group_id"]))
+    debrief_sibs = await storage.list_capture_group_siblings(str(debrief_row["capture_group_id"]))
+    assert len(race_sibs) == len(debrief_sibs) == 2
+    assert race_row["capture_group_id"] != debrief_row["capture_group_id"]
+
+    # USB identities matched between corresponding ordinals.
+    for r, d in zip(race_sibs, debrief_sibs, strict=True):
+        assert (r["vendor_id"], r["product_id"], r["serial"], r["usb_port_path"]) == (
+            d["vendor_id"],
+            d["product_id"],
+            d["serial"],
+            d["usb_port_path"],
+        )
+
+    # Recorder instance was the same for both captures (app.state.recorder).
+    assert isinstance(rec, FakeGroupRecorder)

--- a/tests/test_diarize_crew.py
+++ b/tests/test_diarize_crew.py
@@ -170,33 +170,38 @@ async def test_assign_speaker_crew_overwrite(storage: Storage, tmp_path: Path) -
 
 @pytest.mark.asyncio
 async def test_speaker_map_coexists_with_anon(storage: Storage, tmp_path: Path) -> None:
-    """speaker_map crew entries and speaker_anon_map redactions coexist."""
+    """speaker_anon_map redacts; speaker_map crew assignments leave the raw
+    label intact (display substitution is now a client concern, #648)."""
     audio_id = await _create_audio_session(storage, tmp_path)
     tid = await _create_transcript_with_segments(storage, audio_id)
     uid = await _create_user(storage, "dave@boat.com", "Dave")
 
-    # Assign speaker 0 to crew
+    # Assign speaker 0 to crew (affects speaker_map, NOT segment speaker)
     await storage.assign_speaker_crew(tid, "SPEAKER_00", uid, "Dave")
-    # Anonymize speaker 1
+    # Anonymize speaker 1 (rewrites segment speaker for PII)
     await storage.anonymize_speaker(tid, "SPEAKER_01")
 
     t = await storage.get_transcript_with_anon(audio_id)
     assert t is not None
     segs = json.loads(t["segments_json"])
-    # SPEAKER_00 should show as Dave (crew mapping)
-    assert segs[0]["speaker"] == "Dave"
-    # SPEAKER_01 should be redacted (anonymization takes priority)
+    # SPEAKER_00 stays raw — the frontend resolves it via speaker_map.
+    assert segs[0]["speaker"] == "SPEAKER_00"
+    # SPEAKER_01 is redacted (anonymization rewrites).
     assert segs[1]["speaker"] == "REDACTED"
     assert segs[1]["text"] == "[REDACTED]"
-    # SPEAKER_00 in third segment should also show as Dave
-    assert segs[2]["speaker"] == "Dave"
+    # SPEAKER_00 in third segment also stays raw.
+    assert segs[2]["speaker"] == "SPEAKER_00"
+    # And speaker_map carries the crew assignment for the client to resolve.
+    sm = json.loads(t["speaker_map"])
+    assert sm["SPEAKER_00"]["name"] == "Dave"
 
 
 @pytest.mark.asyncio
-async def test_get_transcript_with_anon_applies_speaker_map(
+async def test_get_transcript_with_anon_preserves_raw_labels(
     storage: Storage, tmp_path: Path
 ) -> None:
-    """get_transcript_with_anon replaces speaker labels with crew names from speaker_map."""
+    """#648: raw speaker labels stay in the segments so click-to-assign
+    round-trips cleanly. Crew-name substitution is a client concern."""
     audio_id = await _create_audio_session(storage, tmp_path)
     tid = await _create_transcript_with_segments(storage, audio_id)
     uid = await _create_user(storage, "dave@boat.com", "Dave")
@@ -206,10 +211,10 @@ async def test_get_transcript_with_anon_applies_speaker_map(
     t = await storage.get_transcript_with_anon(audio_id)
     assert t is not None
     segs = json.loads(t["segments_json"])
-    assert segs[0]["speaker"] == "Dave"
-    assert segs[2]["speaker"] == "Dave"
-    # Unmapped speaker stays as-is
+    # Raw labels preserved — client displays Dave via speaker_map lookup.
+    assert segs[0]["speaker"] == "SPEAKER_00"
     assert segs[1]["speaker"] == "SPEAKER_01"
+    assert segs[2]["speaker"] == "SPEAKER_00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migration_v75.py
+++ b/tests/test_migration_v75.py
@@ -60,8 +60,9 @@ async def test_v75_attitudes_ts_index_exists() -> None:
 
 
 @pytest.mark.asyncio
-async def test_schema_version_is_76_on_fresh_db() -> None:
-    from helmlog.storage import Storage, StorageConfig
+async def test_schema_version_is_current_on_fresh_db() -> None:
+    """Fresh DB reaches the module's _CURRENT_VERSION after migrate()."""
+    from helmlog.storage import _CURRENT_VERSION, Storage, StorageConfig
 
     s = Storage(StorageConfig(db_path=":memory:"))
     await s.connect()
@@ -70,6 +71,6 @@ async def test_schema_version_is_76_on_fresh_db() -> None:
         async with s._db.execute("SELECT MAX(version) FROM schema_version") as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == 76
+        assert row[0] == _CURRENT_VERSION
     finally:
         await s.close()

--- a/tests/test_segment_override.py
+++ b/tests/test_segment_override.py
@@ -1,0 +1,295 @@
+"""Per-segment speaker override (#648).
+
+Label-wide assignments via ``speaker_map`` re-label every segment that
+shares a label. Overrides let a single misattributed segment point at a
+different crew member without touching the rest. Covers:
+
+- Storage: set/clear override, per-transcript lookup, users FK ON DELETE SET NULL
+- API: POST /transcripts/segments/{idx}/speaker-override + merged transcript
+       response carries override_user_id / override_name per segment
+- Integration: race → debrief sibling captures round-trip
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.audio import AudioSession
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+
+_START_UTC = datetime(2026, 4, 21, 10, 0, 0, tzinfo=UTC)
+_END_UTC = datetime(2026, 4, 21, 10, 5, 0, tzinfo=UTC)
+
+
+async def _seed_sibling_pair(storage: Storage, tmp_path: Path) -> tuple[int, int]:
+    """Two mono sibling audio_sessions in a capture group + relational segments."""
+    group_id = "grp-override"
+    paths = [tmp_path / f"sib{i}.wav" for i in range(2)]
+    for p in paths:
+        p.write_bytes(b"RIFF0000WAVEfmt ")
+
+    ids: list[int] = []
+    for ordinal, p in enumerate(paths):
+        sess = AudioSession(
+            file_path=str(p),
+            device_name=f"Sib {ordinal}",
+            start_utc=_START_UTC,
+            end_utc=_END_UTC,
+            sample_rate=48000,
+            channels=1,
+            capture_group_id=group_id,
+            capture_ordinal=ordinal,
+        )
+        ids.append(await storage.write_audio_session(sess, session_type="race", name="test"))
+
+    # Seed transcripts + segments for both siblings.
+    for ordinal, asid in enumerate(ids):
+        tid = await storage.create_transcript_job(asid, "base")
+        segments = [
+            {
+                "start": 0.0 + ordinal,
+                "end": 2.0 + ordinal,
+                "speaker": f"sib{ordinal}:SPEAKER_00",
+                "text": f"hello from sib{ordinal}",
+                "channel_index": ordinal,
+                "position_name": f"sib{ordinal}",
+            },
+            {
+                "start": 3.0 + ordinal,
+                "end": 5.0 + ordinal,
+                "speaker": f"sib{ordinal}:SPEAKER_01",
+                "text": f"second speaker on sib{ordinal}",
+                "channel_index": ordinal,
+                "position_name": f"sib{ordinal}",
+            },
+        ]
+        await storage.update_transcript(tid, status="done", segments_json=json.dumps(segments))
+        relational = [
+            {
+                "segment_index": idx,
+                "start_time": seg["start"],
+                "end_time": seg["end"],
+                "text": seg["text"],
+                "speaker": seg["speaker"],
+                "channel_index": seg["channel_index"],
+                "position_name": seg["position_name"],
+            }
+            for idx, seg in enumerate(segments)
+        ]
+        await storage.insert_transcript_segments(tid, relational)
+    return ids[0], ids[1]
+
+
+async def _create_user(storage: Storage, email: str, name: str) -> int:
+    db = storage._conn()
+    now = datetime.now(UTC).isoformat()
+    cur = await db.execute(
+        "INSERT INTO users (email, name, role, created_at) VALUES (?, ?, 'crew', ?)",
+        (email, name, now),
+    )
+    await db.commit()
+    assert cur.lastrowid is not None
+    return cur.lastrowid
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+async def test_migration_77_adds_override_column(storage: Storage) -> None:
+    """transcript_segments.override_user_id must exist after migration 77."""
+    db = storage._conn()
+    cur = await db.execute("PRAGMA table_info(transcript_segments)")
+    cols = {row["name"] for row in await cur.fetchall()}
+    assert "override_user_id" in cols
+
+
+# ---------------------------------------------------------------------------
+# Storage roundtrip
+# ---------------------------------------------------------------------------
+
+
+async def test_set_segment_override_roundtrip(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+
+    # Override segment 1 on sib0 to Alex
+    found, name = await storage.set_segment_speaker_override(int(t["id"]), 1, alex)
+    assert found is True
+    assert name == "Alex"
+
+    overrides = await storage.get_segment_overrides(int(t["id"]))
+    assert overrides == {1: {"user_id": alex, "name": "Alex"}}
+
+
+async def test_override_clears_on_null_user(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+
+    await storage.set_segment_speaker_override(int(t["id"]), 1, alex)
+    cleared, name = await storage.set_segment_speaker_override(int(t["id"]), 1, None)
+    assert cleared is True
+    assert name is None
+    assert await storage.get_segment_overrides(int(t["id"])) == {}
+
+
+async def test_override_unknown_segment_returns_not_found(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+    found, _ = await storage.set_segment_speaker_override(int(t["id"]), 99, alex)
+    assert found is False
+
+
+async def test_override_unknown_user_returns_not_found(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    found, _ = await storage.set_segment_speaker_override(int(t["id"]), 0, 99999)
+    assert found is False
+
+
+# ---------------------------------------------------------------------------
+# API: /transcript response carries override info; endpoint writes it
+# ---------------------------------------------------------------------------
+
+
+async def test_transcript_response_exposes_override_per_segment(
+    storage: Storage, tmp_path: Path
+) -> None:
+    sib0_id, sib1_id = await _seed_sibling_pair(storage, tmp_path)
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+
+    # Override segment 1 on sib0 (where speaker is "sib0:SPEAKER_01") to Alex
+    t0 = await storage.get_transcript(sib0_id)
+    assert t0 is not None
+    await storage.set_segment_speaker_override(int(t0["id"]), 1, alex)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/api/audio/{sib0_id}/transcript")
+    assert resp.status_code == 200
+    data = resp.json()
+    segs = data["segments"]
+    # Merged response has 4 segments (2 from sib0 + 2 from sib1), sorted by start.
+    assert len(segs) == 4
+    # Every segment tagged with its source audio_session_id + segment_index
+    # so the client can address them for override POSTs.
+    for s in segs:
+        assert "audio_session_id" in s
+        assert "segment_index" in s
+    # Exactly one segment carries the override we set.
+    with_ov = [s for s in segs if s.get("override_user_id")]
+    assert len(with_ov) == 1
+    assert with_ov[0]["override_user_id"] == alex
+    assert with_ov[0]["override_name"] == "Alex"
+    assert with_ov[0]["audio_session_id"] == sib0_id
+    assert with_ov[0]["segment_index"] == 1
+    # Other sib0 segment + both sib1 segments carry no override.
+    no_ov = [s for s in segs if not s.get("override_user_id")]
+    assert len(no_ov) == 3
+
+
+async def test_post_override_endpoint_writes_and_returns(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{sib0_id}/transcript/segments/0/speaker-override",
+            json={"user_id": alex},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["audio_session_id"] == sib0_id
+    assert data["segment_index"] == 0
+    assert data["user_id"] == alex
+    assert data["name"] == "Alex"
+
+    # Verify it's persisted
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    overrides = await storage.get_segment_overrides(int(t["id"]))
+    assert overrides == {0: {"user_id": alex, "name": "Alex"}}
+
+
+async def test_post_override_endpoint_clears_on_null(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+    await storage.set_segment_speaker_override(int(t["id"]), 0, alex)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{sib0_id}/transcript/segments/0/speaker-override",
+            json={"user_id": None},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["name"] is None
+    assert await storage.get_segment_overrides(int(t["id"])) == {}
+
+
+async def test_post_override_rejects_non_int_user_id(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{sib0_id}/transcript/segments/0/speaker-override",
+            json={"user_id": "alex"},
+        )
+    assert resp.status_code == 422
+
+
+async def test_post_override_unknown_user_returns_404(storage: Storage, tmp_path: Path) -> None:
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/audio/{sib0_id}/transcript/segments/0/speaker-override",
+            json={"user_id": 99999},
+        )
+    assert resp.status_code == 404
+
+
+async def test_override_does_not_affect_speaker_map(storage: Storage, tmp_path: Path) -> None:
+    """Overriding one segment must not mutate speaker_map (label-wide state)."""
+    sib0_id, _ = await _seed_sibling_pair(storage, tmp_path)
+    alex = await _create_user(storage, "alex@boat.com", "Alex")
+    t = await storage.get_transcript(sib0_id)
+    assert t is not None
+
+    await storage.set_segment_speaker_override(int(t["id"]), 0, alex)
+    sm = await storage.get_speaker_map(int(t["id"]))
+    assert sm == {}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -185,6 +185,36 @@ async def test_monitor_interval_setting_exists(client: httpx.AsyncClient) -> Non
 
 
 @pytest.mark.asyncio
+async def test_audio_stream_threshold_setting_exists(client: httpx.AsyncClient) -> None:
+    """AUDIO_STREAM_THRESHOLD_MINUTES is listed with default 45 and number input."""
+    resp = await client.get("/api/settings")
+    settings = {s["key"]: s for s in resp.json()["settings"]}
+    assert "AUDIO_STREAM_THRESHOLD_MINUTES" in settings
+    s = settings["AUDIO_STREAM_THRESHOLD_MINUTES"]
+    assert s["effective_value"] == "45"
+    assert s["input_type"] == "number"
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_threshold_roundtrip(client: httpx.AsyncClient) -> None:
+    """PUT overrides the default; subsequent GET returns the override.
+
+    The PUT endpoint also writes to ``os.environ`` so running code picks up
+    the change without restart — pop the env var in a finally so that global
+    side-effect doesn't leak into sibling tests.
+    """
+    import os
+
+    try:
+        await client.put("/api/settings", json={"AUDIO_STREAM_THRESHOLD_MINUTES": "20"})
+        resp = await client.get("/api/settings")
+        settings = {s["key"]: s for s in resp.json()["settings"]}
+        assert settings["AUDIO_STREAM_THRESHOLD_MINUTES"]["effective_value"] == "20"
+    finally:
+        os.environ.pop("AUDIO_STREAM_THRESHOLD_MINUTES", None)
+
+
+@pytest.mark.asyncio
 async def test_settings_page_returns_200(client: httpx.AsyncClient) -> None:
     """GET /admin/settings returns the HTML page."""
     resp = await client.get("/admin/settings")

--- a/tests/test_transcribe_siblings.py
+++ b/tests/test_transcribe_siblings.py
@@ -117,6 +117,96 @@ async def test_transcribe_session_tags_sibling_segments(storage: Storage, tmp_pa
     assert all(r["speaker"] == "Bow pair" for r in rows)
 
 
+async def test_debrief_sibling_preserves_diarized_speaker(storage: Storage, tmp_path: Path) -> None:
+    """#648: debrief siblings keep pyannote speaker labels instead of position_name.
+
+    Race audio relies on hardware isolation (one mic per crew member) so
+    race siblings collapse speaker to position_name. Debrief audio breaks
+    that assumption — multiple crew share mics — so we must keep the real
+    diarized labels.
+    """
+    wav = tmp_path / "debrief-sib0.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    session = AudioSession(
+        file_path=str(wav),
+        device_name="Jieli card 0",
+        start_utc=datetime(2026, 4, 12, 17, 0, 0, tzinfo=UTC),
+        end_utc=datetime(2026, 4, 12, 17, 5, 0, tzinfo=UTC),
+        sample_rate=48000,
+        channels=1,
+        capture_group_id="grp-debrief",
+        capture_ordinal=0,
+    )
+    sid = await storage.write_audio_session(session, session_type="debrief", name="dbg-debrief")
+    tid = await storage.create_transcript_job(sid, "base")
+
+    # Simulate a remote worker response with real diarization — the kind of
+    # payload the Mac-side transcribe_worker sends back when pyannote ran.
+    fake_remote = (
+        "helm: go go go. tactician: gybe now.",
+        [
+            {"start": 0.0, "end": 2.0, "text": "go go go", "speaker": "SPEAKER_01"},
+            {"start": 2.0, "end": 4.0, "text": "gybe now", "speaker": "SPEAKER_02"},
+        ],
+    )
+    from unittest.mock import AsyncMock
+
+    with patch("helmlog.transcribe._try_remote_transcribe", AsyncMock(return_value=fake_remote)):
+        from helmlog.transcribe import transcribe_session
+
+        await transcribe_session(
+            storage, sid, tid, model_size="base", diarize=True, transcribe_url="http://fake"
+        )
+
+    rows = await storage.list_transcript_segments(tid)
+    assert len(rows) == 2
+    # Pyannote speaker labels preserved, NOT collapsed to "sib0".
+    assert [r["speaker"] for r in rows] == ["SPEAKER_01", "SPEAKER_02"]
+    # But mic assignment hints still recorded so the UI can show "sib0" badges.
+    assert all(r["channel_index"] == 0 for r in rows)
+    assert all(r["position_name"] == "sib0" for r in rows)
+
+
+async def test_race_sibling_still_collapses_speaker_to_position(
+    storage: Storage, tmp_path: Path
+) -> None:
+    """Regression guard: race siblings keep the existing position_name override."""
+    wav = tmp_path / "race-sib0.wav"
+    wav.write_bytes(b"RIFF0000WAVEfmt ")
+    session = AudioSession(
+        file_path=str(wav),
+        device_name="Jieli card 0",
+        start_utc=datetime(2026, 4, 12, 17, 0, 0, tzinfo=UTC),
+        end_utc=datetime(2026, 4, 12, 17, 5, 0, tzinfo=UTC),
+        sample_rate=48000,
+        channels=1,
+        capture_group_id="grp-race",
+        capture_ordinal=0,
+    )
+    sid = await storage.write_audio_session(session, session_type="race", name="race-test")
+    tid = await storage.create_transcript_job(sid, "base")
+
+    fake_remote = (
+        "go go go. gybe now.",
+        [
+            {"start": 0.0, "end": 2.0, "text": "go go go", "speaker": "SPEAKER_01"},
+            {"start": 2.0, "end": 4.0, "text": "gybe now", "speaker": "SPEAKER_02"},
+        ],
+    )
+    from unittest.mock import AsyncMock
+
+    with patch("helmlog.transcribe._try_remote_transcribe", AsyncMock(return_value=fake_remote)):
+        from helmlog.transcribe import transcribe_session
+
+        await transcribe_session(
+            storage, sid, tid, model_size="base", diarize=True, transcribe_url="http://fake"
+        )
+
+    rows = await storage.list_transcript_segments(tid)
+    # Race path — speaker is collapsed to the mic's position_name.
+    assert all(r["speaker"] == "sib0" for r in rows)
+
+
 async def test_transcribe_session_sibling_falls_back_to_sibN_when_unmapped(
     storage: Storage, tmp_path: Path
 ) -> None:

--- a/tests/test_transcribe_siblings.py
+++ b/tests/test_transcribe_siblings.py
@@ -160,9 +160,11 @@ async def test_debrief_sibling_preserves_diarized_speaker(storage: Storage, tmp_
 
     rows = await storage.list_transcript_segments(tid)
     assert len(rows) == 2
-    assert [r["speaker"] for r in rows] == ["sib0:SPEAKER_01", "sib0:SPEAKER_02"]
+    # #648: R1 is the 1-indexed, user-friendly fallback name for receiver 1
+    # (ordinal 0). Used when no admin channel_map is configured.
+    assert [r["speaker"] for r in rows] == ["R1:SPEAKER_01", "R1:SPEAKER_02"]
     assert all(r["channel_index"] == 0 for r in rows)
-    assert all(r["position_name"] == "sib0" for r in rows)
+    assert all(r["position_name"] == "R1" for r in rows)
 
 
 async def test_race_sibling_also_preserves_diarized_speaker(
@@ -205,14 +207,15 @@ async def test_race_sibling_also_preserves_diarized_speaker(
 
     rows = await storage.list_transcript_segments(tid)
     # Race siblings get the same prefixed diarization now (no more collapse).
-    assert [r["speaker"] for r in rows] == ["sib1:SPEAKER_00", "sib1:SPEAKER_01"]
-    assert all(r["position_name"] == "sib1" for r in rows)
+    # R2 is the 1-indexed label for receiver 2 (ordinal 1).
+    assert [r["speaker"] for r in rows] == ["R2:SPEAKER_00", "R2:SPEAKER_01"]
+    assert all(r["position_name"] == "R2" for r in rows)
 
 
-async def test_transcribe_session_sibling_falls_back_to_sibN_when_unmapped(
+async def test_transcribe_session_sibling_falls_back_to_RN_when_unmapped(
     storage: Storage, tmp_path: Path
 ) -> None:
-    """No channel_map entry → fall back to sib{ordinal} label."""
+    """No channel_map entry → fall back to R{ordinal + 1} label (#648)."""
     wav = tmp_path / "loose.wav"
     wav.write_bytes(b"RIFF0000WAVEfmt ")
     session = AudioSession(
@@ -232,7 +235,7 @@ async def test_transcribe_session_sibling_falls_back_to_sibN_when_unmapped(
 
         await transcribe_session(storage, sid, tid, model_size="base")
     rows = await storage.list_transcript_segments(tid)
-    assert rows[0]["position_name"] == "sib3"
+    assert rows[0]["position_name"] == "R4"  # ordinal 3 → R4 (1-indexed)
     assert rows[0]["channel_index"] == 3
 
 

--- a/tests/test_transcribe_siblings.py
+++ b/tests/test_transcribe_siblings.py
@@ -98,7 +98,11 @@ async def _make_sibling_pair(storage: Storage, tmp_path: Path) -> tuple[int, int
 
 
 async def test_transcribe_session_tags_sibling_segments(storage: Storage, tmp_path: Path) -> None:
-    """A mono sibling gets channel_index=capture_ordinal and position from channel_map."""
+    """A mono sibling gets channel_index=capture_ordinal and position from channel_map.
+
+    When whisper runs without diarization, segments have no speaker field, so
+    we fall back to the bare position_name as the speaker label.
+    """
     primary_id, secondary_id, _ = await _make_sibling_pair(storage, tmp_path)
     transcript_id = await storage.create_transcript_job(secondary_id, "base")
 
@@ -114,16 +118,14 @@ async def test_transcribe_session_tags_sibling_segments(storage: Storage, tmp_pa
     # Ordinal 1 → virtual channel index 1.
     assert all(r["channel_index"] == 1 for r in rows)
     assert all(r["position_name"] == "Bow pair" for r in rows)
+    # No pyannote labels from the plain whisper path → fall back to position.
     assert all(r["speaker"] == "Bow pair" for r in rows)
 
 
 async def test_debrief_sibling_preserves_diarized_speaker(storage: Storage, tmp_path: Path) -> None:
-    """#648: debrief siblings keep pyannote speaker labels instead of position_name.
-
-    Race audio relies on hardware isolation (one mic per crew member) so
-    race siblings collapse speaker to position_name. Debrief audio breaks
-    that assumption — multiple crew share mics — so we must keep the real
-    diarized labels.
+    """#648: debrief siblings prefix pyannote labels with the mic's position
+    name so sib0:SPEAKER_01 stays distinct from sib1:SPEAKER_01 (pyannote
+    labels are per-WAV, not correlated across siblings).
     """
     wav = tmp_path / "debrief-sib0.wav"
     wav.write_bytes(b"RIFF0000WAVEfmt ")
@@ -140,8 +142,6 @@ async def test_debrief_sibling_preserves_diarized_speaker(storage: Storage, tmp_
     sid = await storage.write_audio_session(session, session_type="debrief", name="dbg-debrief")
     tid = await storage.create_transcript_job(sid, "base")
 
-    # Simulate a remote worker response with real diarization — the kind of
-    # payload the Mac-side transcribe_worker sends back when pyannote ran.
     fake_remote = (
         "helm: go go go. tactician: gybe now.",
         [
@@ -160,37 +160,38 @@ async def test_debrief_sibling_preserves_diarized_speaker(storage: Storage, tmp_
 
     rows = await storage.list_transcript_segments(tid)
     assert len(rows) == 2
-    # Pyannote speaker labels preserved, NOT collapsed to "sib0".
-    assert [r["speaker"] for r in rows] == ["SPEAKER_01", "SPEAKER_02"]
-    # But mic assignment hints still recorded so the UI can show "sib0" badges.
+    assert [r["speaker"] for r in rows] == ["sib0:SPEAKER_01", "sib0:SPEAKER_02"]
     assert all(r["channel_index"] == 0 for r in rows)
     assert all(r["position_name"] == "sib0" for r in rows)
 
 
-async def test_race_sibling_still_collapses_speaker_to_position(
+async def test_race_sibling_also_preserves_diarized_speaker(
     storage: Storage, tmp_path: Path
 ) -> None:
-    """Regression guard: race siblings keep the existing position_name override."""
-    wav = tmp_path / "race-sib0.wav"
+    """#648 (follow-up): race audio also keeps pyannote labels now — the
+    hardware-isolation shortcut ("one mic = one person") breaks even during
+    the race when someone talks into a neighbor's mic during a maneuver.
+    """
+    wav = tmp_path / "race-sib1.wav"
     wav.write_bytes(b"RIFF0000WAVEfmt ")
     session = AudioSession(
         file_path=str(wav),
-        device_name="Jieli card 0",
+        device_name="Jieli card 1",
         start_utc=datetime(2026, 4, 12, 17, 0, 0, tzinfo=UTC),
         end_utc=datetime(2026, 4, 12, 17, 5, 0, tzinfo=UTC),
         sample_rate=48000,
         channels=1,
         capture_group_id="grp-race",
-        capture_ordinal=0,
+        capture_ordinal=1,
     )
     sid = await storage.write_audio_session(session, session_type="race", name="race-test")
     tid = await storage.create_transcript_job(sid, "base")
 
     fake_remote = (
-        "go go go. gybe now.",
+        "go go go. alex shouting.",
         [
-            {"start": 0.0, "end": 2.0, "text": "go go go", "speaker": "SPEAKER_01"},
-            {"start": 2.0, "end": 4.0, "text": "gybe now", "speaker": "SPEAKER_02"},
+            {"start": 0.0, "end": 2.0, "text": "go go go", "speaker": "SPEAKER_00"},
+            {"start": 2.0, "end": 4.0, "text": "alex shouting", "speaker": "SPEAKER_01"},
         ],
     )
     from unittest.mock import AsyncMock
@@ -203,8 +204,9 @@ async def test_race_sibling_still_collapses_speaker_to_position(
         )
 
     rows = await storage.list_transcript_segments(tid)
-    # Race path — speaker is collapsed to the mic's position_name.
-    assert all(r["speaker"] == "sib0" for r in rows)
+    # Race siblings get the same prefixed diarization now (no more collapse).
+    assert [r["speaker"] for r in rows] == ["sib1:SPEAKER_00", "sib1:SPEAKER_01"]
+    assert all(r["position_name"] == "sib1" for r in rows)
 
 
 async def test_transcribe_session_sibling_falls_back_to_sibN_when_unmapped(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2933,7 +2933,11 @@ async def test_transcript_done_with_segments(
     segs = data["segments"]
     assert isinstance(segs, list)
     assert len(segs) == 2
-    assert set(segs[0].keys()) == {"start", "end", "speaker", "text"}
+    # #648: every segment now carries audio_session_id + segment_index so the
+    # client can address it for per-segment speaker-override POSTs.
+    assert {"start", "end", "speaker", "text", "audio_session_id", "segment_index"} <= set(
+        segs[0].keys()
+    )
     assert segs[0]["speaker"] == "SPEAKER_00"
     assert segs[1]["speaker"] == "SPEAKER_01"
 


### PR DESCRIPTION
## Summary

What actually landed in this PR grew beyond the original "Part 1 bug fix" scope — this is the accurate ship list.

## Shipped

**Debrief multi-channel parity (bug-fix scope from #648, C1–C6):**
- `api_start_debrief` uses the same `recorder` + `audio_config` as `api_start_race`; debrief `audio_sessions` rows now match race rows on `channels`, `channel_map`, and sibling-group shape (C1–C4, C6 integration test in `tests/test_debrief_parity.py`).
- USB device-set change between race-end and debrief-start logs a WARNING via `capture_start(..., prev_capture_group_id=...)` — debrief is not blocked (C5).

**Diarization on both race and debrief (enhancement scope from #648):**
- `_persist_sibling_segments` now preserves pyannote labels and prefixes them with the mic position (`R1:SPEAKER_00`, `R2:SPEAKER_01`, …) so labels stay globally unique across siblings.
- `num_speakers` hint threaded through the Pi → worker → `pyannote Pipeline(..., num_speakers=N)` chain. Configurable via `AUDIO_SPEAKERS_PER_CHANNEL` (default 2). Pyannote's over-splitting on noisy race audio (9 labels on one WAV) drops to 2 clean labels.
- `_extract_speaker_embeddings` keeps raw prefixed labels end-to-end so `_try_auto_match` + `maybe_build_voice_profile` can key on the same label segments store.
- `get_transcript_with_anon` stopped rewriting segment `speaker` fields to crew names — the client resolves display names via `speaker_map`, keeping raw labels round-trippable for click-to-assign.

**Speaker assignment + override UX:**
- Click the underlined speaker name on any segment → crew picker → label-wide assignment. Assignment fans out across all sibling transcripts so the merged view updates atomically.
- ✎ pencil icon on each block → per-segment override (new `transcript_segments.override_user_id` column, migration v77, `POST /api/audio/{id}/transcript/segments/{idx}/speaker-override`). A misattributed utterance points at a different crew member without mutating the label.
- Overridden segments visually break out of their speaker's block and render with an italicized override name + tooltip exposing the raw speaker.
- Retranscribe-with-diarization button on both race and debrief transcripts.

**Session page UX:**
- Single shared transcript renderer for race and debrief (`_renderTranscriptPane`). Same block grouping, Follow toggle, pencil, speaker-click, and clock-synced auto-scroll on both.
- Debrief gets its own pane state (`_transcriptPanes.debrief`) so follow / active-segment / surface registration don't collide with race.
- Collapsible `Race Audio ▼` / `Debrief Audio ▼` section headers (same style as `Transcript ▼`).
- R1 / R2 sibling isolation buttons on both race and debrief players (race previously had only `All channels`).
- Streaming audio path for long sibling sessions: when `duration_s ≥ AUDIO_STREAM_THRESHOLD_MINUTES × 60` (default 45) the session page plays via `<audio>` + `MediaElementAudioSourceNode` instead of `decodeAudioData`, keeping memory flat. Exposed on the admin settings page.
- Transcript jumping root cause fixed: `_scrollTranscriptSegmentIntoView` now computes position via `getBoundingClientRect` instead of `offsetTop`; best-match block picker + pending-seek target eliminate jitter.
- Labels renamed: `sib0` / `sib1` → `R1` / `R2` (falls back from the admin `channel_map` if configured).

**Operational / housekeeping:**
- `data/vakaros-inbox/` added to `.gitignore` — was triggering `dirty` version badge.
- `AUDIO_STREAM_THRESHOLD_MINUTES` + `AUDIO_SPEAKERS_PER_CHANNEL` exposed on the admin settings page.
- Debrief retranscribe endpoint + UI button.

## Not shipped (deferred — still tracked in #648)

- Voice-profile lifecycle state machine (NoConsent → ConsentedEmpty → Training → Active → Revoked) with guard conditions and revocation cleanup, from Part 2 of the structured spec.
- Per-segment speaker-label decision table rows R1–R14 (confidence tiers, conflict flagging, manual-review queue, mapped-vs-unmapped channel rules) from Part 3.
- Privacy fail-safe invariants P1–P8 from Part 4 (strict consent gating on extraction, on-delete embedding purge, no-consent segment fallback) — some partially covered by existing #443 code, not audited against spec.
- Automatic consent-gated voice-profile accumulation from race audio (ex. "feed labeled helm-channel segments to Alice's profile without manual per-segment assignment"). Infrastructure is wired (`_try_auto_match` + `maybe_build_voice_profile` now key on prefixed labels correctly) but not validated end-to-end.
- Persisted confidence scores on `transcript_segments` + UI confidence badges.

## Schema change

New migration `v77` adds `transcript_segments.override_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL`. Idempotent ALTER TABLE; no data migration needed.

## Tests

- `tests/test_debrief_parity.py` — C1–C6 (6 tests)
- `tests/test_audio_streaming_threshold.py` — buffer vs stream gating + env override (7 tests)
- `tests/test_segment_override.py` — schema + storage + API + invariants (11 tests)
- `tests/test_transcribe_siblings.py` — debrief-diarization preservation + race-diarization preservation + label prefix fallback (expanded)
- `tests/test_diarize_crew.py` — updated to reflect raw-label preservation after `get_transcript_with_anon` change
- `tests/test_settings.py` — `AUDIO_STREAM_THRESHOLD_MINUTES` roundtrip
- `tests/test_web.py::test_transcript_done_with_segments` — updated segment shape expectation
- `tests/test_migration_v75.py` — schema_version check reads `_CURRENT_VERSION` so future bumps don't break it

## Validation on corvopi-tst1

Ran the full race → debrief → retranscribe → click-to-assign loop against a real 82-minute sibling race + matching debrief. All four pyannote labels (`R1:SPEAKER_00`, `R1:SPEAKER_01`, `R2:SPEAKER_00`, `R2:SPEAKER_01`) map cleanly to the 4-crew setup (Dan / Alex / Steve / Stefan). Streaming-mode audio loads without the earlier "Loading audio…" hang; transcript auto-scroll follows the playhead.

Addresses #648 (scope delivered above; remaining scope tracked on that issue).

🤖 Generated with [Claude Code](https://claude.ai/code)