### PR TITLE
fix(moments): preserve maneuver anchor times on re-run + permission tests

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -5804,9 +5804,21 @@ class Storage:
         import json
 
         db = self._conn()
-        # Downgrade dependent moments before the FKs vanish.
+        # Downgrade dependent moments before the FKs vanish. Copy the maneuver's
+        # ts into anchor_t_start so the moment keeps its place on the timeline —
+        # the read-time resolver can't recover it once the maneuvers row is gone.
         await db.execute(
-            "UPDATE moments SET anchor_kind = 'timestamp', anchor_entity_id = NULL"
+            "UPDATE moments"
+            " SET anchor_kind = 'timestamp',"
+            "     anchor_t_start = COALESCE("
+            "         anchor_t_start,"
+            "         (SELECT ts FROM maneuvers WHERE id = moments.anchor_entity_id)"
+            "     ),"
+            "     anchor_t_end = COALESCE("
+            "         anchor_t_end,"
+            "         (SELECT end_ts FROM maneuvers WHERE id = moments.anchor_entity_id)"
+            "     ),"
+            "     anchor_entity_id = NULL"
             " WHERE anchor_kind = 'maneuver'"
             " AND anchor_entity_id IN (SELECT id FROM maneuvers WHERE session_id = ?)",
             (session_id,),

--- a/tests/test_moments_api.py
+++ b/tests/test_moments_api.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
 import pytest_asyncio
 
+import helmlog.auth as auth_module
 from helmlog.storage import Storage, StorageConfig
 from helmlog.web import create_app
 
@@ -174,6 +175,126 @@ class TestCounterparties:
             resp = await c.get("/api/moments/counterparties")
             assert resp.status_code == 200
             assert "Orca" in resp.json()["counterparties"]
+
+
+def _as_viewer(user_id: int) -> dict[str, Any]:
+    return {
+        "id": user_id,
+        "email": f"u{user_id}@example.com",
+        "name": f"User {user_id}",
+        "role": "viewer",
+        "is_developer": 0,
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "last_seen": None,
+        "is_active": 1,
+    }
+
+
+async def _seed_user(storage: Storage, user_id: int) -> None:
+    """Insert a real users row so created_by FK references resolve."""
+    db = storage._conn()
+    await db.execute(
+        "INSERT OR IGNORE INTO users (id, email, role, created_at)"
+        " VALUES (?, ?, 'viewer', '2024-01-01T00:00:00+00:00')",
+        (user_id, f"u{user_id}@example.com"),
+    )
+    await db.commit()
+
+
+class TestPermissionMatrix:
+    """PATCH/DELETE /api/moments/{id} must enforce author-or-admin (#683).
+
+    The default test fixture authenticates as the mock admin (id=None),
+    which trivially satisfies `_moment_is_author`. These tests swap
+    `_MOCK_ADMIN` mid-flight to simulate non-admin viewers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_author_viewer_cannot_edit(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await _seed_user(storage, 1)
+        await _seed_user(storage, 2)
+        sid = await _race(storage)
+        monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(1))
+        async with await _client(storage) as c:
+            mid = (
+                await c.post(
+                    f"/api/sessions/{sid}/moments",
+                    json={"anchor_kind": "session", "subject": "mine"},
+                )
+            ).json()["id"]
+
+            monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(2))
+            resp = await c.patch(f"/api/moments/{mid}", json={"subject": "hijacked"})
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_non_author_viewer_cannot_delete(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await _seed_user(storage, 1)
+        await _seed_user(storage, 2)
+        sid = await _race(storage)
+        monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(1))
+        async with await _client(storage) as c:
+            mid = (
+                await c.post(
+                    f"/api/sessions/{sid}/moments",
+                    json={"anchor_kind": "session", "subject": "mine"},
+                )
+            ).json()["id"]
+
+            monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(2))
+            resp = await c.delete(f"/api/moments/{mid}")
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_author_viewer_can_edit_and_delete(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await _seed_user(storage, 7)
+        sid = await _race(storage)
+        monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(7))
+        async with await _client(storage) as c:
+            mid = (
+                await c.post(
+                    f"/api/sessions/{sid}/moments",
+                    json={"anchor_kind": "session", "subject": "mine"},
+                )
+            ).json()["id"]
+
+            patch = await c.patch(f"/api/moments/{mid}", json={"subject": "renamed"})
+            assert patch.status_code == 200
+            assert patch.json()["subject"] == "renamed"
+
+            delete = await c.delete(f"/api/moments/{mid}")
+            assert delete.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_admin_can_edit_and_delete_other_users_moment(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await _seed_user(storage, 1)
+        await _seed_user(storage, 99)
+        sid = await _race(storage)
+        monkeypatch.setattr(auth_module, "_MOCK_ADMIN", _as_viewer(1))
+        async with await _client(storage) as c:
+            mid = (
+                await c.post(
+                    f"/api/sessions/{sid}/moments",
+                    json={"anchor_kind": "session", "subject": "owned by 1"},
+                )
+            ).json()["id"]
+
+            admin_user = _as_viewer(99)
+            admin_user["role"] = "admin"
+            monkeypatch.setattr(auth_module, "_MOCK_ADMIN", admin_user)
+
+            patch = await c.patch(f"/api/moments/{mid}", json={"subject": "moderated"})
+            assert patch.status_code == 200
+            delete = await c.delete(f"/api/moments/{mid}")
+            assert delete.status_code == 204
 
 
 class TestLegacyPhotoShim:

--- a/tests/test_storage_moments.py
+++ b/tests/test_storage_moments.py
@@ -143,8 +143,9 @@ class TestReadMoment:
         sid = await _race(storage)
         db = storage._conn()
         cur = await db.execute(
-            "INSERT INTO maneuvers (session_id, type, ts)"
-            " VALUES (?, 'tack', '2026-01-01T12:08:00+00:00')",
+            "INSERT INTO maneuvers (session_id, type, ts, end_ts)"
+            " VALUES (?, 'tack', '2026-01-01T12:08:00+00:00',"
+            "         '2026-01-01T12:08:30+00:00')",
             (sid,),
         )
         await db.commit()
@@ -155,11 +156,15 @@ class TestReadMoment:
             anchor_entity_id=mv_id,
         )
         # write_maneuvers replaces the session's maneuvers, downgrading moments.
+        # The anchor times must be persisted before the maneuvers row is gone —
+        # otherwise the moment loses its place on the timeline (#683).
         await storage.write_maneuvers(sid, [])
         m = await storage.get_moment(mid)
         assert m is not None
         assert m["anchor_kind"] == "timestamp"
         assert m["anchor_entity_id"] is None
+        assert m["anchor_t_start"] == "2026-01-01T12:08:00+00:00"
+        assert m["anchor_t_end"] == "2026-01-01T12:08:30+00:00"
 
 
 class TestMutateMoment:


### PR DESCRIPTION
## Summary

Addresses both findings from the nightly Claude review on `main` (#683):

- **HIGH** — Permission-matrix tests for `PATCH/DELETE /api/moments/{id}` were missing. `test_moments_api.py` exercised only the mock-admin happy path (always satisfies `_moment_is_author`), so any regression in the author/admin guard would slip through. Ported the four equivalent tests from the deleted `test_bookmarks_api.py`:
  - non-author viewer cannot edit (403)
  - non-author viewer cannot delete (403)
  - author viewer can edit and delete (200/204)
  - admin can edit/delete another user's moment (200/204)

- **MEDIUM** — `storage.write_maneuvers` downgraded maneuver-anchored moments to `anchor_kind='timestamp'` but didn't copy the maneuver's `ts` into `anchor_t_start`. Since maneuver-anchored moments are stored with `anchor_t_start = NULL` (the timestamp is derived at read time from the `maneuvers` row), after the row was deleted the resolver had nothing to fall back on and the moment sorted to session-start via `COALESCE(anchor_t_start, created_at)`. The `UPDATE` now COALESCEs the maneuver's `ts`/`end_ts` into the moment row **before** the `DELETE FROM maneuvers`, so the subquery still resolves. The existing downgrade test was extended to assert `anchor_t_start` and `anchor_t_end` are preserved.

Closes #683

## Test plan

- [x] `uv run pytest tests/test_moments_api.py tests/test_storage_moments.py -v` — 29 passed
- [x] `uv run pytest tests/` — 2291 passed, 2 skipped
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src/helmlog/storage.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)