### PR TITLE
perf(polar): grade off event loop + warm on race end (#603)

### DIFF
--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -7,6 +7,7 @@ this baseline to show whether the boat is over or under-performing.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import math
 import os
@@ -528,6 +529,95 @@ def _interp_position(
     return None, None
 
 
+def _grade_segments_sync(
+    start: datetime,
+    end: datetime,
+    width: int,
+    speeds: list[dict[str, Any]],
+    winds: list[dict[str, Any]],
+    headings: list[dict[str, Any]],
+    positions: list[dict[str, Any]],
+    polar_map: dict[tuple[int, int], dict[str, Any]],
+    min_sessions: int = 3,
+) -> tuple[list[GradedSegment], dict[str, int]]:
+    """Pure-Python segmentation + grading. No I/O; safe to run in a worker thread.
+
+    *polar_map* is the full (tws_bin, twa_bin) → baseline row mapping, pre-fetched
+    so no ``await`` is needed inside the loop (#603).
+    """
+
+    def _ts_of(rec: dict[str, Any]) -> datetime:
+        return datetime.fromisoformat(str(rec["ts"])).replace(tzinfo=UTC)
+
+    speeds_dt = [(_ts_of(r), r) for r in speeds]
+    winds_dt = [
+        (_ts_of(r), r)
+        for r in winds
+        if int(r.get("reference", -1)) in (_WIND_REF_BOAT, _WIND_REF_NORTH)
+    ]
+    hdg_dt = [(_ts_of(r), r) for r in headings]
+
+    segments: list[GradedSegment] = []
+    grade_hist: dict[str, int] = defaultdict(int)
+
+    n_segments = math.ceil((end - start).total_seconds() / width)
+    for idx in range(n_segments):
+        seg_start = start + timedelta(seconds=idx * width)
+        seg_end = min(end, seg_start + timedelta(seconds=width))
+        t_mid = seg_start + (seg_end - seg_start) / 2
+
+        spd_in = [float(r["speed_kts"]) for ts, r in speeds_dt if seg_start <= ts < seg_end]
+        wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
+        hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
+
+        lat, lon = _interp_position(positions, t_mid) if positions else (None, None)
+
+        bsp = _mean(spd_in)
+        tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
+        twa: float | None = None
+        if wind_in:
+            wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
+            ref = int(wind_in[0][1].get("reference", -1))
+            heading_mean = _mean(hdg_in) if ref == _WIND_REF_NORTH else None
+            twa = _compute_twa(wind_angle_mean, ref, heading_mean)
+
+        target: float | None = None
+        pct: float | None = None
+        delta: float | None = None
+        if bsp is not None and tws is not None and twa is not None:
+            lp = polar_map.get((_tws_bin(tws), _twa_bin(twa)))
+            if lp is not None and int(lp["session_count"]) >= min_sessions:
+                target = float(lp["mean_bsp"])
+                pct = bsp / target if target > 0 else None
+                delta = round(bsp - target, 4)
+
+        if bsp is not None and tws is not None and twa is not None:
+            grade = _grade_from_pct(pct)
+        else:
+            grade = "unknown"
+        if lat is None or lon is None:
+            grade = "unknown"
+
+        seg = GradedSegment(
+            segment_index=idx,
+            t_start=seg_start,
+            t_end=seg_end,
+            lat=lat,
+            lon=lon,
+            tws_kts=round(tws, 4) if tws is not None else None,
+            twa_deg=round(twa, 4) if twa is not None else None,
+            bsp_kts=round(bsp, 4) if bsp is not None else None,
+            target_bsp_kts=round(target, 4) if target is not None else None,
+            pct_target=round(pct, 4) if pct is not None else None,
+            delta_kts=delta,
+            grade=grade,
+        )
+        segments.append(seg)
+        grade_hist[grade] += 1
+
+    return segments, grade_hist
+
+
 async def grade_session_segments(
     storage: Storage,
     session_id: int,
@@ -540,6 +630,9 @@ async def grade_session_segments(
     range. Each segment carries averaged conditions, the polar target, and
     a grade label. Results are cached in ``polar_segment_grades`` and
     invalidated when the polar baseline is rebuilt.
+
+    The CPU-bound segmentation runs in a worker thread (#603) so long sessions
+    don't block the event loop for other HTTP requests.
     """
     width = segment_seconds or POLAR_SEGMENT_SECONDS
     db = storage._conn()
@@ -586,89 +679,27 @@ async def grade_session_segments(
     headings = await storage.query_range("headings", start, end)
     positions = await storage.query_range("positions", start, end)
 
-    # Detect un-migrated DB: lookup_polar will raise on missing table.
-    baseline_missing = False
+    # Pre-load the entire polar baseline once so the tight per-segment loop
+    # has no I/O and can run in a worker thread. Un-migrated DBs (no
+    # polar_baseline table) fall through to an empty map → all segments grade
+    # "unknown", matching the original per-lookup fallback behavior.
+    try:
+        polar_map = await storage.get_all_polar_points()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Polar grading: baseline lookup failed for session {}: {}", session_id, e)
+        polar_map = {}
 
-    def _ts_of(rec: dict[str, Any]) -> datetime:
-        return datetime.fromisoformat(str(rec["ts"])).replace(tzinfo=UTC)
-
-    speeds_dt = [(_ts_of(r), r) for r in speeds]
-    winds_dt = [
-        (_ts_of(r), r)
-        for r in winds
-        if int(r.get("reference", -1)) in (_WIND_REF_BOAT, _WIND_REF_NORTH)
-    ]
-    hdg_dt = [(_ts_of(r), r) for r in headings]
-
-    segments: list[GradedSegment] = []
-    grade_hist: dict[str, int] = defaultdict(int)
-
-    n_segments = math.ceil((end - start).total_seconds() / width)
-    for idx in range(n_segments):
-        seg_start = start + timedelta(seconds=idx * width)
-        seg_end = min(end, seg_start + timedelta(seconds=width))
-        t_mid = seg_start + (seg_end - seg_start) / 2
-
-        spd_in = [float(r["speed_kts"]) for ts, r in speeds_dt if seg_start <= ts < seg_end]
-        wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
-        hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
-        pos_in = [r for ts, r in [(_ts_of(r), r) for r in positions] if seg_start <= ts < seg_end]
-
-        lat, lon = _interp_position(positions, t_mid) if positions else (None, None)
-
-        bsp = _mean(spd_in)
-
-        tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
-        # Compute segment TWA from the mean wind angle / mean heading.
-        twa: float | None = None
-        if wind_in:
-            wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
-            ref = int(wind_in[0][1].get("reference", -1))
-            heading_mean = _mean(hdg_in) if ref == _WIND_REF_NORTH else None
-            twa = _compute_twa(wind_angle_mean, ref, heading_mean)
-
-        target: float | None = None
-        pct: float | None = None
-        delta: float | None = None
-        if bsp is not None and tws is not None and twa is not None and not baseline_missing:
-            try:
-                lp = await lookup_polar(storage, tws, twa)
-            except Exception as e:  # un-migrated DB or other table-missing error
-                logger.warning(
-                    "Polar grading: baseline lookup failed for session {}: {}", session_id, e
-                )
-                baseline_missing = True
-                lp = None
-            if lp is not None:
-                target = float(lp["mean_bsp"])
-                pct = bsp / target if target > 0 else None
-                delta = round(bsp - target, 4)
-
-        if bsp is not None and tws is not None and twa is not None:
-            grade = _grade_from_pct(pct)
-        else:
-            grade = "unknown"
-        if lat is None or lon is None:
-            grade = "unknown"
-
-        seg = GradedSegment(
-            segment_index=idx,
-            t_start=seg_start,
-            t_end=seg_end,
-            lat=lat,
-            lon=lon,
-            tws_kts=round(tws, 4) if tws is not None else None,
-            twa_deg=round(twa, 4) if twa is not None else None,
-            bsp_kts=round(bsp, 4) if bsp is not None else None,
-            target_bsp_kts=round(target, 4) if target is not None else None,
-            pct_target=round(pct, 4) if pct is not None else None,
-            delta_kts=delta,
-            grade=grade,
-        )
-        segments.append(seg)
-        grade_hist[grade] += 1
-        # silence unused
-        _ = pos_in
+    segments, grade_hist = await asyncio.to_thread(
+        _grade_segments_sync,
+        start,
+        end,
+        width,
+        speeds,
+        winds,
+        headings,
+        positions,
+        polar_map,
+    )
 
     # Persist cache
     await storage.upsert_polar_segment_grades(

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -501,9 +501,21 @@ async def api_end_race(
         except Exception as exc:  # noqa: BLE001
             logger.warning("Auto maneuver detection failed for race {}: {}", rid, exc)
 
+    async def _warm_polar_grades(rid: int) -> None:
+        # Populate polar_segment_grades cache before the user opens the debrief,
+        # so the first view doesn't pay the 2-3 min compute (#603).
+        try:
+            from helmlog.polar import grade_session_segments
+
+            segs = await grade_session_segments(storage, rid)
+            logger.info("Warmed polar grades for race {}: {} segments", rid, len(segs))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Polar warm-on-complete failed for race {}: {}", rid, exc)
+
     asyncio.ensure_future(_stop_cameras(race_id))
     asyncio.ensure_future(_network_auto_switch_end())
     asyncio.ensure_future(_auto_detect_maneuvers(race_id))
+    asyncio.ensure_future(_warm_polar_grades(race_id))
 
     # Warm-on-complete (#594 / #611): pre-compute summary/track/wind-field
     # in the background so the history page hits a warm T2 cache on first

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -5671,6 +5671,20 @@ class Storage:
         row = await cur.fetchone()
         return dict(row) if row else None
 
+    async def get_all_polar_points(self) -> dict[tuple[int, int], dict[str, Any]]:
+        """Return every polar_baseline row keyed by (tws_bin, twa_bin).
+
+        Used by ``grade_session_segments`` to batch-load the whole baseline
+        before dispatching CPU-bound segmentation to a worker thread — avoids
+        one await-per-segment on the event loop for long sessions.
+        """
+        cur = await self._read_conn().execute(
+            "SELECT tws_bin, twa_bin, mean_bsp, p90_bsp, session_count, sample_count"
+            " FROM polar_baseline"
+        )
+        rows = await cur.fetchall()
+        return {(int(r["tws_bin"]), int(r["twa_bin"])): dict(r) for r in rows}
+
     async def upsert_polar_baseline(self, rows: list[dict[str, Any]], built_at: str) -> None:
         """Replace all polar_baseline rows with the freshly computed set."""
         db = self._conn()

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -760,3 +760,62 @@ async def test_grade_distinct_polar_source_caches_separately(storage: Storage) -
     own = await grade_session_segments(storage, sid, polar_source="own", segment_seconds=10)
     ref = await grade_session_segments(storage, sid, polar_source="reference", segment_seconds=10)
     assert len(own) == len(ref) == 3
+
+
+@pytest.mark.asyncio
+async def test_grade_runs_in_worker_thread(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#603: the CPU-bound grading must be dispatched via asyncio.to_thread so
+    the event loop stays responsive while a long session is being graded."""
+    import asyncio as _asyncio
+    from typing import Any
+
+    import helmlog.polar as polar_mod
+
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    sid = await _seed_session(storage, duration_s=30, bsp=6.0, tws=10.0, twa=45.0)
+
+    calls: list[str] = []
+    real_to_thread = _asyncio.to_thread
+
+    async def spy_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        calls.append(getattr(func, "__name__", repr(func)))
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(polar_mod.asyncio, "to_thread", spy_to_thread)
+
+    segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    assert len(segs) == 3
+    assert "_grade_segments_sync" in calls
+
+
+@pytest.mark.asyncio
+async def test_grade_does_not_block_event_loop(storage: Storage) -> None:
+    """#603: other coroutines must be able to make progress while a grading
+    call is in flight. Runs a ticker in parallel and asserts it ticked."""
+    import asyncio as _asyncio
+
+    await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+    # Larger synthetic session so the sync work is non-trivial.
+    sid = await _seed_session(storage, duration_s=600, bsp=6.0, tws=10.0, twa=45.0)
+
+    ticks = 0
+    stop = False
+
+    async def ticker() -> None:
+        nonlocal ticks
+        while not stop:
+            await _asyncio.sleep(0)
+            ticks += 1
+
+    t = _asyncio.create_task(ticker())
+    try:
+        segs = await grade_session_segments(storage, sid, segment_seconds=10)
+    finally:
+        stop = True
+        await t
+    assert len(segs) == 60
+    # If the grader held the loop, ticks would be 0-ish. With to_thread the
+    # ticker runs freely while the thread computes.
+    assert ticks > 10


### PR DESCRIPTION
## Summary

- Pre-load the full polar baseline in a single batch query, then run the CPU-bound per-segment grading in `asyncio.to_thread` via a new pure `_grade_segments_sync` helper. The first view of a completed session no longer blocks every other API on the Pi for 2-3 minutes.
- Warm `polar_segment_grades` on race end by scheduling `grade_session_segments` from `api_end_race` alongside the existing camera-stop / auto-maneuver / web-cache background tasks. The cache is populated before the crew opens the debrief.

## Root cause

`helmlog.polar.grade_session_segments()` was called synchronously from the replay route and performed ~400 `await lookup_polar` DB calls inside a CPU-heavy segmentation loop. Because the work was CPU-bound and on the event loop, every other request queued behind it — confirmed live on corvopi-live 2026-04-19 (see issue for journal/nginx evidence).

## Risk

High tier (polar.py). Output is unchanged — the existing 64 polar tests pass byte-for-byte with the refactor, including cache-hit, source-separation, and baseline-rebuild invalidation tests. `polar_segment_grades` semantics (data_hash / baseline_version keying) are untouched.

## Test plan

- [x] `uv run pytest tests/test_polar.py -v` (66 pass)
- [x] `uv run pytest --no-cov -q` full suite (2281 pass, 2 skipped)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src/` clean
- [ ] Deploy to corvopi-tst1, end a race, confirm `Warmed polar grades for race {N}` in journal within seconds of `race.end`
- [ ] Open a previously-ungraded session on corvopi-live after promote and confirm parallel API calls on the same page return normally instead of queueing

Closes #603

🤖 Generated with [Claude Code](https://claude.ai/code)