### PR TITLE
feat: replay scrubber + samples extend into prestart

### DIFF
--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1134,12 +1134,12 @@ async def api_session_replay(
     async def _compute() -> dict[str, Any]:
         return await _compute_session_replay(storage, session_id)
 
-    # v2: payload schema changed (heel, trim added in #645). The cache hash
-    # tracks source-data changes but not payload-shape changes, so bump the
-    # family suffix whenever fields are added/removed to force a recompute
-    # rather than serving a stale blob that lacks the new keys.
+    # v3: payload schema changed (prestart_start_utc + samples extended
+    # backwards into the prestart window so the scrubber can range over
+    # pre-gun data). Bump the family suffix to force recompute on the
+    # cached blobs that lack the new field.
     return await cached_json_response(
-        request, race_id=session_id, key_family="session_replay_v2", compute=_compute
+        request, race_id=session_id, key_family="session_replay_v3", compute=_compute
     )
 
 
@@ -1151,6 +1151,18 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
         raise HTTPException(status_code=404, detail="Race not found")
     start_utc = row["start_utc"]
     end_utc = row["end_utc"] or row["start_utc"]
+
+    # Replay scrubber spans the prestart prefix too — same window the track
+    # is extended by (#707 / prestart-scrub). Instrument series queries use
+    # this lower bound so the HUD has data when the scrubber drops below
+    # the gun. The race_gun marker still points at start_utc.
+    try:
+        _start_dt_for_prestart = datetime.fromisoformat(start_utc)
+        prestart_start_utc = (
+            _start_dt_for_prestart - timedelta(seconds=_PRESTART_WINDOW_S)
+        ).isoformat()
+    except ValueError:
+        prestart_start_utc = start_utc
 
     # Effective race gun: for Vakaros-matched races, prefer the latest
     # race_start event inside the race window. Races that were recalled
@@ -1256,10 +1268,12 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
         )
 
     # Thin instrument series for HUD. 1 Hz dedup by truncated timestamp key.
+    # Lower bound is prestart_start_utc so the scrubber has gauges in the
+    # pre-gun window.
     async def _series(table: str, fields: list[str]) -> dict[str, dict[str, Any]]:
         cols = ", ".join(["ts", *fields])
         q = f"SELECT {cols} FROM {table} WHERE ts >= ? AND ts <= ? ORDER BY ts"
-        qcur = await db.execute(q, (start_utc, end_utc))
+        qcur = await db.execute(q, (prestart_start_utc, end_utc))
         rows = await qcur.fetchall()
         out: dict[str, dict[str, Any]] = {}
         for r in rows:
@@ -1276,7 +1290,7 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
             "SELECT ts, wind_speed_kts, wind_angle_deg, reference FROM winds "
             f"WHERE ts >= ? AND ts <= ? AND {where} ORDER BY ts"
         )
-        qcur = await db.execute(q, (start_utc, end_utc))
+        qcur = await db.execute(q, (prestart_start_utc, end_utc))
         rows = await qcur.fetchall()
         out: dict[str, dict[str, Any]] = {}
         for r in rows:
@@ -1376,6 +1390,14 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
         # time label, and YT sync.
         "start_utc": (start_utc if ("Z" in start_utc or "+" in start_utc) else start_utc + "Z"),
         "end_utc": end_utc if ("Z" in end_utc or "+" in end_utc) else end_utc + "Z",
+        # Lower bound for the scrubber: start_utc minus the prestart window.
+        # The scrubber uses this as its "0"; race_gun_utc still flags the
+        # actual race start moment.
+        "prestart_start_utc": (
+            prestart_start_utc
+            if ("Z" in prestart_start_utc or "+" in prestart_start_utc)
+            else prestart_start_utc + "Z"
+        ),
         # Effective race gun (prefers the latest Vakaros race_start
         # event inside the race window). Frontend uses this to filter
         # pre-gun "roundings" out of the replay laylines.

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -8586,9 +8586,12 @@ async function _loadReplayData() {
     const r = await fetch('/api/sessions/' + SESSION_ID + '/replay');
     if (!r.ok) return;
     const data = await r.json();
-    _replayStart = new Date(data.start_utc);
+    // Scrubber 0 is the prestart-window cutoff (start_utc − 20 min) so the
+    // helm can scrub through pre-gun maneuvers and have video / gauges /
+    // track follow. Falls back to start_utc for older payloads (cache).
+    _replayStart = new Date(data.prestart_start_utc || data.start_utc);
     _replayEnd = new Date(data.end_utc);
-    _raceGun = data.race_gun_utc ? new Date(data.race_gun_utc) : _replayStart;
+    _raceGun = data.race_gun_utc ? new Date(data.race_gun_utc) : new Date(data.start_utc);
     _replaySamples = (data.samples || []).map(s => ({
       ts: new Date(s.ts),
       stw: s.stw,

--- a/tests/test_session_track_prestart.py
+++ b/tests/test_session_track_prestart.py
@@ -119,6 +119,62 @@ async def test_track_excludes_prior_race_positions(
 
 
 @pytest.mark.asyncio
+async def test_replay_payload_exposes_prestart_start_utc(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replay endpoint advertises the scrubber lower bound so the JS can
+    range over the prestart window."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race_id = await _seed_race_with_prestart(storage)
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race_id}/replay")
+    assert r.status_code == 200
+    body = r.json()
+    assert "prestart_start_utc" in body
+    prestart = datetime.fromisoformat(body["prestart_start_utc"].replace("Z", "+00:00"))
+    start = datetime.fromisoformat(body["start_utc"].replace("Z", "+00:00"))
+    delta = (start - prestart).total_seconds()
+    assert delta == pytest.approx(1200.0, abs=1.0)
+
+
+@pytest.mark.asyncio
+async def test_replay_samples_extend_into_prestart(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Instrument samples include rows whose ts < race start_utc so the
+    HUD has data when the scrubber drops below the gun."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race = await storage.start_race(
+        event="CYC", start_utc=_GUN, date_str="2026-04-30", race_num=1, name="R"
+    )
+    db = storage._conn()
+    # 4 prestart speed samples, 2 in-race samples.
+    for offset_s in (-300, -200, -100, -10, 5, 60):
+        ts = (_GUN + timedelta(seconds=offset_s)).isoformat()
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 0, 4.5),
+        )
+    await db.commit()
+    await storage.end_race(race.id, _END)
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race.id}/replay")
+    body = r.json()
+    sample_ts = [s["ts"] for s in body["samples"]]
+    pre_gun = [t for t in sample_ts if t < body["start_utc"]]
+    post_gun = [t for t in sample_ts if t >= body["start_utc"]]
+    assert len(pre_gun) >= 4
+    assert len(post_gun) >= 2
+
+
+@pytest.mark.asyncio
 async def test_track_window_falls_back_when_no_race_id_tagged(
     storage: Storage, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_web_cache_routes.py
+++ b/tests/test_web_cache_routes.py
@@ -213,7 +213,7 @@ async def test_replay_cache_blob_written_and_invalidated(
     db = storage._conn()
     cur = await db.execute(
         "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
-        (race_id, "session_replay_v2"),
+        (race_id, "session_replay_v3"),
     )
     assert (await cur.fetchone())["n"] == 1
 
@@ -221,7 +221,7 @@ async def test_replay_cache_blob_written_and_invalidated(
     await storage.rename_race(race_id, new_name="After Rename")
     cur = await db.execute(
         "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
-        (race_id, "session_replay_v2"),
+        (race_id, "session_replay_v3"),
     )
     assert (await cur.fetchone())["n"] == 0
 


### PR DESCRIPTION
## Summary

Follows #707 (prestart on the track). Now the **replay scrubber** ranges over the prestart too — drag the slider below the gun and the cursor walks the prestart track, the HUD gauges read the right sensor data, and any linked video seeks to that moment.

## What changed

- \`_compute_session_replay\` derives \`prestart_start_utc = start_utc − _PRESTART_WINDOW_S\` (20 min).
- The 1 Hz instrument and wind \`_series\` queries use \`prestart_start_utc\` as the lower bound, so the per-second sample bucket covers the pre-gun window.
- New \`prestart_start_utc\` field in the JSON response.
- Cache key family bumped \`session_replay_v2 → v3\` to invalidate stale blobs that don't carry the new field.
- \`session.js\`: \`_replayStart = data.prestart_start_utc || data.start_utc\`; \`_raceGun = data.race_gun_utc || data.start_utc\`. Fallback chain keeps older cached responses working.

The \`_raceGun\` marker still pins \`start_utc\`, so race-relative time labels and pre-gun layline filtering are unchanged. Only the scrubber's "0" moves.

## Risk tier

**Standard**. \`routes/sessions.py\` + \`static/session.js\`. No schema, no auth, no migration. Cache invalidation is automatic via the family suffix bump.

## Tests

- \`test_replay_payload_exposes_prestart_start_utc\` — field present, 1200 s before \`start_utc\`
- \`test_replay_samples_extend_into_prestart\` — samples include \`ts < start_utc\` rows
- existing cache test updated to v3 family

\`uv run pytest tests/test_session_track_prestart.py tests/test_web_cache_routes.py\`: 16 pass. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)