### PR TITLE
chore(skills): slim /tdd, /spec, /data-license, /release-notes after Bucket A audit

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -3,207 +3,81 @@ name: architecture
 description: Codebase comprehension and complexity tracking — module map, data flow, recent changes, and complexity hotspots. Run with no arguments for a full snapshot or with a date/commit/tag for a delta briefing. TRIGGER when the user asks for a system overview, wants to understand the architecture, asks "what changed while I was away", or needs to orient before a large task. DO NOT trigger for specific code questions, bug fixes, or implementation tasks — those are better served by reading the relevant module directly.
 ---
 
-# Architecture — Codebase Comprehension
+# /architecture — Codebase Briefing
 
-Produce a concise, scannable system overview. Two modes:
+Produce a concise, scannable system overview. The methodology (which files
+to count, which imports to grep, how to derive responsibilities) is left to
+the model — this skill specifies the **output shape and conventions**, not
+the steps to get there.
 
-- **Full snapshot** (no arguments): Complete system overview — module map, data
-  flow, complexity hotspots, risk tier overlay. Use after returning from a break.
-- **Delta briefing** (`$ARGUMENTS`): What changed since a date, commit, or tag.
-  Shows structural changes, new/removed modules, complexity shifts, and affected
-  data flow paths.
+## Mode
 
----
+- No `$ARGUMENTS` → **full snapshot**.
+- `$ARGUMENTS` is a date / commit SHA / tag → **delta briefing** since that
+  ref. If ambiguous, ask.
 
-## 1. Determine mode
+## Severity thresholds (use these exact labels, not synonyms)
 
-If `$ARGUMENTS` is empty → **full snapshot**.
+The 200-line module convention from CLAUDE.md applies. Classify hotspots:
 
-Otherwise parse `$ARGUMENTS` as one of:
-- A date (`2026-03-01`, `last week`, `yesterday`)
-- A commit SHA or short SHA
-- A git tag (`stage/2026-03-15`)
-
-Resolve to a commit ref for `git log` and `git diff`. If ambiguous, ask.
-
----
-
-## 2. Module map
-
-### Full snapshot
-
-List every `.py` module under `src/helmlog/` with:
-
-```bash
-wc -l src/helmlog/*.py | sort -rn
-```
-
-For each module, provide:
-- **Responsibility** (one line — derive from docstring, class names, or function names)
-- **Key dependencies** (imports from other helmlog modules)
-- **Risk tier** (from the Risk Tiers table in CLAUDE.md; "Unclassified" if missing)
-
-Format as a table. Group by risk tier (Critical → High → Standard → Low → Unclassified).
-
-### Delta briefing
-
-Show only modules that were added, removed, or structurally changed (new
-classes, new public functions, significant line count changes) since the
-reference commit:
-
-```bash
-git diff --stat <ref>...HEAD -- src/helmlog/
-git log --oneline <ref>...HEAD -- src/helmlog/
-```
-
-Flag any module that crossed the 200-line threshold in either direction.
-
----
-
-## 3. Data flow
-
-### Full snapshot
-
-Trace the primary data flow paths through the codebase. Derive these from
-actual imports, not from memory. Check the current import graph:
-
-```bash
-grep -rn "^from helmlog\.\|^import helmlog\." src/helmlog/*.py
-```
-
-Produce a concise ASCII diagram showing:
-1. **Instrument ingest:** Signal K / CAN → decoded records → storage
-2. **Read paths:** storage → web, export, polar, maneuver detection
-3. **External data:** weather, tides → storage
-4. **Federation:** peer_client ↔ peer_api, federation, peer_auth
-5. **Audio pipeline:** audio → transcribe → storage → web
-
-### Delta briefing
-
-Show only data flow paths that were affected by changes since the reference.
-Highlight new connections and removed connections.
-
----
-
-## 4. Complexity hotspots
-
-Identify modules and functions that may need attention.
-
-### Module size
-
-```bash
-wc -l src/helmlog/*.py | sort -rn
-```
-
-Flag any module exceeding 200 lines (the project convention from CLAUDE.md).
-For modules well over 200 lines, note how far over they are:
-
-| Severity | Threshold | Action |
+| Severity | Lines | Stance |
 |---|---|---|
-| **Watch** | 200-300 lines | Note — may be fine if cohesive |
-| **Warning** | 300-500 lines | Recommend reviewing for split opportunities |
-| **Alert** | 500+ lines | Strongly recommend splitting |
+| **Watch**   | 200–300 | Note, may be fine if cohesive |
+| **Warning** | 300–500 | Recommend reviewing for split opportunities |
+| **Alert**   | 500+    | Strongly recommend splitting |
 
-### Function complexity
+## Risk-tier escalation rule
 
-For modules at Warning or Alert level, identify functions with high branching
-complexity:
+A complexity hotspot in a Critical or High tier module is more urgent than
+the same severity in a Standard module — call this out explicitly. The
+canonical risk-tier mapping is in `docs/risk-tiers.md`; do not re-state it,
+just apply it.
 
-```bash
-grep -c "if \|elif \|for \|while \|except \|case " src/helmlog/<module>.py
-```
+## Output: full snapshot
 
-Also scan for long functions (rough heuristic — functions spanning many lines):
-
-```bash
-grep -n "^    def \|^    async def " src/helmlog/<module>.py
-```
-
-Flag functions that appear to span more than 50 lines (estimate from line
-number gaps between consecutive `def` lines).
-
-### Change clustering (delta mode only)
-
-For delta briefings, identify files with disproportionate churn:
-
-```bash
-git log --format="" --name-only <ref>...HEAD -- src/helmlog/ | sort | uniq -c | sort -rn
-```
-
-Files appearing in many commits may be complexity magnets.
-
----
-
-## 5. Risk tier overlay
-
-Cross-reference hotspots with the Risk Tiers table from CLAUDE.md:
-
-| Tier | Modules |
-|---|---|
-| **Critical** | `auth.py`, `peer_auth.py`, `federation.py`, `storage.py` (migrations), `can_reader.py` |
-| **High** | `sk_reader.py`, `peer_api.py`, `peer_client.py`, `export.py`, `transcribe.py`, `boat_settings.py` |
-| **Standard** | `web.py`, `polar.py`, `external.py`, `races.py`, `triggers.py`, `maneuver_detector.py`, `race_classifier.py`, `courses.py` |
-| **Low** | Templates, CSS, JS, docs, config, scripts |
-
-**Escalation rule:** A complexity hotspot in a Critical or High tier module is
-more urgent than one in a Standard module. Call these out explicitly:
-
-> **web.py** (Standard, 6868 lines, Alert) — massively exceeds convention but
-> has E501 suppression; splitting would require route-group extraction.
->
-> **storage.py** (Critical when migrations touched, 5923 lines, Alert) — schema
-> migrations + query methods in one file; migration extraction would reduce risk.
-
----
-
-## 6. Output format
-
-Structure the output as a briefing, not a dump. Use headers, tables, and short
-prose. Target length:
-
-- **Full snapshot:** 80-150 lines of output
-- **Delta briefing:** 30-80 lines of output
-
-### Full snapshot structure
+Target 80–150 lines. Structure:
 
 ```
 ## Module Map
-<table grouped by risk tier>
+<table grouped by risk tier (Critical → High → Standard → Low/Unclassified):
+ module · lines · one-line responsibility · key helmlog-internal deps>
 
 ## Data Flow
-<ASCII diagram>
+<ASCII diagram derived from actual imports — instrument ingest, storage
+ reads, federation, audio pipeline, external fetches>
 
 ## Complexity Hotspots
-<table: module, lines, severity, tier, notes>
+<table: module · lines · severity · risk tier · notes — Critical/High
+ tier hotspots called out as more urgent>
 
 ## Recommendations
-<2-5 bullet points: most actionable observations>
+<2–5 bullets, most actionable observations>
 ```
 
-### Delta briefing structure
+## Output: delta briefing
+
+Target 30–80 lines. Show only what changed; do not produce a full snapshot.
 
 ```
 ## Changes Since <ref> (<date>)
-<N commits, M files changed>
+<commit count, commit-shape breakdown by feat/fix/docs/perf/refactor>
 
 ## Structural Changes
-<new/removed modules, significant growth/shrinkage>
+<new/removed modules; modules with significant line-count changes;
+ any module that crossed the 200-line threshold in either direction>
+
+## Change Clustering
+<files appearing in many commits — complexity magnets>
 
 ## Affected Data Flow
-<which paths changed>
-
-## Complexity Shifts
-<modules that crossed thresholds or had high churn>
+<which connections were added/removed/altered>
 
 ## Recommendations
-<2-5 bullet points>
+<2–5 bullets>
 ```
 
----
+## Out of scope
 
-## 7. What this skill does NOT do
-
-- Does not modify any code
-- Does not create issues or PRs
-- Does not run tests, lint, or type checks (use `/pr-checklist` for that)
-- Does not replace reading the code — it orients you so you know *where* to read
+This skill does not run lint/type/tests, modify code, or open issues/PRs.
+Its job is to orient — to tell the reader *where* to read, not to replace
+reading.

--- a/.claude/skills/data-license/SKILL.md
+++ b/.claude/skills/data-license/SKILL.md
@@ -1,88 +1,84 @@
 ---
 name: data-license
-description: Review code changes against the data licensing policy (docs/data-licensing.md) for compliance. TRIGGER when modifying code that handles user data, PII (audio, photos, emails, biometrics, diarized transcripts), co-op/federation data sharing, export endpoints, deletion/anonymization, or audit logging. Key files — storage.py, export.py, peer_api.py, peer_client.py, federation.py, transcribe.py, audio.py, web.py (data endpoints). DO NOT trigger for UI-only changes, instrument decoding, polar analysis, config, docs, or CSS/JS/templates.
+description: Review code changes against the HelmLog-specific data licensing policy (docs/data-licensing.md) — embargoes, protest firewall, biometrics consent, gambling exclusion, fleet-benchmark thresholds, coach access expiry. The model recovers general PII / cross-tenant / audit-logging concerns by default; this skill encodes only the HelmLog-specific items that are not recoverable from general engineering judgment. TRIGGER when modifying code that handles user data, PII, co-op/federation data sharing, export endpoints, deletion/anonymization, or audit logging. Key files — storage.py, export.py, peer_api.py, peer_client.py, federation.py, transcribe.py, audio.py, web.py (data endpoints). DO NOT trigger for UI-only changes, instrument decoding, polar analysis, config, docs, or CSS/JS/templates.
 ---
 
-# Data License Compliance Review
+# /data-license — HelmLog-specific compliance review
 
-Review the current changes against `docs/data-licensing.md` to ensure
-compliance with the Helm Log data licensing policy.
+The model already catches general PII concerns by default (crew emails as
+PII, cross-tenant boundary violations, audit-log gaps, rate limits). This
+skill encodes only the HelmLog-specific policies a generalist would miss.
+For the exhaustive policy, read `docs/data-licensing.md` directly.
 
-## 1. Identify Data-Touching Changes
+## 1. Identify data-touching changes
 
-Check `git diff` (staged + unstaged) and any new files for code that:
+Check `git diff` (staged + unstaged) and any new files. Skip if no
+data-touching code is involved — report "No data licensing impact."
 
-- Stores, reads, exports, or deletes user data
-- Serves data via API endpoints
-- Handles PII (video, audio, photos, emails, biometrics, transcripts)
-- Implements co-op membership, sharing, or governance
-- Adds new data types or collection mechanisms
+## 2. HelmLog-specific items to verify
 
-If no data-touching changes are found, report "No data licensing impact" and stop.
+These are the policies a general PII review will NOT catch:
 
-## 2. Check Against Policy Sections
+### Temporal sharing embargoes (Section 2)
+- [ ] Track data shared to co-op peers respects per-session embargo
+      timestamps before serving.
+- [ ] When an embargo check is present, verify it is **semantically
+      correct** — the comparison operator must match the meaning of
+      `embargo_until` (is it the first shareable moment or the last
+      blocked moment?). Presence of a check is not sufficient.
+- [ ] Embargo policy is enforced at the co-op level, not per-boat.
+- [ ] Benchmarks exclude embargoed session data until embargo lifts.
 
-For each data-touching change, verify compliance with the relevant sections:
+### Fleet benchmarks (Section 2)
+- [ ] No boat identities or per-boat data points exposed in benchmark
+      outputs.
+- [ ] Minimum 4-boat threshold per condition bin enforced before a
+      benchmark is published.
 
-### Section 1 — Data Ownership
-- [ ] Boat owner retains full export/delete/restrict rights over their data
-- [ ] AIS and proximity data from other vessels is excluded
-- [ ] Audio/photo/email deletion and anonymization rights are supported
-- [ ] Video PII: crew can request face-blur or removal from video recordings
-- [ ] Camera consent: crew are informed when cameras are recording
-- [ ] YouTube uploads default to unlisted; video links are boat-private
-- [ ] Processing offload: offload hosts do not retain data after task completion
-- [ ] Biometric data (if any) has per-person consent separate from instrument sharing
-- [ ] Biometric data cannot be used in personnel decisions
-- [ ] Crew emails are deleted when access is revoked
+### Coach access (Section 2)
+- [ ] Coach access grants are time-limited with an expiry date — no
+      permanent grants.
+- [ ] Per-session authorization required from boat owner, not blanket
+      access.
+- [ ] Coaches may not bulk-export or aggregate multiple boats' data
+      into a derived dataset retained independently of the platform.
 
-### Section 2 — Data Sharing
-- [ ] Default shared data is limited to: instrument data, session metadata,
-      derived metrics, race results
-- [ ] Private data (audio, notes, sails, currents, photos, YouTube, crew roster)
-      is not exposed to co-op endpoints
-- [ ] No bulk export of other boats' co-op data
-- [ ] Temporal sharing embargo timestamps are respected before serving track data.
-      When an embargo check exists, verify it is **semantically correct** — the
-      comparison operator must match the meaning of `embargo_until` (is it the
-      first shareable moment or the last blocked moment?). Presence of a check
-      is not sufficient; the boundary condition must be right.
-- [ ] Temporal sharing policy is enforced at the co-op level, not per-boat
-- [ ] Fleet benchmarks contain no boat identities or per-boat data points
-- [ ] Benchmarks enforce minimum 4-boat threshold per condition bin
-- [ ] Benchmarks exclude embargoed session data until embargo lifts
-- [ ] Coach access grants are time-limited with an expiry date (seasonal renewal
-      required — no permanent grants). Coach access requires authorization from
-      the boat owner per session, not blanket access.
-- [ ] Coaches may not bulk-export or aggregate multiple boats' data into a
-      derived dataset retained independently of the platform
+### Biometric data (Section 1)
+- [ ] Biometric data has per-person consent separate from instrument
+      sharing — boat-owner consent is not sufficient.
+- [ ] Biometric data cannot be used in personnel decisions.
 
-### Section 5 — Retention and Deletion
-- [ ] Data portability: own-boat data exportable in CSV, GPX, JSON, WAV
-- [ ] Suppression (soft delete) works during 30-day grace periods
-- [ ] Hard delete is irreversible after grace period
+### AIS / other-vessel data (Section 1)
+- [ ] AIS and proximity data from other vessels is excluded from
+      ingest, storage, export, and federation.
 
-### Section 8 — AI/ML
-- [ ] Co-op data is not used for ML without governance approval
-- [ ] ML opt-out flag is respected
+### Protest firewall (Section 11)
+- [ ] Co-op data from other boats is not exportable in protest-ready
+      formats.
 
-### Section 9 — Commercial Use
-- [ ] Co-op data is not used for gambling, betting, or wagering purposes
-- [ ] No commercial use without co-op vote
+### Gambling / commercial use (Section 9)
+- [ ] Co-op data is not used for gambling, betting, or wagering.
+- [ ] No commercial use without a co-op vote.
 
-### Section 11 — Liability
-- [ ] Co-op data from other boats is not exportable in protest-ready formats
+### ML opt-out (Section 8)
+- [ ] Co-op data is not used for ML without governance approval.
+- [ ] ML opt-out flag is respected.
 
-### Section 12 — Technical Requirements
-- [ ] Audit logging for co-op data access
-- [ ] Rate limiting with auto-freeze on anomalous patterns
+### Crew / video PII deletion (Section 1)
+- [ ] Crew emails are deleted when access is revoked (not soft-retained).
+- [ ] Video face-blur / removal requests are supported per-crew.
+- [ ] Camera consent: crew are informed when cameras are recording.
+- [ ] YouTube uploads default to unlisted; video links are boat-private.
 
-## 3. Report Findings
+### Retention boundaries (Section 5)
+- [ ] Data portability formats: CSV, GPX, JSON, WAV.
+- [ ] Soft delete (suppression) supported during 30-day grace period.
+- [ ] Hard delete is irreversible after grace period.
 
-For each issue found:
-1. State the policy section violated
-2. Quote the relevant policy language
-3. Describe the code that violates it
-4. Suggest a fix
+## 3. Report findings
 
-If all checks pass, report "Data licensing review: compliant."
+For each issue: state the policy section, quote the relevant policy
+language, describe the violating code, suggest a fix.
+
+If all checks pass, report "Data licensing review: compliant — verified
+against HelmLog-specific policies."

--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -5,281 +5,90 @@ description: Systematic Pi troubleshooting runbook — checks all subsystems (sy
 
 # /diagnose — Pi Troubleshooting Runbook
 
-Systematically check the health of a HelmLog Pi deployment. Run this when the
-Pi is misbehaving (no data, CAN errors, audio issues, web UI down) instead of
-ad-hoc debugging.
+Produce a structured diagnostic plan when the Pi misbehaves. The actual
+commands and known-failure signatures live in the code (`scripts/setup.sh`
+defines the units; `can_reader.py`, `sk_reader.py`, `audio.py`, `storage.py`
+each document their own failure modes); read those rather than duplicating
+them here. This skill specifies the **runbook shape** — phases, status
+tags, dependency rules, summary format.
 
 ## Usage
 
 - `/diagnose` — run all subsystem checks
-- `/diagnose system` — system health only
-- `/diagnose services` — systemd services only
-- `/diagnose can` — CAN bus only
-- `/diagnose signalk` — Signal K only
-- `/diagnose audio` — audio subsystem only
-- `/diagnose database` — SQLite database only
-- `/diagnose network` — network and connectivity only
-- `/diagnose aihat` — AI HAT (Hailo) only
+- `/diagnose <subsystem>` — one of: `system`, `services`, `can`, `signalk`,
+  `audio`, `database`, `network`, `aihat`. Argument is `$ARGUMENTS`.
 
-The argument is available as `$ARGUMENTS`. If empty, run all subsystems.
-
-## Output Format
-
-For each check, report a status line:
+## Status tags (use these exact strings)
 
 ```
-[OK]   Check name — detail
-[WARN] Check name — detail → suggested fix
-[FAIL] Check name — detail → suggested fix
+[OK]   <check>  — <detail>
+[WARN] <check>  — <detail> → <suggested fix>
+[FAIL] <check>  — <detail> → <suggested fix>
+[SKIP] <check>  — skipped because <dependency> is <state>
 ```
 
-After all checks, print a summary: total checks, pass/warn/fail counts, and
-the most likely root cause if any failures were found.
+Every check produces exactly one status line. Group commands under the
+check, but the status line is what the operator scans.
 
-## Diagnostic Sequence
-
-Checks are ordered by dependency — earlier failures make later checks moot.
-If a dependency fails, skip dependent checks and note why.
-
-### 1. System Health
-
-```bash
-# Disk space (WARN >80%, FAIL >95%)
-df -h /
-
-# Memory (WARN >80% used, FAIL >95%)
-free -m
-
-# CPU temperature (WARN >70°C, FAIL >80°C)
-cat /sys/class/thermal/thermal_zone0/temp
-# Divide by 1000 for °C
-
-# SD card health — check for read-only filesystem
-touch /tmp/helmlog-health-check && rm /tmp/helmlog-health-check
-
-# Uptime and load average
-uptime
-```
-
-### 2. Services
-
-**Dependency:** System health must not be FAIL (read-only filesystem blocks
-everything).
-
-```bash
-# HelmLog service
-# Note: is-active doesn't need sudo; status needs sudo for full output.
-systemctl is-active helmlog
-sudo systemctl status helmlog --no-pager -l
-# If failed: sudo journalctl -u helmlog -n 30 --no-pager
-
-# Signal K server (setup.sh names the service "signalk", not "signalk-server")
-systemctl is-active signalk
-# If failed: sudo journalctl -u signalk -n 30 --no-pager
-
-# nginx (reverse proxy)
-systemctl is-active nginx
-# If failed: sudo nginx -t
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `ModuleNotFoundError` | Stale venv | `cd ~/helmlog && uv sync` then restart |
-| `Address already in use` | Port conflict | `sudo lsof -i :3002` to find conflict |
-| `Permission denied: data/` | Ownership wrong | `sudo chown -R helmlog:helmlog data/` |
-
-### 3. CAN Bus
-
-**Dependency:** HelmLog service must be active.
-
-```bash
-# Interface present and UP
-ip link show can0
-
-# Message rate (should be >0 frames/sec when instruments on)
-# Read for 2 seconds and count frames
-timeout 2 candump can0 2>/dev/null | wc -l
-
-# Error frames and bus-off state
-ip -details -statistics link show can0
-# Look for: "bus-off", "error-warning", "error-passive"
-# tx_errors and rx_errors should be low (<100)
-
-# CAN state
-cat /sys/class/net/can0/operstate
-# Should be "up"; "stopped" or missing = interface down
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `Network is down` on can0 | Interface not brought up | `sudo ip link set can0 up type can bitrate 250000` |
-| `No buffer space available` | CAN TX queue full | `sudo ip link set can0 txqueuelen 1000` then restart interface |
-| High `rx_errors` / `tx_errors` | Bus noise or termination issue | Check CAN wiring and 120Ω termination resistors |
-| `bus-off` state | Severe bus errors, controller shut down | `sudo ip link set can0 down && sudo ip link set can0 up type can bitrate 250000` |
-
-### 4. Signal K
-
-**Dependency:** Signal K service must be active.
-
-```bash
-# WebSocket connectivity — attempt connection to Signal K
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3000/signalk/v1/api/
-
-# Delta message flow — check if deltas are arriving
-# Look in helmlog logs for recent SK messages
-sudo journalctl -u helmlog --since "2 minutes ago" --no-pager | grep -c "sk_reader"
-
-# Self endpoint (API health check)
-curl -s http://127.0.0.1:3000/signalk/v1/api/self
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `WebSocket connection closed` repeating | SK server dropping connections | Restart signalk: `sudo systemctl restart signalk` |
-| `connection refused` on :3000 | SK not listening | Check `systemctl status signalk` |
-| No deltas but SK is up | No CAN data reaching SK | Check CAN bus (subsystem 3) |
-| `401 Unauthorized` | Auth token expired | Check SK admin password in `~/.signalk-admin-pass.txt` |
-
-### 5. Audio
-
-**Dependency:** HelmLog service must be active.
-
-```bash
-# USB audio device presence
-arecord -l
-# Should list at least one capture device (e.g., Gordik USB Audio)
-
-# ALSA state — check for errors
-cat /proc/asound/cards
-
-# Quick recording test (1 second)
-timeout 1 arecord -D default -f S16_LE -r 16000 -c 1 /tmp/helmlog-audio-test.wav 2>&1
-# Check exit code: 0 = success
-rm -f /tmp/helmlog-audio-test.wav
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `no soundcards found` | USB device disconnected | Re-seat USB audio device, check `lsusb` |
-| `Device or resource busy` | Another process using device | `sudo lsof /dev/snd/*` to find conflicting process |
-| `Input/output error` on recording | Device error | Unplug and replug USB audio device |
-
-### 6. Database
-
-**Dependency:** None — can always check.
-
-```bash
-# SQLite integrity check
-sqlite3 data/logger.db "PRAGMA integrity_check;" 2>&1
-# Must return "ok"
-
-# WAL file size (WARN >100MB, FAIL >500MB)
-ls -lh data/logger.db-wal 2>/dev/null
-
-# Recent write timestamp — check last insert
-sqlite3 data/logger.db "SELECT MAX(ts) FROM headings;" 2>&1
-# If significantly old, data pipeline is stalled
-
-# Database file size
-ls -lh data/logger.db
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `database is locked` | Long-running transaction or WAL checkpoint stuck | Restart helmlog service |
-| `disk I/O error` | SD card failing | **Critical:** back up data immediately, replace SD card |
-| Integrity check ≠ "ok" | Corruption | Restore from backup; investigate SD card health |
-| WAL > 500MB | Checkpointing not running | `sqlite3 data/logger.db "PRAGMA wal_checkpoint(TRUNCATE);"` |
-
-### 7. Network
-
-**Dependency:** None — can always check.
-
-```bash
-# Tailscale status
-tailscale status
-
-# Peer connectivity (if peers configured)
-tailscale ping <peer-hostname> --timeout 5s 2>/dev/null
-
-# nginx upstream health
-curl -s -o /dev/null -w "%{http_code}" http://localhost/
-# Should return 200
-
-# DNS resolution
-host github.com
-
-# Internet connectivity
-curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://api.github.com
-```
-
-**Known failure patterns:**
-
-| Log signature | Meaning | Fix |
-|---|---|---|
-| `Tailscale is stopped` | Tailscale not running | `sudo tailscale up` |
-| `502 Bad Gateway` from nginx | Upstream service down | Restart helmlog: `sudo systemctl restart helmlog` |
-| `connection timed out` | Network unreachable | Check ethernet/WiFi: `ip addr`, `nmcli` |
-| `DERP` in tailscale ping | No direct connection, relayed | Check firewall/NAT; may be acceptable for remote debugging |
-
-### 8. AI HAT (Future)
-
-**Dependency:** HelmLog service must be active.
-
-```bash
-# Hailo device presence
-ls /dev/hailo*
-
-# Hailo runtime status
-hailortcli fw-control identify 2>/dev/null
-
-# Inference test (if available)
-# This section will be expanded when the AI HAT is integrated
-```
-
-**Note:** This subsystem is not yet deployed. Skip checks gracefully if Hailo
-device is not present — report `[OK] AI HAT — not installed (expected)`.
-
-## Dependency Graph
+## Dependency graph (skip rules)
 
 ```
 System Health
-  └── Services (skip if filesystem read-only)
-        ├── CAN Bus (skip if helmlog service down)
-        ├── Signal K (skip if signalk down)
-        └── Audio (skip if helmlog service down)
-Database (independent)
-Network (independent)
-AI HAT (skip if helmlog service down)
+  └── Services         (skip if filesystem read-only)
+        ├── CAN Bus    (skip if helmlog service down — runs in-process)
+        ├── Signal K   (skip if signalk service down)
+        ├── Audio      (skip if helmlog service down — runs in-process)
+        └── AI HAT     (skip if helmlog service down — runs in-process)
+Database               (independent — always run)
+Network                (independent — always run)
 ```
 
-If a parent check fails, skip its children and report:
+**Key fact:** CAN ingest, Signal K subscription, audio capture, and the
+FastAPI app all live inside the `helmlog` process. If `helmlog` is
+inactive, those checks have no consumer to observe — mark `[SKIP]` with
+that reason, do not attempt them.
+
+If a parent check fails, emit `[SKIP]` for every dependent and continue;
+never silently omit a subsystem.
+
+## Phasing (when helmlog is down)
+
+When the request is a full diagnosis and `helmlog` is inactive, run in
+three phases — do not interleave:
+
+1. **Independent checks first** — system health, database, network. These
+   tell you whether the host is healthy enough to run the app at all.
+2. **Inspect why helmlog is inactive, then restart** — `systemctl status`,
+   `journalctl -u helmlog -n 80`, match against known failure signatures
+   (most common: `ModuleNotFoundError` from a stale venv after `git pull`
+   — the service runs `--no-sync`). Restart and confirm `is-active`.
+3. **Dependent checks only after helmlog is active.** Until then, every
+   in-process subsystem is `[SKIP]`.
+
+For partial outages (helmlog active but a specific subsystem failing),
+phasing is unnecessary — just walk the dependency graph.
+
+## Summary format (always emit at the end)
+
 ```
-[SKIP] CAN Bus — skipped because helmlog service is not running
+=== /diagnose summary ===
+Total checks:  N
+[OK]   N
+[WARN] N
+[FAIL] N
+[SKIP] N
+
+Most likely root cause: <one sentence, derived from the failure pattern>
+Recommended next action: <one command or one decision>
 ```
 
-## Root Cause Heuristics
+If there are no failures, omit the root-cause line and emit
+`No failures — system is healthy`.
 
-After running all checks, if failures exist, suggest the most likely root cause
-based on the failure pattern:
+## Out of scope
 
-| Failure pattern | Likely root cause |
-|---|---|
-| System FAIL + all services down | SD card failure or power issue |
-| Services FAIL + everything else OK | Bad deploy or stale venv — run `uv sync` and restart |
-| CAN FAIL + Signal K no deltas | CAN bus wiring or interface not up |
-| Signal K FAIL + CAN OK | Signal K server issue — restart signalk |
-| Audio FAIL only | USB device disconnected or conflict |
-| Database FAIL only | SD card degradation or WAL bloat |
-| Network FAIL only | Tailscale or connectivity issue |
-| No failures but "no data" symptom | Instruments not powered on or CAN bus silent |
+- Does not modify code, configs, or services.
+- Does not run lint/tests/type checks.
+- Does not deploy. Use `/deploy-pi` for that.
+- AI HAT is not yet deployed; `[OK] AI HAT — not installed (expected)` is
+  the expected outcome until that changes.

--- a/.claude/skills/domain/SKILL.md
+++ b/.claude/skills/domain/SKILL.md
@@ -1,354 +1,115 @@
 ---
 name: domain
-description: Sailing instrument domain reference — Signal K paths, NMEA 2000 PGNs, instrument relationships, racing concepts, and calibration parameters. Auto-triggers when working on sk_reader.py, can_reader.py, nmea2000.py, polar.py, boat_settings.py, synthesize.py, maneuver_detector.py, export.py, or calibration-related code.
+description: Sailing instrument tribal knowledge that is NOT directly grep-recoverable from the code — common-mistake guards, B&G/instrument-vendor quirks, J/105 polar reference targets, and calibration miscalibration symptoms. Auto-triggers when working on sk_reader.py, can_reader.py, nmea2000.py, polar.py, boat_settings.py, synthesize.py, maneuver_detector.py, export.py, or calibration-related code. Skill content is intentionally narrow — for paths, PGN byte layouts, conversion constants, and table schemas already encoded in the source, read sk_reader.py / nmea2000.py / storage.py directly.
 ---
 
-# Sailing Instrument Domain Reference
+# Sailing Instrument Domain — Tribal Knowledge
 
-This skill provides authoritative domain knowledge for HelmLog's sailing
-instrument system. Use it as a reference when writing or reviewing code that
-handles instrument data. **Do not guess** at Signal K paths, PGN numbers, or
-instrument relationships — consult this reference.
-
----
-
-## 1. Instrument Relationships
-
-### The Core Seven
-
-| Abbreviation | Full Name | Source | Units | What It Measures |
-|---|---|---|---|---|
-| **HDG** | Heading (True) | Compass + variation | degrees (0-360) | Direction the bow points, relative to true north |
-| **BSP** | Boat Speed (Through Water) | Paddlewheel / ultrasonic | knots | Speed through the water (affected by current) |
-| **SOG** | Speed Over Ground | GPS | knots | Speed relative to the earth's surface |
-| **COG** | Course Over Ground | GPS | degrees (0-360) | Track direction relative to true north |
-| **TWS** | True Wind Speed | Derived | knots | Wind speed relative to the water/ground |
-| **TWA** | True Wind Angle | Derived | degrees (0-180) | Angle of true wind relative to bow (0 = headwind) |
-| **AWA** | Apparent Wind Angle | Masthead unit | degrees (0-180) | Angle of wind as felt on the boat |
-| **AWS** | Apparent Wind Speed | Masthead unit | knots | Wind speed as felt on the boat |
-
-### Derived Quantities
-
-| Quantity | Formula | Inputs | Notes |
-|---|---|---|---|
-| **VMG upwind** | `BSP * cos(TWA)` | BSP, TWA | TWA < 90 degrees. Higher is better. |
-| **VMG downwind** | `BSP * cos(180 - TWA)` | BSP, TWA | TWA > 90 degrees. Higher is better. |
-| **Apparent wind** | Vector sum of true wind + boat motion | TWS, TWA, BSP | `synthesize.py:apparent_wind()` |
-| **TWA from TWD** | `(TWD - HDG + 360) % 360` | TWD, HDG | When wind reference = 4 (north-referenced) |
-
-### How Wind Instruments Relate (Critical)
-
-```
-Physical sensors:
-  Masthead wand → AWA, AWS (what the crew sees)
-  GPS           → SOG, COG
-  Compass       → HDG
-  Paddlewheel   → BSP
-
-Derivation chain:
-  AWA + AWS + BSP → TWA + TWS  (instrument processor does this)
-                                 NOT the other way around.
-
-  TWA is derived FROM apparent wind, not the reverse.
-  The instrument processor (B&G Zeus) resolves true from apparent.
-```
-
-**Common mistakes the model makes:**
-- Confusing `speedThroughWater` (BSP, for polars) with `speedOverGround` (SOG, for navigation). **Polar calculations always use BSP.**
-- Thinking TWA is an input to AWA. It's the opposite: AWA is measured, TWA is derived.
-- Treating TWA as 0-360. TWA is 0-180 in HelmLog (port/starboard symmetry assumed for polars).
-
-### Wind Reference Codes (PGN 130306)
-
-| Code | Name | `wind_angle_deg` Means | Used In Polars? |
-|---|---|---|---|
-| **0** | True, boat-referenced | TWA directly (0 = headwind) | Yes |
-| **2** | Apparent | AWA (0 = head-to-wind) | No — filtered out |
-| **4** | True, north-referenced | TWD (compass direction wind blows FROM) | Yes, after `TWA = (TWD - HDG) % 360` |
-
-**B&G systems typically emit reference 4** (TWD), not reference 0 (TWA). Code
-that computes TWA must check the reference field and apply heading correction
-when reference = 4. See `polar.py:_compute_twa()`.
+This skill encodes only what the codebase does NOT make obvious on its own:
+common mistakes the model has made before, vendor-specific quirks, polar
+target speeds for our hull, and miscalibration symptoms. For Signal K paths,
+PGN byte layouts, conversion constants, table schemas, and unit conversions,
+read `sk_reader.py`, `nmea2000.py`, and `storage.py` directly — those files
+are the source of truth and are always more current than this skill.
 
 ---
 
-## 2. Signal K Path Reference
+## 1. Common mistakes (priming guards)
 
-These are the actual paths HelmLog reads from Signal K Server. All paths are
-under the `vessels.self` context.
+These are errors the model has historically made. Read these before writing
+instrument-handling code.
 
-### Simple Paths (single value per update)
-
-| Signal K Path | PGN | Record Type | SK Units | Conversion | Output Field |
-|---|---|---|---|---|---|
-| `navigation.headingTrue` | 127250 | `HeadingRecord` | radians | x 180/pi | `heading_deg` |
-| `navigation.speedThroughWater` | 128259 | `SpeedRecord` | m/s | x 1.94384449 | `speed_kts` |
-| `environment.depth.belowKeel` | 128267 | `DepthRecord` | metres | none | `depth_m` |
-| `environment.water.temperature` | 130310 | `EnvironmentalRecord` | Kelvin | - 273.15 | `water_temp_c` |
-
-### Paired Paths (buffered until both arrive)
-
-**COG + SOG (PGN 129026):**
-
-| Signal K Path | Conversion | Output Field |
-|---|---|---|
-| `navigation.courseOverGroundTrue` | rad x 180/pi | `cog_deg` |
-| `navigation.speedOverGround` | m/s x 1.94384449 | `sog_kts` |
-
-**True Wind (PGN 130306, reference 0 or 4):**
-
-| Signal K Path | Conversion | Reference | Priority |
-|---|---|---|---|
-| `environment.wind.angleTrue` | rad x 180/pi | 0 (boat) | 1st choice |
-| `environment.wind.angleTrueWater` | rad x 180/pi | 0 (boat) | 2nd choice |
-| `environment.wind.angleTrueGround` | rad x 180/pi | 0 (boat) | 3rd choice |
-| `environment.wind.directionTrue` | rad x 180/pi | 4 (north) | Last resort |
-| `environment.wind.speedTrue` | m/s x 1.94384449 | — | Paired with any above |
-
-**Apparent Wind (PGN 130306, reference 2):**
-
-| Signal K Path | Conversion | Output Field |
-|---|---|---|
-| `environment.wind.angleApparent` | rad x 180/pi | `wind_angle_deg` |
-| `environment.wind.speedApparent` | m/s x 1.94384449 | `wind_speed_kts` |
-
-**Position (PGN 129025):**
-
-| Signal K Path | Format | Output Fields |
-|---|---|---|
-| `navigation.position` | Object: `{latitude, longitude}` | `latitude_deg`, `longitude_deg` |
-
-### Unit Conversion Constants (`sk_reader.py`)
-
-```python
-_RAD_TO_DEG = 180.0 / math.pi      # 57.29577951...
-_MPS_TO_KTS = 1.94384449           # metres/second to knots
-_KELVIN_OFFSET = 273.15            # Kelvin to Celsius
-SK_SOURCE_ADDR = 0                 # Source address for SK-originated records
-```
-
-### Self-Vessel Filtering
-
-Only deltas with `context == "vessels.self"` are processed. Other-vessel data
-(AIS targets, nearby boats) is rejected to prevent data corruption (#208).
+- **Polar calculations always use BSP (`navigation.speedThroughWater`), never
+  SOG (`navigation.speedOverGround`).** SOG includes current — a 1-knot
+  favorable current makes the boat look 1 knot faster at every TWA/TWS bin
+  and contaminates the polar.
+- **TWA is derived FROM apparent wind, not the reverse.** AWA + AWS + BSP →
+  TWA + TWS. The masthead wand measures AWA directly; TWA is computed by the
+  instrument processor (B&G Zeus). Code that "derives AWA from TWA" is
+  upside-down.
+- **TWA is 0–180 in HelmLog**, not 0–360. Port/starboard symmetry is assumed
+  for polars. If you find yourself wrapping a TWA value through 360, you are
+  probably handling TWD (true wind direction), not TWA.
+- **Wind reference field matters.** PGN 130306's reference field decides
+  what `wind_angle_deg` actually means. Mishandling this is a recurring bug.
+  Codes (also in `nmea2000.py`):
+  - `0` — true, boat-referenced — value IS TWA
+  - `2` — apparent — filter out for polars
+  - `4` — true, north-referenced — value is TWD;
+    **TWA = `(TWD - HDG + 360) % 360`** then fold to 0–180
+- **B&G systems typically emit reference 4 (TWD), not reference 0 (TWA).**
+  So `_compute_twa()` in `polar.py` is on the hot path; do not bypass it.
+- **Reference=4 needs a contemporaneous heading.** If `HeadingRecord` is
+  missing or stale, drop the wind sample — do not guess.
+- **AIS PGNs (129038–129810) are never ingested.** Data licensing
+  requirement (#208), not a technical limitation. If you find yourself
+  adding an AIS decoder, stop and check `docs/data-licensing.md`.
 
 ---
 
-## 3. NMEA 2000 PGN Reference
+## 2. J/105 reference polars (used for synthetic test data)
 
-Seven PGNs are decoded. All use little-endian byte order.
-
-### PGN 127250 — Vessel Heading
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1-2 | Heading | 0.0001 rad/bit | radians -> degrees | 0xFFFF |
-| 3-4 | Deviation | 0.0001 rad/bit | radians -> degrees | 0x7FFF |
-| 5-6 | Variation | 0.0001 rad/bit | radians -> degrees | 0x7FFF |
-| 7 | Reference | bits 0-1 | 0=true, 1=magnetic | — |
-
-### PGN 128259 — Speed Through Water
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1-2 | Speed | 0.01 m/s per bit | m/s -> knots | 0xFFFF |
-| 3-4 | Speed (transducer) | 0.01 m/s per bit | m/s -> knots | — |
-| 5 | Speed Type | bits | — | — |
-
-### PGN 128267 — Water Depth
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1-4 | Depth | 0.01 m/bit | metres (below transducer) | 0xFFFFFFFF |
-| 5-6 | Offset | 0.001 m/bit (signed) | metres (keel-to-transducer) | 0x8000 |
-
-### PGN 129025 — Position Rapid Update
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0-3 | Latitude | 1e-7 deg/bit (signed) | degrees (+N) | 0x80000000 |
-| 4-7 | Longitude | 1e-7 deg/bit (signed) | degrees (+E) | 0x80000000 |
-
-### PGN 129026 — COG & SOG Rapid Update
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1 | COG Reference | bits 0-1 | 0=true, 1=magnetic | — |
-| 2-3 | COG | 0.0001 rad/bit | radians -> degrees | 0xFFFF |
-| 4-5 | SOG | 0.01 m/s per bit | m/s -> knots | 0xFFFF |
-| 6-7 | Reserved | — | — | — |
-
-### PGN 130306 — Wind Data
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1-2 | Wind Speed | 0.01 m/s per bit | m/s -> knots | 0xFFFF |
-| 3-4 | Wind Angle | 0.0001 rad/bit | radians -> degrees | 0xFFFF |
-| 5 | Reference | bits 0-2 | 0=true, 2=apparent, 4=true north | — |
-
-### PGN 130310 — Environmental Parameters
-
-| Bytes | Field | Scale | Units | Not-Available |
-|---|---|---|---|---|
-| 0 | SID | — | — | — |
-| 1-2 | Water Temp | 0.01 K/bit | Kelvin -> Celsius | 0xFFFF |
-| 3-4 | Atm. Pressure | 0.1 hPa/bit | hPa (ignored) | — |
-| 5-6 | Reserved | — | — | — |
-
-### Blocked PGNs (AIS — data licensing policy)
-
-PGNs 129038-129810 (AIS and DSC) are **never ingested or stored**. This is a
-data licensing requirement (#208), not a technical limitation.
-
-### CAN Bus / J1939 Arbitration ID (29-bit extended)
-
-```
-bits 28-26: priority (3 bits, typically 6)
-bit  24:    data page (0 or 1)
-bits 23-16: PDU format (PF)
-bits 15-8:  PDU specific (PS)
-bits  7-0:  source address
-```
-
-PGN extraction: for PDU2 (PF >= 240, broadcast), `PGN = (data_page << 16) | (PF << 8) | PS`.
-
----
-
-## 4. Racing Concepts
-
-### Race Structure
-
-A **session** is a contiguous period of data recording. Sessions contain
-**legs** between **marks**. A mark rounding changes the leg.
-
-### Maneuver Classification (`maneuver_detector.py`)
-
-| TWA Before | TWA After | Heading Change | Classification |
-|---|---|---|---|
-| < 90 (upwind) | < 90 (upwind) | >= 60 deg | **Tack** |
-| > 90 (downwind) | > 90 (downwind) | >= 60 deg | **Gybe** |
-| < 90 | > 90 (or vice versa) | >= 60 deg | **Mark rounding** |
-
-### Polar Performance
-
-A **polar** maps `(TWS, TWA) -> BSP` — the expected boat speed for given wind
-conditions. HelmLog builds a polar baseline from completed race sessions:
-
-- **TWS bins:** floor of TWS in knots (0, 1, 2, ... 30+)
-- **TWA bins:** floor to nearest 5 degrees (0, 5, 10, ... 175, 180)
-- **Per bin:** mean BSP, P90 BSP, session count, sample count
-- **Minimum sessions:** 3 races before baseline is published
-
-**Polar calculations always use BSP (speed through water), never SOG (speed
-over ground).** SOG includes current effects and produces misleading polars.
-
-### VMG (Velocity Made Good)
-
-VMG is the speed component toward the wind (upwind) or away from it (downwind).
-
-- **Upwind VMG** = `BSP * cos(TWA)` where TWA < 90 degrees
-- **Downwind VMG** = `BSP * cos(180 - TWA)` where TWA >= 90 degrees
-- VMG is analyzed **per sail** and **per wind band** (0-6, 6-10, 10-15, 15-20, 20+ kts)
-
-"Good VMG" upwind means sailing as close to the wind as possible while
-maintaining speed. There's an optimal TWA for each wind speed — sailing too
-close (pinching) kills BSP; sailing too wide (footing) wastes angle.
-
-### J/105 Reference Polars (`synthesize.py`)
-
-Used for test data generation. Optimal upwind/downwind angles and speeds:
+These are the optimal upwind/downwind targets for our hull, used by
+`synthesize.py` to generate fixture data. They are not in the SQL schema; if
+you need numeric ground truth for a test, this is it:
 
 | TWS (kts) | Upwind TWA | Upwind BSP | Downwind TWA | Downwind BSP |
 |---|---|---|---|---|
-| 6 | 44 deg | 5.2 kts | 150 deg | 4.8 kts |
-| 8 | 43 deg | 6.0 kts | 145 deg | 5.8 kts |
-| 10 | 42 deg | 6.5 kts | 140 deg | 6.5 kts |
-| 12 | 41 deg | 6.8 kts | 135 deg | 7.0 kts |
-| 16 | 39 deg | 7.3 kts | 130 deg | 7.6 kts |
+| 6  | 44° | 5.2 kts | 150° | 4.8 kts |
+| 8  | 43° | 6.0 kts | 145° | 5.8 kts |
+| 10 | 42° | 6.5 kts | 140° | 6.5 kts |
+| 12 | 41° | 6.8 kts | 135° | 7.0 kts |
+| 16 | 39° | 7.3 kts | 130° | 7.6 kts |
+
+If observed BSP is consistently >10% above or below these for the same
+(TWS, TWA), suspect BSP calibration drift before assuming the model is fast
+or slow.
 
 ---
 
-## 5. Calibration Parameters (`boat_settings.py`)
+## 3. Polar binning conventions
 
-These are crew-entered tuning parameters, not instrument readings. They don't
-feed into calculations (yet) — they're stored for debrief correlation.
+Not obvious from code at a glance:
 
-### What Miscalibration Looks Like
+- **TWS bins:** floor of TWS in knots (0, 1, 2, … 30+).
+- **TWA bins:** floor to nearest 5° (0, 5, 10, … 175, 180).
+- **Per bin:** mean BSP, P90 BSP, session count, sample count.
+- **Minimum sessions:** 3 races before the baseline is published.
 
-| Parameter | What It Controls | Miscalibration Symptom |
-|---|---|---|
-| **BSP calibration** | Paddlewheel scale factor | Polars consistently above/below known target; VMG unreliable |
-| **AWA offset** | Wind vane zero point | Upwind performance looks different on port vs starboard tack |
-| **Compass deviation** | Heading correction table | TWA wrong when derived from TWD (reference=4); tack/gybe misclassified |
-| **Depth offset** | Transducer-to-keel distance | `offset_m` in DepthRecord; shallow-water alarms fire at wrong depth |
-| **SOG/COG** | GPS antenna position | Usually accurate; offset matters for match racing (boat length precision) |
-
-### Rig and Sail Controls (Stored in `boat_settings.py`)
-
-**Rig tension:** `shroud_tension_upper`, `shroud_tension_d2`, `shroud_tension_lowers` (Loos units)
-
-**Sail controls:** `main_halyard`, `jib_halyard`, `vang`, `cunningham`, `outhaul`,
-`backstay`, `main_sheet_tension`, `jib_sheet_tension_port/starboard`,
-`traveler_position` (inches)
-
-**Deck:** `car_position_port`, `car_position_starboard` (hole numbers)
-
-**Conditions:** `weight_distribution` (preset), `swell_height`, `swell_period`, `chop`
+VMG bands (for VMG-per-sail analysis): 0–6, 6–10, 10–15, 15–20, 20+ kts.
 
 ---
 
-## 6. Data Flow Summary
+## 4. Calibration miscalibration symptoms
 
-```
-Signal K Server                  CAN Bus (legacy)
-      |                               |
-  sk_reader.py                   can_reader.py
-      |                               |
-      +--- same PGNRecord types ------+
-                     |
-               storage.py (SQLite)
-                     |
-      +---------+----+--------+--------+
-      |         |             |        |
-   polar.py  export.py   web.py   maneuver_detector.py
-      |
-  analysis/plugins/
-  (sail_vmg, polar_baseline)
-```
+Crew-entered tuning parameters live in `boat_settings.py`. They are stored
+for debrief correlation; most do not yet feed calculations. The non-obvious
+part is what miscalibration *looks like* in the data:
 
-Both data paths produce identical `PGNRecord` dataclasses. Downstream code is
-data-source agnostic.
-
-### Storage Tables
-
-| Table | Key Columns | From PGN |
+| Parameter | What it controls | Miscalibration symptom |
 |---|---|---|
-| `headings` | ts, heading_deg, deviation_deg, variation_deg | 127250 |
-| `speeds` | ts, speed_kts | 128259 |
-| `depths` | ts, depth_m, offset_m | 128267 |
-| `positions` | ts, latitude_deg, longitude_deg | 129025 |
-| `cogsog` | ts, cog_deg, sog_kts | 129026 |
-| `winds` | ts, wind_speed_kts, wind_angle_deg, reference | 130306 |
-| `environmental` | ts, water_temp_c | 130310 |
+| **BSP calibration** | Paddlewheel scale factor | Polars consistently above/below J/105 targets; VMG unreliable |
+| **AWA offset** | Wind vane zero point | Upwind performance differs port vs. starboard tack |
+| **Compass deviation** | Heading correction table | TWA wrong when derived from TWD (ref=4); tack/gybe misclassified |
+| **Depth offset** | Transducer-to-keel distance | `offset_m` in `DepthRecord`; shallow-water alarms fire at wrong depth |
+| **GPS antenna position** | SOG/COG | Usually accurate; offset matters only for match-racing precision |
 
-All tables indexed by ISO 8601 UTC timestamp, truncated to the second.
+If a debrief shows asymmetric upwind speed across tacks, the first
+hypothesis should be AWA offset, not crew technique.
 
-### Export Column Mapping
+---
 
-| Export Column | Source Table | Notes |
-|---|---|---|
-| HDG | headings | heading_deg |
-| BSP | speeds | speed_kts |
-| COG, SOG | cogsog | cog_deg, sog_kts |
-| TWS, TWA | winds (ref 0 or 4) | True wind only; TWA computed if ref=4 |
-| AWS, AWA | winds (ref 2) | Apparent wind |
-| DEPTH | depths | depth_m |
-| LAT, LON | positions | latitude_deg, longitude_deg |
-| WTEMP | environmental | water_temp_c |
-| BSP_BASELINE | polar baseline | Expected BSP for (TWS_bin, TWA_bin) |
-| BSP_DELTA | computed | session_BSP - baseline_BSP |
+## 5. Maneuver classification rule
+
+Heading change alone does NOT classify a tack vs. gybe — TWA before and
+after determines it. Source of truth is `maneuver_detector.py`, but the
+rule in plain English:
+
+| TWA before | TWA after | Heading change | Classification |
+|---|---|---|---|
+| <90° (upwind) | <90° (upwind) | ≥60° | **Tack** |
+| >90° (downwind) | >90° (downwind) | ≥60° | **Gybe** |
+| crosses 90° boundary | — | ≥60° | **Mark rounding** |
+
+Without true wind data the detector falls back to a generic `"maneuver"`
+type — heading change with no TWA context is unclassified, not assumed.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -3,85 +3,45 @@ name: release-notes
 description: Draft a curated RELEASES.md entry from commits since the last stage/* tag. TRIGGER when preparing to promote main → stage, when the user asks for release notes, or when running the promote workflow. DO NOT trigger for general documentation edits, mid-development work, or changes to RELEASES.md that aren't promotion-related.
 ---
 
-# Release Notes: Draft Entry
+# /release-notes — Draft a RELEASES.md entry
 
-Draft a new RELEASES.md entry summarizing commits on `main` since the latest
-`stage/*` tag. Run this skill before promoting `main` to `stage`.
+Format conventions emerge naturally from reading the existing
+`RELEASES.md`; this skill encodes only the operational rules that are NOT
+recoverable from existing entries.
 
-## 1. Find the Commit Range
+## Operational rules
 
-Run `git tag -l 'stage/*' --sort=-creatordate | head -1` to find the latest
-stage tag. If no stage tags exist, use the initial commit as the base.
+- **Commit range:** from the latest `stage/*` tag (by creation date) to
+  HEAD. Use `git tag -l 'stage/*' --sort=-creatordate | head -1`. If no
+  stage tag exists, use the initial commit.
+- **Filter ideation-log-only commits.** A commit whose only changed file
+  is `docs/ideation-log.md` is excluded entirely. A commit that touches
+  `docs/ideation-log.md` AND other files is included, but the entry
+  describes only the non-ideation changes. Use:
+  `git diff-tree --no-commit-id --name-only -r <sha>`.
+- **If only ideation-log commits remain after filtering**, tell the user:
+  "All commits since the last stage tag only touch the ideation log —
+  nothing to document. The promote workflow will allow this through
+  automatically." Stop there.
+- **Today's date** in YYYY-MM-DD goes in the entry heading.
+- **Insertion point:** prepend immediately after the `# Release Notes`
+  H1 (line 1), separated by a blank line. Do not modify existing entries.
+- **Do NOT commit.** Present the draft for review; the user commits when
+  satisfied.
+- **Do NOT mention the ideation log** anywhere in the entry.
 
-Save the tag as `$LAST_TAG` and collect the commit range:
+## Link format
 
-```bash
-git log --oneline "$LAST_TAG"..HEAD
-```
+Reference numbers as clickable Markdown links. Determine PR vs issue with
+`gh pr view <N> --json state -q .state 2>/dev/null` — success means PR.
 
-## 2. Filter Out Ideation-Log-Only Commits
+- PR: `([#NNN](https://github.com/weaties/helmlog/pull/NNN))`
+- Issue: `([#NNN](https://github.com/weaties/helmlog/issues/NNN))`
 
-For each commit in the range, check which files it touches:
+## Theme grouping
 
-```bash
-git diff-tree --no-commit-id --name-only -r <sha>
-```
-
-- **Exclude entirely:** Commits where every changed file is `docs/ideation-log.md`
-- **Include (code changes only):** Commits that touch `docs/ideation-log.md` AND
-  other files — describe only the non-ideation changes
-
-If no non-ideation commits remain after filtering, tell the user:
-> All commits since the last stage tag only touch the ideation log — nothing to
-> document. The promote workflow will allow this through automatically.
-
-And stop here.
-
-## 3. Analyze Changes and Group by Theme
-
-For each included commit, examine:
-- The commit message and any PR title (from `(#NNN)` references)
-- The files changed and the nature of the diff
-
-Group changes into logical themes (e.g., "Performance analysis", "Synthesizer
-improvements", "Deploy & infrastructure", "Bug fixes"). Use your judgment — aim
-for 2–5 groups. A single-commit release can have just one group.
-
-## 4. Draft the RELEASES.md Entry
-
-Read `RELEASES.md` to match the existing format. Draft a new entry following
-this pattern:
-
-```markdown
-## Title — Description (YYYY-MM-DD)
-
-Optional 1–2 sentence summary of the release.
-
-### Theme group
-- **Feature name** (#issue) — one-line description
-- **Feature name** (#issue) — one-line description with enough context to
-  understand the change without reading the code
-```
-
-Rules:
-- Use today's date (YYYY-MM-DD format)
-- Bold feature names, reference issue/PR numbers as clickable Markdown links:
-  `([#NNN](https://github.com/weaties/helmlog/issues/NNN))` for issues,
-  `([#NNN](https://github.com/weaties/helmlog/pull/NNN))` for PRs.
-  Use `gh pr view NNN --json state -q .state 2>/dev/null` to determine whether
-  a number is a PR or issue — if the command succeeds it's a PR, otherwise use
-  the issues URL.
-- One bullet per logical change — merge related commits into a single bullet
-- Use sub-bullets only when a change needs a brief clarification
-- Do NOT mention ideation log updates anywhere in the entry
-
-## 5. Insert into RELEASES.md
-
-Prepend the new entry immediately after the `# Release Notes` heading (line 1),
-with a blank line separating it from the next entry. Do not modify existing
-entries.
-
-## 6. Present for Review
-
-Show the user the drafted entry and ask them to review and edit before
-committing. Do NOT commit automatically — the user will commit when satisfied.
+Group commits into 2–5 logical themes (e.g., "Performance analysis",
+"Synthesizer improvements", "Deploy & infrastructure", "Bug fixes"). One
+bullet per logical change — merge related commits into a single bullet.
+Use sub-bullets only when a change needs a brief clarification. A
+single-commit release can have just one group.

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -3,81 +3,41 @@ name: spec
 description: Generate a structured spec (decision table, state diagram, or EARS) from a GitHub issue. TRIGGER when starting work on a feature with combinatorial logic (role × policy × state), lifecycle state machines, or hardware-critical behavior — especially Critical or High tier modules (auth.py, federation.py, peer_auth.py, storage.py migrations, can_reader.py). DO NOT trigger for simple bug fixes, Low-tier changes, straightforward linear features, or documentation.
 ---
 
-# Structured Feature Spec
+# /spec — Structured Feature Spec
 
-Generate a precise, reviewable spec for a GitHub issue before starting TDD.
-The spec is posted as an issue comment for human review. No code is written
-until the spec is approved.
+For combinatorial / lifecycle / hardware-critical features, generate a
+spec BEFORE writing tests or code. Post it as an issue comment on the
+target issue, then wait for review.
 
-## Usage
+`/spec <issue-number>` reads the issue with `gh issue view`, picks the
+right format from the table below, and posts the spec for review.
 
-```
-/spec <issue-number>
-```
+## Format selection
 
-## Workflow
-
-### 1. Read the issue
-
-```bash
-gh issue view <number> --json title,body,labels
-```
-
-Read the issue body carefully. Identify the **feature shape** — the kind of
-logic the implementation will need.
-
-### 2. Determine the risk tier
-
-Check which modules the feature will likely touch against the Risk Tiers
-table in CLAUDE.md. Report the tier.
-
-### 3. Choose the spec format
-
-Match the format to the feature shape:
-
-| Feature shape | Spec format | Signs you need it |
+| Feature shape | Spec format | Telltale signs |
 |---|---|---|
-| **Policy / permission logic** | Decision table | Multiple input variables (role, state, config) combine to determine an outcome (allow/deny, show/hide). The issue mentions "rules", "access control", "visibility", "filtering". |
-| **Lifecycle / workflow** | State diagram (Mermaid) | An entity moves through named states with explicit transitions. The issue mentions "create", "activate", "expire", "revoke", states, or transitions. |
-| **Hardware / safety-critical** | EARS requirements | Behavior depends on real-time conditions with fail-safe requirements. The issue mentions sensors, devices, thresholds, or "THE SYSTEM SHALL". |
-| **Mixed** | Combine formats | Complex features may need a state diagram for the lifecycle AND a decision table for the permission logic within each state. |
+| Policy / permission logic | **Decision table** | role × state × config combine to decide allow/deny/show/hide |
+| Lifecycle / workflow      | **State diagram** (Mermaid) | named states with explicit transitions (create → activate → expire) |
+| Hardware / safety-critical | **EARS requirements** | sensors, devices, thresholds, fail-safes, "THE SYSTEM SHALL" |
+| Mixed                      | **Combine** | e.g., state diagram for the lifecycle + decision table for permissions inside each state |
 
-If the feature is simple enough that a spec adds no value (e.g., a
-straightforward CRUD endpoint with no combinatorial logic), say so and skip
-the spec. Not every issue needs one.
+If the issue is simple enough that none of the formats add value (plain
+CRUD, no combinatorial logic), say so and skip the spec. Not every issue
+needs one.
 
-### 4. Generate the spec
+## Decision-table cookbook
 
-#### Decision Table
+- Columns: every input variable that affects the outcome (role, state,
+  config flag, tier).
+- Output column(s): the result for each combination.
+- **Every row is one test case.**
+- Include the exhaustive set of meaningful combinations — no implicit
+  "and everything else is denied". Mark impossible rows as `n/a` rather
+  than omitting them.
 
-Structure as a Markdown table with:
-- **Input columns:** Each variable that affects the outcome (role, state,
-  config flag, tier, etc.)
-- **Output column(s):** The result for each combination (allowed/denied,
-  visible/hidden, action taken)
-- **Every row is a test case** — the agent can generate one test per row
+## State-diagram cookbook
 
-Example:
-```markdown
-| User role | Thread visibility | Co-op taggable? | Can @mention? |
-|---|---|---|---|
-| crew (own boat) | boat-private | n/a | Yes |
-| crew (other boat) | boat-private | n/a | No (thread not visible) |
-| crew (other boat) | co-op-wide | yes | Yes |
-| crew (other boat) | co-op-wide | no | No (opted out) |
-| coach | intra-boat (coached) | yes | Yes |
-| coach | intra-boat (not coached) | n/a | No (thread not visible) |
-```
-
-Guidelines:
-- Include the **exhaustive** set of meaningful combinations — don't leave
-  implicit "and everything else is denied" rows
-- Mark impossible/nonsensical combinations as "n/a" rather than omitting them
-- Group rows logically (by role, then by state)
-
-#### State Diagram
-
-Use Mermaid syntax so it renders in GitHub:
+Use Mermaid `stateDiagram-v2` so it renders in GitHub:
 
 ````markdown
 ```mermaid
@@ -86,38 +46,29 @@ stateDiagram-v2
     Available --> Selected : user selects
     Selected --> Active : analysis runs
     Active --> Selected : new session loaded
-    Selected --> Available : user deselects
-    Available --> Deprecated : author deprecates
 ```
 ````
 
-Guidelines:
-- Name every state and every transition trigger
-- Include error/failure states if they exist
-- Add a brief note below the diagram listing any **guard conditions** on
-  transitions (e.g., "Selected → Active: only if session has required data
-  fields")
+Name every state and every transition trigger. List guard conditions
+below the diagram (e.g., "Selected → Active: only if session has required
+data fields").
 
-#### EARS Requirements
-
-Use the EARS (Easy Approach to Requirements Syntax) patterns:
+## EARS cookbook
 
 | Pattern | Template |
 |---|---|
-| Ubiquitous | THE SYSTEM SHALL \<action\> |
+| Ubiquitous   | THE SYSTEM SHALL \<action\> |
 | Event-driven | WHEN \<trigger\> THE SYSTEM SHALL \<action\> |
 | State-driven | WHILE \<state\> THE SYSTEM SHALL \<action\> |
-| Conditional | IF \<condition\> THEN THE SYSTEM SHALL \<action\> |
-| Optional | WHERE \<feature\> IS SUPPORTED THE SYSTEM SHALL \<action\> |
+| Conditional  | IF \<condition\> THEN THE SYSTEM SHALL \<action\> |
+| Optional     | WHERE \<feature\> IS SUPPORTED THE SYSTEM SHALL \<action\> |
 
-Guidelines:
-- One requirement per line — each is independently testable
-- Use measurable conditions (thresholds, timeouts, counts), not vague
-  qualifiers ("quickly", "reliably")
-- Include fail-safe requirements (what happens when inputs are missing or
-  stale)
+One requirement per line; each independently testable. Use measurable
+conditions (thresholds, timeouts, counts), not vague qualifiers
+("quickly", "reliably"). Include fail-safe requirements (what happens
+when inputs are missing or stale).
 
-### 5. Post the spec as an issue comment
+## Posting and approval
 
 ```bash
 gh issue comment <number> --body "$(cat <<'EOF'
@@ -129,31 +80,18 @@ gh issue comment <number> --body "$(cat <<'EOF'
 <spec content>
 
 ---
-
-*Generated by `/spec`. Review and approve before implementation begins.
+*Generated by /spec. Review and approve before implementation begins.
 Each row in a decision table = one test case. Each state transition = one
 test case.*
 EOF
 )"
 ```
 
-### 6. Wait for review
+**Do not proceed to TDD until the spec is approved.** If the user
+requests changes, update the comment and re-request review.
 
-Tell the user the spec is posted and ask them to review it. Do NOT proceed
-to TDD until the spec is approved. If the user requests changes, update the
-comment and re-request review.
-
-## Tips
-
-- **Read related docs** before generating the spec. For features touching
-  federation or data licensing, read `docs/federation-design.md` and/or
-  `docs/data-licensing.md` to ensure the spec is consistent with existing
-  policy.
-- **Cross-reference the ideation log** if the issue was promoted from an
-  IDX entry — the ideation log often has design decisions and open questions
-  that should be resolved in the spec.
-- **Keep it minimal** — the spec captures the combinatorial/lifecycle logic
-  that's hard to get right from prose. Don't spec obvious CRUD operations
-  or straightforward UI layouts.
-- **One spec per issue** — if an issue needs multiple formats (e.g., state
-  diagram + decision table), combine them in one comment.
+For features touching federation or data licensing, also read
+`docs/federation-design.md` and `docs/data-licensing.md` so the spec is
+consistent with existing policy. If the issue was promoted from an IDX
+entry, cross-reference the ideation log for design decisions and open
+questions.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,100 +1,58 @@
 ---
 name: tdd
-description: Use test-driven development when implementing new features or fixing bugs. TRIGGER when writing or modifying Python source code in src/helmlog/ — new functionality, bug fixes, or refactors that change behavior. DO NOT trigger for documentation, config, templates, CSS/JS, skill definitions, or changes that don't affect runtime behavior.
+description: HelmLog-specific test patterns and the pre-existing-error allowlist for ruff/mypy. The Red-Green-Refactor cycle and lint commands are already mandated in CLAUDE.md — this skill encodes only the patterns and known-pre-existing-errors list that aren't recoverable from existing tests at a glance. TRIGGER when writing or modifying Python source code in src/helmlog/. DO NOT trigger for documentation, config, templates, CSS/JS, skill definitions, or changes that don't affect runtime behavior.
 ---
 
-# Test-Driven Development (Red-Green-Refactor)
+# TDD — HelmLog patterns
 
-Always follow this cycle when implementing new functionality or fixing bugs.
+CLAUDE.md already mandates: failing test → implement → green → lint. This
+skill encodes only the project-specific bits that aren't obvious from
+existing tests:
 
-## 0. Enter a worktree
+## Test patterns
 
-Before writing any test or code, make sure the session is in a git worktree.
-Check `git worktree list` — if one already exists for this task, enter it via
-`EnterWorktree(path=...)`; otherwise create a new one via
-`EnterWorktree(name=...)`. See the "Always work in a git worktree" rule in
-CLAUDE.md for the why. Skip only if already in a worktree.
+**Storage tests** — use the shared `storage` fixture from `conftest.py`
+(in-memory SQLite, fully migrated; never construct `Storage` by hand in a
+test):
 
-## 1. Red — Write a Failing Test
-
-Write the test **before** writing the implementation.
-
-- Test file: `tests/test_<module>.py`
-- Use the `storage` fixture from `conftest.py` for in-memory SQLite
-- Use `httpx.AsyncClient` with `ASGITransport` for web route tests
-- Mock hardware modules (`audio.py`, `can_reader.py`, `sk_reader.py`, `cameras.py`)
-- All tests are `@pytest.mark.asyncio` for async code
-
-```bash
-uv run pytest tests/test_<module>.py -xvs
-```
-
-Confirm the test **fails** with the expected error (not an import error or fixture issue).
-
-## 2. Green — Write Minimal Code to Pass
-
-Implement just enough to make the failing test pass. No more.
-
-```bash
-uv run pytest tests/test_<module>.py -xvs
-```
-
-Confirm the test **passes**.
-
-## 3. Refactor — Improve Without Breaking
-
-Clean up the implementation. Then run the **full** test suite:
-
-```bash
-uv run pytest
-```
-
-All tests must pass.
-
-## 4. Lint and Type-Check
-
-```bash
-uv run ruff check . && uv run ruff format . && uv run mypy src/
-```
-
-**Pre-existing errors to ignore** (do not fix unless explicitly asked):
-- `web.py`: `Item "None" of "datetime | None" has no attribute "isoformat"`
-- `web.py`: `Item "None" of "AudioRecorder | None" has no attribute "stop"` (x2)
-- `main.py`: `Unused "type: ignore" comment`
-- `storage.py`: 2 pre-existing E501 line-length violations
-
-## 5. Commit
- 
-Commit the test and implementation together. Use conventional commit format.
-If working on a GitHub issue, include the issue number in the commit message:
-`feat: description (#332)`
-
-## Testing Patterns
-
-**Storage tests** — use the `storage` fixture (in-memory SQLite, fully migrated):
 ```python
 @pytest.mark.asyncio
-async def test_my_feature(storage: object) -> None:
-    from logger.storage import Storage
-    assert isinstance(storage, Storage)
+async def test_my_feature(storage: Storage) -> None:
     # storage is ready with all migrations applied
+    ...
 ```
 
-**Web route tests** — use `httpx.AsyncClient`:
+**Web route tests** — use `httpx.AsyncClient` with `ASGITransport`, not the
+sync `TestClient`:
+
 ```python
 @pytest.mark.asyncio
-async def test_my_endpoint(storage: object) -> None:
-    from logger.storage import Storage
-    assert isinstance(storage, Storage)
-    from logger.web import create_app
+async def test_my_endpoint(storage: Storage) -> None:
+    from helmlog.web import create_app
     app = create_app(storage)
-    async with httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.get("/api/my-endpoint")
         assert resp.status_code == 200
 ```
 
-**Hardware mocking** — patch at the module level:
+**Hardware mocking** — patch hardware modules at the import site so the
+test never touches real devices:
+
 ```python
-with patch("logger.cameras.httpx.AsyncClient") as mock_client:
-    # test camera operations without real hardware
+with patch("helmlog.cameras.httpx.AsyncClient") as mock_client:
+    ...
 ```
+
+Hardware modules to mock: `audio.py`, `can_reader.py`, `sk_reader.py`,
+`cameras.py`.
+
+## Pre-existing errors to ignore
+
+Do not fix these unless explicitly asked — they are tracked separately:
+
+- `web.py`: `Item "None" of "datetime | None" has no attribute "isoformat"`
+- `web.py`: `Item "None" of "AudioRecorder | None" has no attribute "stop"` (×2)
+- `main.py`: `Unused "type: ignore" comment`
+- `storage.py`: 2 pre-existing E501 line-length violations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,9 @@ reviewed against this bar regardless of how small they look.
   if all commits only touch `docs/ideation-log.md`). Run `/release-notes`
   before promoting. `stage → live` has no gate.
 - **Skill catalog and domain reference:** the harness lists available
-  skills each session; `/domain` is the authoritative reference for Signal K
-  paths and PGNs.
+  skills each session. For Signal K paths, PGN byte layouts, and unit
+  conversions, `sk_reader.py` and `nmea2000.py` are the source of truth;
+  `/domain` only encodes tribal knowledge that is not directly visible in
+  those files (B&G quirks, J/105 polar targets, miscalibration symptoms).
 - **Past decisions on this file** (e.g. why `/domain` isn't split, why no
   `AGENTS.md` symlink): [docs/agent-context-decisions.md](docs/agent-context-decisions.md).


### PR DESCRIPTION
## Summary

Audit Bucket A (workflow gates) per #692. Adapted Bucket B methodology: instead of Q&A probes, give a bare-model agent the same starting point as a real merged PR and see whether the discipline emerges by default.

4/4 disciplines emerge naturally from CLAUDE.md + reading the codebase:
- `/tdd` probe (against PR #686 shape) → bare model produced 10-step plan including risk-tier escalation, test-first, lint/types, integration tests, `Fixes #N` convention
- `/spec` probe (against issue #644 shape) → bare model picked the right formats (state diagram + decision table + EARS), invoked /spec by name, ordered companion skills correctly
- `/release-notes` probe → format conventions emerged from reading existing RELEASES.md
- `/data-license` probe → caught general PII concerns but **self-identified** gaps on HelmLog-specific policies (embargo, protest firewall, biometrics, gambling, benchmarks, coach expiry)

| Skill | Before | After | Δ |
|---|---|---|---|
| `/tdd` | 101 | 58 | −43% |
| `/spec` | 160 | 97 | −39% |
| `/data-license` | 89 | 84 | −6% (restructured) |
| `/release-notes` | 88 | 47 | −47% |
| **Total** | **438** | **286** | **−35%** |

`/data-license` retained nearly all its content because it's the highest-value skill in the audit so far — bare model has clear gaps that the skill genuinely fills. It was restructured to drop the general-PII checklist (recoverable) and emphasize the HelmLog-specific policy items (not recoverable).

NOT audited: `/pr-checklist` and `/integration-test` need different probe shapes (conversation-flow behavior, layer-selection nuance respectively). Tracked in #692.

## Test plan

- [ ] Diff reads coherently; slimmed content is self-sufficient
- [ ] Existing `evals/cases.yaml` for these skills (if any) still pass
- [ ] Manually trigger each skill in a fresh session — `/data-license` in particular should still flag the HelmLog-specific items it kept

Refs #692