### PR TITLE
feat: unified Moments panel — collapse Bookmarks/Notes/Discussion (#672)

### DIFF
--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -314,13 +314,20 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
 
     storage = get_storage(request)
 
+    # Preserve query string across the canonical-slug redirect so deep links
+    # like /session/104?moment=38&comment=20 don't lose their params on the
+    # 301 hop to /session/104/{slug}.
+    qs = f"?{request.url.query}" if request.url.query else ""
+
     if session_ref.isdigit():
         numeric_id = int(session_ref)
         race = await storage.get_race(numeric_id)
         if race is not None:
             slug = race.slug or await storage.ensure_race_slug(race.id) or ""
             if slug:
-                return RedirectResponse(url=_canonical_session_url(race.id, slug), status_code=301)
+                return RedirectResponse(
+                    url=_canonical_session_url(race.id, slug) + qs, status_code=301
+                )
             # Last-resort fallback — render inline rather than redirect-loop.
             return await _render_session_page(request, race)
         # Not a race — try the debrief (audio_sessions) id space so history
@@ -332,7 +339,9 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
 
     race = await storage.get_race_by_slug(session_ref)
     if race is not None:
-        return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
+        return RedirectResponse(
+            url=_canonical_session_url(race.id, race.slug) + qs, status_code=301
+        )
 
     retired = await storage.lookup_retired_slug(session_ref)
     if retired is None:
@@ -343,7 +352,9 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
     current = await storage.get_race(race_id)
     if current is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    return RedirectResponse(url=_canonical_session_url(current.id, current.slug), status_code=301)
+    return RedirectResponse(
+        url=_canonical_session_url(current.id, current.slug) + qs, status_code=301
+    )
 
 
 @router.get("/sails", response_class=HTMLResponse, include_in_schema=False)

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -253,8 +253,11 @@ async def session_detail_page_canonical(request: Request, session_id: int, slug:
     """Canonical session URL carrying both the stable id and the slug (#449).
 
     * If the id exists and the slug matches the current slug → render.
-    * If the id exists but the slug is stale (renamed) → 301 to the new
-      canonical URL so old bookmarks keep working indefinitely.
+    * If the id exists but the slug is stale (renamed) → 302 to the new
+      canonical URL so old bookmarks keep working indefinitely. 302 (not
+      301) so browsers don't permanently cache the redirect — a re-rename
+      back to the original slug should resolve correctly without a cache
+      bust.
     * If the id doesn't exist → 404.
     """
     storage = get_storage(request)
@@ -262,7 +265,10 @@ async def session_detail_page_canonical(request: Request, session_id: int, slug:
     if race is None:
         raise HTTPException(status_code=404, detail="Session not found")
     if race.slug and slug != race.slug:
-        return RedirectResponse(url=_canonical_session_url(race.id, race.slug), status_code=301)
+        qs = f"?{request.url.query}" if request.url.query else ""
+        return RedirectResponse(
+            url=_canonical_session_url(race.id, race.slug) + qs, status_code=302
+        )
     return await _render_session_page(request, race)
 
 
@@ -326,7 +332,7 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
             slug = race.slug or await storage.ensure_race_slug(race.id) or ""
             if slug:
                 return RedirectResponse(
-                    url=_canonical_session_url(race.id, slug) + qs, status_code=301
+                    url=_canonical_session_url(race.id, slug) + qs, status_code=302
                 )
             # Last-resort fallback — render inline rather than redirect-loop.
             return await _render_session_page(request, race)
@@ -340,7 +346,7 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
     race = await storage.get_race_by_slug(session_ref)
     if race is not None:
         return RedirectResponse(
-            url=_canonical_session_url(race.id, race.slug) + qs, status_code=301
+            url=_canonical_session_url(race.id, race.slug) + qs, status_code=302
         )
 
     retired = await storage.lookup_retired_slug(session_ref)
@@ -353,7 +359,7 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
     if current is None:
         raise HTTPException(status_code=404, detail="Session not found")
     return RedirectResponse(
-        url=_canonical_session_url(current.id, current.slug) + qs, status_code=301
+        url=_canonical_session_url(current.id, current.slug) + qs, status_code=302
     )
 
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6710,6 +6710,16 @@ function _updateBoatSettingsForUtc(utcDate) {
 
 let _threads = [];
 let _discussionMarkers = [];
+// Currently-focused moment (open in the detail view). Renders as a larger,
+// pulsing marker on the map so the user can see at a glance where on the
+// track the moment they're reading is anchored. Null when the panel is
+// showing the list view.
+let _focusedMomentId = null;
+function _setFocusedMoment(id) {
+  if (_focusedMomentId === id) return;
+  _focusedMomentId = id;
+  if (_threads && _threads.length) _addDiscussionMarkers();
+}
 
 function _threadTitle(t) {
   if (t.title) return esc(t.title);
@@ -6772,6 +6782,10 @@ async function loadMoments(opts) {
   const totalUnread = _threads.reduce((s, t) => s + (t.unread_count || 0), 0);
   const badge = document.getElementById('moments-badge');
   badge.textContent = totalUnread > 0 ? '(' + totalUnread + ' unread)' : '';
+  // List render → user is back to overview; drop the focus highlight.
+  // (renderList:false is the deep-link init path, where openThread is in
+  // flight and has set the focus — leave it alone.)
+  if (renderList) _focusedMomentId = null;
   _addDiscussionMarkers();
   // When called with renderList:false (deep-link init), we've populated
   // _threads, _anchorIndex, the badge, and the map markers — but skip
@@ -7063,11 +7077,14 @@ function _addDiscussionMarkers() {
     const markerStyle = t.resolved
       ? 'width:14px;height:14px;background:transparent;border:2px solid ' + cssVar('--success') + ';border-radius:50%'
       : 'width:14px;height:14px;background:' + markerColor + ';border:2px solid ' + bgPrimary + ';border-radius:50%;box-shadow:0 0 4px ' + markerColor;
+    const isFocused = (t.id === _focusedMomentId);
     const icon = L.divIcon({
-      className: 'discussion-marker',
-      html: '<div style="' + markerStyle + '"></div>',
-      iconSize: [14, 14],
-      iconAnchor: [7, 7],
+      className: isFocused ? 'discussion-marker focused' : 'discussion-marker',
+      html: isFocused
+        ? '<div class="moment-marker-focused-dot"></div>'
+        : '<div style="' + markerStyle + '"></div>',
+      iconSize: isFocused ? [22, 22] : [14, 14],
+      iconAnchor: isFocused ? [11, 11] : [7, 7],
     });
     const threadId = t.id;
     const marker = L.marker(latLng, {icon: icon})
@@ -7185,6 +7202,10 @@ async function submitNewThread() {
 async function openThread(threadId, scrollToCommentId) {
   const body = document.getElementById('moments-body');
   body.innerHTML = '<span style="color:var(--text-secondary)">Loading\u2026</span>';
+  // Promote this moment's map marker to the focused (large + pulsing) style
+  // so the user can see at a glance where on the track the open moment is
+  // anchored. Cleared when loadMoments() repaints the list view.
+  _setFocusedMoment(threadId);
   // Mark as read
   fetch('/api/moments/' + threadId + '/read', {method: 'POST'});
   const r = await fetch('/api/moments/' + threadId);

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -655,7 +655,6 @@ async function loadTrack() {
     if (utc) {
       _moveCursorToIndex(idx);
       showNewMomentForm(utc.toISOString());
-      document.getElementById('moments-card').scrollIntoView({behavior: 'smooth', block: 'start'});
     }
   });
 
@@ -5899,6 +5898,14 @@ function renderManeuverCard() {
     const yt = m.youtube_url
       ? '<a href="' + esc(m.youtube_url) + '" target="_blank" rel="noopener" title="Watch on YouTube" style="color:var(--accent);text-decoration:none" onclick="event.stopPropagation()">&#9654;</a>'
       : '';
+    // "+ Moment" action — open the Moments panel's new-moment form anchored
+    // to this maneuver. Inline in the actions column alongside the YouTube
+    // link so there's no new column churn.
+    const momentBtn = m.id != null
+      ? '<a href="#" title="Create a moment anchored to this maneuver" '
+        + 'onclick="event.preventDefault();event.stopPropagation();createMomentFromManeuver(' + idx + ')" '
+        + 'style="color:var(--accent);text-decoration:none;margin-left:6px;font-size:.9em" aria-label="Create moment here">+</a>'
+      : '';
     return '<tr id="mrow-' + idx + '" style="cursor:pointer"'
       + ' onclick="highlightManeuver(' + idx + ')"'
       + ' onmouseenter="_highlightOverlayTrack(' + idx + ',true)"'
@@ -5913,7 +5920,7 @@ function renderManeuverCard() {
       + '<td title="BSP dip from pre-maneuver baseline to minimum BSP during the turn. Not exit−entry.">' + bspDip + '</td>'
       + '<td>' + distLoss + '</td>'
       + '<td>' + esc(cond) + '</td>'
-      + '<td>' + yt + '</td>'
+      + '<td style="white-space:nowrap">' + yt + momentBtn + '</td>'
       + '</tr>';
   }).join('');
 
@@ -6084,7 +6091,7 @@ function _addManeuverMarkers() {
       fillOpacity: 0.9,
       weight: 2,
     });
-    marker.bindPopup(_renderManeuverPopup(m));
+    marker.bindPopup(_renderManeuverPopup(m, idx));
     // Map marker clicks keep the focus on the track — they highlight the
     // maneuver and seek the replay, but do NOT scroll the page down to the
     // maneuvers card (which yanks the user away from the map).
@@ -6094,7 +6101,7 @@ function _addManeuverMarkers() {
   });
 }
 
-function _renderManeuverPopup(m) {
+function _renderManeuverPopup(m, idx) {
   const ringColor = _MANEUVER_COLORS[m.type] || 'var(--text-secondary)';
   const pctSuffix = m.loss_percentile != null ? ' (p' + m.loss_percentile + ')' : '';
   const rankBadge = m.rank
@@ -6115,7 +6122,17 @@ function _renderManeuverPopup(m) {
   }
   if (m.loss_kts != null) lines.push(m.loss_kts.toFixed(2) + ' kt loss');
   if (m.distance_loss_m != null) lines.push(Math.round(m.distance_loss_m) + ' m loss');
-  return lines.join('<br>');
+  const body = lines.join('<br>');
+  // "+ Create moment" action — opens the Moments panel's new-moment form
+  // anchored to this maneuver. Only rendered when the maneuver has a stable
+  // id (all detected maneuvers do; defensive against any unusual rows).
+  const createMoment = (idx != null && m.id != null)
+    ? '<div style="margin-top:6px;border-top:1px solid var(--border);padding-top:6px">'
+      + '<a href="#" onclick="event.preventDefault();createMomentFromManeuver(' + idx + ')" '
+      + 'style="color:var(--accent);font-size:.78rem;text-decoration:none">+ Create moment here &rarr;</a>'
+      + '</div>'
+    : '';
+  return body + createMoment;
 }
 
 let _showManeuverMarkers = true;
@@ -7130,7 +7147,19 @@ async function _loadMarkerPreview(threadId) {
   }).join('');
 }
 
-function showNewMomentForm(anchorTimestamp) {
+// Open the New Moment form in the Moments panel. `prefill` may be:
+//   - a string ISO timestamp \u2192 preselect as a timestamp anchor
+//   - an anchor object {kind, entity_id?, t_start?, label?} \u2192 preselect verbatim
+//   - falsy \u2192 no preselection (user picks in the picker)
+function showNewMomentForm(prefill) {
+  // Make sure the Moments card is visible and the page scrolls to it so the
+  // user always sees the form they just opened (important when creation was
+  // triggered from the map popup or the maneuvers table far below).
+  const card = document.getElementById('moments-card');
+  if (card) {
+    card.style.display = '';
+    card.scrollIntoView({behavior: 'smooth', block: 'start'});
+  }
   const body = document.getElementById('moments-body');
   const form = document.createElement('div');
   form.className = 'thread-form';
@@ -7153,14 +7182,25 @@ function showNewMomentForm(anchorTimestamp) {
   const picker = document.getElementById('new-thread-anchor-picker');
   if (picker) {
     picker.fallbackCursor = cursor;
-    // If caller passed a preferred timestamp (e.g. map-click), preselect it
-    if (anchorTimestamp) {
-      picker.addEventListener('connected', () => {}, {once: true});
-      setTimeout(() => {
-        picker._pickAnchor({kind: 'timestamp', t_start: anchorTimestamp, label: fmtTime(anchorTimestamp)});
-      }, 0);
+    if (prefill) {
+      const anchor = typeof prefill === 'string'
+        ? {kind: 'timestamp', t_start: prefill, label: fmtTime(prefill)}
+        : prefill;
+      setTimeout(() => picker._pickAnchor(anchor), 0);
     }
   }
+}
+
+// Open the New Moment form prefilled with a maneuver anchor. Used by the
+// maneuver map-popup "+ Create moment" button and the maneuver-table action.
+function createMomentFromManeuver(idx) {
+  const m = _maneuvers && _maneuvers[idx];
+  if (!m || m.id == null) return;
+  // Close any open map popup so the maneuver's popup doesn't hang around
+  // over the track while the user fills out the form below.
+  if (_map && typeof _map.closePopup === 'function') _map.closePopup();
+  const label = (m.type || 'maneuver') + (m.ts ? ' at ' + fmtTime(m.ts) : '');
+  showNewMomentForm({kind: 'maneuver', entity_id: m.id, label: label});
 }
 
 async function submitNewThread() {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -312,6 +312,13 @@ async function init() {
     document.getElementById('live-instruments-card').style.display = '';
   }
 
+  // If a deep-link query string targets a specific moment, start opening
+  // it immediately so the user sees the moment detail without waiting for
+  // the rest of the session page (track, video, polar, etc.) to finish
+  // loading. The moments card shows a spinner; loadMoments() runs later
+  // alongside everything else and seeds _threads / map markers.
+  _maybeOpenDeepLinkMoment();
+
   const r = await fetch('/api/sessions/' + SESSION_ID + '/detail');
   if (!r.ok) {
     document.getElementById('session-name').textContent = 'Session not found';
@@ -337,14 +344,36 @@ async function init() {
     loadTranscript();
     loadAudio();
   }
-  await loadMoments();
-  _checkThreadHash();
+  // When a deep-link moment is in flight, skip the list body render so
+  // openThread()'s detail view (already rendering in parallel) isn't
+  // clobbered. The moment list still gets populated (_threads, anchor
+  // index, map markers) so the back-button can repaint instantly.
+  await loadMoments({renderList: !_deepLinkMomentInFlight});
+  if (!_deepLinkMomentInFlight) _checkThreadHash();
   loadSharing();
   loadMatch();
   renderExports();
   renderDangerZone();
   if (cfg.dataset.live === '1') _startLiveRefresh();
   _applyDeepLink();
+}
+
+let _deepLinkMomentInFlight = false;
+
+function _maybeOpenDeepLinkMoment() {
+  const params = new URLSearchParams(window.location.search);
+  const momentParam = params.get('moment') || params.get('thread');
+  if (!momentParam) return;
+  const momentId = parseInt(momentParam, 10);
+  if (isNaN(momentId)) return;
+  const commentParam = params.get('comment');
+  const commentId = commentParam ? parseInt(commentParam, 10) : null;
+  const card = document.getElementById('moments-card');
+  if (card) card.style.display = '';
+  _deepLinkMomentInFlight = true;
+  // openThread is async — fire it and let it render while init() continues
+  // its other work in parallel.
+  openThread(momentId, commentId && !isNaN(commentId) ? commentId : null);
 }
 
 // ---------------------------------------------------------------------------
@@ -6694,7 +6723,8 @@ const _threadTagFilter = new Set();
 let _threadTagMode = 'and';
 let _threadAvailableTags = [];
 
-async function loadMoments() {
+async function loadMoments(opts) {
+  const renderList = !opts || opts.renderList !== false;
   const card = document.getElementById('moments-card');
   card.style.display = '';
   const body = document.getElementById('moments-body');
@@ -6711,7 +6741,10 @@ async function loadMoments() {
     fetch(threadsUrl),
     _ensureAnchorIndex(),
   ]);
-  if (!threadsResp.ok) { body.innerHTML = '<span style="color:var(--text-secondary)">Failed to load</span>'; return; }
+  if (!threadsResp.ok) {
+    if (renderList) body.innerHTML = '<span style="color:var(--text-secondary)">Failed to load</span>';
+    return;
+  }
   const data = await threadsResp.json();
   // The list endpoint now returns `moments`. Map each moment to the
   // thread-ish shape the existing discussion UI expects (title = subject,
@@ -6740,6 +6773,10 @@ async function loadMoments() {
   const badge = document.getElementById('moments-badge');
   badge.textContent = totalUnread > 0 ? '(' + totalUnread + ' unread)' : '';
   _addDiscussionMarkers();
+  // When called with renderList:false (deep-link init), we've populated
+  // _threads, _anchorIndex, the badge, and the map markers — but skip
+  // body.innerHTML so the openThread() detail render isn't clobbered.
+  if (!renderList) return;
 
   const filterBar = _renderThreadTagFilterRow();
   if (!_threads.length) {

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -7017,7 +7017,7 @@ function _addDiscussionMarkers() {
       + '<div id="discussion-marker-preview-' + t.id + '">'
       + '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:4px">Loading\u2026</div></div>'
       + '<div style="margin-top:6px"><a href="#" data-open-thread="' + t.id + '" '
-      + 'style="color:var(--accent);font-size:.78rem;text-decoration:none">Open thread &rarr;</a></div>'
+      + 'style="color:var(--accent);font-size:.78rem;text-decoration:none">Open moment &rarr;</a></div>'
       + '</div>';
 
     const hasUnread = t.unread_count > 0;
@@ -7177,7 +7177,7 @@ async function openThread(threadId, scrollToCommentId) {
       + '<div class="comment-body">' + _renderMentions(esc(c.body)) + '</div>'
       + '</div>';
   }).join('');
-  const copyThreadBtn = '<button class="btn-copy-link" title="Copy link to this thread" '
+  const copyThreadBtn = '<button class="btn-copy-link" title="Copy link to this moment" '
     + 'onclick="copyThreadLink(' + t.id + ',null,this)">\ud83d\udd17 Copy link</button>';
   body.innerHTML = '<div style="margin-bottom:8px">'
     + '<button style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.78rem;padding:0" onclick="loadMoments()">&larr; All moments</button>'

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -330,7 +330,6 @@ async function init() {
     loadCrew();
     loadSails();
     loadBoatSettings();
-    loadNotes();
     if (_session.end_utc) loadPolar();
     loadAnalysis();
   }
@@ -338,7 +337,7 @@ async function init() {
     loadTranscript();
     loadAudio();
   }
-  await loadDiscussion();
+  await loadMoments();
   _checkThreadHash();
   loadSharing();
   loadMatch();
@@ -626,13 +625,13 @@ async function loadTrack() {
     const utc = _utcForIndex(idx);
     if (utc) {
       _moveCursorToIndex(idx);
-      showNewThreadForm(utc.toISOString());
-      document.getElementById('discussion-card').scrollIntoView({behavior: 'smooth', block: 'start'});
+      showNewMomentForm(utc.toISOString());
+      document.getElementById('moments-card').scrollIntoView({behavior: 'smooth', block: 'start'});
     }
   });
 
   _map.fitBounds(line.getBounds(), {padding: [20, 20]});
-  document.getElementById('track-hint').textContent = 'Click track to seek \u00b7 Right-click to start a discussion at that point';
+  document.getElementById('track-hint').textContent = 'Click track to seek \u00b7 Right-click to start a moment at that point';
 
   // #458 — if a matched Vakaros session exists, overlay start line, line pings,
   // and race-start marker on top of the SK track.
@@ -2425,47 +2424,6 @@ async function loadSailChangeTimeline() {
     html += '</div>';
     container.innerHTML = html;
   } catch (e) { console.error('sail changes timeline error', e); }
-}
-
-// ---------------------------------------------------------------------------
-// Notes
-// ---------------------------------------------------------------------------
-
-async function loadNotes() {
-  const card = document.getElementById('notes-card');
-  card.style.display = '';
-  const body = document.getElementById('notes-body');
-  const r = await fetch('/api/sessions/' + SESSION_ID + '/moments');
-  const notes = await r.json();
-  if (notes.length) {
-    body.innerHTML = notes.map(n => {
-      const t = fmtTime(n.ts);
-      let content = '';
-      if (n.note_type === 'photo' && n.photo_path) {
-        const src = '/attachments/' + n.photo_path;
-        content = '<img src="' + src + '" loading="lazy" style="max-width:100px;max-height:80px;border-radius:4px;cursor:pointer;margin-top:2px" onclick="window.open(this.dataset.src)" data-src="' + src + '"/>';
-      } else if (n.note_type === 'settings' && n.body) {
-        try {
-          const obj = JSON.parse(n.body);
-          content = Object.entries(obj).map(([k, v]) =>
-            '<span style="color:var(--text-secondary)">' + esc(k) + ':</span> ' + esc(v)
-          ).join(' &middot; ');
-        } catch { content = esc(n.body); }
-      } else {
-        content = esc(n.body);
-      }
-      const del = '<button onclick="deleteNote(' + n.id + ')" style="background:none;border:none;color:var(--danger);cursor:pointer;font-size:.8rem;padding:0 4px;float:right">&#10005;</button>';
-      return '<div style="padding:4px 0;border-bottom:1px solid ' + cssVar('--border') + ';overflow:hidden">'
-        + del + '<span style="color:var(--text-secondary);margin-right:6px">' + t + '</span>' + content + '</div>';
-    }).join('');
-  } else {
-    body.innerHTML = '<span style="color:var(--text-secondary)">No notes</span>';
-  }
-}
-
-async function deleteNote(noteId) {
-  await fetch('/api/moments/' + noteId, {method: 'DELETE'});
-  loadNotes();
 }
 
 // ---------------------------------------------------------------------------
@@ -6736,10 +6694,10 @@ const _threadTagFilter = new Set();
 let _threadTagMode = 'and';
 let _threadAvailableTags = [];
 
-async function loadDiscussion() {
-  const card = document.getElementById('discussion-card');
+async function loadMoments() {
+  const card = document.getElementById('moments-card');
   card.style.display = '';
-  const body = document.getElementById('discussion-body');
+  const body = document.getElementById('moments-body');
   // Fetch anchor index in parallel so entity-ref chips can resolve labels
   _anchorIndex = null;
   const params = new URLSearchParams();
@@ -6779,15 +6737,15 @@ async function loadDiscussion() {
   }));
   _threadAvailableTags = data.available_tags || [];
   const totalUnread = _threads.reduce((s, t) => s + (t.unread_count || 0), 0);
-  const badge = document.getElementById('discussion-badge');
+  const badge = document.getElementById('moments-badge');
   badge.textContent = totalUnread > 0 ? '(' + totalUnread + ' unread)' : '';
   _addDiscussionMarkers();
 
   const filterBar = _renderThreadTagFilterRow();
   if (!_threads.length) {
     const emptyMsg = _threadTagFilter.size
-      ? '<span style="color:var(--text-secondary)">No discussions match the current tag filter.</span>'
-      : '<span style="color:var(--text-secondary)">No discussions yet. Start one with + New Thread above.</span>';
+      ? '<span style="color:var(--text-secondary)">No moments match the current tag filter.</span>'
+      : '<span style="color:var(--text-secondary)">No moments on this session yet. Use + New Moment or the &#128278; Bookmark button while replaying.</span>';
     body.innerHTML = filterBar + emptyMsg;
     return;
   }
@@ -6847,10 +6805,10 @@ function _renderThreadTagFilterRow() {
 function _toggleThreadTagFilter(id) {
   if (_threadTagFilter.has(id)) _threadTagFilter.delete(id);
   else _threadTagFilter.add(id);
-  loadDiscussion();
+  loadMoments();
 }
-function _setThreadTagMode(m) { _threadTagMode = m; loadDiscussion(); }
-function _clearThreadTagFilter() { _threadTagFilter.clear(); loadDiscussion(); }
+function _setThreadTagMode(m) { _threadTagMode = m; loadMoments(); }
+function _clearThreadTagFilter() { _threadTagFilter.clear(); loadMoments(); }
 
 function _renderRowTagChipsInline(tags) {
   if (!tags || !tags.length) return '';
@@ -7087,7 +7045,7 @@ function _addDiscussionMarkers() {
             ev.preventDefault();
             marker.closePopup();
             openThread(threadId);
-            document.getElementById('discussion-card').scrollIntoView({behavior: 'smooth', block: 'start'});
+            document.getElementById('moments-card').scrollIntoView({behavior: 'smooth', block: 'start'});
           });
         }
       }
@@ -7116,15 +7074,15 @@ async function _loadMarkerPreview(threadId) {
   }).join('');
 }
 
-function showNewThreadForm(anchorTimestamp) {
-  const body = document.getElementById('discussion-body');
+function showNewMomentForm(anchorTimestamp) {
+  const body = document.getElementById('moments-body');
   const form = document.createElement('div');
   form.className = 'thread-form';
   form.style.marginBottom = '10px';
   const cursor = _playClock.positionUtc ? _playClock.positionUtc.toISOString() : null;
   form.innerHTML = ''
     + '<div style="display:flex;gap:6px;margin-bottom:6px">'
-    + '<input id="new-thread-title" placeholder="Thread title (optional)" style="flex:1"/>'
+    + '<input id="new-thread-title" placeholder="Moment title (optional)" style="flex:1"/>'
     + '</div>'
     + '<div style="margin-bottom:6px;font-size:.72rem;color:var(--text-secondary)">'
     + 'Anchor (optional):'
@@ -7132,8 +7090,8 @@ function showNewThreadForm(anchorTimestamp) {
     + '<anchor-picker id="new-thread-anchor-picker" session-id="' + esc(SESSION_ID) + '"></anchor-picker>'
     + '<textarea id="new-thread-body" placeholder="First comment\u2026" style="margin-top:8px"></textarea>'
     + '<div style="margin-top:6px;display:flex;gap:6px">'
-    + '<button class="btn-thread" onclick="submitNewThread()">Create Thread</button>'
-    + '<button class="btn-thread" style="background:none;color:var(--text-secondary)" onclick="loadDiscussion()">Cancel</button>'
+    + '<button class="btn-thread" onclick="submitNewThread()">Create Moment</button>'
+    + '<button class="btn-thread" style="background:none;color:var(--text-secondary)" onclick="loadMoments()">Cancel</button>'
     + '</div>';
   body.prepend(form);
   const picker = document.getElementById('new-thread-anchor-picker');
@@ -7186,12 +7144,12 @@ async function submitNewThread() {
 }
 
 async function openThread(threadId, scrollToCommentId) {
-  const body = document.getElementById('discussion-body');
+  const body = document.getElementById('moments-body');
   body.innerHTML = '<span style="color:var(--text-secondary)">Loading\u2026</span>';
   // Mark as read
   fetch('/api/moments/' + threadId + '/read', {method: 'POST'});
   const r = await fetch('/api/moments/' + threadId);
-  if (!r.ok) { loadDiscussion(); return; }
+  if (!r.ok) { loadMoments(); return; }
   const t = await r.json();
   const title = _threadTitle(t);
   await _ensureAnchorIndex();
@@ -7220,7 +7178,7 @@ async function openThread(threadId, scrollToCommentId) {
   const copyThreadBtn = '<button class="btn-copy-link" title="Copy link to this thread" '
     + 'onclick="copyThreadLink(' + t.id + ',null,this)">\ud83d\udd17 Copy link</button>';
   body.innerHTML = '<div style="margin-bottom:8px">'
-    + '<button style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.78rem;padding:0" onclick="loadDiscussion()">&larr; All threads</button>'
+    + '<button style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.78rem;padding:0" onclick="loadMoments()">&larr; All moments</button>'
     + '</div>'
     + '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;margin-bottom:6px">'
     + '<div style="flex:1;min-width:0"><strong style="color:var(--text-primary);font-size:.9rem">' + title + '</strong>' + anchor + '</div>'
@@ -7236,7 +7194,7 @@ async function openThread(threadId, scrollToCommentId) {
     + '<textarea id="reply-body" placeholder="Reply\u2026"></textarea>'
     + '<div style="margin-top:4px"><button class="btn-thread" onclick="submitReply(' + t.id + ')">Reply</button></div>'
     + '</div>';
-  const card = document.getElementById('discussion-card');
+  const card = document.getElementById('moments-card');
   _scrollDeepLinkTarget(card, scrollToCommentId);
 }
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -6932,16 +6932,17 @@ function _refreshThreadHighlights(utc) {
 registerSurface('threads', function(utc) { _refreshThreadHighlights(utc); });
 
 function _checkThreadHash() {
-  // Prefer query params (?thread=<id>&comment=<id>) — survive Slack unfurls.
+  // Prefer query params (?moment=<id>&comment=<id>) — survive Slack unfurls.
+  // ?thread= is accepted as a legacy alias from links generated before #663.
   // Fallback to #thread-<id> fragment for backwards compat.
   const params = new URLSearchParams(window.location.search);
-  const threadParam = params.get('thread');
+  const momentParam = params.get('moment') || params.get('thread');
   const commentParam = params.get('comment');
-  if (threadParam) {
-    const threadId = parseInt(threadParam, 10);
-    if (!isNaN(threadId)) {
+  if (momentParam) {
+    const momentId = parseInt(momentParam, 10);
+    if (!isNaN(momentId)) {
       const commentId = commentParam ? parseInt(commentParam, 10) : null;
-      openThread(threadId, commentId && !isNaN(commentId) ? commentId : null);
+      openThread(momentId, commentId && !isNaN(commentId) ? commentId : null);
       return;
     }
   }
@@ -6957,8 +6958,9 @@ function _threadShareUrl(threadId, commentId) {
   const url = new URL(window.location.href);
   url.hash = '';
   url.searchParams.delete('thread');
+  url.searchParams.delete('moment');
   url.searchParams.delete('comment');
-  url.searchParams.set('thread', String(threadId));
+  url.searchParams.set('moment', String(threadId));
   if (commentId) url.searchParams.set('comment', String(commentId));
   return url.toString();
 }

--- a/src/helmlog/templates/attention.html
+++ b/src/helmlog/templates/attention.html
@@ -23,7 +23,7 @@ h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:4px}
 .notif-type{font-size:.72rem;padding:2px 6px;border-radius:3px;font-weight:600}
 .notif-type.mention{background:var(--border);color:var(--accent)}
 .notif-type.reply{background:var(--bg-secondary);color:var(--success)}
-.notif-type.new_thread{background:var(--bg-secondary);color:var(--warning)}
+.notif-type.new_moment,.notif-type.new_thread{background:var(--bg-secondary);color:var(--warning)}
 .notif-type.resolved{background:var(--bg-secondary);color:var(--accent)}
 .notif-snippet{color:var(--text-secondary);font-size:.78rem;margin-top:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:500px}
 .notif-actions{display:flex;gap:6px;flex-shrink:0;align-items:flex-start}
@@ -71,6 +71,22 @@ function snippet(text,max){
   return text.substring(0,max)+'\u2026';
 }
 
+// Notifications written before #663 used thread/discussion wording. Map them
+// to current moment-language at display time so the Attention list reads
+// consistently without needing a DB backfill.
+const _LEGACY_NOTIF_TYPES={new_thread:'new_moment'};
+const _LEGACY_NOTIF_MESSAGES={
+  'started a new discussion':'flagged a new moment',
+  'replied in a discussion':'replied to a moment',
+  'resolved a thread':'resolved a moment',
+  'resolved a discussion':'resolved a moment',
+};
+function normalizeNotif(n){
+  if(_LEGACY_NOTIF_TYPES[n.type]) n.type=_LEGACY_NOTIF_TYPES[n.type];
+  if(_LEGACY_NOTIF_MESSAGES[n.message]) n.message=_LEGACY_NOTIF_MESSAGES[n.message];
+  return n;
+}
+
 function notifUrl(n){
   if(n.session_id && n.source_moment_id){
     let u='/session/'+n.session_id+'?moment='+n.source_moment_id;
@@ -93,9 +109,10 @@ async function loadNotifications(){
     return;
   }
 
-  // Group by session_id
+  // Group by session_id (after normalizing legacy thread/discussion wording).
   const groups={};const groupOrder=[];
   for(const n of notifs){
+    normalizeNotif(n);
     const sid=n.session_id||'general';
     if(!groups[sid]){groups[sid]=[];groupOrder.push(sid);}
     groups[sid].push(n);

--- a/src/helmlog/templates/attention.html
+++ b/src/helmlog/templates/attention.html
@@ -72,8 +72,10 @@ function snippet(text,max){
 }
 
 function notifUrl(n){
-  if(n.session_id && n.source_thread_id){
-    return '/session/'+n.session_id+'#thread-'+n.source_thread_id;
+  if(n.session_id && n.source_moment_id){
+    let u='/session/'+n.session_id+'?moment='+n.source_moment_id;
+    if(n.source_comment_id) u+='&comment='+n.source_comment_id;
+    return u;
   }
   if(n.session_id){
     return '/session/'+n.session_id;
@@ -128,8 +130,8 @@ async function loadNotifications(){
       // Meta line: time + thread title
       html+='<div class="notif-meta">';
       html+='<span class="notif-time">'+relTime(n.created_at)+'</span>';
-      if(n.thread_title){
-        html+='<span class="notif-thread">'+esc(n.thread_title)+'</span>';
+      if(n.moment_subject){
+        html+='<span class="notif-thread">'+esc(n.moment_subject)+'</span>';
       }
       html+='</div>';
 

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -87,7 +87,6 @@
    is served at /, collapse to: photo, track, instruments, boat setup, notes.
    Everything else is forcibly hidden even if its loader calls display=''. */
 body.live-race #video-container,
-body.live-race #bookmarks-card,
 body.live-race #wind-field-card,
 body.live-race #polar-card,
 body.live-race #videos-card,
@@ -95,7 +94,7 @@ body.live-race #analysis-card,
 body.live-race #results-card,
 body.live-race #crew-card,
 body.live-race #sails-card,
-body.live-race #discussion-card,
+body.live-race #moments-card,
 body.live-race #audio-card,
 body.live-race #tuning-extraction-card,
 body.live-race #maneuvers-card,
@@ -326,15 +325,6 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
   </div>
 </div>
 
-<div id="bookmarks-card" class="card" style="display:none">
-  <div class="section-title" onclick="toggleSection('bookmarks')">Bookmarks <span id="bookmarks-toggle">&#9660;</span></div>
-  <div class="section-body" id="bookmarks-body">
-    <div id="bookmarks-tag-filter" class="session-tag-filter-row" style="display:none"></div>
-    <ul id="bookmarks-list" style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px"></ul>
-    <p id="bookmarks-empty" style="font-size:.78rem;color:var(--text-secondary);margin:0;display:none">No bookmarks on this session yet. Use the &#128278; Bookmark button in the replay controls to add one.</p>
-  </div>
-</div>
-
 <div id="wind-field-card" class="card" style="display:none">
   <div class="section-title" onclick="toggleSection('wind-field')">Wind Field <span id="wind-field-toggle">&#9660;</span></div>
   <div class="section-body" id="wind-field-body">
@@ -441,17 +431,12 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
   <div class="section-body" id="boat-settings-body" style="display:none"></div>
 </div>
 
-<div class="card" id="notes-card" style="display:none">
-  <div class="section-title" onclick="toggleSection('notes')">Notes <span id="notes-toggle">&#9660;</span></div>
-  <div class="section-body" id="notes-body"></div>
-</div>
-
-<div class="card" id="discussion-card" style="display:none">
+<div class="card" id="moments-card" style="display:none">
   <div style="display:flex;align-items:center;justify-content:space-between">
-    <div class="section-title" style="margin-bottom:0" onclick="toggleSection('discussion')">Discussion <span id="discussion-badge" style="font-size:.7rem;color:var(--accent)"></span> <span id="discussion-toggle">&#9660;</span></div>
-    <button onclick="showNewThreadForm()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.82rem;padding:2px 0">+ New Thread</button>
+    <div class="section-title" style="margin-bottom:0" onclick="toggleSection('moments')">Moments <span id="moments-badge" style="font-size:.7rem;color:var(--accent)"></span> <span id="moments-toggle">&#9660;</span></div>
+    <button onclick="showNewMomentForm()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.82rem;padding:2px 0">+ New Moment</button>
   </div>
-  <div class="section-body" id="discussion-body" style="margin-top:6px"></div>
+  <div class="section-body" id="moments-body" style="margin-top:6px"></div>
 </div>
 
 <div id="audio-card" class="card" style="display:none">
@@ -545,258 +530,25 @@ async function renameSession() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// "Bookmarks" card: interim adapter over /api/moments (#662). The bookmark
-// concept is now a timestamp-anchored moment with a subject and an optional
-// first comment. The UI rework in the follow-up PR will replace this card
-// with a unified moments view; for now we map bookmark actions onto moment
-// endpoints so the page keeps functioning.
-// ---------------------------------------------------------------------------
-
-function _sessionId() {
-  return document.getElementById('app-config').dataset.sessionId;
-}
-
-async function dropBookmark() {
-  let t = null;
-  try {
-    if (typeof _playClock !== 'undefined' && _playClock.positionUtc) {
-      t = _playClock.positionUtc.toISOString();
-    }
-  } catch { /* ignore */ }
+// Bookmark-drop button in the replay controls: opens the Moments panel
+// quick-create form prefilled with the current playback timestamp as the
+// anchor. The actual form lives in session.js (showNewMomentForm).
+function dropBookmark() {
+  if (typeof showNewMomentForm !== 'function') return;
+  const t = (typeof _playClock !== 'undefined' && _playClock.positionUtc)
+    ? _playClock.positionUtc.toISOString()
+    : null;
   if (!t) {
-    window.alert('Play or scrub the session first so there is a timestamp to anchor the bookmark to.');
+    window.alert('Play or scrub the session first so there is a timestamp to anchor to.');
     return;
   }
-  const name = window.prompt('Bookmark name:', '');
-  if (name === null) return;
-  const trimmed = name.trim();
-  if (!trimmed) return;
-  const note = window.prompt('Optional note (leave blank for none):', '') || null;
-  try {
-    const resp = await fetch(`/api/sessions/${_sessionId()}/moments`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
-        anchor_kind: 'timestamp',
-        t_start: t,
-        subject: trimmed,
-        first_comment: note ? note.trim() : null,
-      }),
-    });
-    if (!resp.ok) { window.alert(`Create failed: ${resp.status}`); return; }
-    await loadBookmarks();
-  } catch (err) { window.alert(`Create failed: ${err}`); }
-}
-
-// Tag filter state for the Bookmarks card.
-const _bookmarkTagFilter = new Set();
-let _bookmarkTagMode = 'and'; // 'and'|'or'
-let _bookmarkAvailableTags = [];
-
-async function loadBookmarks() {
-  try {
-    const params = new URLSearchParams();
-    if (_bookmarkTagFilter.size) {
-      params.set('tags', [...(_bookmarkTagFilter)].join(','));
-      params.set('tag_mode', _bookmarkTagMode);
-    }
-    const qs = params.toString();
-    const url = `/api/sessions/${_sessionId()}/moments` + (qs ? '?' + qs : '');
-    const resp = await fetch(url);
-    if (!resp.ok) return;
-    const data = await resp.json();
-    _bookmarkAvailableTags = data.available_tags || [];
-    // Map moments -> bookmark-shaped rows for the existing renderer:
-    // subject -> name, first_comment_body -> note, anchor.t_start -> t_start.
-    const rows = (data.moments || [])
-      .filter(m => m.anchor_kind === 'timestamp' && m.anchor_t_start)
-      .map(m => ({
-        id: m.id,
-        name: m.subject || 'Moment',
-        note: m.first_comment_body || null,
-        t_start: m.anchor_t_start,
-        tags: m.tags || [],
-        created_by: m.created_by,
-      }));
-    _renderBookmarks(rows);
-    _renderBookmarkTagFilterRow();
-  } catch (err) { /* non-fatal */ }
-}
-
-function _renderBookmarkTagFilterRow() {
-  const wrap = document.getElementById('bookmarks-tag-filter');
-  if (!wrap) return;
-  const byId = new Map();
-  for (const t of _bookmarkAvailableTags) {
-    byId.set(t.id, {id: t.id, name: t.name, color: t.color, count: t.count || 0});
+  const card = document.getElementById('moments-card');
+  if (card) {
+    card.style.display = '';
+    card.scrollIntoView({behavior: 'smooth', block: 'start'});
   }
-  for (const tid of _bookmarkTagFilter) {
-    if (!byId.has(tid)) byId.set(tid, {id: tid, name: '#' + tid, color: null, count: 0});
-  }
-  if (byId.size === 0) { wrap.style.display = 'none'; return; }
-  wrap.style.display = '';
-  const sorted = [...byId.values()].sort((a, b) => a.name.localeCompare(b.name));
-  const chips = sorted.map(t => {
-    const active = _bookmarkTagFilter.has(t.id);
-    const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
-    return `<span class="session-tag-chip${active ? ' active' : ''}" onclick="_toggleBookmarkTagFilter(${t.id})">${swatch}${esc(t.name)} <span class="session-tag-count">(${t.count})</span></span>`;
-  }).join('');
-  const dim = _bookmarkTagFilter.size < 2 ? ';opacity:.6' : '';
-  const modeToggle = `<span class="session-tag-mode" style="margin-left:6px${dim}">`
-    + `<button class="${_bookmarkTagMode === 'and' ? 'active' : ''}" onclick="_setBookmarkTagMode('and')" title="Require every selected tag">all</button>`
-    + `<button class="${_bookmarkTagMode === 'or' ? 'active' : ''}" onclick="_setBookmarkTagMode('or')" title="Match any selected tag">any</button>`
-    + '</span>';
-  const clear = _bookmarkTagFilter.size
-    ? '<a href="#" onclick="event.preventDefault();_clearBookmarkTagFilter()" style="font-size:.7rem;color:var(--text-secondary);margin-left:6px">clear</a>'
-    : '';
-  wrap.innerHTML = '<span class="session-tag-label">Tags</span>' + chips + modeToggle + clear;
+  showNewMomentForm(t);
 }
 
-function _toggleBookmarkTagFilter(id) {
-  if (_bookmarkTagFilter.has(id)) _bookmarkTagFilter.delete(id);
-  else _bookmarkTagFilter.add(id);
-  loadBookmarks();
-}
-function _setBookmarkTagMode(m) { _bookmarkTagMode = m; loadBookmarks(); }
-function _clearBookmarkTagFilter() { _bookmarkTagFilter.clear(); loadBookmarks(); }
-
-function _renderBookmarks(rows) {
-  const card = document.getElementById('bookmarks-card');
-  const list = document.getElementById('bookmarks-list');
-  const empty = document.getElementById('bookmarks-empty');
-  if (!card || !list) return;
-  card.style.display = '';
-  list.innerHTML = '';
-  if (!rows || rows.length === 0) {
-    empty.style.display = _bookmarkTagFilter.size ? 'none' : '';
-    if (_bookmarkTagFilter.size) {
-      list.innerHTML = '<li style="list-style:none;padding:8px;color:var(--text-secondary);font-size:.78rem">No bookmarks match the current tag filter.</li>';
-    }
-    return;
-  }
-  empty.style.display = 'none';
-  for (const bm of rows) {
-    const li = document.createElement('li');
-    li.style.cssText = 'display:flex;flex-direction:column;gap:4px;padding:6px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px';
-
-    const mainRow = document.createElement('div');
-    mainRow.style.cssText = 'display:flex;align-items:center;gap:8px';
-    const timeLabel = document.createElement('span');
-    timeLabel.style.cssText = 'font-family:monospace;font-size:.72rem;color:var(--text-secondary);min-width:64px';
-    timeLabel.textContent = _fmtBookmarkTime(bm.t_start);
-    const title = document.createElement('button');
-    title.type = 'button';
-    title.style.cssText = 'flex:1;text-align:left;background:none;border:none;color:var(--accent);cursor:pointer;padding:0;font-size:.82rem';
-    title.textContent = bm.name;
-    title.onclick = () => _seekToBookmark(bm.t_start);
-    const noteEl = document.createElement('span');
-    if (bm.note) {
-      noteEl.style.cssText = 'font-size:.72rem;color:var(--text-secondary);flex:2';
-      noteEl.textContent = bm.note;
-    }
-    const tagBtn = document.createElement('button');
-    tagBtn.type = 'button';
-    tagBtn.title = 'Tags';
-    tagBtn.style.cssText = 'background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:2px 4px';
-    tagBtn.innerHTML = '&#127991;';
-    const renameBtn = document.createElement('button');
-    renameBtn.type = 'button';
-    renameBtn.title = 'Rename';
-    renameBtn.style.cssText = 'background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:2px 4px';
-    renameBtn.innerHTML = '&#9998;';
-    renameBtn.onclick = () => renameBookmark(bm.id, bm.name, bm.note);
-    const delBtn = document.createElement('button');
-    delBtn.type = 'button';
-    delBtn.title = 'Delete';
-    delBtn.style.cssText = 'background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:2px 4px';
-    delBtn.innerHTML = '&#128465;';
-    delBtn.onclick = () => deleteBookmark(bm.id);
-    mainRow.appendChild(timeLabel);
-    mainRow.appendChild(title);
-    if (bm.note) mainRow.appendChild(noteEl);
-    mainRow.appendChild(tagBtn);
-    mainRow.appendChild(renameBtn);
-    mainRow.appendChild(delBtn);
-
-    // Inline tag chip strip shown below the main row when tags are attached,
-    // so users can see the tags at a glance without expanding the picker.
-    const chipStrip = document.createElement('div');
-    chipStrip.style.cssText = 'display:flex;flex-wrap:wrap;gap:3px;padding-left:72px';
-    const tags = Array.isArray(bm.tags) ? bm.tags : [];
-    if (tags.length) {
-      chipStrip.innerHTML = tags.map(t => {
-        const swatch = t.color ? `<span class="hist-tag-chip-swatch" style="background:${t.color}"></span>` : '';
-        const name = (t.name || '').replace(/</g, '&lt;');
-        return `<span class="session-tag-chip" style="cursor:default;font-size:.66rem">${swatch}${name}</span>`;
-      }).join('');
-    } else {
-      chipStrip.style.display = 'none';
-    }
-
-    const tagRow = document.createElement('div');
-    tagRow.style.cssText = 'display:none;padding-left:72px';
-    const picker = document.createElement('tag-picker');
-    picker.setAttribute('entity-type', 'moment');
-    picker.setAttribute('entity-id', String(bm.id));
-    // When the user attaches/detaches from the expanded picker, refresh
-    // the list so the inline chip strip + filter row pick up the change.
-    picker.addEventListener('change', () => { loadBookmarks(); });
-    tagRow.appendChild(picker);
-
-    tagBtn.onclick = () => {
-      tagRow.style.display = tagRow.style.display === 'none' ? '' : 'none';
-    };
-
-    li.appendChild(mainRow);
-    if (tags.length) li.appendChild(chipStrip);
-    li.appendChild(tagRow);
-    list.appendChild(li);
-  }
-}
-
-function _fmtBookmarkTime(iso) {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', second: '2-digit'});
-  } catch { return iso; }
-}
-
-function _seekToBookmark(utc) {
-  if (typeof _seekTo === 'function') {
-    _seekTo(utc, 'moment');
-  }
-}
-
-async function renameBookmark(id, currentName, currentNote) {
-  const name = window.prompt('Name:', currentName || '');
-  if (name === null) return;
-  const trimmed = name.trim();
-  if (!trimmed) return;
-  // PATCH only the subject — existing first-comment edits go through the
-  // moment detail UI in the follow-up PR.
-  try {
-    const resp = await fetch(`/api/moments/${id}`, {
-      method: 'PATCH',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({subject: trimmed}),
-    });
-    if (resp.status === 403) { window.alert('Only the author or an admin can edit this.'); return; }
-    if (!resp.ok) { window.alert(`Rename failed: ${resp.status}`); return; }
-    await loadBookmarks();
-  } catch (err) { window.alert(`Rename failed: ${err}`); }
-}
-
-async function deleteBookmark(id) {
-  if (!window.confirm('Delete this?')) return;
-  try {
-    const resp = await fetch(`/api/moments/${id}`, {method: 'DELETE'});
-    if (resp.status === 403) { window.alert('Only the author or an admin can delete this.'); return; }
-    if (!resp.ok && resp.status !== 204) { window.alert(`Delete failed: ${resp.status}`); return; }
-    await loadBookmarks();
-  } catch (err) { window.alert(`Delete failed: ${err}`); }
-}
-
-document.addEventListener('DOMContentLoaded', () => { loadBookmarks(); });
 </script>
 {% endblock %}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -65,7 +65,18 @@
 .btn-copy-link:hover{border-color:var(--accent);color:var(--accent)}
 @keyframes flash-highlight-kf{0%{box-shadow:0 0 0 2px var(--accent-strong);background:rgba(126,184,247,.2)}100%{box-shadow:0 0 0 0 transparent;background:transparent}}
 .flash-highlight{animation:flash-highlight-kf 2.2s ease-out;border-radius:6px}
-.discussion-marker{background:none!important;border:none!important}
+.discussion-marker{background:none!important;border:none!important;z-index:600}
+.discussion-marker.focused{z-index:1000}
+@keyframes moment-marker-pulse-kf{
+  0%{box-shadow:0 0 0 0 rgba(96,165,250,.65),0 0 10px var(--accent-strong)}
+  70%{box-shadow:0 0 0 14px rgba(96,165,250,0),0 0 10px var(--accent-strong)}
+  100%{box-shadow:0 0 0 0 rgba(96,165,250,0),0 0 10px var(--accent-strong)}
+}
+.moment-marker-focused-dot{
+  width:22px;height:22px;background:var(--accent-strong);
+  border:3px solid var(--bg-primary);border-radius:50%;
+  animation:moment-marker-pulse-kf 1.6s ease-out infinite;
+}
 .mention{color:var(--accent);font-weight:600;text-decoration:none}
 .stale-banner{background:var(--warning);color:var(--bg-primary);padding:6px 10px;border-radius:6px;font-size:.8rem;margin-bottom:8px;display:flex;align-items:center;justify-content:space-between;gap:8px}
 .stale-banner button{background:var(--bg-primary);color:var(--warning);border:none;border-radius:4px;padding:4px 10px;font-size:.78rem;cursor:pointer;white-space:nowrap}

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -338,6 +338,14 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
   </div>
 </div>
 
+<div class="card" id="moments-card" style="display:none">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <div class="section-title" style="margin-bottom:0" onclick="toggleSection('moments')">Moments <span id="moments-badge" style="font-size:.7rem;color:var(--accent)"></span> <span id="moments-toggle">&#9660;</span></div>
+    <button onclick="showNewMomentForm()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.82rem;padding:2px 0">+ New Moment</button>
+  </div>
+  <div class="section-body" id="moments-body" style="margin-top:6px"></div>
+</div>
+
 <div id="polar-card" class="card" style="display:none">
   <div class="section-title" onclick="toggleSection('polar')">Polar Performance <span id="polar-toggle">&#9660;</span></div>
   <div class="section-body" id="polar-body">
@@ -429,14 +437,6 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
 <div class="card" id="boat-settings-card" style="display:none">
   <div class="section-title" onclick="toggleSection('boat-settings')">Boat Setup <span id="boat-settings-toggle">&#9654;</span></div>
   <div class="section-body" id="boat-settings-body" style="display:none"></div>
-</div>
-
-<div class="card" id="moments-card" style="display:none">
-  <div style="display:flex;align-items:center;justify-content:space-between">
-    <div class="section-title" style="margin-bottom:0" onclick="toggleSection('moments')">Moments <span id="moments-badge" style="font-size:.7rem;color:var(--accent)"></span> <span id="moments-toggle">&#9660;</span></div>
-    <button onclick="showNewMomentForm()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.82rem;padding:2px 0">+ New Moment</button>
-  </div>
-  <div class="section-body" id="moments-body" style="margin-top:6px"></div>
 </div>
 
 <div id="audio-card" class="card" style="display:none">

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -543,7 +543,8 @@ async function renameSession() {
 
 // Bookmark-drop button in the replay controls: opens the Moments panel
 // quick-create form prefilled with the current playback timestamp as the
-// anchor. The actual form lives in session.js (showNewMomentForm).
+// anchor. The form itself (showNewMomentForm in session.js) handles making
+// the Moments card visible and scrolling it into view.
 function dropBookmark() {
   if (typeof showNewMomentForm !== 'function') return;
   const t = (typeof _playClock !== 'undefined' && _playClock.positionUtc)
@@ -552,11 +553,6 @@ function dropBookmark() {
   if (!t) {
     window.alert('Play or scrub the session first so there is a timestamp to anchor to.');
     return;
-  }
-  const card = document.getElementById('moments-card');
-  if (card) {
-    card.style.display = '';
-    card.scrollIntoView({behavior: 'smooth', block: 'start'});
   }
   showNewMomentForm(t);
 }

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -182,7 +182,7 @@ async def test_int_id_redirects_to_canonical(
 ) -> None:
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     resp = await admin_client.get(f"/session/{race_id}")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1"
 
 
@@ -192,7 +192,7 @@ async def test_slug_only_redirects_to_canonical(
 ) -> None:
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     resp = await admin_client.get("/session/20260408-cyc-1")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1"
 
 
@@ -200,14 +200,14 @@ async def test_slug_only_redirects_to_canonical(
 async def test_canonical_redirect_preserves_query_string(
     storage: Storage, admin_client: httpx.AsyncClient
 ) -> None:
-    """Deep-link query params (?moment=&comment=, ?t=) survive the 301 hop (#672)."""
+    """Deep-link query params (?moment=&comment=, ?t=) survive the 302 hop (#672)."""
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     resp = await admin_client.get(f"/session/{race_id}?moment=38&comment=20")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1?moment=38&comment=20"
     # Slug-only path also preserves the query string.
     resp = await admin_client.get("/session/20260408-cyc-1?t=12:34")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1?t=12:34"
 
 
@@ -228,9 +228,9 @@ async def test_canonical_url_stale_slug_redirects(
     """Old bookmarks with a renamed slug still resolve via the stable id (#449)."""
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     await storage.rename_race(race_id, new_name="New Name")
-    # Canonical id/old-slug should 301 to canonical id/new-slug.
+    # Canonical id/old-slug should 302 to canonical id/new-slug.
     resp = await admin_client.get(f"/session/{race_id}/20260408-cyc-1")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/new-name"
 
 
@@ -249,7 +249,7 @@ async def test_retired_slug_redirects_within_window(
     race_id = await _seed_race(storage, name="20260408-CYC-1")
     await storage.rename_race(race_id, new_name="New Name")
     resp = await admin_client.get("/session/20260408-cyc-1")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/new-name"
 
 
@@ -342,7 +342,7 @@ async def test_race_without_slug_is_lazily_assigned(
     assert race_id is not None
 
     resp = await admin_client.get(f"/session/{race_id}")
-    assert resp.status_code == 301
+    assert resp.status_code == 302
     assert resp.headers["location"] == f"/session/{race_id}/20260408-practice-1"
 
     # Subsequent calls should keep redirecting (slug now persisted).

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -197,6 +197,21 @@ async def test_slug_only_redirects_to_canonical(
 
 
 @pytest.mark.asyncio
+async def test_canonical_redirect_preserves_query_string(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """Deep-link query params (?moment=&comment=, ?t=) survive the 301 hop (#672)."""
+    race_id = await _seed_race(storage, name="20260408-CYC-1")
+    resp = await admin_client.get(f"/session/{race_id}?moment=38&comment=20")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1?moment=38&comment=20"
+    # Slug-only path also preserves the query string.
+    resp = await admin_client.get("/session/20260408-cyc-1?t=12:34")
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"/session/{race_id}/20260408-cyc-1?t=12:34"
+
+
+@pytest.mark.asyncio
 async def test_canonical_url_renders_page(
     storage: Storage, admin_client: httpx.AsyncClient
 ) -> None:


### PR DESCRIPTION
Rebased onto \`main\` after #674 merged. Closes #672.

Follow-up to #674 (which brought the moments data unification to main). This PR is the **session-page UI cleanup** that #674 deferred.

## What this PR does

### Headline: collapse three cards into one

Before #674, the session page rendered three separate cards all backed by the same \`/api/moments\` endpoints — Bookmarks (interim adapter), Notes (broken since #663 — treated \`data.moments\` as a flat array with old \`note_type\`/\`photo_path\`/\`body\` shape), and Discussion (the real moments UI). Promote the Discussion card to a single **Moments** card; delete the other two.

### Layered fixes that surfaced during testing

1. **Notification deep-link regression** (Attention page) — \`notifUrl()\` was reading the pre-#663 field names \`source_thread_id\` and \`thread_title\` (no longer on the API payload), so every row fell through to the bare \`/session/<id>\` URL with no anchor. Now reads \`source_moment_id\` + \`source_comment_id\` and emits \`/session/<id>?moment=<id>&comment=<id>\`. Legacy thread/discussion message strings normalize at render-time to current moment-language.
2. **Query-string preservation across canonical-slug redirect** — \`/session/{id}?moment=<id>&comment=<id>\` was 301-redirecting to \`/session/{id}/{slug}\` and dropping the query string. Now appends \`request.url.query\` across all four redirect paths in the session page handler. Plus a regression test.
3. **301 → 302 on canonical-slug redirects** — browsers cache 301s permanently keyed on the request URL, so any client that hit the broken URL once kept getting served the cached params-stripped redirect. 302 keeps the redirect re-evaluated each time.
4. **Parallel deep-link \`openThread\`** — \`init()\` previously \`await loadMoments()\` BEFORE checking the deep-link query. On a heavy session that made the deep-linked moment wait 5–10s for first paint. Now: detect the deep-link query at the top of \`init()\` and fire \`openThread()\` immediately while the rest of the page loads in parallel.
5. **Focused-moment marker** — when a moment's detail view is open, its track marker promotes from a 14px dim dot to a 22px accent-strong pulsing dot so the user can see at a glance where on the track the open moment is anchored. Reverts when they go back to the list.
6. **Moments panel reordered** above Polar Performance.
7. **Maneuver → moment anchoring** — both the maneuver map popup and the maneuver table row gain a "+ Create moment" action that opens the new-moment form anchored to that maneuver. Closes the popup when triggered from the map.

## Bookmark-drop button (in replay controls)

Kept as 🔖 Bookmark; now opens the Moments quick-create form prefilled with the current playback timestamp as the anchor instead of the previous double-prompt for name + note.

## Deliberately out of scope (future PRs)

- Counterparty chip + subject-first edit + attachment gallery — the next PR in the unified-moments series.
- Per-moment visibility override.
- Transcript-segment anchor composition in the transcript UI.
- Internal naming cleanup — \`_threads\`, \`openThread\`, \`_threadTagFilter\`, \`.thread-form\`, \`.thread-item\`, \`.discussion-marker\` are still moment-state under the hood. Mechanical rename, deferred to the counterparty/subject-first PR since it's rewriting those paths anyway.

## Checks

- \`uv run pytest\` — 2279 passing / 2 skipped / 0 failures
- \`uv run ruff check .\` — clean
- \`uv run ruff format --check .\` — clean
- \`uv run mypy src/\` — \`Success: no issues found in 109 source files\`
- Manually validated on \`corvopi-tst1\` against a fresh restore of live data after #674 deployed (deep-links resolved, focused marker promoted/reverted, maneuver→moment anchor created, attachments served via \`/attachments/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)