### PR TITLE
perf(storage): add indexes for audio_sessions.race_id and winds(reference, ts)

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -198,7 +198,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 80
+_CURRENT_VERSION: int = 81
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1951,6 +1951,22 @@ _MIGRATIONS: dict[int, str] = {
             read              INTEGER NOT NULL DEFAULT 0,
             dismissed         INTEGER NOT NULL DEFAULT 0
         );
+    """,
+    81: """
+        -- #670: hot-path index gaps.
+        -- audio_sessions is joined to races on race_id from the race list
+        -- page (EXISTS subquery per row), race detail, and session cleanup.
+        -- Previously a full table scan per lookup.
+        CREATE INDEX IF NOT EXISTS idx_audio_sessions_race_id
+            ON audio_sessions(race_id);
+        -- latest_instruments() and per-session wind aggregates filter winds
+        -- by reference (IN (0,4) for true wind, =2 for apparent) before an
+        -- ORDER BY ts / ts-range filter. The existing idx_winds_ts has no
+        -- reference column, so SQLite scanned rows in ts order checking
+        -- reference for each. This composite lets it seek straight to the
+        -- matching reference partition and take the newest row in O(log n).
+        CREATE INDEX IF NOT EXISTS idx_winds_reference_ts
+            ON winds(reference, ts);
     """,
 }
 


### PR DESCRIPTION
Two hot-path queries were doing full scans:

- audio_sessions is filtered by race_id from the race list (EXISTS
  subquery per row), race detail, and session cleanup. No index existed.
- winds is filtered by reference (IN (0,4) for true wind, =2 for
  apparent) before ORDER BY ts / ts-range aggregates in latest_instruments
  and per-session wind stats. idx_winds_ts didn't cover reference.

Migration v78 adds idx_audio_sessions_race_id and composite
idx_winds_reference_ts. EXPLAIN QUERY PLAN confirms both are picked up;
audio_sessions.race_id lookups become COVERING index searches.

Closes #670

https://claude.ai/code/session_01NHMFpkRudKHfN4HfarF6Bh