### PR TITLE
fix: hide polar rebuild button for non-admin users (#597)

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -4469,12 +4469,17 @@ async function loadPolar() {
     }
     const sign = avgDelta >= 0 ? '+' : '';
     const summary = document.getElementById('polar-summary');
+    // POST /api/polar/rebuild requires admin — only show the affordance to
+    // users who can use it (#597).
+    const rebuildBtn = _sessionUserRole === 'admin'
+      ? ' &middot; <button onclick="rebuildPolarBaseline()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.78rem;text-decoration:underline;padding:0">Rebuild baseline</button>'
+      : '';
     summary.innerHTML =
       sign + avgDelta.toFixed(2) + ' kt weighted avg vs baseline &middot; '
       + above + ' bins above, ' + below + ' below'
       + (noBaseline ? ' &middot; ' + noBaseline + ' bins no baseline' : '')
       + ' &middot; ' + data.session_sample_count + ' samples'
-      + ' &middot; <button onclick="rebuildPolarBaseline()" style="background:none;border:none;color:var(--accent);cursor:pointer;font-size:.78rem;text-decoration:underline;padding:0">Rebuild baseline</button>';
+      + rebuildBtn;
   } catch (e) { /* non-fatal */ }
 }
 


### PR DESCRIPTION
## Summary
- The polar diagram footer rendered a `Rebuild baseline` button for every viewer, but `POST /api/polar/rebuild` requires the `admin` role — non-admins clicking it got `Rebuild failed: 403`.
- Gate the button on `_sessionUserRole === 'admin'`. The role is already exposed by the session route via `data-user-role` on `#app-config` and read synchronously into `_sessionUserRole`, so there's no race with the `/api/me` fetch.

Closes #597

## Test plan
- [ ] Log in as a `viewer` / `crew` user, open a session with a polar — confirm the footer no longer shows `Rebuild baseline`.
- [ ] Log in as an `admin`, open a session with a polar — confirm the button is still present and rebuilds the baseline as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)