### PR TITLE
feat(#702): start-line pings carry over to consecutive same-date races

### DIFF
--- a/src/helmlog/routes/race_start.py
+++ b/src/helmlog/routes/race_start.py
@@ -157,9 +157,12 @@ async def _build_snapshot(request: Request, state: SequenceState) -> dict[str, A
     storage = get_storage(request)
     current_race = await storage.get_current_race()
     race_id = current_race.id if current_race else None
+    # Storage handles per-end carry-over from prior same-date races when
+    # *race_id* is set (#702). When no race is active we still fall back
+    # to unscoped pre-arm pings so the helm can ping before the race row
+    # exists.
     line_row = await storage.get_latest_start_line(race_id=race_id)
-    if line_row is None:
-        # Fall back to unscoped pings (pre-arm flow).
+    if line_row is None and race_id is not None:
         line_row = await storage.get_latest_start_line(race_id=None)
     line = StartLine(
         boat_end_lat=line_row.get("boat_end_lat") if line_row else None,
@@ -234,10 +237,28 @@ async def _build_snapshot(request: Request, state: SequenceState) -> dict[str, A
             "boat_end_captured_at": (
                 line.boat_end_captured_at.isoformat() if line.boat_end_captured_at else None
             ),
+            "boat_end_carried_over_from_race_id": (
+                line_row.get("boat_end_race_id")
+                if (
+                    line_row
+                    and race_id is not None
+                    and line_row.get("boat_end_race_id") not in (None, race_id)
+                )
+                else None
+            ),
             "pin_end_lat": line.pin_end_lat,
             "pin_end_lon": line.pin_end_lon,
             "pin_end_captured_at": (
                 line.pin_end_captured_at.isoformat() if line.pin_end_captured_at else None
+            ),
+            "pin_end_carried_over_from_race_id": (
+                line_row.get("pin_end_race_id")
+                if (
+                    line_row
+                    and race_id is not None
+                    and line_row.get("pin_end_race_id") not in (None, race_id)
+                )
+                else None
             ),
             "is_complete": line.is_complete,
         },

--- a/src/helmlog/static/race_start.js
+++ b/src/helmlog/static/race_start.js
@@ -87,8 +87,29 @@
     }
   }
 
+  function renderLineCarryover() {
+    const el = document.getElementById("rs-line-carryover");
+    if (!el || !snapshot || !snapshot.start_line) return;
+    const sl = snapshot.start_line;
+    const parts = [];
+    if (sl.boat_end_carried_over_from_race_id) {
+      parts.push("boat end from race " + sl.boat_end_carried_over_from_race_id);
+    }
+    if (sl.pin_end_carried_over_from_race_id) {
+      parts.push("pin end from race " + sl.pin_end_carried_over_from_race_id);
+    }
+    if (parts.length === 0) {
+      el.style.display = "none";
+      return;
+    }
+    el.textContent = "⚠ Line carried over: " + parts.join(", ")
+      + ". Re-ping if RC has moved the line.";
+    el.style.display = "";
+  }
+
   function renderLineMetrics(metrics) {
     function set(id, value) { document.getElementById(id).textContent = value; }
+    renderLineCarryover();
     if (!metrics) {
       set("rs-line-bearing", "—");
       set("rs-line-length", "—");

--- a/src/helmlog/static/race_start_widget.js
+++ b/src/helmlog/static/race_start_widget.js
@@ -165,12 +165,16 @@
     const sl = snapshot.start_line;
     const boat = [sl.boat_end_lat, sl.boat_end_lon];
     const pin = [sl.pin_end_lat, sl.pin_end_lon];
+    const boatCarry = sl.boat_end_carried_over_from_race_id;
+    const pinCarry = sl.pin_end_carried_over_from_race_id;
+    const anyCarry = boatCarry || pinCarry;
 
-    // The HelmLog start line: solid orange dashed polyline so it reads
-    // distinctly from the dashed-rose Vakaros line (different agent, same
-    // map). Tooltip explains.
+    // HelmLog start line: solid orange dashed polyline (distinct from the
+    // dashed-rose Vakaros line). When either end is carried over from a
+    // prior race (#702), drop opacity + use a sparser dash so the helm
+    // sees at-a-glance that it should re-ping if RC moved the line.
     const m = snapshot.line_metrics;
-    let tip = "HelmLog start line";
+    let tip = anyCarry ? "HelmLog start line (carried over)" : "HelmLog start line";
     if (m) {
       tip += " · " + m.line_length_m.toFixed(0) + " m · "
         + m.line_bearing_deg.toFixed(0) + "°";
@@ -180,20 +184,30 @@
           + (m.favoured_end ? " " + m.favoured_end : "");
       }
     }
+    if (boatCarry) tip += "\nboat end from race " + boatCarry;
+    if (pinCarry) tip += "\npin end from race " + pinCarry;
     const line = L.polyline([pin, boat], {
       color: "#f59e0b",
-      weight: 4,
-      opacity: 0.95,
-      dashArray: "8, 8",
+      weight: anyCarry ? 3 : 4,
+      opacity: anyCarry ? 0.55 : 0.95,
+      dashArray: anyCarry ? "2, 10" : "8, 8",
     }).addTo(map).bindTooltip(tip, { sticky: true }).bindPopup(tip);
     mapLayers.push(line);
 
+    const boatTip = boatCarry
+      ? "HelmLog boat-end ping (from race " + boatCarry + ")"
+      : "HelmLog boat-end ping";
+    const pinTip = pinCarry
+      ? "HelmLog pin-end ping (from race " + pinCarry + ")"
+      : "HelmLog pin-end ping";
     const boatMarker = L.circleMarker(boat, {
-      radius: 6, color: "#f59e0b", fillColor: "#f59e0b", fillOpacity: 1, weight: 2,
-    }).addTo(map).bindTooltip("HelmLog boat-end ping");
+      radius: 6, color: "#f59e0b", fillColor: "#f59e0b",
+      fillOpacity: boatCarry ? 0.4 : 1, weight: 2,
+    }).addTo(map).bindTooltip(boatTip);
     const pinMarker = L.circleMarker(pin, {
-      radius: 6, color: "#f59e0b", fillColor: "#fbbf24", fillOpacity: 1, weight: 2,
-    }).addTo(map).bindTooltip("HelmLog pin-end ping");
+      radius: 6, color: "#f59e0b", fillColor: "#fbbf24",
+      fillOpacity: pinCarry ? 0.4 : 1, weight: 2,
+    }).addTo(map).bindTooltip(pinTip);
     mapLayers.push(boatMarker, pinMarker);
   }
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -4242,13 +4242,19 @@ class Storage:
     async def get_latest_start_line(self, race_id: int | None) -> dict[str, Any] | None:
         """Return the latest boat-end and pin-end ping for *race_id*.
 
-        When ``race_id`` is None, returns the latest *unscoped* pings (used
-        in pre-arm flow before a race row exists).
+        Carry-over (#702): when *race_id* is given and a particular end has
+        no ping for this race, fall back to the most recent ping of that
+        end_kind from any prior race on the same UTC date. The carried-over
+        end is tagged with ``{end}_end_race_id`` so callers can render a
+        "from race N" hint when the line wasn't explicitly re-pinged.
+
+        When *race_id* is ``None`` (pre-arm flow before a race row exists),
+        returns the latest unscoped pings only — no cross-race fallback.
         """
         db = self._read_conn()
         if race_id is None:
-            sql = (
-                "SELECT end_kind, latitude_deg, longitude_deg, captured_at"
+            cur = await db.execute(
+                "SELECT end_kind, latitude_deg, longitude_deg, captured_at, race_id"
                 "  FROM start_line_pings"
                 " WHERE race_id IS NULL"
                 " AND id IN ("
@@ -4256,27 +4262,58 @@ class Storage:
                 "   WHERE race_id IS NULL GROUP BY end_kind"
                 " )"
             )
-            cur = await db.execute(sql)
-        else:
-            sql = (
-                "SELECT end_kind, latitude_deg, longitude_deg, captured_at"
+            rows = await cur.fetchall()
+            if not rows:
+                return None
+            out: dict[str, Any] = {}
+            for end_kind, lat, lon, ts, rid in rows:
+                out[f"{end_kind}_end_lat"] = lat
+                out[f"{end_kind}_end_lon"] = lon
+                out[f"{end_kind}_end_captured_at"] = ts
+                out[f"{end_kind}_end_race_id"] = rid
+            return out
+
+        # Race-scoped path with carry-over fallback per end.
+        race_cur = await db.execute("SELECT date FROM races WHERE id = ?", (race_id,))
+        race_row = await race_cur.fetchone()
+        date_str = race_row["date"] if race_row else None
+
+        out = {}
+        for end_kind in ("boat", "pin"):
+            # Prefer a ping for this exact race.
+            cur = await db.execute(
+                "SELECT latitude_deg, longitude_deg, captured_at, race_id"
                 "  FROM start_line_pings"
-                " WHERE race_id = ?"
-                " AND id IN ("
-                "   SELECT MAX(id) FROM start_line_pings"
-                "   WHERE race_id = ? GROUP BY end_kind"
-                " )"
+                " WHERE race_id = ? AND end_kind = ?"
+                " ORDER BY captured_at DESC LIMIT 1",
+                (race_id, end_kind),
             )
-            cur = await db.execute(sql, (race_id, race_id))
-        rows = await cur.fetchall()
-        if not rows:
-            return None
-        out: dict[str, Any] = {}
-        for end_kind, lat, lon, ts in rows:
-            out[f"{end_kind}_end_lat"] = lat
-            out[f"{end_kind}_end_lon"] = lon
-            out[f"{end_kind}_end_captured_at"] = ts
-        return out
+            row = await cur.fetchone()
+
+            # Carry-over: most recent ping of this end_kind on the same
+            # UTC date, from a different race. Same-date keeps the helm
+            # safe across consecutive starts but won't reach into older
+            # sessions where the line is irrelevant.
+            if row is None and date_str is not None:
+                cur = await db.execute(
+                    "SELECT slp.latitude_deg, slp.longitude_deg,"
+                    "       slp.captured_at, slp.race_id"
+                    "  FROM start_line_pings slp"
+                    "  JOIN races r ON r.id = slp.race_id"
+                    " WHERE slp.end_kind = ? AND r.date = ? AND r.id != ?"
+                    " ORDER BY slp.captured_at DESC LIMIT 1",
+                    (end_kind, date_str, race_id),
+                )
+                row = await cur.fetchone()
+
+            if row is None:
+                continue
+            out[f"{end_kind}_end_lat"] = row["latitude_deg"]
+            out[f"{end_kind}_end_lon"] = row["longitude_deg"]
+            out[f"{end_kind}_end_captured_at"] = row["captured_at"]
+            out[f"{end_kind}_end_race_id"] = row["race_id"]
+
+        return out or None
 
     async def list_start_line_pings(self, race_id: int | None) -> list[dict[str, Any]]:
         """Return full ping history for *race_id*, ordered oldest → newest."""

--- a/src/helmlog/templates/race_start.html
+++ b/src/helmlog/templates/race_start.html
@@ -79,6 +79,8 @@
   </div>
 
   <div class="rs-line">
+    <div id="rs-line-carryover" style="display:none;color:var(--warning,#f5c518);
+         font-size:.85rem;padding:.25rem 0;font-style:italic"></div>
     <dl>
       <dt>Line bearing</dt><dd id="rs-line-bearing">—</dd>
       <dt>Line length</dt><dd id="rs-line-length">—</dd>

--- a/tests/test_race_start_storage.py
+++ b/tests/test_race_start_storage.py
@@ -259,6 +259,152 @@ async def test_list_pings_ordered_oldest_first(storage: Storage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Carry-over from prior same-date race (#702)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_carry_over_from_prior_race_same_date(storage: Storage) -> None:
+    """When race 2 has no pings, fall back to race 1's pings on the same
+    date, tagged with the source race_id."""
+    date = "2026-04-30"
+    r1 = await storage.start_race("CYC", T0, date, 1, "20260430-CYC-1")
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="boat",
+        latitude_deg=47.6895,
+        longitude_deg=-122.4160,
+        captured_at=T0,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="pin",
+        latitude_deg=47.6901,
+        longitude_deg=-122.4189,
+        captured_at=T0,
+        captured_by=None,
+    )
+    r2 = await storage.start_race("CYC", T0, date, 2, "20260430-CYC-2")
+
+    line = await storage.get_latest_start_line(race_id=r2.id)
+    assert line is not None
+    assert line["boat_end_lat"] == 47.6895
+    assert line["pin_end_lat"] == 47.6901
+    # Both ends came from race 1 — annotated for the UI banner.
+    assert line["boat_end_race_id"] == r1.id
+    assert line["pin_end_race_id"] == r1.id
+
+
+@pytest.mark.asyncio
+async def test_carry_over_mixes_per_end(storage: Storage) -> None:
+    """If race 2 re-pinged the boat end only, that end is fresh while the
+    pin end carries over from race 1."""
+    date = "2026-04-30"
+    r1 = await storage.start_race("CYC", T0, date, 1, "20260430-CYC-1")
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="boat",
+        latitude_deg=47.6895,
+        longitude_deg=-122.4160,
+        captured_at=T0,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="pin",
+        latitude_deg=47.6901,
+        longitude_deg=-122.4189,
+        captured_at=T0,
+        captured_by=None,
+    )
+    r2 = await storage.start_race("CYC", T0, date, 2, "20260430-CYC-2")
+    await storage.add_start_line_ping(
+        race_id=r2.id,
+        end_kind="boat",
+        latitude_deg=47.6905,
+        longitude_deg=-122.4170,
+        captured_at=T0,
+        captured_by=None,
+    )
+
+    line = await storage.get_latest_start_line(race_id=r2.id)
+    assert line is not None
+    # Boat end is the new race-2 ping.
+    assert line["boat_end_lat"] == 47.6905
+    assert line["boat_end_race_id"] == r2.id
+    # Pin end carried over from race 1.
+    assert line["pin_end_lat"] == 47.6901
+    assert line["pin_end_race_id"] == r1.id
+
+
+@pytest.mark.asyncio
+async def test_carry_over_does_not_cross_dates(storage: Storage) -> None:
+    """Pings from a different UTC date must not bleed forward."""
+    yesterday = "2026-04-29"
+    today = "2026-04-30"
+    r_yesterday = await storage.start_race("CYC", T0, yesterday, 1, "20260429-CYC-1")
+    await storage.add_start_line_ping(
+        race_id=r_yesterday.id,
+        end_kind="boat",
+        latitude_deg=47.0,
+        longitude_deg=-122.0,
+        captured_at=T0,
+        captured_by=None,
+    )
+    r_today = await storage.start_race("CYC", T0, today, 1, "20260430-CYC-1")
+
+    line = await storage.get_latest_start_line(race_id=r_today.id)
+    assert line is None
+
+
+@pytest.mark.asyncio
+async def test_no_carry_over_when_race_has_own_pings(storage: Storage) -> None:
+    """If the race has both ends pinged itself, it doesn't reach back."""
+    date = "2026-04-30"
+    r1 = await storage.start_race("CYC", T0, date, 1, "20260430-CYC-1")
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="boat",
+        latitude_deg=1.0,
+        longitude_deg=1.0,
+        captured_at=T0,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="pin",
+        latitude_deg=2.0,
+        longitude_deg=2.0,
+        captured_at=T0,
+        captured_by=None,
+    )
+    r2 = await storage.start_race("CYC", T0, date, 2, "20260430-CYC-2")
+    await storage.add_start_line_ping(
+        race_id=r2.id,
+        end_kind="boat",
+        latitude_deg=10.0,
+        longitude_deg=10.0,
+        captured_at=T0,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r2.id,
+        end_kind="pin",
+        latitude_deg=20.0,
+        longitude_deg=20.0,
+        captured_at=T0,
+        captured_by=None,
+    )
+    line = await storage.get_latest_start_line(race_id=r2.id)
+    assert line is not None
+    assert line["boat_end_lat"] == 10.0
+    assert line["pin_end_lat"] == 20.0
+    assert line["boat_end_race_id"] == r2.id
+    assert line["pin_end_race_id"] == r2.id
+
+
+# ---------------------------------------------------------------------------
 # Schema migration sanity
 # ---------------------------------------------------------------------------
 

--- a/tests/test_race_start_web.py
+++ b/tests/test_race_start_web.py
@@ -524,6 +524,69 @@ async def test_gun_with_no_current_race_does_not_error(storage: Storage) -> None
 
 
 @pytest.mark.asyncio
+async def test_state_snapshot_exposes_carry_over(storage: Storage) -> None:
+    """Snapshot's start_line block surfaces carried_over_from_race_id per
+    end so the UI can warn the helm to re-ping (#702)."""
+    date = "2026-04-30"
+    r1 = await storage.start_race("CYC", datetime.now(UTC), date, 1, "20260430-CYC-1")
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="boat",
+        latitude_deg=47.6895,
+        longitude_deg=-122.4160,
+        captured_at=datetime.now(UTC),
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="pin",
+        latitude_deg=47.6901,
+        longitude_deg=-122.4189,
+        captured_at=datetime.now(UTC),
+        captured_by=None,
+    )
+    # Close race 1, start race 2 — race 2 has no pings of its own.
+    await storage.end_race(r1.id, datetime.now(UTC))
+    await storage.start_race("CYC", datetime.now(UTC), date, 2, "20260430-CYC-2")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get("/api/race-start/state")
+    body = r.json()
+    sl = body["start_line"]
+    assert sl["is_complete"] is True
+    assert sl["boat_end_carried_over_from_race_id"] == r1.id
+    assert sl["pin_end_carried_over_from_race_id"] == r1.id
+
+
+@pytest.mark.asyncio
+async def test_state_snapshot_no_carry_over_for_fresh_pings(storage: Storage) -> None:
+    """When pings belong to the active race, carried_over_from_race_id is null."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Start a race and ping its line.
+        await storage.start_race("CYC", datetime.now(UTC), "2026-04-30", 1, "20260430-CYC-1")
+        await client.post(
+            "/api/race-start/ping/boat",
+            json={"latitude_deg": 47.65, "longitude_deg": -122.40},
+        )
+        await client.post(
+            "/api/race-start/ping/pin",
+            json={"latitude_deg": 47.66, "longitude_deg": -122.41},
+        )
+        r = await client.get("/api/race-start/state")
+    body = r.json()
+    sl = body["start_line"]
+    assert sl["is_complete"] is True
+    assert sl["boat_end_carried_over_from_race_id"] is None
+    assert sl["pin_end_carried_over_from_race_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_state_persists_across_clients(storage: Storage) -> None:
     """Arming via one client and reading via a fresh client returns the same
     state — the singleton row is the source of truth (#644 EARS §E)."""


### PR DESCRIPTION
## Summary

Fixes the silent-disappearance failure mode observed on 2026-04-30: race 1 pinged correctly, race 2 had no line drawn because pings were stamped with race 1's id.

Closes #702

## What changed

\`storage.get_latest_start_line(race_id)\` does per-end carry-over: if this race has no ping for an end, walk back to the most recent ping of that end_kind on the same UTC date from any prior race. Each end is annotated with \`{end}_end_race_id\` so the snapshot can flag carry-over to the UI.

Boat and pin fall back **independently** — when only one end is re-pinged for the new race, that end is fresh and the other carries over. Matches the common workflow where RC only moves one end.

## UX

- **/race-start page**: warning banner above the line-metrics panel — \"⚠ Line carried over: pin end from race 122. Re-ping if RC has moved the line.\"
- **Session map + global widget**: line drops opacity (~0.55) and switches to a sparser dash pattern; endpoint markers fade. Tooltips on each end name the source race.

Same-date scoping prevents pings from a previous regatta from bleeding forward.

## Risk tier

**Standard** — read-path change in \`storage.py\`, snapshot field addition in \`routes/race_start.py\`, JS-only UI changes. No schema migration. No auth changes.

## Tests

- \`test_carry_over_from_prior_race_same_date\` — both ends carry over
- \`test_carry_over_mixes_per_end\` — boat fresh, pin carries over (the real race-2 case)
- \`test_carry_over_does_not_cross_dates\` — yesterday's pings stay buried
- \`test_no_carry_over_when_race_has_own_pings\` — fresh pings short-circuit fallback
- \`test_state_snapshot_exposes_carry_over\` — snapshot wiring
- \`test_state_snapshot_no_carry_over_for_fresh_pings\` — null when not needed

\`uv run pytest tests/test_race_start*.py\`: 137 pass. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)