### PR TITLE
fix(backup): atomic DB snapshot + integrity validator (#676)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -15,12 +15,38 @@ and how to restore from it if the card fails.
 
 | Source | Destination in snapshot |
 |---|---|
-| `~/helmlog/data/` — SQLite DB, WAV audio, photo notes, exports | `<snapshot>/data/` |
+| `~/helmlog/data/logger.db` — consistent copy via `sqlite3 .backup` | `<snapshot>/data/logger.db` |
+| `~/helmlog/data/audio/` — race + debrief WAV files | `<snapshot>/data/audio/` |
+| `~/helmlog/data/notes/` — photo attachments (camera + phone) | `<snapshot>/data/notes/` |
+| `~/helmlog/data/avatars/` — user profile photos | `<snapshot>/data/avatars/` |
+| `~/helmlog/data/vakaros-inbox/` — pending race session uploads | `<snapshot>/data/vakaros-inbox/` |
+| `~/helmlog/data/exports/` — CSV / GPX / JSON exports | `<snapshot>/data/exports/` |
+| `~/helmlog/.env` | `<snapshot>/config/helmlog.env` |
 | InfluxDB (system health metrics) | `<snapshot>/influxdb/` |
 | Grafana (dashboards, datasources) | `<snapshot>/grafana/` |
 
 Snapshots land in `~/backups/helmlog/<timestamp>/`.
 The 10 most recent are kept; older ones are deleted automatically.
+
+### Snapshot integrity (#676)
+
+`backup.sh` runs `scripts/validate_snapshot.py` against every freshly
+written snapshot. The validator cross-checks each `moment_attachments.path`,
+`audio_sessions.file_path`, and `users.avatar_path` row against the files
+actually present under `<snapshot>/data/` and reports orphans in the
+backup-report email. `restore.sh` runs the same validator against the
+snapshot before wiping the target, and again against the restored tree on
+the Pi — so a restore that would land broken attachments is visible
+immediately, not days later as broken image placeholders in the UI.
+
+Run it manually against any snapshot:
+
+```bash
+python3 scripts/validate_snapshot.py ~/backups/helmlog/20260228T030000Z/data
+```
+
+Exit code `0` means every referenced file is present; `1` means one or more
+orphans were found (sample paths are printed).
 
 ---
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -361,15 +361,51 @@ run_rsync_step() {
   esac
 }
 
-# ── 1. SQLite — WAL checkpoint then rsync ────────────────────────────────────
-ssh "$PI" "sqlite3 ~/helmlog/data/logger.db 'PRAGMA wal_checkpoint(TRUNCATE);'" 2>/dev/null || \
-  log "  WARNING: WAL checkpoint failed (DB may not exist yet); continuing"
+# ── 1. SQLite — consistent snapshot via sqlite3 .backup, then rsync ──────────
+# Previous versions relied on PRAGMA wal_checkpoint(TRUNCATE) and hoped no
+# writes landed mid-rsync. `sqlite3 .backup` gives an atomic copy that is
+# safe to transfer regardless of active WAL (#676). We overwrite the raw DB
+# that rsync picks up with the staged snapshot after the tree copy.
+ssh "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-* 2>/dev/null; \
+  sqlite3 ~/helmlog/data/logger.db \".backup '/tmp/logger.db.snap'\"" 2>/dev/null && \
+  log "  DB snapshot staged at /tmp/logger.db.snap on $PI" || \
+  log "  WARNING: sqlite3 .backup failed (DB may not exist yet); continuing"
 
 # shellcheck disable=SC2086  # LINK_DATA is intentionally unquoted (empty or single flag)
 run_rsync_step "SQLite + file data" "$SNAP/data" \
   rsync -az $RSYNC_PROGRESS $LINK_DATA \
     "$PI:~/helmlog/data/" \
     "$SNAP/data/" || true
+
+# Replace rsync's live-DB copy with the consistent snapshot, then tidy up.
+if ssh "$PI" "test -f /tmp/logger.db.snap" 2>/dev/null; then
+  rsync -az "$PI:/tmp/logger.db.snap" "$SNAP/data/logger.db" && \
+    log "  DB replaced with consistent snapshot"
+  ssh "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-*" 2>/dev/null || true
+fi
+
+# Cross-check the snapshot: every moment_attachments / audio_sessions /
+# users.avatar_path row must point at a file that actually exists in the
+# snapshot. Silent losses here are how corvopi-tst1 ended up with 25 photo
+# rows pointing at empty directories (#676).
+VALIDATOR="$SCRIPT_DIR/validate_snapshot.py"
+if [ -f "$SNAP/data/logger.db" ] && [ -f "$VALIDATOR" ] && command -v python3 >/dev/null; then
+  log "Step: Snapshot validation"
+  VALIDATE_OUT="/tmp/helmlog-validate-$DATE.txt"
+  if python3 "$VALIDATOR" "$SNAP/data" > "$VALIDATE_OUT" 2>&1; then
+    log "  OK (all referenced files present)"
+    report_line "- **Snapshot validation**: OK (all referenced files present)"
+  else
+    rc=$?
+    log "  WARNING: orphaned DB rows detected (rc=$rc)"
+    report_line "- **Snapshot validation**: WARN (rc=$rc) — orphaned DB rows detected"
+    report_line '```'
+    head -40 "$VALIDATE_OUT" >> "$REPORT" || true
+    report_line '```'
+    mark_warning "Snapshot validation: orphaned rows (see report body)"
+  fi
+  rm -f "$VALIDATE_OUT"
+fi
 
 # ── 2. InfluxDB — remote backup then rsync ───────────────────────────────────
 influx_backup() {

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -40,7 +40,22 @@ if [ -z "$SNAP" ]; then
 fi
 [ -d "$SNAP" ] || { echo "Snapshot directory not found: $SNAP" >&2; exit 1; }
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR="$SCRIPT_DIR/validate_snapshot.py"
+
 log() { echo "[$(date -u +%H:%M:%SZ)] $*"; }
+
+# ── 0. Pre-flight: validate the snapshot before wiping the target ────────────
+# Catches "DB references files that aren't in the snapshot" before the target
+# is destroyed (#676). Warns only — the user can still proceed, since a
+# recent DB with older photos may still be preferable to no restore at all.
+if [ -f "$VALIDATOR" ] && [ -f "$SNAP/data/logger.db" ] && command -v python3 >/dev/null; then
+  log "Pre-flight: validating snapshot $SNAP"
+  if ! python3 "$VALIDATOR" "$SNAP/data"; then
+    log "  WARNING: snapshot has orphaned DB rows (files missing from $SNAP/data/)"
+    log "  Restoring this snapshot will reproduce the missing-attachment symptom."
+  fi
+fi
 
 # rsync 3.1+ has --info=progress2; macOS ships with 2.6.9.
 if rsync --info=progress2 --version >/dev/null 2>&1; then
@@ -203,6 +218,20 @@ fi
 ssh "$PI" "sudo systemctl start signalk grafana-server helmlog" || \
   log "  WARNING: one or more services failed to start"
 log "  Services restarted"
+
+# ── Post-restore: validate the restored tree on the target ───────────────────
+# Surfaces any orphaned DB rows on the live target so the operator knows
+# immediately whether photos/audio/avatars made it across (#676).
+if [ -f "$VALIDATOR" ]; then
+  log "Post-restore: validating restored tree on $PI"
+  if ssh "$PI" "command -v python3 >/dev/null" 2>/dev/null; then
+    scp -q "$VALIDATOR" "$PI:/tmp/validate_snapshot.py" && \
+      ssh "$PI" "python3 /tmp/validate_snapshot.py ~/helmlog/data; rm -f /tmp/validate_snapshot.py" || \
+      log "  WARNING: post-restore validation failed"
+  else
+    log "  WARNING: python3 not on $PI; skipping post-restore validation"
+  fi
+fi
 
 echo
 log "Restore complete: $SNAP → $PI"

--- a/scripts/validate_snapshot.py
+++ b/scripts/validate_snapshot.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate that every on-disk artifact referenced by logger.db exists.
+
+Issue #676: backup snapshots silently lose photo/audio/avatar files when
+the DB is copied but the attachment tree isn't (or when paths in the DB
+point outside the backed-up root). This script cross-checks:
+
+  moment_attachments.path  → <data_root>/notes/<path>
+  audio_sessions.file_path → absolute, or <data_root>/audio/<path>
+  users.avatar_path        → <data_root>/avatars/<path>
+
+Usage:
+  python3 scripts/validate_snapshot.py <data_root>
+    data_root should contain logger.db plus the notes/, audio/,
+    avatars/ subdirectories (i.e. the equivalent of ~/helmlog/data/
+    on the Pi, or <snapshot>/data/ in a backup tree).
+
+Exit codes:
+  0   all referenced files present
+  1   one or more orphaned DB rows (missing files)
+  2   could not open the DB or data root
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class OrphanReport:
+    kind: str
+    total: int
+    missing: int
+    samples: list[str]
+
+
+def _check_attachments(db: sqlite3.Connection, notes_root: Path) -> OrphanReport:
+    try:
+        cur = db.execute(
+            "SELECT path FROM moment_attachments WHERE path IS NOT NULL AND path != ''"
+        )
+    except sqlite3.OperationalError:
+        # Pre-moments schema, or a non-standard test DB.
+        return OrphanReport("moment_attachments", 0, 0, [])
+    rows = cur.fetchall()
+    missing: list[str] = []
+    for (path,) in rows:
+        full = notes_root / str(path)
+        if not full.is_file():
+            missing.append(str(path))
+    return OrphanReport("moment_attachments", len(rows), len(missing), missing[:5])
+
+
+def _check_audio(db: sqlite3.Connection, data_root: Path) -> OrphanReport:
+    # file_path is typically absolute (/home/weaties/helmlog/data/audio/...)
+    # but older rows may be relative to the helmlog CWD.
+    try:
+        cur = db.execute(
+            "SELECT file_path FROM audio_sessions WHERE file_path IS NOT NULL AND file_path != ''"
+        )
+    except sqlite3.OperationalError:
+        # Pre-audio schema
+        return OrphanReport("audio_sessions", 0, 0, [])
+    rows = cur.fetchall()
+    missing: list[str] = []
+    for (fp,) in rows:
+        p = Path(fp)
+        candidates = [p] if p.is_absolute() else [data_root / p, data_root / "audio" / p.name]
+        if not any(c.is_file() for c in candidates):
+            missing.append(str(fp))
+    return OrphanReport("audio_sessions", len(rows), len(missing), missing[:5])
+
+
+def _check_avatars(db: sqlite3.Connection, avatars_root: Path) -> OrphanReport:
+    try:
+        cur = db.execute(
+            "SELECT avatar_path FROM users WHERE avatar_path IS NOT NULL AND avatar_path != ''"
+        )
+    except sqlite3.OperationalError:
+        return OrphanReport("users.avatar_path", 0, 0, [])
+    rows = cur.fetchall()
+    missing: list[str] = []
+    for (ap,) in rows:
+        p = Path(ap)
+        full = p if p.is_absolute() else avatars_root / p
+        if not full.is_file():
+            missing.append(str(ap))
+    return OrphanReport("users.avatar_path", len(rows), len(missing), missing[:5])
+
+
+def validate(data_root: Path) -> tuple[int, list[OrphanReport]]:
+    db_path = data_root / "logger.db"
+    if not db_path.is_file():
+        print(f"ERROR: {db_path} not found", file=sys.stderr)
+        return 2, []
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        reports = [
+            _check_attachments(db, data_root / "notes"),
+            _check_audio(db, data_root),
+            _check_avatars(db, data_root / "avatars"),
+        ]
+    finally:
+        db.close()
+
+    worst = 0 if all(r.missing == 0 for r in reports) else 1
+    return worst, reports
+
+
+def _format_report(reports: list[OrphanReport]) -> str:
+    lines = []
+    for r in reports:
+        pct = f"{(r.total - r.missing) / r.total * 100:.1f}%" if r.total else "n/a"
+        status = "OK" if r.missing == 0 else f"MISSING {r.missing}"
+        lines.append(f"- {r.kind}: {r.total} rows, {status} ({pct} present)")
+        for s in r.samples:
+            lines.append(f"    missing: {s}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("data_root", type=Path, help="Directory containing logger.db")
+    p.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print output on failure or when orphans are found",
+    )
+    args = p.parse_args()
+
+    if not args.data_root.is_dir():
+        print(f"ERROR: {args.data_root} is not a directory", file=sys.stderr)
+        return 2
+
+    rc, reports = validate(args.data_root)
+    if rc == 0 and args.quiet:
+        return 0
+    header = "Snapshot validation: " + ("OK" if rc == 0 else "ORPHANED ROWS FOUND")
+    print(header)
+    print(_format_report(reports))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_validate_snapshot.py
+++ b/tests/test_validate_snapshot.py
@@ -1,0 +1,110 @@
+"""Tests for scripts/validate_snapshot.py — backup completeness guard (#676)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT = _HERE.parent / "scripts" / "validate_snapshot.py"
+
+spec = importlib.util.spec_from_file_location("validate_snapshot", _SCRIPT)
+assert spec is not None and spec.loader is not None
+validate_snapshot = importlib.util.module_from_spec(spec)
+sys.modules["validate_snapshot"] = validate_snapshot
+spec.loader.exec_module(validate_snapshot)
+
+
+def _make_db(data_root: Path) -> None:
+    db_path = data_root / "logger.db"
+    db = sqlite3.connect(db_path)
+    db.executescript(
+        """
+        CREATE TABLE moment_attachments (
+            id INTEGER PRIMARY KEY, moment_id INTEGER, kind TEXT, path TEXT
+        );
+        CREATE TABLE audio_sessions (
+            id INTEGER PRIMARY KEY, file_path TEXT
+        );
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY, avatar_path TEXT
+        );
+        """
+    )
+    db.commit()
+    db.close()
+
+
+def test_all_present(tmp_path: Path) -> None:
+    _make_db(tmp_path)
+    (tmp_path / "notes" / "108").mkdir(parents=True)
+    (tmp_path / "notes" / "108" / "a.jpg").write_bytes(b"x")
+    db = sqlite3.connect(tmp_path / "logger.db")
+    db.execute(
+        "INSERT INTO moment_attachments(moment_id, kind, path) VALUES (1, 'photo', ?)",
+        ("108/a.jpg",),
+    )
+    db.commit()
+    db.close()
+    rc, reports = validate_snapshot.validate(tmp_path)
+    assert rc == 0
+    (ma,) = [r for r in reports if r.kind == "moment_attachments"]
+    assert ma.total == 1 and ma.missing == 0
+
+
+def test_missing_attachment_reported(tmp_path: Path) -> None:
+    _make_db(tmp_path)
+    db = sqlite3.connect(tmp_path / "logger.db")
+    db.execute(
+        "INSERT INTO moment_attachments(moment_id, kind, path) VALUES (1, 'photo', ?)",
+        ("108/missing.jpg",),
+    )
+    db.commit()
+    db.close()
+    rc, reports = validate_snapshot.validate(tmp_path)
+    assert rc == 1
+    (ma,) = [r for r in reports if r.kind == "moment_attachments"]
+    assert ma.missing == 1
+    assert "108/missing.jpg" in ma.samples
+
+
+def test_absent_tables_tolerated(tmp_path: Path) -> None:
+    """Older backups may lack audio_sessions / users tables — validator must
+    not crash; those checks return 0/0 and overall status stays OK."""
+    db_path = tmp_path / "logger.db"
+    db = sqlite3.connect(db_path)
+    db.executescript("CREATE TABLE moment_attachments (id INTEGER PRIMARY KEY, path TEXT);")
+    db.commit()
+    db.close()
+    rc, reports = validate_snapshot.validate(tmp_path)
+    assert rc == 0
+    kinds = {r.kind for r in reports}
+    assert {"moment_attachments", "audio_sessions", "users.avatar_path"} == kinds
+
+
+def test_missing_db_returns_rc_2(tmp_path: Path) -> None:
+    rc, reports = validate_snapshot.validate(tmp_path)
+    assert rc == 2
+    assert reports == []
+
+
+@pytest.mark.parametrize("abs_path", [True, False])
+def test_audio_absolute_and_relative(tmp_path: Path, abs_path: bool) -> None:
+    _make_db(tmp_path)
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    wav = audio_dir / "race42.wav"
+    wav.write_bytes(b"riff")
+    stored = str(wav) if abs_path else "audio/race42.wav"
+    db = sqlite3.connect(tmp_path / "logger.db")
+    db.execute("INSERT INTO audio_sessions(file_path) VALUES (?)", (stored,))
+    db.commit()
+    db.close()
+    rc, reports = validate_snapshot.validate(tmp_path)
+    (a,) = [r for r in reports if r.kind == "audio_sessions"]
+    assert a.total == 1 and a.missing == 0
+    assert rc == 0


### PR DESCRIPTION
## Summary

- `backup.sh` now stages the DB via `sqlite3 .backup` on the Pi before rsync so the snapshot is atomic, even with active writes. The live-DB copy pulled by rsync is overwritten with the consistent copy.
- New `scripts/validate_snapshot.py` cross-checks `moment_attachments.path`, `audio_sessions.file_path`, and `users.avatar_path` against the files actually present in the snapshot. Orphan rows become a warning in the backup-report email and a pre-flight + post-restore check in `restore.sh`.
- `docs/backup.md` enumerates the canonical backup set (logger.db / audio / notes / avatars / vakaros-inbox / exports / .env / influxdb / grafana) and documents the validator.

## Root cause

`corvopi-tst1` came back from a restore with 25 `moment_attachments` rows pointing at JPEGs that weren't on disk — the attachment tree existed only as empty session subdirectories. The DB copy and the attachment tree drifted out of sync because the DB was read mid-write with only a WAL checkpoint as guard, and the tree had no integrity check either way.

## Risk tier

Critical — this is a data-loss bug per `docs/data-licensing.md` (boat owns its photo data and must be able to retrieve it). Validator is non-invasive: read-only, warn-only; never blocks backup rotation or restore.

## Test plan

- [x] `uv run pytest tests/test_validate_snapshot.py -v` — 6 new tests, all pass (happy path, missing file, absent tables, missing DB, absolute + relative audio paths).
- [x] `uv run pytest --no-cov -q` — full suite 2285 passed, 2 skipped.
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy scripts/validate_snapshot.py` — clean.
- [x] `bash -n scripts/backup.sh scripts/restore.sh` — syntax clean.
- [ ] `./scripts/backup.sh` against corvopi-live — confirm `DB snapshot staged` and `Snapshot validation: OK` in the backup report.
- [ ] `./scripts/restore.sh ~/backups/helmlog/<snap> PI=...-tst1` — confirm pre-flight + post-restore validator runs and reports orphan counts.

Fixes #676

🤖 Generated with [Claude Code](https://claude.ai/code)