### PR TITLE
Add counterparty field to bookmarks (#651)

### DIFF
--- a/src/helmlog/routes/bookmarks.py
+++ b/src/helmlog/routes/bookmarks.py
@@ -29,6 +29,7 @@ def _serialize(bm: dict[str, Any]) -> dict[str, Any]:
         "t_start": bm["anchor_t_start"],
         "created_at": bm["created_at"],
         "updated_at": bm["updated_at"],
+        "counterparty": bm.get("counterparty"),
     }
 
 
@@ -49,6 +50,10 @@ async def api_create_bookmark(
     note_raw = body.get("note")
     note = note_raw.strip() if isinstance(note_raw, str) and note_raw.strip() else None
     t_start = body.get("t_start")
+    cp_raw = body.get("counterparty")
+    # Blank strings collapse to NULL so the SELECT DISTINCT typeahead
+    # doesn't end up with empty-string entries from casual form input.
+    counterparty = cp_raw.strip() if isinstance(cp_raw, str) and cp_raw.strip() else None
 
     if not name:
         raise HTTPException(status_code=422, detail="name is required")
@@ -66,6 +71,7 @@ async def api_create_bookmark(
         name=name,
         note=note,
         t_start=t_start,
+        counterparty=counterparty,
     )
     await audit(
         request,
@@ -159,6 +165,7 @@ async def api_update_bookmark(
     body = await request.json()
     name_in = body.get("name")
     note_in = body.get("note", ...)  # sentinel: absent vs. explicit None
+    cp_in = body.get("counterparty", ...)  # same sentinel pattern
 
     name = name_in.strip() if isinstance(name_in, str) else None
     if name is not None and not name:
@@ -178,7 +185,28 @@ async def api_update_bookmark(
         else:
             raise HTTPException(status_code=422, detail="note must be a string or null")
 
-    await storage.update_bookmark(bookmark_id, name=name, note=note, clear_note=clear_note)
+    clear_counterparty = False
+    counterparty: str | None = None
+    if cp_in is not ...:
+        if cp_in is None:
+            clear_counterparty = True
+        elif isinstance(cp_in, str):
+            stripped_cp = cp_in.strip()
+            if not stripped_cp:
+                clear_counterparty = True
+            else:
+                counterparty = stripped_cp
+        else:
+            raise HTTPException(status_code=422, detail="counterparty must be a string or null")
+
+    await storage.update_bookmark(
+        bookmark_id,
+        name=name,
+        note=note,
+        clear_note=clear_note,
+        counterparty=counterparty,
+        clear_counterparty=clear_counterparty,
+    )
     await audit(
         request,
         "bookmark.update",
@@ -188,6 +216,23 @@ async def api_update_bookmark(
     updated = await storage.get_bookmark(bookmark_id)
     assert updated is not None
     return JSONResponse(_serialize(updated))
+
+
+@router.get("/api/bookmarks/counterparties")
+async def api_list_bookmark_counterparties(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return distinct counterparty values for typeahead suggestions.
+
+    Returns a plain sorted list of strings; the UI is free to filter it
+    client-side. Free-text entry is still accepted in create/patch —
+    this endpoint just seeds the dropdown with values that already
+    exist so spelling stays consistent.
+    """
+    storage = get_storage(request)
+    values = await storage.list_bookmark_counterparties()
+    return JSONResponse(values)
 
 
 @router.delete("/api/bookmarks/{bookmark_id}", status_code=204)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -200,7 +200,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 79
+_CURRENT_VERSION: int = 80
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1828,6 +1828,24 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE entity_tags ADD COLUMN confirmed_at TEXT;
         ALTER TABLE entity_tags ADD COLUMN confirmed_by INTEGER REFERENCES users(id);
         CREATE INDEX IF NOT EXISTS idx_entity_tags_source ON entity_tags(source);
+    """,
+    80: """
+        -- #651: which OTHER boat was involved in a bookmarked moment
+        -- (close crossing with Absolutely, got rolled by Zephyr, etc.).
+        -- Free-text for now. A typeahead driven by SELECT DISTINCT keeps
+        -- spelling drift manageable without forcing a controlled
+        -- vocabulary or introducing a competitors table prematurely.
+        --
+        -- Elevating to a real competitor entity is tracked in #656 and
+        -- should wait until we have real usage signal showing
+        -- typeahead-level dedup is insufficient.
+        --
+        -- Partial index keeps the common "no counterparty" rows out of
+        -- the index entirely, so the index only materialises entries
+        -- for rows that can actually be looked up.
+        ALTER TABLE bookmarks ADD COLUMN counterparty TEXT;
+        CREATE INDEX IF NOT EXISTS idx_bookmarks_counterparty
+            ON bookmarks(counterparty) WHERE counterparty IS NOT NULL;
     """,
 }
 
@@ -6829,16 +6847,23 @@ class Storage:
         name: str,
         note: str | None,
         t_start: str,
+        counterparty: str | None = None,
     ) -> int:
-        """Create a timestamp-kind bookmark on a session. Returns new id."""
+        """Create a timestamp-kind bookmark on a session. Returns new id.
+
+        ``counterparty`` is the *other* boat involved in the moment (close
+        crossing with Absolutely, got rolled by Zephyr). Free-text; a
+        typeahead over ``list_bookmark_counterparties`` keeps spelling
+        consistent without a controlled vocabulary.
+        """
         now = datetime.now(UTC).isoformat()
         db = self._conn()
         cur = await db.execute(
             "INSERT INTO bookmarks "
             "(session_id, created_by, name, note, anchor_kind, anchor_t_start, "
-            "created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, 'timestamp', ?, ?, ?)",
-            (session_id, user_id, name, note, t_start, now, now),
+            "created_at, updated_at, counterparty) "
+            "VALUES (?, ?, ?, ?, 'timestamp', ?, ?, ?, ?)",
+            (session_id, user_id, name, note, t_start, now, now, counterparty),
         )
         await db.commit()
         assert cur.lastrowid is not None
@@ -6848,7 +6873,8 @@ class Storage:
         """Return a single bookmark row as a dict, or None if not found."""
         cur = await self._read_conn().execute(
             "SELECT id, session_id, created_by, name, note, anchor_kind, "
-            "anchor_entity_id, anchor_t_start, anchor_t_end, created_at, updated_at "
+            "anchor_entity_id, anchor_t_start, anchor_t_end, created_at, "
+            "updated_at, counterparty "
             "FROM bookmarks WHERE id = ?",
             (bookmark_id,),
         )
@@ -6859,12 +6885,27 @@ class Storage:
         """Return all bookmarks on a session, ordered by anchor_t_start."""
         cur = await self._read_conn().execute(
             "SELECT id, session_id, created_by, name, note, anchor_kind, "
-            "anchor_entity_id, anchor_t_start, anchor_t_end, created_at, updated_at "
+            "anchor_entity_id, anchor_t_start, anchor_t_end, created_at, "
+            "updated_at, counterparty "
             "FROM bookmarks WHERE session_id = ? "
             "ORDER BY anchor_t_start, id",
             (session_id,),
         )
         return [dict(r) for r in await cur.fetchall()]
+
+    async def list_bookmark_counterparties(self) -> list[str]:
+        """Return distinct non-null counterparties, alphabetically sorted.
+
+        Used by the typeahead so users type once and pick again; also the
+        only shape needed to see drift in the free-text field before
+        elevating to a competitor entity (#656).
+        """
+        cur = await self._read_conn().execute(
+            "SELECT DISTINCT counterparty FROM bookmarks"
+            " WHERE counterparty IS NOT NULL"
+            " ORDER BY counterparty"
+        )
+        return [r[0] for r in await cur.fetchall()]
 
     async def update_bookmark(
         self,
@@ -6873,11 +6914,15 @@ class Storage:
         name: str | None = None,
         note: str | None = None,
         clear_note: bool = False,
+        counterparty: str | None = None,
+        clear_counterparty: bool = False,
     ) -> bool:
-        """Update bookmark name and/or note.
+        """Update bookmark name, note, and/or counterparty.
 
-        Pass `clear_note=True` to explicitly set note to NULL; otherwise a
-        `note=None` argument is treated as "don't change note".
+        Pass ``clear_note=True`` / ``clear_counterparty=True`` to set the
+        field to NULL; otherwise a ``None`` kwarg is treated as "don't
+        change this field", so callers that only touch one field don't
+        clobber the others.
         """
         parts: list[str] = []
         params: list[Any] = []
@@ -6889,6 +6934,11 @@ class Storage:
         elif note is not None:
             parts.append("note = ?")
             params.append(note)
+        if clear_counterparty:
+            parts.append("counterparty = NULL")
+        elif counterparty is not None:
+            parts.append("counterparty = ?")
+            params.append(counterparty)
         if not parts:
             return await self.get_bookmark(bookmark_id) is not None
         parts.append("updated_at = ?")

--- a/tests/test_bookmark_counterparty.py
+++ b/tests/test_bookmark_counterparty.py
@@ -1,0 +1,271 @@
+"""Storage + API tests for bookmark counterparty (#651).
+
+Covers:
+- create_bookmark persists counterparty
+- update_bookmark sets / clears / leaves counterparty alone per sentinel
+- list_bookmark_counterparties returns distinct non-null values sorted
+- POST /api/sessions/{id}/bookmarks accepts counterparty
+- PATCH /api/bookmarks/{id} — null clears, absent leaves alone
+- GET /api/bookmarks/counterparties typeahead endpoint
+- Serialized response includes counterparty
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _seed_session(storage: Storage, idx: int = 1) -> int:
+    now = datetime.now(UTC).isoformat()
+    assert storage._db is not None
+    cur = await storage._db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+        (f"s{idx}", "E", idx, "2024-06-15", now),
+    )
+    await storage._db.commit()
+    assert cur.lastrowid is not None
+    return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_bookmark_persists_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="close crossing",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    bm = await storage.get_bookmark(bm_id)
+    assert bm is not None
+    assert bm["counterparty"] == "Absolutely"
+
+
+@pytest.mark.asyncio
+async def test_create_bookmark_without_counterparty_defaults_null(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="no counterparty",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+    )
+    bm = await storage.get_bookmark(bm_id)
+    assert bm is not None
+    assert bm["counterparty"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_bookmark_sets_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="bm",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+    )
+    await storage.update_bookmark(bm_id, counterparty="Zephyr")
+    bm = await storage.get_bookmark(bm_id)
+    assert bm is not None
+    assert bm["counterparty"] == "Zephyr"
+
+
+@pytest.mark.asyncio
+async def test_update_bookmark_clears_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="bm",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    await storage.update_bookmark(bm_id, clear_counterparty=True)
+    bm = await storage.get_bookmark(bm_id)
+    assert bm is not None
+    assert bm["counterparty"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_bookmark_absent_counterparty_leaves_alone(storage: Storage) -> None:
+    """Name-only update must not clobber the counterparty."""
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="bm",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    await storage.update_bookmark(bm_id, name="renamed")
+    bm = await storage.get_bookmark(bm_id)
+    assert bm is not None
+    assert bm["name"] == "renamed"
+    assert bm["counterparty"] == "Absolutely"
+
+
+@pytest.mark.asyncio
+async def test_list_bookmark_counterparties_distinct_sorted(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    for cp, name in [
+        ("Absolutely", "a"),
+        ("Zephyr", "b"),
+        ("Absolutely", "c"),
+        (None, "d"),
+        ("Mistral", "e"),
+    ]:
+        await storage.create_bookmark(
+            session_id=sid,
+            user_id=None,
+            name=name,
+            note=None,
+            t_start="2024-06-15T12:00:30",
+            counterparty=cp,
+        )
+    values = await storage.list_bookmark_counterparties()
+    assert values == ["Absolutely", "Mistral", "Zephyr"]
+
+
+@pytest.mark.asyncio
+async def test_list_bookmarks_for_session_includes_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="with",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    rows = await storage.list_bookmarks_for_session(sid)
+    assert len(rows) == 1
+    assert rows[0]["counterparty"] == "Absolutely"
+
+
+# ---------------------------------------------------------------------------
+# API layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_bookmark_accepts_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/sessions/{sid}/bookmarks",
+            json={
+                "name": "close crossing",
+                "t_start": "2024-06-15T12:00:30",
+                "counterparty": "Absolutely",
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["counterparty"] == "Absolutely"
+
+
+@pytest.mark.asyncio
+async def test_patch_bookmark_null_clears_counterparty(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="bm",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.patch(f"/api/bookmarks/{bm_id}", json={"counterparty": None})
+        assert resp.status_code == 200
+        assert resp.json()["counterparty"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_bookmark_absent_counterparty_leaves_alone(storage: Storage) -> None:
+    """PATCH without counterparty key must not clobber — many existing
+    callers send only name / note."""
+    sid = await _seed_session(storage)
+    bm_id = await storage.create_bookmark(
+        session_id=sid,
+        user_id=None,
+        name="bm",
+        note=None,
+        t_start="2024-06-15T12:00:30",
+        counterparty="Absolutely",
+    )
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.patch(f"/api/bookmarks/{bm_id}", json={"name": "renamed"})
+        assert resp.status_code == 200
+        assert resp.json()["counterparty"] == "Absolutely"
+        assert resp.json()["name"] == "renamed"
+
+
+@pytest.mark.asyncio
+async def test_get_counterparties_typeahead_endpoint(storage: Storage) -> None:
+    sid = await _seed_session(storage)
+    for cp in ("Absolutely", "Zephyr", "Absolutely"):
+        await storage.create_bookmark(
+            session_id=sid,
+            user_id=None,
+            name="bm",
+            note=None,
+            t_start="2024-06-15T12:00:30",
+            counterparty=cp,
+        )
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/bookmarks/counterparties")
+        assert resp.status_code == 200
+        assert resp.json() == ["Absolutely", "Zephyr"]
+
+
+@pytest.mark.asyncio
+async def test_post_bookmark_blank_counterparty_stored_as_null(storage: Storage) -> None:
+    """Blank strings from the UI typeahead shouldn't clutter DISTINCT queries."""
+    sid = await _seed_session(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            f"/api/sessions/{sid}/bookmarks",
+            json={
+                "name": "bm",
+                "t_start": "2024-06-15T12:00:30",
+                "counterparty": "   ",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["counterparty"] is None

--- a/tests/test_migration_v80.py
+++ b/tests/test_migration_v80.py
@@ -1,0 +1,102 @@
+"""Tests for migration v80 — counterparty column on bookmarks (#651)."""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_v80_adds_counterparty_column() -> None:
+    db = await _build_db_at(79)
+    try:
+        await _apply_migration(db, 80)
+        async with db.execute("PRAGMA table_info(bookmarks)") as cur:
+            cols = {r[1]: r for r in await cur.fetchall()}
+        assert "counterparty" in cols
+        # Must be nullable — most bookmarks won't have a counterparty.
+        assert cols["counterparty"][3] == 0, "counterparty must be nullable"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v80_creates_partial_index() -> None:
+    """Partial index keeps the common 'no counterparty' case out of the
+    index entirely — indexed entries only exist for rows that actually
+    have a counterparty to look up."""
+    db = await _build_db_at(80)
+    try:
+        async with db.execute(
+            "SELECT sql FROM sqlite_master"
+            " WHERE type = 'index' AND name = 'idx_bookmarks_counterparty'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert "WHERE" in row[0].upper(), "index must be partial"
+        assert "counterparty IS NOT NULL" in row[0]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v80_existing_bookmarks_unaffected() -> None:
+    """A bookmark created before v80 must still read cleanly; counterparty
+    is simply NULL on legacy rows."""
+    db = await _build_db_at(79)
+    try:
+        await db.execute(
+            "INSERT INTO races (name, event, race_num, date, start_utc) VALUES (?, ?, ?, ?, ?)",
+            ("legacy", "E", 1, "2026-01-01", "2026-01-01T00:00:00"),
+        )
+        sid_row = await (await db.execute("SELECT last_insert_rowid()")).fetchone()
+        assert sid_row is not None
+        sid = sid_row[0]
+        await db.execute(
+            "INSERT INTO bookmarks"
+            " (session_id, name, anchor_kind, anchor_t_start, created_at, updated_at)"
+            " VALUES (?, 'old', 'timestamp', '2026-01-01T00:00:30', '2026-01-01', '2026-01-01')",
+            (sid,),
+        )
+        await db.commit()
+
+        await _apply_migration(db, 80)
+
+        cur = await db.execute("SELECT counterparty FROM bookmarks WHERE session_id = ?", (sid,))
+        row = await cur.fetchone()
+        assert row is not None
+        assert row[0] is None
+    finally:
+        await db.close()
+
+
+# Fresh-DB schema_version is asserted dynamically against _CURRENT_VERSION
+# in test_migration_v75.py::test_schema_version_is_current_on_fresh_db.


### PR DESCRIPTION
## Summary

Migration v80 adds `bookmarks.counterparty` — a free-text field that captures which *other* boat was involved in a bookmarked moment (close crossing with Absolutely, got rolled by Zephyr, we protested Mistral). Paired with tag filters, this enables queries like "every moment we tangled with Absolutely across the season" without stuffing per-boat identity into the tag namespace.

Numbered v80 so this stack sits above #649's v77 (speaker override).

Closes #651

**⚠️ Stacked on #658** — this PR targets `feature/650-tag-source`. GitHub will auto-update the base after upstream PRs merge.

## Key design calls

- **Free-text, not a competitor entity** (tracked as #656).
- **Blank strings collapse to NULL.**
- **PATCH uses sentinel absent/null** — name-only updates must not clobber counterparty.
- **Partial index** keeps no-counterparty rows out entirely.

## New API surface

- `POST /api/sessions/{id}/bookmarks` accepts optional `counterparty`
- `PATCH /api/bookmarks/{id}` accepts `counterparty` (null-to-clear)
- `GET /api/bookmarks/counterparties` — typeahead endpoint

## Not in scope

- UI wiring (typeahead input, subtitle, filter chip) — follow-up
- Competitor entity migration (#656)
- Multi-counterparty moments — if needed, join table is the right answer

## Test plan

- [x] Migration v80 adds column + partial index
- [x] Legacy rows read cleanly with counterparty=NULL
- [x] `create_bookmark` persists counterparty
- [x] `update_bookmark` set / clear / leave-alone sentinel works
- [x] `list_bookmark_counterparties` distinct + sorted
- [x] POST accepts counterparty; blanks collapse to NULL
- [x] PATCH null clears; PATCH absent leaves alone
- [x] Full test suite green, lint/format/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)