### PR TITLE
Seed starter tag vocabulary for racing-event moments (#652)

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -200,7 +200,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 77
+_CURRENT_VERSION: int = 78
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1771,6 +1771,46 @@ _MIGRATIONS: dict[int, str] = {
         -- means "use the label-wide speaker_map lookup".
         ALTER TABLE transcript_segments ADD COLUMN override_user_id INTEGER
             REFERENCES users(id) ON DELETE SET NULL;
+    """,
+    78: """
+        -- #652: seed starter tag vocabulary for human-judgment racing
+        -- moments (close crossings, protests, places gained/lost, etc.).
+        -- Conditions like light/heavy air are NOT seeded — they are
+        -- queries against wind data, not tags.
+        --
+        -- Color convention, load-bearing for UX:
+        --   green  (#16a34a) — us-good outcome
+        --   red    (#b91c1c) — us-bad outcome
+        --   amber  (#eab308 / #f59e0b) — severity (close-crossing / near-miss)
+        --   red    (#dc2626) — severe incident (collision, hit-mark, ocs)
+        --   purple (#7c3aed) — rules bucket
+        --   grey   (#6b7280) — gear/crew incident
+        --
+        -- Directional pairs (rolled-them / got-rolled, etc.) are kept
+        -- SEPARATE on purpose — collapsing them would destroy the
+        -- "every moment we got rolled" query. Do not merge in admin UI.
+        INSERT OR IGNORE INTO tags (name, color, created_at) VALUES
+            ('close-crossing',  '#eab308', datetime('now')),
+            ('collision',       '#dc2626', datetime('now')),
+            ('near-miss',       '#f59e0b', datetime('now')),
+            ('rolled-them',     '#16a34a', datetime('now')),
+            ('got-rolled',      '#b91c1c', datetime('now')),
+            ('lee-bowed-them',  '#16a34a', datetime('now')),
+            ('got-lee-bowed',   '#b91c1c', datetime('now')),
+            ('pinned-them',     '#16a34a', datetime('now')),
+            ('got-pinned',      '#b91c1c', datetime('now')),
+            ('places-gained',   '#16a34a', datetime('now')),
+            ('places-lost',     '#b91c1c', datetime('now')),
+            ('passed-boat',     '#16a34a', datetime('now')),
+            ('got-passed',      '#b91c1c', datetime('now')),
+            ('we-protested',    '#7c3aed', datetime('now')),
+            ('got-protested',   '#7c3aed', datetime('now')),
+            ('took-penalty',    '#7c3aed', datetime('now')),
+            ('hit-mark',        '#dc2626', datetime('now')),
+            ('ocs',             '#dc2626', datetime('now')),
+            ('gear-failure',    '#6b7280', datetime('now')),
+            ('crew-incident',   '#6b7280', datetime('now')),
+            ('grounded',        '#6b7280', datetime('now'));
     """,
 }
 

--- a/src/helmlog/templates/admin/tags.html
+++ b/src/helmlog/templates/admin/tags.html
@@ -29,6 +29,33 @@ input.inline{background:var(--bg-input);border:1px solid var(--border);border-ra
 {% block content %}
 <h1 style="margin-bottom:12px">Tag Manager</h1>
 
+<div class="card" style="font-size:.82rem;line-height:1.45">
+  <strong>Convention.</strong> Tags capture <em>human-judgment racing events</em>
+  (close crossings, protests, places gained/lost, rollings). Conditions like
+  light or heavy air are <em>not</em> tags &mdash; they are queries against the
+  wind data.
+  <br><br>
+  <strong>Directional pairs are intentional.</strong> <code>rolled-them</code>
+  and <code>got-rolled</code> are separate tags so &ldquo;every moment we got
+  rolled&rdquo; remains a filterable query. Do <strong>not</strong> merge
+  directional pairs &mdash; collapsing them destroys the query. Same for
+  <code>pinned-them</code>&nbsp;/&nbsp;<code>got-pinned</code>,
+  <code>we-protested</code>&nbsp;/&nbsp;<code>got-protested</code>,
+  <code>places-gained</code>&nbsp;/&nbsp;<code>places-lost</code>, etc.
+  <br><br>
+  <strong>Colors are load-bearing.</strong>
+  <span style="color:#16a34a">green</span> = us-good,
+  <span style="color:#b91c1c">red</span> = us-bad,
+  <span style="color:#7c3aed">purple</span> = rules,
+  <span style="color:#6b7280">grey</span> = gear/crew incident,
+  <span style="color:#dc2626">red</span>/<span style="color:#eab308">amber</span>
+  = collision severity. Keep new tags in the convention where it applies.
+  <br><br>
+  <strong>Counterparty is not a tag.</strong> Which <em>other</em> boat was
+  involved lives on the bookmark itself, not as a per-boat tag &mdash;
+  otherwise the tag list drifts into half-boats per season.
+</div>
+
 <div class="card">
   <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
     <input id="new-tag-name" class="inline" placeholder="New tag name" />

--- a/tests/test_migration_v78.py
+++ b/tests/test_migration_v78.py
@@ -1,0 +1,155 @@
+"""Tests for migration v78 — seed starter tag vocabulary (#652)."""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+EXPECTED_SEED_TAGS = {
+    # Boat-on-boat, directional
+    "close-crossing",
+    "collision",
+    "near-miss",
+    "rolled-them",
+    "got-rolled",
+    "lee-bowed-them",
+    "got-lee-bowed",
+    "pinned-them",
+    "got-pinned",
+    # Position change
+    "places-gained",
+    "places-lost",
+    "passed-boat",
+    "got-passed",
+    # Rules
+    "we-protested",
+    "got-protested",
+    "took-penalty",
+    "hit-mark",
+    "ocs",
+    # Incident
+    "gear-failure",
+    "crew-incident",
+    "grounded",
+}
+
+
+@pytest.mark.asyncio
+async def test_v78_inserts_seed_tags() -> None:
+    db = await _build_db_at(78)
+    try:
+        await _apply_migration(db, 78)
+        async with db.execute("SELECT name FROM tags") as cur:
+            names = {r[0] for r in await cur.fetchall()}
+        missing = EXPECTED_SEED_TAGS - names
+        assert not missing, f"seed tags missing after v78: {sorted(missing)}"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v78_seed_tags_have_colors() -> None:
+    """Every seed tag should have a non-null color — the us-good / us-bad /
+    rules / incident color convention is the whole point of seeding."""
+    db = await _build_db_at(78)
+    try:
+        async with db.execute(
+            "SELECT name, color FROM tags WHERE name IN ({})".format(
+                ",".join("?" * len(EXPECTED_SEED_TAGS))
+            ),
+            tuple(EXPECTED_SEED_TAGS),
+        ) as cur:
+            rows = await cur.fetchall()
+        uncolored = [r[0] for r in rows if not r[1]]
+        assert not uncolored, f"seed tags missing color: {uncolored}"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v78_directional_pairs_have_opposite_colors() -> None:
+    """us-good (green) / us-bad (red) pairs must render distinctly — that's
+    the whole reason the pair isn't collapsed into one neutral tag."""
+    db = await _build_db_at(78)
+    try:
+        pairs = [
+            ("rolled-them", "got-rolled"),
+            ("lee-bowed-them", "got-lee-bowed"),
+            ("pinned-them", "got-pinned"),
+            ("places-gained", "places-lost"),
+            ("passed-boat", "got-passed"),
+        ]
+        for good, bad in pairs:
+            async with db.execute(
+                "SELECT name, color FROM tags WHERE name IN (?, ?)", (good, bad)
+            ) as cur:
+                colors = {r[0]: r[1] for r in await cur.fetchall()}
+            assert colors[good] != colors[bad], (
+                f"directional pair {good}/{bad} must use different colors"
+            )
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v78_is_idempotent() -> None:
+    """Running v78 on a DB that already has some of the seed tags (from
+    earlier manual creation) must not error or duplicate."""
+    db = await _build_db_at(77)
+    try:
+        now = "2026-04-21T00:00:00"
+        await db.execute(
+            "INSERT INTO tags (name, color, created_at) VALUES (?, ?, ?)",
+            ("collision", "#ff0000", now),
+        )
+        await db.commit()
+
+        await _apply_migration(db, 78)
+        # Run it a second time — should still not error or duplicate.
+        await _apply_migration(db, 78)
+
+        async with db.execute("SELECT COUNT(*) FROM tags WHERE name = ?", ("collision",)) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 1, "idempotent insert must not duplicate existing tag"
+
+        async with db.execute("SELECT color FROM tags WHERE name = ?", ("collision",)) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "#ff0000", "existing tag's color must be preserved"
+    finally:
+        await db.close()
+
+
+# Fresh-DB schema_version is asserted dynamically against _CURRENT_VERSION
+# in test_migration_v75.py::test_schema_version_is_current_on_fresh_db, so
+# a fixed v78 assertion here would be redundant.

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -55,12 +55,14 @@ async def test_audit_log_limit_offset(storage: Storage) -> None:
 
 @pytest.mark.asyncio
 async def test_create_and_list_tags(storage: Storage) -> None:
+    # Fresh DBs now include a seeded racing-event vocabulary (#652), so this
+    # test looks for its own tag by name rather than asserting total count.
     tag_id = await storage.create_tag("protest", "#e53e3e")
     tags = await storage.list_tags()
-    assert len(tags) == 1
-    assert tags[0]["name"] == "protest"
-    assert tags[0]["color"] == "#e53e3e"
-    assert tags[0]["id"] == tag_id
+    by_name = {t["name"]: t for t in tags}
+    assert "protest" in by_name
+    assert by_name["protest"]["color"] == "#e53e3e"
+    assert by_name["protest"]["id"] == tag_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_entity_tags.py
+++ b/tests/test_storage_entity_tags.py
@@ -155,10 +155,13 @@ async def test_attach_idempotent_does_not_double_count(storage: Storage) -> None
 
 @pytest.mark.asyncio
 async def test_list_tags_order_by_name(storage: Storage) -> None:
+    # Fresh DBs include seeded tags (#652), so filter to the names this test
+    # actually created before asserting relative order.
     await storage.create_tag("zebra")
     await storage.create_tag("alpha")
     await storage.create_tag("mongoose")
-    names = [t["name"] for t in await storage.list_tags(order_by="name")]
+    own = {"alpha", "mongoose", "zebra"}
+    names = [t["name"] for t in await storage.list_tags(order_by="name") if t["name"] in own]
     assert names == ["alpha", "mongoose", "zebra"]
 
 
@@ -174,7 +177,10 @@ async def test_list_tags_order_by_usage(storage: Storage) -> None:
     sid2 = await _session(storage, 2)
     await storage.attach_tag("session", sid2, t_hot, user_id=None)
 
-    names = [t["name"] for t in await storage.list_tags(order_by="usage")]
+    # Seeded tags (#652) have 0 usage, same as "cold" — filter to this test's
+    # own tags to make the ordering assertion meaningful.
+    own = {"hot", "warm", "cold"}
+    names = [t["name"] for t in await storage.list_tags(order_by="usage") if t["name"] in own]
     # hot (2) comes first, warm (1), cold (0)
     assert names[:2] == ["hot", "warm"]
     assert names[-1] == "cold"


### PR DESCRIPTION
## Summary

Migration v78 seeds 21 curated tags focused on **human-judgment racing events** — boat-on-boat interactions, position change, rules, and incidents. Conditions (light/heavy air) are intentionally **not** seeded; those remain queries against wind data, not tags.

Also adds a convention blurb to the admin Tag Manager page explaining the three load-bearing choices (directional pairs, color coding, counterparty-is-not-a-tag).

Numbered v78 so this stack sits above #649's v77 (speaker override).

Closes #652

## Key design calls

- **Directional pairs preserved.** `rolled-them` and `got-rolled` are separate tags.
- **Colors are load-bearing.** green = us-good, red = us-bad, purple = rules, grey = gear/crew incident, red/amber = collision severity.
- **Idempotent migration.** `INSERT OR IGNORE` by unique `name`.

## Test plan

- [x] Migration v78 inserts all 21 seed tags on a fresh DB
- [x] Every seed tag has a non-null color
- [x] Directional pairs have opposite colors
- [x] Migration is idempotent — preserves an existing tag's user-chosen color
- [x] Schema version is 78 on fresh DB
- [x] Pre-existing entity-tag tests updated to tolerate seed data
- [x] Full test suite green, lint/format/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)