### PR TITLE
fix: invalidate cached session_summary after results import (#666)

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -91,7 +91,7 @@ async def import_results(
 
         counts["races_upserted"] += 1
 
-    await _link_regatta_races_to_local_sessions(db, regatta_id)
+    _linked, touched_sessions = await _link_regatta_races_to_local_sessions(db, regatta_id)
 
     for standing in results.standings:
         boat_id = await _upsert_boat_minimal(db, standing.sail_number, boat_cache)
@@ -104,7 +104,27 @@ async def import_results(
     )
 
     counts["boats_upserted"] = len(boat_cache)
+
+    # Collect every race id touched by this import (imported rows and any
+    # live sessions now linked to them) so we can drop stale cached
+    # session_summary blobs after the commit lands. Without this, a
+    # pre-import summary fetch that populated the cache with
+    # ``results: []`` survives the import and the /history card never
+    # reflects the imported results (#666).
+    invalidation_ids: set[int] = set(touched_sessions)
+    cur = await db.execute(
+        "SELECT id, local_session_id FROM races WHERE regatta_id = ?",
+        (regatta_id,),
+    )
+    for row in await cur.fetchall():
+        invalidation_ids.add(row[0])
+        if row[1] is not None:
+            invalidation_ids.add(row[1])
+
     await db.commit()
+
+    for rid in invalidation_ids:
+        await storage._invalidate_race_cache(rid)
 
     await storage.log_action(
         "results_import",
@@ -152,7 +172,7 @@ async def _link_regatta_races_to_local_sessions(
     regatta_id: int,
     *,
     force: bool = False,
-) -> int:
+) -> tuple[int, set[int]]:
     """Link imported races to local race sessions on the same date.
 
     When the number of local race-type sessions on a date is greater
@@ -172,7 +192,10 @@ async def _link_regatta_races_to_local_sessions(
     endpoint to fix up data that was linked before zip-in-order was
     implemented.
 
-    Returns the number of links written.
+    Returns ``(count_linked, touched_local_session_ids)`` — the second
+    value is the union of every local session id written as a new link
+    plus every prior link replaced by ``force=True``. Callers use it to
+    drop cached session_summary blobs keyed on those session ids (#666).
     """
     cur = await db.execute(
         "SELECT id, date, race_num, local_session_id FROM races"
@@ -182,7 +205,7 @@ async def _link_regatta_races_to_local_sessions(
     )
     imported_rows = await cur.fetchall()
     if not imported_rows:
-        return 0
+        return 0, set()
 
     by_date: dict[date, list[tuple[int, int | None, int | None]]] = {}
     for r in imported_rows:
@@ -193,6 +216,7 @@ async def _link_regatta_races_to_local_sessions(
         by_date.setdefault(d, []).append((r[0], r[2], r[3]))
 
     linked_count = 0
+    touched: set[int] = set()
     for d, imported in by_date.items():
         local_sessions = await _list_local_race_sessions_on_date(db, d)
         if not local_sessions:
@@ -213,6 +237,9 @@ async def _link_regatta_races_to_local_sessions(
                 "UPDATE races SET local_session_id = ? WHERE id = ?",
                 (local_id, imp_id),
             )
+            if existing_link is not None:
+                touched.add(existing_link)
+            touched.add(local_id)
             logger.debug(
                 "Linked imported race {} → local session {} (date {})",
                 imp_id,
@@ -220,7 +247,7 @@ async def _link_regatta_races_to_local_sessions(
                 d.isoformat(),
             )
             linked_count += 1
-    return linked_count
+    return linked_count, touched
 
 
 async def _list_local_race_sessions_on_date(

--- a/src/helmlog/routes/results.py
+++ b/src/helmlog/routes/results.py
@@ -370,8 +370,27 @@ async def api_rematch_regatta(
     row = await cur.fetchone()
     races_checked = int(row[0]) if row else 0
 
-    linked = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
+    linked, touched_sessions = await _link_regatta_races_to_local_sessions(
+        db, regatta_id, force=True
+    )
+
+    # Drop cached session_summary blobs for every live session we rewrote
+    # the link of (old link and new link) plus the imported race rows
+    # themselves — see #666.
+    invalidation_ids: set[int] = set(touched_sessions)
+    cur = await db.execute(
+        "SELECT id, local_session_id FROM races WHERE regatta_id = ?",
+        (regatta_id,),
+    )
+    for row in await cur.fetchall():
+        invalidation_ids.add(row[0])
+        if row[1] is not None:
+            invalidation_ids.add(row[1])
+
     await db.commit()
+
+    for rid in invalidation_ids:
+        await storage._invalidate_race_cache(rid)
 
     await audit(
         request,

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -447,7 +447,7 @@ async def test_force_relinks_existing_wrong_links(storage: Storage) -> None:
     )
     (regatta_id,) = await cur.fetchone()  # type: ignore[misc]
 
-    linked = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
+    linked, _touched = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
     await db.commit()
     # Race 1 was already pointing at a_id, so only race 2 needs rewriting.
     assert linked == 1, "race 2 should be moved off the earliest session"
@@ -500,6 +500,115 @@ async def test_reimport_backfills_null_local_session(storage: Storage) -> None:
     assert rows
     for row in rows:
         assert row["local_session_id"] == local_id
+
+
+class _RecordingCache:
+    """Minimal stand-in that records invalidate() calls."""
+
+    def __init__(self) -> None:
+        self.invalidations: list[int] = []
+
+    async def invalidate(self, race_id: int) -> None:
+        self.invalidations.append(race_id)
+
+
+@pytest.mark.asyncio
+async def test_import_invalidates_cache_for_linked_live_session(
+    storage: Storage,
+) -> None:
+    """Regression for #666: results import must invalidate the cached
+    session_summary blob for every live session it links imported races to.
+
+    Scenario: the live session's summary was computed (and cached with
+    ``results: []``) before the importer ran. After import, the importer
+    upserts race_results and links them to the live session's id — but
+    the cache entry keyed to that live session id still carries the
+    stale empty results. Subsequent /history requests return the stale
+    blob and the imported results never surface.
+    """
+    from datetime import datetime
+
+    recorder = _RecordingCache()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    db = storage._conn()
+    results = await _fetch_results()
+    race_date = results.races[0].date
+    start = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Local live session", "Local", 1, race_date, start.isoformat()),
+    )
+    await db.commit()
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (local_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    # Reset recorder so only the importer's invalidations are counted.
+    recorder.invalidations.clear()
+
+    await import_results(storage, results)
+
+    assert local_id in recorder.invalidations, (
+        f"expected import to invalidate live session {local_id}, got {recorder.invalidations!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_rematch_invalidates_old_and_new_live_sessions(
+    storage: Storage,
+) -> None:
+    """Regression for #666: the admin rematch (force=True) path must
+    invalidate the OLD live session id when an imported race is moved
+    off it, not just the new target."""
+    from datetime import datetime
+
+    from helmlog.results.importer import _link_regatta_races_to_local_sessions
+
+    recorder = _RecordingCache()
+    storage.bind_race_cache(recorder)  # type: ignore[arg-type]
+
+    db = storage._conn()
+    results = await _fetch_results()
+    race_date = results.races[0].date
+    a = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    b = datetime.fromisoformat(race_date + "T19:10:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Race 1", "Local", 1, race_date, a.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (a_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        ("Race 2", "Local", 2, race_date, b.isoformat()),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (b_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.commit()
+
+    await import_results(storage, results)
+
+    # Simulate pre-#550 state: both imported races pinned to session A.
+    await db.execute(
+        "UPDATE races SET local_session_id = ? WHERE source = 'clubspot' AND date = ?",
+        (a_id, race_date),
+    )
+    await db.commit()
+
+    cur = await db.execute(
+        "SELECT regatta_id FROM races WHERE source = 'clubspot' LIMIT 1",
+    )
+    (regatta_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    recorder.invalidations.clear()
+    _linked, touched = await _link_regatta_races_to_local_sessions(db, regatta_id, force=True)
+    await db.commit()
+
+    assert a_id in touched, "old link (session A) must be reported as touched"
+    assert b_id in touched, "new link (session B) must be reported as touched"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `import_results` now drops cached `session_summary` blobs for every live session it links imported races to (plus every imported race id), so a summary fetched with `results: []` during the race is replaced when scores arrive.
- `_link_regatta_races_to_local_sessions` returns `(count, touched_local_session_ids)`; the admin rematch (`force=True`) path additionally invalidates the old link it rewrites, not just the new target.
- Adds regression tests covering both the import path and the admin rematch path.

## Root cause
`routes/sessions.py` caches `/api/sessions/{id}/summary` keyed to the live session's race id. The importer upserts `race_results` on the **imported** race rows and then `UPDATE`s `local_session_id` on those imported rows — it never touches the live session row, so the race-mutation cache hook never fires for the live session id. Any cache blob populated before import (e.g. a cold summary fetched during the race that naturally contained `results: []`) survived the import.

## Fix
- `_link_regatta_races_to_local_sessions` now returns `(count, touched_local_session_ids)` — the set includes every session id it wrote a new link for, plus every prior link replaced by `force=True`.
- `import_results` unions those with the imported race ids for this regatta and calls `storage._invalidate_race_cache(...)` on each after commit.
- The admin rematch route does the same, covering both the old and new `local_session_id` when a link is moved (#666 related concern).

## Test plan
- [x] `uv run pytest tests/test_results_importer.py -v` — 21 tests pass (2 new regression cases + existing suite updated for new tuple return)
- [x] `uv run pytest` — full suite (2316 passed, 2 skipped)
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/`
- [ ] Manual verification on `corvopi-live` after deploy: re-import CYC Spring 1/2 and STYC Ballard Cup I-1, confirm `/history` summary now reflects imported results without the SQL workaround.

Fixes #666

Generated with [Claude Code](https://claude.ai/code)