### PR TITLE
fix(videos): idempotent race-video link + dedupe duplicates

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1913,7 +1913,7 @@ function _videoAddForm() {
     + '<div style="font-size:.72rem;color:var(--text-secondary);margin-bottom:2px">Sync calibration (optional):</div>'
     + '<input id="video-sync-utc" class="field" type="datetime-local" step="1" value="' + defaultSync + '" style="width:100%;margin-bottom:4px;padding:6px 8px;font-size:.82rem"/>'
     + '<input id="video-sync-pos" class="field" placeholder="Video position (mm:ss)" style="width:100%;margin-bottom:4px;padding:6px 8px;font-size:.82rem"/>'
-    + '<button class="btn-export" style="background:var(--accent-strong);color:var(--bg-primary);border-color:var(--accent-strong)" onclick="submitAddVideo()">Add Video</button>'
+    + '<button id="video-add-submit" class="btn-export" style="background:var(--accent-strong);color:var(--bg-primary);border-color:var(--accent-strong)" onclick="submitAddVideo()">Add Video</button>'
     + ' <button onclick="document.getElementById(\'video-add-form\').style.display=\'none\'" style="background:none;border:none;color:var(--text-secondary);cursor:pointer;font-size:.82rem">Cancel</button>'
     + '</div>'
     + '<button onclick="document.getElementById(\'video-add-form\').style.display=\'\'" style="font-size:.78rem;color:var(--accent);background:none;border:none;cursor:pointer;padding:4px 0;margin-top:4px">+ Add Video</button>';
@@ -1928,11 +1928,27 @@ async function submitAddVideo() {
   const syncUtc = syncUtcVal ? (syncUtcVal.includes('Z') ? syncUtcVal : syncUtcVal + 'Z') : new Date().toISOString();
   const syncOffsetS = syncPosVal ? parseVideoPosition(syncPosVal) : 0;
   if (syncOffsetS === null) { alert('Video position must be mm:ss or seconds'); return; }
-  const resp = await fetch('/api/sessions/' + SESSION_ID + '/videos', {
-    method: 'POST', headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({youtube_url: url, label, sync_utc: syncUtc, sync_offset_s: syncOffsetS})
-  });
-  if (!resp.ok) { alert('Failed: ' + resp.status); return; }
+  // Disable the button while the POST is in flight: yt-dlp metadata lookup
+  // can take several seconds, and a second click would have created a
+  // duplicate row (now also blocked at the DB layer, but the UX should
+  // never let it get that far).
+  const btn = document.getElementById('video-add-submit');
+  if (btn) { btn.disabled = true; btn.textContent = 'Adding…'; }
+  try {
+    const resp = await fetch('/api/sessions/' + SESSION_ID + '/videos', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({youtube_url: url, label, sync_utc: syncUtc, sync_offset_s: syncOffsetS})
+    });
+    if (!resp.ok) {
+      alert('Failed: ' + resp.status);
+      if (btn) { btn.disabled = false; btn.textContent = 'Add Video'; }
+      return;
+    }
+  } catch (e) {
+    alert('Error adding video: ' + e.message);
+    if (btn) { btn.disabled = false; btn.textContent = 'Add Video'; }
+    return;
+  }
   // Reload everything to pick up new video in player
   location.reload();
 }

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -198,7 +198,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 82
+_CURRENT_VERSION: int = 83
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -1997,6 +1997,28 @@ _MIGRATIONS: dict[int, str] = {
         );
         CREATE INDEX IF NOT EXISTS idx_start_line_pings_race
             ON start_line_pings(race_id, end_kind, captured_at);
+    """,
+    83: """
+        -- Dedupe race_videos and enforce one link per (race_id, video_id).
+        -- Double-submits and re-paste-to-edit attempts created duplicate
+        -- rows (no UNIQUE constraint, no idempotency in add_race_video).
+        -- Per-group, keep the row with the latest created_at — that's the
+        -- one most likely to carry the user's most recent sync calibration.
+        DELETE FROM race_videos
+        WHERE id NOT IN (
+            SELECT id FROM race_videos rv
+            WHERE rv.created_at = (
+                SELECT MAX(created_at) FROM race_videos
+                WHERE race_id = rv.race_id AND video_id = rv.video_id
+            )
+            AND rv.id = (
+                SELECT MAX(id) FROM race_videos
+                WHERE race_id = rv.race_id AND video_id = rv.video_id
+                  AND created_at = rv.created_at
+            )
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_race_videos_unique_race_video
+            ON race_videos(race_id, video_id);
     """,
 }
 
@@ -5083,12 +5105,50 @@ class Storage:
         duration_s: float | None = None,
         user_id: int | None = None,
     ) -> int:
-        """Add a YouTube video linked to a race.  Returns the new row id."""
+        """Add or replace a YouTube video link on a race.
+
+        Idempotent on ``(race_id, video_id)``: if a link already exists for
+        the same video on the same race, the mutable fields (label,
+        sync_utc, sync_offset_s, duration_s, title, youtube_url) are
+        updated and the existing row id is returned. Prevents duplicate
+        links from double-submits or re-paste-to-edit attempts.
+        """
         from datetime import UTC
         from datetime import datetime as _datetime
 
         db = self._conn()
         now_str = _datetime.now(UTC).isoformat()
+        existing_cur = await db.execute(
+            "SELECT id FROM race_videos WHERE race_id = ? AND video_id = ?",
+            (race_id, video_id),
+        )
+        existing_row = await existing_cur.fetchone()
+        if existing_row is not None:
+            row_id = int(existing_row["id"])
+            await db.execute(
+                "UPDATE race_videos SET"
+                " youtube_url = ?, title = ?, label = ?,"
+                " sync_utc = ?, sync_offset_s = ?, duration_s = ?"
+                " WHERE id = ?",
+                (
+                    youtube_url,
+                    title,
+                    label,
+                    sync_utc.isoformat(),
+                    sync_offset_s,
+                    duration_s,
+                    row_id,
+                ),
+            )
+            await db.execute("DELETE FROM maneuver_cache WHERE session_id = ?", (race_id,))
+            await db.commit()
+            logger.info(
+                "Race video re-linked (idempotent): id={} race_id={} video_id={}",
+                row_id,
+                race_id,
+                video_id,
+            )
+            return row_id
         cur = await db.execute(
             "INSERT INTO race_videos"
             " (race_id, youtube_url, video_id, title, label,"

--- a/tests/test_migration_v83.py
+++ b/tests/test_migration_v83.py
@@ -1,0 +1,138 @@
+"""Tests for migration v83 — dedupe race_videos and add UNIQUE index."""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+async def _seed_race(db: aiosqlite.Connection, race_id: int) -> None:
+    await db.execute(
+        "INSERT INTO races (id, name, event, race_num, date, start_utc)"
+        " VALUES (?, ?, 'TestEvent', 1, '2026-04-30', '2026-04-30T01:25:03+00:00')",
+        (race_id, f"race-{race_id}"),
+    )
+
+
+async def _seed_video(
+    db: aiosqlite.Connection,
+    race_id: int,
+    video_id: str,
+    *,
+    sync_offset_s: float,
+    created_at: str,
+) -> int:
+    cur = await db.execute(
+        "INSERT INTO race_videos"
+        " (race_id, youtube_url, video_id, title, label,"
+        "  sync_utc, sync_offset_s, duration_s, created_at, user_id)"
+        " VALUES (?, ?, ?, '', '',"
+        "  '2026-04-30T01:25:03+00:00', ?, 3600.0, ?, NULL)",
+        (race_id, f"https://youtu.be/{video_id}", video_id, sync_offset_s, created_at),
+    )
+    assert cur.lastrowid is not None
+    return cur.lastrowid
+
+
+@pytest.mark.asyncio
+async def test_v83_collapses_duplicate_rows_keeping_latest_created_at() -> None:
+    """Three rows for the same (race_id, video_id) collapse to one — the
+    latest created_at — preserving the most recent sync calibration."""
+    db = await _build_db_at(82)
+    try:
+        await _seed_race(db, 1)
+        oldest = await _seed_video(
+            db, 1, "vid-aaaaaaa", sync_offset_s=0.0, created_at="2026-04-30T09:18:21+00:00"
+        )
+        middle = await _seed_video(
+            db, 1, "vid-aaaaaaa", sync_offset_s=100.0, created_at="2026-04-30T09:18:28+00:00"
+        )
+        latest = await _seed_video(
+            db, 1, "vid-aaaaaaa", sync_offset_s=243.0, created_at="2026-04-30T09:31:12+00:00"
+        )
+        await db.commit()
+
+        await _apply_migration(db, 83)
+
+        async with db.execute("SELECT id, sync_offset_s FROM race_videos WHERE race_id = 1") as cur:
+            rows = await cur.fetchall()
+        assert len(rows) == 1
+        assert rows[0]["id"] == latest
+        assert rows[0]["sync_offset_s"] == 243.0
+        assert oldest != latest and middle != latest
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v83_preserves_distinct_video_ids() -> None:
+    db = await _build_db_at(82)
+    try:
+        await _seed_race(db, 1)
+        await _seed_video(
+            db, 1, "vid-aaaaaaa", sync_offset_s=0.0, created_at="2026-04-30T09:18:21+00:00"
+        )
+        await _seed_video(
+            db, 1, "vid-bbbbbbb", sync_offset_s=0.0, created_at="2026-04-30T09:18:21+00:00"
+        )
+        await db.commit()
+
+        await _apply_migration(db, 83)
+
+        async with db.execute(
+            "SELECT video_id FROM race_videos WHERE race_id = 1 ORDER BY video_id"
+        ) as cur:
+            rows = await cur.fetchall()
+        assert [r["video_id"] for r in rows] == ["vid-aaaaaaa", "vid-bbbbbbb"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v83_unique_index_blocks_future_duplicates() -> None:
+    db = await _build_db_at(83)
+    try:
+        await _seed_race(db, 1)
+        await _seed_video(
+            db, 1, "vid-aaaaaaa", sync_offset_s=0.0, created_at="2026-04-30T09:18:21+00:00"
+        )
+        await db.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await _seed_video(
+                db,
+                1,
+                "vid-aaaaaaa",
+                sync_offset_s=243.0,
+                created_at="2026-04-30T09:18:22+00:00",
+            )
+    finally:
+        await db.close()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1137,8 +1137,8 @@ class TestRaceVideos:
     async def test_list_ordered_by_created_at(self, storage: Storage) -> None:
         """Videos are returned in insertion order."""
         race_id = await self._make_race(storage)
-        id1 = await self._add_video(storage, race_id, label="Bow cam")
-        id2 = await self._add_video(storage, race_id, label="Cockpit cam")
+        id1 = await self._add_video(storage, race_id, video_id="aaaaaaaaaaa", label="Bow cam")
+        id2 = await self._add_video(storage, race_id, video_id="bbbbbbbbbbb", label="Cockpit cam")
         rows = await storage.list_race_videos(race_id)
         assert [r["id"] for r in rows] == [id1, id2]
 
@@ -1181,6 +1181,32 @@ class TestRaceVideos:
         await db.execute("DELETE FROM races WHERE id = ?", (race_id,))
         await db.commit()
         assert await storage.list_race_videos(race_id) == []
+
+    async def test_add_race_video_is_idempotent_on_race_id_video_id(self, storage: Storage) -> None:
+        """Re-adding the same (race_id, video_id) updates the existing row.
+
+        Prevents duplicate-link rows on double-submit. The second call
+        returns the same row id and the new sync values overwrite the old.
+        """
+        race_id = await self._make_race(storage)
+        first_id = await self._add_video(storage, race_id, sync_offset_s=0.0, label="Bow cam")
+        second_id = await self._add_video(
+            storage, race_id, sync_offset_s=243.0, label="Bow cam (resynced)"
+        )
+        assert second_id == first_id
+        rows = await storage.list_race_videos(race_id)
+        assert len(rows) == 1
+        assert rows[0]["sync_offset_s"] == 243.0
+        assert rows[0]["label"] == "Bow cam (resynced)"
+
+    async def test_add_race_video_distinct_video_ids_coexist(self, storage: Storage) -> None:
+        """Different video_ids on the same race remain as separate rows."""
+        race_id = await self._make_race(storage)
+        a = await self._add_video(storage, race_id, video_id="aaaaaaaaaaa", label="A")
+        b = await self._add_video(storage, race_id, video_id="bbbbbbbbbbb", label="B")
+        assert a != b
+        rows = await storage.list_race_videos(race_id)
+        assert {r["video_id"] for r in rows} == {"aaaaaaaaaaa", "bbbbbbbbbbb"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `storage.add_race_video()` is idempotent on `(race_id, video_id)` — re-add becomes update of the mutable fields. Existing maneuver_cache invalidation preserved.
- Migration **83** collapses existing duplicate rows (keep the latest `created_at` per group — preserves the most recent sync calibration), then adds a UNIQUE index on `(race_id, video_id)`.
- `session.js` `submitAddVideo()` now disables the "Add Video" button + shows `Adding…` while the POST is in flight (mirrors the home.js pattern that already had this).

## Why
Session 123 on corvopi-live ended up with three duplicate links to the same YouTube video (ids 25, 26, 28; created at 09:18:21, 09:18:28, 09:31:12). The 7s gap between 25 and 26 matches a double-click during yt-dlp metadata lookup; the 13min gap to 28 was the user re-pasting because the form has no edit affordance. Without a UNIQUE constraint and without UI debouncing, both modes landed unchecked.

Defense in depth: backend upsert + DB constraint + UI debounce. Any one of them prevents the bug, but together they survive a future regression in any single layer.

## Test plan
- [x] `uv run pytest tests/test_storage.py tests/test_migration_v83.py` — 102 passed (3 new: idempotency, distinct video_ids coexist, migration dedupe + UNIQUE)
- [x] `uv run pytest tests/test_web.py tests/test_session_rename.py` — 212 passed (existing race_videos call sites unaffected)
- [x] `uv run pytest -q --no-cov` (full suite) — 2427 passed, 2 skipped
- [x] `uv run ruff check . && uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [ ] Smoke test on Pi: paste a YouTube URL into the session video form, confirm button disables + shows "Adding…", confirm a second click during the request is blocked.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)