### PR TITLE
feat(backup): dedicated helmlog-backup user (fixes Tailscale headless SSH + photo-skip)

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -4,10 +4,16 @@ The logger stores all data on a microSD card inside the Raspberry Pi.
 This guide covers how to pull a complete backup to your Mac automatically,
 and how to restore from it if the card fails.
 
-> **Multiple Pis?** All scripts accept a `PI` environment variable for the SSH
-> target (e.g. `PI=weaties@testpi ./scripts/backup.sh`). The default is
-> `weaties@corvopi`. Examples below use the placeholder `<pi-user>@<pi-host>` —
-> substitute your actual SSH target.
+> **Identity:** Backups run as a dedicated `helmlog-backup` user on the Pi
+> (provisioned by `scripts/setup-backup-user.sh`), authenticated with a
+> dedicated key (`~/.ssh/helmlog-backup`) — not as the boat owner's
+> account. This decouples the backup path from per-boat usernames and lets a
+> narrow Tailscale ACL rule grant the daily cron headless SSH without
+> tripping `check`-mode re-auth.
+>
+> **Multiple Pis?** Pass the `PI` env var
+> (e.g. `PI=helmlog-backup@testpi ./scripts/backup.sh`). Examples below use
+> the placeholder `<pi-host>`.
 
 ---
 
@@ -55,42 +61,78 @@ orphans were found (sample paths are printed).
 ### 1. Prerequisites on the Mac
 
 ```bash
-# SSH key-based auth to the Pi (skip if already done)
-ssh-keygen -t ed25519 -C "mac-to-pi-backup"
-ssh-copy-id <pi-user>@<pi-host>
+# Dedicated SSH keypair for the backup user (separate from your interactive key)
+ssh-keygen -t ed25519 -f ~/.ssh/helmlog-backup -N "" -C "helmlog-backup-mac"
 
-# InfluxDB CLI (for restore; backup is handled on the Pi)
+# InfluxDB CLI (used during restore)
 brew install influxdb-cli
 ```
 
-### 2. Pi: allow sudo rsync without a password (for Grafana backup)
+### 2. Pi: provision the helmlog-backup user
 
-SSH into the Pi and add a sudoers rule:
+From the project root, copy the setup script to the Pi and run it (sudo will
+prompt for the boat owner's password):
 
 ```bash
-ssh <pi-user>@<pi-host>
-echo '<pi-user> ALL=(ALL) NOPASSWD: /usr/bin/rsync' | sudo tee /etc/sudoers.d/rsync-backup
-sudo chmod 440 /etc/sudoers.d/rsync-backup
+scp scripts/setup-backup-user.sh <owner>@<pi-host>:/tmp/
+ssh -t <owner>@<pi-host> 'bash /tmp/setup-backup-user.sh && rm /tmp/setup-backup-user.sh'
 ```
 
-### 3. Install the daily launchd agent on the Mac
+The script is idempotent. It:
+- Creates the `helmlog-backup` system user, member of the boat owner's group
+- Authorises `~/.ssh/helmlog-backup.pub` for SSH login
+- Adds `/etc/sudoers.d/helmlog-backup` with `NOPASSWD: ALL` (needed for
+  restore writes into helmlog-owned paths and service control)
+- Loosens `~/helmlog/.env` and `~/influx-token.txt` to mode 640 so the new
+  user can read them via group membership
+
+If the boat owner is not `weaties`, set `OWNER_USER=<name>` before running.
+
+### 3. Tailscale ACL: bypass check mode for the backup user
+
+Add an `ssh` rule that **accepts** (rather than `check`s) connections from
+this Mac to the Pis when the SSH login user is `helmlog-backup`. Without
+this, the cron-driven backup at 03:00 will fail any time Tailscale's
+periodic re-auth window expires (this is what caused the 2026-04-23 and
+2026-04-24 missed backups).
+
+Minimal addition to the tailnet policy file:
+
+```hujson
+"ssh": [
+  // existing check-mode rule stays for interactive humans
+  // ...
+  {
+    "action":          "accept",
+    "src":             ["autogroup:member"],
+    "dst":             ["autogroup:self"],
+    "users":           ["helmlog-backup"],
+    "sessionDuration": "8760h",
+  },
+],
+```
+
+Apply via the admin UI at <https://login.tailscale.com/admin/acls/file>.
+
+### 4. Install the daily launchd agent on the Mac
 
 From the project root:
 
 ```bash
-./scripts/setup-backup-mac.sh
+PI=helmlog-backup@<pi-host> REPORT_TO=you@example.com ./scripts/setup-backup-mac.sh
 ```
 
 This:
-- Checks SSH connectivity to the Pi
+- Checks SSH connectivity to the Pi using `~/.ssh/helmlog-backup`
 - Creates `~/backups/helmlog/`
-- Installs `~/Library/LaunchAgents/com.helmlog.backup.plist`
+- Installs `~/Library/LaunchAgents/com.helmlog.backup.plist` with
+  PI / SSH_KEY / REPORT_TO baked into `EnvironmentVariables`
 - Schedules the backup to run every day at **03:00 local time**
 
-### 4. Run a test backup now
+### 5. Run a test backup now
 
 ```bash
-./scripts/backup.sh
+PI=helmlog-backup@<pi-host> REPORT_TO=you@example.com ./scripts/backup.sh
 ```
 
 Verify the snapshot contains:
@@ -132,52 +174,19 @@ launchctl start com.helmlog.backup
 
 ## Restoring from a backup
 
-Pick the snapshot you want:
+`scripts/restore.sh` does the full sequence — stop services, restore SQLite
++ file data, .env, Signal K, Grafana, InfluxDB (`--full`), wipe boat
+identity, restart services. Run it as the dedicated backup user; sudo on the
+Pi handles the privileged writes.
 
 ```bash
-ls ~/backups/helmlog/
-# e.g. 20260228T030000Z
-SNAP=~/backups/helmlog/20260228T030000Z
+PI=helmlog-backup@<pi-host> ./scripts/restore.sh                                # most recent snapshot
+PI=helmlog-backup@<pi-host> ./scripts/restore.sh ~/backups/helmlog/20260228T030000Z
 ```
 
-### SQLite
-
-```bash
-# Stop the logger service on the Pi first
-ssh $PI "sudo systemctl stop helmlog"
-
-# Copy the DB back
-rsync -az "$SNAP/data/" $PI:~/helmlog/data/
-
-# Restart
-ssh $PI "sudo systemctl start helmlog"
-```
-
-### InfluxDB
-
-```bash
-# Restore to the running InfluxDB instance (overwrites existing data)
-influx restore "$SNAP/influxdb/" \
-  --host http://<pi-host>:8086 \
-  --token "$(cat ~/influx-token.txt)"
-```
-
-If restoring to a fresh InfluxDB install, add `--full` to wipe and replace all buckets.
-
-### Grafana
-
-```bash
-# Stop Grafana on the Pi
-ssh $PI "sudo systemctl stop grafana-server"
-
-# Restore the data directory
-rsync -az --rsync-path='sudo rsync' \
-  "$SNAP/grafana/" \
-  $PI:/var/lib/grafana/
-
-# Fix ownership and restart
-ssh $PI "sudo chown -R grafana:grafana /var/lib/grafana && sudo systemctl start grafana-server"
-```
+After restore, run `helmlog identity init …` on the target so it federates
+as itself rather than impersonating the source. Set `KEEP_IDENTITY=1` only
+when the source Pi is offline during testing.
 
 ---
 
@@ -187,10 +196,15 @@ All settings are overridable via environment variables:
 
 | Variable | Default | Description |
 |---|---|---|
-| `PI` | `weaties@corvopi` | SSH target for the Pi |
+| `PI` | _required_ | SSH target, e.g. `helmlog-backup@<pi-host>` |
+| `SSH_KEY` | `~/.ssh/helmlog-backup` | Local SSH private key for the backup user |
+| `REPORT_TO` | _required_ | Email address for the daily report (or set `SKIP_EMAIL=1`) |
 | `BACKUP_DEST` | `~/backups/helmlog` | Local snapshot root |
 | `KEEP_SNAPSHOTS` | `10` | Number of snapshots to retain |
-| `INFLUX_TOKEN_FILE` | `~/influx-token.txt` | Path on the Pi to the InfluxDB token |
+| `PI_HELMLOG_DIR` | `/home/weaties/helmlog` | Pi-side helmlog directory |
+| `PI_SIGNALK_DIR` | `/home/weaties/.signalk` | Pi-side Signal K directory |
+| `PI_OWNER_USER` (restore) | `weaties` | Pi-side file owner used for `--chown` during restore |
+| `INFLUX_TOKEN_FILE` | `/home/weaties/influx-token.txt` | Pi-side InfluxDB token path |
 
 Example — keep 30 days of snapshots:
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -100,17 +100,21 @@ Minimal addition to the tailnet policy file:
 
 ```hujson
 "ssh": [
+  // place this BEFORE the existing check-mode rule for autogroup:nonroot
+  // so it matches first when the SSH login user is helmlog-backup
+  {
+    "action": "accept",
+    "src":    ["autogroup:member"],
+    "dst":    ["autogroup:self"],
+    "users":  ["helmlog-backup"],
+  },
   // existing check-mode rule stays for interactive humans
   // ...
-  {
-    "action":          "accept",
-    "src":             ["autogroup:member"],
-    "dst":             ["autogroup:self"],
-    "users":           ["helmlog-backup"],
-    "sessionDuration": "8760h",
-  },
 ],
 ```
+
+`sessionDuration` is only valid on `check`-action rules — `accept` has no
+expiry, which is exactly what the headless cron needs.
 
 Apply via the admin UI at <https://login.tailscale.com/admin/acls/file>.
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -8,19 +8,22 @@
 # Keeps the most recent $KEEP_SNAPSHOTS snapshots; older ones are deleted.
 #
 # Prerequisites on the Mac:
-#   - SSH access to the Pi (via Tailscale; key-based auth recommended)
+#   - SSH access to the Pi as `helmlog-backup` (provisioned by
+#     scripts/setup-backup-user.sh; key-based auth via ~/.ssh/helmlog-backup)
 #   - influx CLI for InfluxDB backup: brew install influxdb-cli
-#   - sudo rsync allowed on the Pi for the SSH user (for Grafana dir)
 #   - Python 3 on PATH (for the email report helper; stdlib only)
 #
 # Required environment:
-#   PI                 SSH target, e.g. user@pi-hostname (no default)
+#   PI                 SSH target, e.g. helmlog-backup@pi-hostname (no default)
 #   REPORT_TO          email recipient (required unless SKIP_EMAIL=1)
 #
 # Optional environment overrides:
 #   BACKUP_DEST        local snapshot root       (default: ~/backups/helmlog)
 #   KEEP_SNAPSHOTS     how many to retain        (default: 10)
-#   INFLUX_TOKEN_FILE  path on the Pi            (default: ~/influx-token.txt)
+#   SSH_KEY            local SSH key path        (default: ~/.ssh/helmlog-backup)
+#   PI_HELMLOG_DIR     helmlog dir on the Pi     (default: /home/weaties/helmlog)
+#   PI_SIGNALK_DIR     signalk dir on the Pi     (default: /home/weaties/.signalk)
+#   INFLUX_TOKEN_FILE  path on the Pi            (default: /home/weaties/influx-token.txt)
 #   SMTP_CACHE         local creds cache path    (default: ~/.config/helmlog-backup/smtp.env)
 #   MIN_SNAPSHOT_BYTES safety-gate threshold     (default: 10485760 — 10 MiB)
 #   SKIP_EMAIL         set to 1 to suppress mail (default: unset)
@@ -39,9 +42,20 @@ if [ "${SKIP_EMAIL:-0}" != "1" ]; then
 fi
 BACKUP_DEST="${BACKUP_DEST:-$HOME/backups/helmlog}"
 KEEP_SNAPSHOTS="${KEEP_SNAPSHOTS:-10}"
-INFLUX_TOKEN_FILE="${INFLUX_TOKEN_FILE:-~/influx-token.txt}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/helmlog-backup}"
+PI_HELMLOG_DIR="${PI_HELMLOG_DIR:-/home/weaties/helmlog}"
+PI_SIGNALK_DIR="${PI_SIGNALK_DIR:-/home/weaties/.signalk}"
+INFLUX_TOKEN_FILE="${INFLUX_TOKEN_FILE:-/home/weaties/influx-token.txt}"
 SMTP_CACHE="${SMTP_CACHE:-$HOME/.config/helmlog-backup/smtp.env}"
 MIN_SNAPSHOT_BYTES="${MIN_SNAPSHOT_BYTES:-10485760}"
+
+# Pin every ssh/scp/rsync to the dedicated key + non-interactive options. This
+# avoids picking up a stale agent identity and ensures predictable behaviour
+# under launchd. `-F /dev/null` ignores ~/.ssh/config so a stray Host stanza
+# can't redirect the connection.
+SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -F /dev/null)
+SSH="ssh ${SSH_OPTS[*]}"
+RSYNC_SSH="ssh ${SSH_OPTS[*]}"
 
 DATE=$(date -u +%Y%m%dT%H%M%SZ)
 SNAP="$BACKUP_DEST/$DATE"
@@ -225,8 +239,7 @@ init_report
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
 log "Preflight: SSH check to $PI"
-if ! ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
-    "$PI" true 2>&1; then
+if ! $SSH -o ConnectTimeout=10 "$PI" true 2>&1; then
   mark_failed "SSH preflight to $PI failed (host unreachable or auth failure)"
   log "  FAIL: SSH preflight"
   report_line "- **Preflight**: FAILED — could not SSH to \`$PI\`"
@@ -243,7 +256,7 @@ mkdir -p "$(dirname "$SMTP_CACHE")"
 # Pull just the SMTP_* lines from the Pi's .env so the cache never holds
 # unrelated secrets. `grep -E` yields rc=1 on no match, which we swallow.
 SMTP_TMP="$(mktemp)"
-if ssh "$PI" "grep -E '^SMTP_' ~/helmlog/.env 2>/dev/null" > "$SMTP_TMP" 2>&1; then
+if $SSH "$PI" "grep -E '^SMTP_' $PI_HELMLOG_DIR/.env 2>/dev/null" > "$SMTP_TMP" 2>&1; then
   if [ -s "$SMTP_TMP" ]; then
     mv "$SMTP_TMP" "$SMTP_CACHE"
     chmod 600 "$SMTP_CACHE"
@@ -366,22 +379,27 @@ run_rsync_step() {
 # writes landed mid-rsync. `sqlite3 .backup` gives an atomic copy that is
 # safe to transfer regardless of active WAL (#676). We overwrite the raw DB
 # that rsync picks up with the staged snapshot after the tree copy.
-ssh "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-* 2>/dev/null; \
-  sqlite3 ~/helmlog/data/logger.db \".backup '/tmp/logger.db.snap'\"" 2>/dev/null && \
+$SSH "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-* 2>/dev/null; \
+  sqlite3 $PI_HELMLOG_DIR/data/logger.db \".backup '/tmp/logger.db.snap'\"" 2>/dev/null && \
   log "  DB snapshot staged at /tmp/logger.db.snap on $PI" || \
   log "  WARNING: sqlite3 .backup failed (DB may not exist yet); continuing"
 
+# --rsync-path='sudo rsync' so we can read photos in notes/<session>/ — those
+# are written by the helmlog service as 0600/helmlog and were previously
+# silently skipped (rc=23 partial transfer), producing the orphaned
+# moment_attachments rows tracked in #676.
 # shellcheck disable=SC2086  # LINK_DATA is intentionally unquoted (empty or single flag)
 run_rsync_step "SQLite + file data" "$SNAP/data" \
-  rsync -az $RSYNC_PROGRESS $LINK_DATA \
-    "$PI:~/helmlog/data/" \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS $LINK_DATA \
+    --rsync-path='sudo rsync' \
+    "$PI:$PI_HELMLOG_DIR/data/" \
     "$SNAP/data/" || true
 
 # Replace rsync's live-DB copy with the consistent snapshot, then tidy up.
-if ssh "$PI" "test -f /tmp/logger.db.snap" 2>/dev/null; then
-  rsync -az "$PI:/tmp/logger.db.snap" "$SNAP/data/logger.db" && \
+if $SSH "$PI" "test -f /tmp/logger.db.snap" 2>/dev/null; then
+  rsync -e "$RSYNC_SSH" -az "$PI:/tmp/logger.db.snap" "$SNAP/data/logger.db" && \
     log "  DB replaced with consistent snapshot"
-  ssh "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-*" 2>/dev/null || true
+  $SSH "$PI" "rm -f /tmp/logger.db.snap /tmp/logger.db.snap-*" 2>/dev/null || true
 fi
 
 # Cross-check the snapshot: every moment_attachments / audio_sessions /
@@ -409,19 +427,19 @@ fi
 
 # ── 2. InfluxDB — remote backup then rsync ───────────────────────────────────
 influx_backup() {
-  if ! ssh "$PI" "test -f $INFLUX_TOKEN_FILE" 2>/dev/null; then
+  if ! $SSH "$PI" "test -f $INFLUX_TOKEN_FILE" 2>/dev/null; then
     log "  $INFLUX_TOKEN_FILE not found on Pi; skipping"
     report_line "- **InfluxDB**: SKIPPED — no token file on Pi"
     return 0
   fi
-  ssh "$PI" "influx backup /tmp/influx-backup \
+  $SSH "$PI" "influx backup /tmp/influx-backup \
     --host http://localhost:8086 \
     --token \$(cat $INFLUX_TOKEN_FILE)" || return $?
   # shellcheck disable=SC2086
-  rsync -az $RSYNC_PROGRESS $LINK_INFLUX \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS $LINK_INFLUX \
     "$PI:/tmp/influx-backup/" \
     "$SNAP/influxdb/" || return $?
-  ssh "$PI" "rm -rf /tmp/influx-backup" || true
+  $SSH "$PI" "rm -rf /tmp/influx-backup" || true
 }
 if influx_backup; then
   size=$(human_size "$SNAP/influxdb")
@@ -434,8 +452,8 @@ fi
 
 # ── 3. Config — .env, Signal K, influx token ────────────────────────────────
 mkdir -p "$SNAP/config"
-if rsync -az $RSYNC_PROGRESS \
-    "$PI:~/helmlog/.env" \
+if rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS \
+    "$PI:$PI_HELMLOG_DIR/.env" \
     "$SNAP/config/helmlog.env" 2>&1; then
   report_line "- **helmlog .env**: OK — $(human_size "$SNAP/config/helmlog.env")"
 else
@@ -446,7 +464,7 @@ fi
 # influx-token.txt is needed by restore.sh to authenticate against the
 # target's InfluxDB after a prior `influx restore --full`, which replaces all
 # auth on the target with the source's tokens.
-if rsync -az "$PI:$INFLUX_TOKEN_FILE" "$SNAP/config/influx-token.txt" 2>&1; then
+if rsync -e "$RSYNC_SSH" -az "$PI:$INFLUX_TOKEN_FILE" "$SNAP/config/influx-token.txt" 2>&1; then
   report_line "- **Influx token file**: OK"
 else
   report_line "- **Influx token file**: FAILED"
@@ -458,16 +476,16 @@ LINK_SK=""
 [ -n "$PREV" ] && [ -d "$PREV/signalk" ] && LINK_SK="--link-dest=$PREV/signalk"
 # shellcheck disable=SC2086
 run_rsync_step "Signal K config + data" "$SNAP/signalk" \
-  rsync -az $RSYNC_PROGRESS $LINK_SK \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS $LINK_SK \
     --exclude='node_modules/' \
     --exclude='package-lock.json' \
-    "$PI:~/.signalk/" \
+    "$PI:$PI_SIGNALK_DIR/" \
     "$SNAP/signalk/" || true
 
 # ── 4. Grafana — data dir + provisioning config ──────────────────────────────
 # shellcheck disable=SC2086
 run_rsync_step "Grafana data dir" "$SNAP/grafana" \
-  rsync -az $RSYNC_PROGRESS \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS \
     --rsync-path='sudo rsync' \
     $LINK_GRAFANA \
     "$PI:/var/lib/grafana/" \
@@ -478,7 +496,7 @@ LINK_GP=""
   LINK_GP="--link-dest=$PREV/grafana-provisioning"
 # shellcheck disable=SC2086
 run_rsync_step "Grafana provisioning" "$SNAP/grafana-provisioning" \
-  rsync -az $RSYNC_PROGRESS \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS \
     --rsync-path='sudo rsync' \
     $LINK_GP \
     "$PI:/etc/grafana/provisioning/" \

--- a/scripts/com.helmlog.backup.plist
+++ b/scripts/com.helmlog.backup.plist
@@ -50,6 +50,12 @@
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>
     <string>HOME_PATH</string>
+    <key>PI</key>
+    <string>PI_TARGET</string>
+    <key>SSH_KEY</key>
+    <string>SSH_KEY_PATH</string>
+    <key>REPORT_TO</key>
+    <string>REPORT_TO_ADDR</string>
   </dict>
 </dict>
 </plist>

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -101,16 +101,20 @@ $SSH "$PI" "sudo -n systemctl stop helmlog signalk grafana-server" || \
 
 # ── 2. SQLite + file data ─────────────────────────────────────────────────────
 log "Step 2/7: Restoring SQLite + file data → $PI_HELMLOG_DIR/data/"
-# Use sudo rsync on the Pi so we can overwrite files regardless of which user
-# the SSH session is running as (the helmlog service writes as `helmlog`,
-# while the SSH user is typically `helmlog-backup`). --chown restores the
-# expected ownership on the target.
+# Use `sudo rsync` on the Pi so we can overwrite files regardless of which
+# user the SSH session is running as (the helmlog service writes as `helmlog`,
+# while the SSH user is typically `helmlog-backup`). Files arrive owned by
+# root; a `chown -R` step below restores the expected ownership.
+# Apple's openrsync on macOS rejects `--chown` pre-send, and even with
+# `--rsync-path` and `--no-o --no-g` the remote GNU rsync 3.4 errors with
+# "You can only specify a user-affecting --chown once" — so chown happens in
+# a separate ssh step instead of during transfer.
 # shellcheck disable=SC2086
 rsync -e "$RSYNC_SSH" -az --delete $RSYNC_PROGRESS \
   --rsync-path="sudo rsync" \
-  --chown="helmlog:$PI_OWNER_USER" \
   "$SNAP/data/" \
   "$PI:$PI_HELMLOG_DIR/data/"
+$SSH "$PI" "sudo -n chown -R helmlog:$PI_OWNER_USER $PI_HELMLOG_DIR/data"
 log "  data/ done"
 
 # ── 3. .env config ────────────────────────────────────────────────────────────
@@ -118,9 +122,8 @@ log "Step 3/7: Restoring helmlog .env"
 if [ -f "$SNAP/config/helmlog.env" ]; then
   rsync -e "$RSYNC_SSH" -az \
     --rsync-path="sudo rsync" \
-    --chown="$PI_OWNER_USER:$PI_OWNER_USER" \
-    --chmod=F640 \
     "$SNAP/config/helmlog.env" "$PI:$PI_HELMLOG_DIR/.env"
+  $SSH "$PI" "sudo -n chown $PI_OWNER_USER:$PI_OWNER_USER $PI_HELMLOG_DIR/.env && sudo -n chmod 640 $PI_HELMLOG_DIR/.env"
   log "  .env done"
 else
   log "  WARNING: $SNAP/config/helmlog.env not present; skipping"
@@ -134,9 +137,9 @@ if [ -d "$SNAP/signalk" ]; then
   # shellcheck disable=SC2086
   rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS \
     --rsync-path="sudo rsync" \
-    --chown="$PI_OWNER_USER:$PI_OWNER_USER" \
     "$SNAP/signalk/" \
     "$PI:$PI_SIGNALK_DIR/"
+  $SSH "$PI" "sudo -n chown -R $PI_OWNER_USER:$PI_OWNER_USER $PI_SIGNALK_DIR"
   log "  signalk/ done (target node_modules preserved)"
 else
   log "  WARNING: $SNAP/signalk not present; skipping"
@@ -191,7 +194,7 @@ if [ -d "$SNAP/influxdb" ]; then
   # Stage candidate tokens on the target (avoid embedding secrets in ssh args).
   # The target token file is owned by $PI_OWNER_USER and may not be readable
   # by the SSH login user, so use sudo to copy it into a world-readable temp.
-  $SSH "$PI" "rm -f /tmp/influx-token-target /tmp/influx-token-snap"
+  $SSH "$PI" "sudo -n rm -f /tmp/influx-token-target /tmp/influx-token-snap"
   $SSH "$PI" "test -f $INFLUX_TOKEN_FILE && sudo -n cp $INFLUX_TOKEN_FILE /tmp/influx-token-target && sudo -n chmod 644 /tmp/influx-token-target" \
     2>/dev/null || true
   if [ -f "$SNAP/config/influx-token.txt" ]; then
@@ -225,7 +228,7 @@ if [ -d "$SNAP/influxdb" ]; then
   else
     log "  WARNING: InfluxDB restore failed (no working token)"
   fi
-  $SSH "$PI" "rm -rf /tmp/influx-restore /tmp/influx-token-target /tmp/influx-token-snap"
+  $SSH "$PI" "sudo -n rm -rf /tmp/influx-restore /tmp/influx-token-target /tmp/influx-token-snap"
 else
   log "  WARNING: $SNAP/influxdb missing; skipping"
 fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -19,19 +19,31 @@
 # wipe (only safe if the source Pi will be offline during testing).
 #
 # Environment:
-#   PI                 SSH target              (required)
+#   PI                 SSH target              (required, e.g. helmlog-backup@host)
 #   BACKUP_DEST        local snapshot root     (default: ~/backups/helmlog)
 #   KEEP_IDENTITY      skip identity wipe      (default: 0)
-#   INFLUX_TOKEN_FILE  path on target          (default: ~/influx-token.txt)
+#   SSH_KEY            local SSH key path      (default: ~/.ssh/helmlog-backup)
+#   PI_HELMLOG_DIR     helmlog dir on target   (default: /home/weaties/helmlog)
+#   PI_SIGNALK_DIR     signalk dir on target   (default: /home/weaties/.signalk)
+#   PI_OWNER_USER      file owner on target    (default: weaties)
+#   INFLUX_TOKEN_FILE  path on target          (default: /home/weaties/influx-token.txt)
 #   FORCE              skip confirmation prompt (default: 0)
 
 set -euo pipefail
 
-PI="${PI:?set PI to the target SSH host, e.g. user@pi-hostname}"
+PI="${PI:?set PI to the target SSH host, e.g. helmlog-backup@pi-hostname}"
 BACKUP_DEST="${BACKUP_DEST:-$HOME/backups/helmlog}"
 KEEP_IDENTITY="${KEEP_IDENTITY:-0}"
-INFLUX_TOKEN_FILE="${INFLUX_TOKEN_FILE:-~/influx-token.txt}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/helmlog-backup}"
+PI_HELMLOG_DIR="${PI_HELMLOG_DIR:-/home/weaties/helmlog}"
+PI_SIGNALK_DIR="${PI_SIGNALK_DIR:-/home/weaties/.signalk}"
+PI_OWNER_USER="${PI_OWNER_USER:-weaties}"
+INFLUX_TOKEN_FILE="${INFLUX_TOKEN_FILE:-/home/weaties/influx-token.txt}"
 FORCE="${FORCE:-0}"
+
+SSH_OPTS=(-i "$SSH_KEY" -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -F /dev/null)
+SSH="ssh ${SSH_OPTS[*]}"
+RSYNC_SSH="ssh ${SSH_OPTS[*]}"
 
 SNAP="${1:-}"
 if [ -z "$SNAP" ]; then
@@ -84,39 +96,47 @@ fi
 
 # ── 1. Stop services ──────────────────────────────────────────────────────────
 log "Step 1/7: Stopping services on $PI"
-ssh "$PI" "sudo systemctl stop helmlog signalk grafana-server" || \
+$SSH "$PI" "sudo -n systemctl stop helmlog signalk grafana-server" || \
   log "  WARNING: one or more services failed to stop"
 
 # ── 2. SQLite + file data ─────────────────────────────────────────────────────
-log "Step 2/7: Restoring SQLite + file data → ~/helmlog/data/"
-# --omit-dir-times: ~/helmlog/data/ subdirs are owned by the `helmlog` service
-# user (with the SSH login user in the group via setgid), so rsync can write
-# files inside them but cannot update the directory mtimes.
+log "Step 2/7: Restoring SQLite + file data → $PI_HELMLOG_DIR/data/"
+# Use sudo rsync on the Pi so we can overwrite files regardless of which user
+# the SSH session is running as (the helmlog service writes as `helmlog`,
+# while the SSH user is typically `helmlog-backup`). --chown restores the
+# expected ownership on the target.
 # shellcheck disable=SC2086
-rsync -az --delete --omit-dir-times $RSYNC_PROGRESS \
+rsync -e "$RSYNC_SSH" -az --delete $RSYNC_PROGRESS \
+  --rsync-path="sudo rsync" \
+  --chown="helmlog:$PI_OWNER_USER" \
   "$SNAP/data/" \
-  "$PI:helmlog/data/"
+  "$PI:$PI_HELMLOG_DIR/data/"
 log "  data/ done"
 
 # ── 3. .env config ────────────────────────────────────────────────────────────
 log "Step 3/7: Restoring helmlog .env"
 if [ -f "$SNAP/config/helmlog.env" ]; then
-  rsync -az "$SNAP/config/helmlog.env" "$PI:helmlog/.env"
-  ssh "$PI" "chmod 600 ~/helmlog/.env"
+  rsync -e "$RSYNC_SSH" -az \
+    --rsync-path="sudo rsync" \
+    --chown="$PI_OWNER_USER:$PI_OWNER_USER" \
+    --chmod=F640 \
+    "$SNAP/config/helmlog.env" "$PI:$PI_HELMLOG_DIR/.env"
   log "  .env done"
 else
   log "  WARNING: $SNAP/config/helmlog.env not present; skipping"
 fi
 
 # ── 4. Signal K config + data ─────────────────────────────────────────────────
-log "Step 4/7: Restoring Signal K → ~/.signalk/"
+log "Step 4/7: Restoring Signal K → $PI_SIGNALK_DIR/"
 if [ -d "$SNAP/signalk" ]; then
   # No --delete: preserve target's node_modules and package-lock.json
   # (they were excluded from the snapshot intentionally).
   # shellcheck disable=SC2086
-  rsync -az $RSYNC_PROGRESS \
+  rsync -e "$RSYNC_SSH" -az $RSYNC_PROGRESS \
+    --rsync-path="sudo rsync" \
+    --chown="$PI_OWNER_USER:$PI_OWNER_USER" \
     "$SNAP/signalk/" \
-    "$PI:.signalk/"
+    "$PI:$PI_SIGNALK_DIR/"
   log "  signalk/ done (target node_modules preserved)"
 else
   log "  WARNING: $SNAP/signalk not present; skipping"
@@ -130,10 +150,10 @@ if [ -d "$SNAP/grafana" ]; then
   # macOS ships Apple's openrsync, which mishandles --chown via --rsync-path,
   # so the chown must happen on the Pi (GNU rsync 3.x).
   # shellcheck disable=SC2086
-  rsync -az --delete $RSYNC_PROGRESS \
+  rsync -e "$RSYNC_SSH" -az --delete $RSYNC_PROGRESS \
     "$SNAP/grafana/" \
     "$PI:/tmp/grafana-restore/"
-  ssh "$PI" "sudo rsync -a --delete --chown=grafana:grafana \
+  $SSH "$PI" "sudo -n rsync -a --delete --chown=grafana:grafana \
     /tmp/grafana-restore/ /var/lib/grafana/ && rm -rf /tmp/grafana-restore"
   log "  grafana data dir done"
 else
@@ -146,10 +166,10 @@ fi
 # dashboards show "No data".
 if [ -d "$SNAP/grafana-provisioning" ]; then
   # shellcheck disable=SC2086
-  rsync -az --delete $RSYNC_PROGRESS \
+  rsync -e "$RSYNC_SSH" -az --delete $RSYNC_PROGRESS \
     "$SNAP/grafana-provisioning/" \
     "$PI:/tmp/grafana-provisioning-restore/"
-  ssh "$PI" "sudo rsync -a --delete --chown=root:grafana \
+  $SSH "$PI" "sudo -n rsync -a --delete --chown=root:grafana \
     /tmp/grafana-provisioning-restore/ /etc/grafana/provisioning/ && \
     rm -rf /tmp/grafana-provisioning-restore"
   log "  grafana provisioning done"
@@ -165,22 +185,24 @@ if [ -d "$SNAP/influxdb" ]; then
   # stale (it has the original target token, but the InfluxDB instance now
   # holds the source's tokens). Try the target's local token first; if that
   # 401s, fall back to the snapshot's captured source token.
-  ssh "$PI" "rm -rf /tmp/influx-restore && mkdir -p /tmp/influx-restore"
-  rsync -az "$SNAP/influxdb/" "$PI:/tmp/influx-restore/"
+  $SSH "$PI" "rm -rf /tmp/influx-restore && mkdir -p /tmp/influx-restore"
+  rsync -e "$RSYNC_SSH" -az "$SNAP/influxdb/" "$PI:/tmp/influx-restore/"
 
   # Stage candidate tokens on the target (avoid embedding secrets in ssh args).
-  ssh "$PI" "rm -f /tmp/influx-token-target /tmp/influx-token-snap"
-  ssh "$PI" "test -f $INFLUX_TOKEN_FILE && cp $INFLUX_TOKEN_FILE /tmp/influx-token-target" \
+  # The target token file is owned by $PI_OWNER_USER and may not be readable
+  # by the SSH login user, so use sudo to copy it into a world-readable temp.
+  $SSH "$PI" "rm -f /tmp/influx-token-target /tmp/influx-token-snap"
+  $SSH "$PI" "test -f $INFLUX_TOKEN_FILE && sudo -n cp $INFLUX_TOKEN_FILE /tmp/influx-token-target && sudo -n chmod 644 /tmp/influx-token-target" \
     2>/dev/null || true
   if [ -f "$SNAP/config/influx-token.txt" ]; then
-    rsync -az "$SNAP/config/influx-token.txt" "$PI:/tmp/influx-token-snap"
+    rsync -e "$RSYNC_SSH" -az "$SNAP/config/influx-token.txt" "$PI:/tmp/influx-token-snap"
   fi
 
   RESTORE_OK=0
   WORKING_TOKEN_FILE=""
   for candidate in /tmp/influx-token-target /tmp/influx-token-snap; do
-    if ssh "$PI" "test -s $candidate" 2>/dev/null; then
-      if ssh "$PI" "influx restore /tmp/influx-restore \
+    if $SSH "$PI" "test -s $candidate" 2>/dev/null; then
+      if $SSH "$PI" "influx restore /tmp/influx-restore \
           --host http://localhost:8086 \
           --token \$(cat $candidate) \
           --full"; then
@@ -197,13 +219,13 @@ if [ -d "$SNAP/influxdb" ]; then
     # If we used the snapshot token, write it back to the canonical location
     # so subsequent restores authenticate without falling back.
     if [ "$WORKING_TOKEN_FILE" = "/tmp/influx-token-snap" ]; then
-      ssh "$PI" "cp /tmp/influx-token-snap $INFLUX_TOKEN_FILE && chmod 600 $INFLUX_TOKEN_FILE"
+      $SSH "$PI" "sudo -n install -o $PI_OWNER_USER -g $PI_OWNER_USER -m 640 /tmp/influx-token-snap $INFLUX_TOKEN_FILE"
       log "  Updated $INFLUX_TOKEN_FILE on $PI to match restored auth"
     fi
   else
     log "  WARNING: InfluxDB restore failed (no working token)"
   fi
-  ssh "$PI" "rm -rf /tmp/influx-restore /tmp/influx-token-target /tmp/influx-token-snap"
+  $SSH "$PI" "rm -rf /tmp/influx-restore /tmp/influx-token-target /tmp/influx-token-snap"
 else
   log "  WARNING: $SNAP/influxdb missing; skipping"
 fi
@@ -211,11 +233,11 @@ fi
 # ── 7. Identity wipe + service restart ────────────────────────────────────────
 log "Step 7/7: Identity wipe + restart services"
 if [ "$KEEP_IDENTITY" != "1" ]; then
-  ssh "$PI" "rm -rf ~/.helmlog/identity/ && \
-    sqlite3 ~/helmlog/data/logger.db 'DELETE FROM boat_identity;' 2>/dev/null || true"
+  $SSH "$PI" "sudo -n rm -rf /home/$PI_OWNER_USER/.helmlog/identity/ && \
+    sudo -n sqlite3 $PI_HELMLOG_DIR/data/logger.db 'DELETE FROM boat_identity;' 2>/dev/null || true"
   log "  Identity wiped on $PI"
 fi
-ssh "$PI" "sudo systemctl start signalk grafana-server helmlog" || \
+$SSH "$PI" "sudo -n systemctl start signalk grafana-server helmlog" || \
   log "  WARNING: one or more services failed to start"
 log "  Services restarted"
 
@@ -224,9 +246,10 @@ log "  Services restarted"
 # immediately whether photos/audio/avatars made it across (#676).
 if [ -f "$VALIDATOR" ]; then
   log "Post-restore: validating restored tree on $PI"
-  if ssh "$PI" "command -v python3 >/dev/null" 2>/dev/null; then
-    scp -q "$VALIDATOR" "$PI:/tmp/validate_snapshot.py" && \
-      ssh "$PI" "python3 /tmp/validate_snapshot.py ~/helmlog/data; rm -f /tmp/validate_snapshot.py" || \
+  if $SSH "$PI" "command -v python3 >/dev/null" 2>/dev/null; then
+    # shellcheck disable=SC2086
+    scp -q ${SSH_OPTS[*]} "$VALIDATOR" "$PI:/tmp/validate_snapshot.py" && \
+      $SSH "$PI" "python3 /tmp/validate_snapshot.py $PI_HELMLOG_DIR/data; rm -f /tmp/validate_snapshot.py" || \
       log "  WARNING: post-restore validation failed"
   else
     log "  WARNING: python3 not on $PI; skipping post-restore validation"

--- a/scripts/setup-backup-mac.sh
+++ b/scripts/setup-backup-mac.sh
@@ -2,13 +2,19 @@
 # setup-backup-mac.sh — Install the daily Pi-to-Mac backup launchd agent.
 #
 # Run once on your Mac from the project root:
-#   PI=user@pi-hostname ./scripts/setup-backup-mac.sh
+#   PI=helmlog-backup@pi-hostname REPORT_TO=you@example.com ./scripts/setup-backup-mac.sh
 #
 # What it does:
-#   1. Verifies SSH connectivity to $PI (required)
+#   1. Verifies SSH connectivity to $PI as helmlog-backup
 #   2. Creates ~/backups/helmlog/
-#   3. Copies com.helmlog.backup.plist → ~/Library/LaunchAgents/ (with real paths)
+#   3. Copies com.helmlog.backup.plist → ~/Library/LaunchAgents/ (with real values)
 #   4. Loads (enables) the agent — runs daily at 03:00
+#
+# Prerequisites (one-time per Pi):
+#   1. ./scripts/setup-backup-user.sh has been run on the Pi (creates the
+#      `helmlog-backup` user and authorises this Mac's helmlog-backup pubkey).
+#   2. The dedicated SSH keypair exists at ~/.ssh/helmlog-backup{,.pub}
+#      (generate with: ssh-keygen -t ed25519 -f ~/.ssh/helmlog-backup -N "")
 #
 # To uninstall:
 #   launchctl unload ~/Library/LaunchAgents/com.helmlog.backup.plist
@@ -22,7 +28,9 @@ PLIST_SRC="$SCRIPT_DIR/com.helmlog.backup.plist"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.helmlog.backup.plist"
 BACKUP_DEST="${BACKUP_DEST:-$HOME/backups/helmlog}"
 LOG_FILE="$BACKUP_DEST/backup.log"
-: "${PI:?PI must be set — e.g. export PI=user@pi-hostname}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/helmlog-backup}"
+: "${PI:?PI must be set — e.g. export PI=helmlog-backup@pi-hostname}"
+: "${REPORT_TO:?REPORT_TO must be set — e.g. export REPORT_TO=you@example.com}"
 
 log() { echo "==> $*"; }
 warn() { echo "    WARNING: $*" >&2; }
@@ -40,14 +48,21 @@ if ! command -v influx &>/dev/null; then
   warn "Install with: brew install influxdb-cli"
 fi
 
-log "Testing SSH connectivity to $PI..."
-if ! ssh -o ConnectTimeout=10 -o BatchMode=yes "$PI" "echo ok" &>/dev/null; then
+if [ ! -f "$SSH_KEY" ]; then
+  echo "ERROR: SSH key not found at $SSH_KEY" >&2
+  echo "Generate with: ssh-keygen -t ed25519 -f $SSH_KEY -N \"\"" >&2
+  exit 1
+fi
+
+log "Testing SSH connectivity to $PI (key: $SSH_KEY)..."
+if ! ssh -i "$SSH_KEY" -o ConnectTimeout=10 -o BatchMode=yes -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=accept-new "$PI" "echo ok" &>/dev/null; then
   echo "" >&2
-  echo "ERROR: Cannot SSH to $PI." >&2
+  echo "ERROR: Cannot SSH to $PI as $(echo "$PI" | cut -d@ -f1)." >&2
   echo "Make sure:" >&2
-  echo "  1. Tailscale is running on both machines ('tailscale status')" >&2
-  echo "  2. SSH key is installed on the Pi ('ssh-copy-id $PI')" >&2
-  echo "  3. You can reach the Pi: ssh $PI" >&2
+  echo "  1. setup-backup-user.sh has been run on the Pi" >&2
+  echo "  2. Tailscale ACL allows ssh user '$(echo "$PI" | cut -d@ -f1)' with action: accept" >&2
+  echo "  3. You can reach the Pi via Tailscale ('tailscale status')" >&2
   exit 1
 fi
 log "  SSH OK"
@@ -59,11 +74,14 @@ log "Backup destination: $BACKUP_DEST"
 # ── 3. Install plist ──────────────────────────────────────────────────────────
 log "Installing launchd agent..."
 
-# Substitute real paths into the plist template
+# Substitute real values into the plist template.
 sed \
   -e "s|BACKUP_SCRIPT_PATH|$BACKUP_SCRIPT|g" \
   -e "s|BACKUP_LOG_PATH|$LOG_FILE|g" \
   -e "s|HOME_PATH|$HOME|g" \
+  -e "s|PI_TARGET|$PI|g" \
+  -e "s|SSH_KEY_PATH|$SSH_KEY|g" \
+  -e "s|REPORT_TO_ADDR|$REPORT_TO|g" \
   "$PLIST_SRC" > "$PLIST_DEST"
 
 log "  Plist written → $PLIST_DEST"

--- a/scripts/setup-backup-user.sh
+++ b/scripts/setup-backup-user.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# setup-backup-user.sh — Provision the dedicated `helmlog-backup` user on a Pi.
+#
+# Run on the Pi (or piped over SSH from the Mac):
+#   ssh -t weaties@<pi-host> 'bash -s' < scripts/setup-backup-user.sh
+#
+# Idempotent — safe to re-run. Requires sudo on the Pi.
+#
+# What it does:
+#   1. Creates system user `helmlog-backup` with home dir, member of `weaties`
+#   2. Authorises the Mac's helmlog-backup public key
+#   3. Adds a sudoers rule: `helmlog-backup` may run `/usr/bin/rsync` NOPASSWD
+#   4. Loosens read perms on .env and influx-token.txt to 640 (group=weaties)
+#      so the backup user can read them via group membership.
+
+set -euo pipefail
+
+# Pinned: the helmlog-backup public key generated on the Mac.
+PUBKEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSEm1oV+D1Oay6IsgVQAkB6THuLpdWCN9bFSArVXhnq helmlog-backup-mac@MacBook-Pro-3'
+
+OWNER_USER="${OWNER_USER:-weaties}"   # the existing user that owns helmlog data
+OWNER_HOME="$(getent passwd "$OWNER_USER" | cut -d: -f6)"
+[ -d "$OWNER_HOME" ] || { echo "Cannot find home dir for $OWNER_USER" >&2; exit 1; }
+
+# 1. Create the user (idempotent).
+if id helmlog-backup >/dev/null 2>&1; then
+  echo "user helmlog-backup already exists"
+else
+  echo "creating user helmlog-backup"
+  sudo useradd -r -m -s /bin/bash -G "$OWNER_USER" helmlog-backup
+fi
+
+# Make sure group membership is correct even if the user pre-existed.
+sudo usermod -aG "$OWNER_USER" helmlog-backup
+
+# 2. Authorise the Mac's pubkey.
+BACKUP_HOME="$(getent passwd helmlog-backup | cut -d: -f6)"
+sudo install -d -o helmlog-backup -g helmlog-backup -m 700 "$BACKUP_HOME/.ssh"
+AUTH_KEYS="$BACKUP_HOME/.ssh/authorized_keys"
+if sudo grep -qF "$PUBKEY" "$AUTH_KEYS" 2>/dev/null; then
+  echo "pubkey already authorised"
+else
+  echo "appending pubkey to $AUTH_KEYS"
+  echo "$PUBKEY" | sudo tee -a "$AUTH_KEYS" >/dev/null
+fi
+sudo chown helmlog-backup:helmlog-backup "$AUTH_KEYS"
+sudo chmod 600 "$AUTH_KEYS"
+
+# 3. Sudoers rule. helmlog-backup needs broad NOPASSWD because:
+#    - backup.sh: sudo rsync for /var/lib/grafana
+#    - restore.sh: sudo systemctl, rsync into helmlog-owned dirs, sqlite3,
+#      cp/install for the influx token, rm for identity wipe
+#    The user is dedicated to backup/restore admin and already has full read
+#    access to all helmlog data. Auth boundary is the SSH key.
+SUDOERS=/etc/sudoers.d/helmlog-backup
+RULE='helmlog-backup ALL=(ALL) NOPASSWD: ALL'
+if [ ! -f "$SUDOERS" ] || ! sudo grep -qF "$RULE" "$SUDOERS"; then
+  echo "writing $SUDOERS"
+  echo "$RULE" | sudo tee "$SUDOERS" >/dev/null
+  sudo chmod 440 "$SUDOERS"
+fi
+sudo visudo -cf "$SUDOERS" >/dev/null
+
+# 4. Loosen read perms on the two single-user files the backup needs.
+TOKEN="$OWNER_HOME/influx-token.txt"
+ENV_FILE="$OWNER_HOME/helmlog/.env"
+for f in "$TOKEN" "$ENV_FILE"; do
+  if [ -f "$f" ]; then
+    sudo chgrp "$OWNER_USER" "$f"
+    sudo chmod 640 "$f"
+    echo "perm: $f -> $(stat -c '%a %U:%G' "$f")"
+  fi
+done
+
+# 5. Smoke check.
+echo "---"
+echo "smoke check as helmlog-backup:"
+sudo -u helmlog-backup test -r "$TOKEN"        && echo "  read $TOKEN: OK"        || echo "  read $TOKEN: FAIL"
+sudo -u helmlog-backup test -r "$ENV_FILE"     && echo "  read $ENV_FILE: OK"     || echo "  read $ENV_FILE: FAIL"
+sudo -u helmlog-backup test -r "$OWNER_HOME/helmlog/data/logger.db" \
+                                                && echo "  read logger.db: OK"     || echo "  read logger.db: FAIL"
+sudo -u helmlog-backup test -r "$OWNER_HOME/.signalk" \
+                                                && echo "  read .signalk: OK"      || echo "  read .signalk: FAIL"
+sudo -u helmlog-backup sudo -n /usr/bin/rsync --version >/dev/null \
+                                                && echo "  sudo rsync: OK"         || echo "  sudo rsync: FAIL"
+
+echo "done."


### PR DESCRIPTION
## Summary

- Provision a dedicated `helmlog-backup` user on each Pi via idempotent `scripts/setup-backup-user.sh` — system account, group-share read with the boat owner, key-only SSH, NOPASSWD sudo (needed for `sudo rsync` reads of helmlog-owned files and for restore's privileged writes).
- Backup and restore scripts authenticate with a dedicated key (`~/.ssh/helmlog-backup`), parameterise all Pi-side paths (`PI_HELMLOG_DIR`, `PI_SIGNALK_DIR`, `PI_OWNER_USER`), and use `--rsync-path='sudo rsync'` for the data tree. This fixes the silent skip of photo files in `notes/<session>/` (root cause of the orphaned `moment_attachments` rows tracked in #676).
- `com.helmlog.backup.plist` now templates `PI` / `SSH_KEY` / `REPORT_TO` so multiple boats can share the same Mac without per-install plist hand-editing.
- `docs/backup.md` rewritten to document the new flow and includes the minimal Tailscale ACL `accept` rule that lets the cron-driven backup bypass `check`-mode periodic re-auth (the cause of the 2026-04-23 and 2026-04-24 missed backups).

## Why now

The launchd 03:00 backup has been failing whenever Tailscale's interactive re-auth window expires. `BatchMode=yes` SSH cannot satisfy the browser-prompt check, and the existing rsync source path (`~weaties/helmlog/data`) ties the backup to a per-boat owner account which doesn't scale to multi-boat installs.

## Validation against corvopi-live

| | Before (weaties) | After (helmlog-backup) |
|---|---|---|
| `data/notes/` files | 0 (perm-denied) | 37 (28 MB) |
| Total `data/` files | 63 | 106 |
| Snapshot validator | orphan rows (rc=1) | OK |
| rsync exit | 23 (partial) | 0 |

## Manual steps after merge

1. On each Pi (idempotent — re-run if helmlog-backup already exists with the rsync-only sudoers): `scp scripts/setup-backup-user.sh <owner>@<pi>:/tmp/ && ssh -t <owner>@<pi> 'bash /tmp/setup-backup-user.sh'`
2. Apply the Tailscale ACL `accept` rule documented in `docs/backup.md`.
3. Re-install the launchd agent: `PI=helmlog-backup@<pi> REPORT_TO=<email> ./scripts/setup-backup-mac.sh`

## Test plan

- [x] Syntax-check all four shell scripts (`bash -n`)
- [x] Provision helmlog-backup on corvopi-live and corvopi-tst1 — smoke checks all OK (data, .env, token, signalk, sudo rsync)
- [x] Run full backup as helmlog-backup against corvopi-live — exit 0, 13 GB snapshot, photos restored, validator clean
- [ ] Apply Tailscale ACL change and confirm a cron-driven 03:00 run no longer fails on check-mode re-auth
- [ ] Run restore.sh against corvopi-tst1 once Pis have the broader `NOPASSWD: ALL` sudoers (re-run setup-backup-user.sh to upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)