### PR TITLE
feat: time-synced HelmLog start-line overlay + bias indicator on session map

### DIFF
--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -644,6 +644,93 @@ async def api_session_vakaros_overlay(
     return JSONResponse({"matched": True, **overlay})
 
 
+@router.get("/api/sessions/{session_id}/race-start-overlay")
+@limiter.limit("30/minute")
+async def api_session_race_start_overlay(
+    request: Request,
+    session_id: int,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Return HelmLog start-line ping history + computed line for the session.
+
+    Used by the session detail page to draw HelmLog's own start-line markers
+    (boat + pin) and a time-synced bias indicator that updates as the user
+    scrubs the replay. Distinct from the Vakaros overlay so both can coexist
+    on the same map.
+    """
+    import math
+
+    storage = get_storage(request)
+    db = storage._conn()
+    cur = await db.execute("SELECT id FROM races WHERE id = ?", (session_id,))
+    if await cur.fetchone() is None:
+        raise HTTPException(status_code=404, detail="Race not found")
+
+    pings = await storage.list_start_line_pings(race_id=session_id)
+    line_row = await storage.get_latest_start_line(race_id=session_id)
+
+    line_payload: dict[str, Any] | None = None
+    if line_row and all(
+        line_row.get(k) is not None
+        for k in ("boat_end_lat", "boat_end_lon", "pin_end_lat", "pin_end_lon")
+    ):
+        boat_lat = line_row["boat_end_lat"]
+        boat_lon = line_row["boat_end_lon"]
+        pin_lat = line_row["pin_end_lat"]
+        pin_lon = line_row["pin_end_lon"]
+        # Bearing from boat-end to pin-end (matches race_start.line_metrics).
+        phi1 = math.radians(boat_lat)
+        phi2 = math.radians(pin_lat)
+        dlam = math.radians(pin_lon - boat_lon)
+        bearing = (
+            math.degrees(
+                math.atan2(
+                    math.sin(dlam) * math.cos(phi2),
+                    math.cos(phi1) * math.sin(phi2)
+                    - math.sin(phi1) * math.cos(phi2) * math.cos(dlam),
+                )
+            )
+            + 360.0
+        ) % 360.0
+        # Length via haversine.
+        dphi = math.radians(pin_lat - boat_lat)
+        a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+        length_m = 2 * 6_371_008.8 * math.asin(math.sqrt(a))
+        line_payload = {
+            "boat": [boat_lat, boat_lon],
+            "pin": [pin_lat, pin_lon],
+            "length_m": length_m,
+            "bearing_deg": bearing,
+            "boat_end_carried_over_from_race_id": (
+                line_row.get("boat_end_race_id")
+                if line_row.get("boat_end_race_id") not in (None, session_id)
+                else None
+            ),
+            "pin_end_carried_over_from_race_id": (
+                line_row.get("pin_end_race_id")
+                if line_row.get("pin_end_race_id") not in (None, session_id)
+                else None
+            ),
+        }
+
+    return JSONResponse(
+        {
+            "session_id": session_id,
+            "pings": [
+                {
+                    "id": p["id"],
+                    "end_kind": p["end_kind"],
+                    "lat": p["latitude_deg"],
+                    "lon": p["longitude_deg"],
+                    "ts": p["captured_at"],
+                }
+                for p in pings
+            ],
+            "line": line_payload,
+        }
+    )
+
+
 @router.get("/api/sessions/{session_id}/course-overlay")
 @limiter.limit("30/minute")
 async def api_session_course_overlay(

--- a/src/helmlog/static/race_start_widget.js
+++ b/src/helmlog/static/race_start_widget.js
@@ -159,6 +159,10 @@
   function drawOnMap() {
     const map = window._helmlogLeafletMap;
     if (!map || !window.L) return;
+    // On /session/* pages, session.js owns a richer time-synced overlay
+    // (loadHelmlogStartLineOverlay). Skip the widget's static draw here so
+    // we don't paint duplicate lines/markers on top of it.
+    if (window.location.pathname.startsWith('/session/')) return;
     clearMapLayers();
     if (!snapshot.start_line || !snapshot.start_line.is_complete) return;
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -671,6 +671,14 @@ async function loadTrack() {
   } catch (err) {
     console.warn('Vakaros overlay failed to load:', err);
   }
+
+  // HelmLog start-line overlay (#644 + bias-overlay): boat/pin markers and
+  // a time-synced bias indicator that updates as the scrubber moves.
+  try {
+    await loadHelmlogStartLineOverlay();
+  } catch (err) {
+    console.warn('HelmLog start-line overlay failed to load:', err);
+  }
 }
 
 async function loadVakarosOverlay() {
@@ -883,6 +891,175 @@ async function loadVakarosOverlay() {
       start_favored_end: ctx.favored_end || null,
     };
     _injectVakarosStartIntoManeuvers();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HelmLog start-line overlay (#644 + bias overlay)
+// ---------------------------------------------------------------------------
+//
+// Renders boat/pin markers, a dashed orange line, and dynamic upwind ticks
+// at each end that follow the replay scrubber. The favoured end is
+// highlighted with a halo. All of it is computed from /race-start-overlay
+// (the line) + _replaySamples (TWD-at-cursor); no extra fetch on scrub.
+
+let _hlStartLineData = null;  // {boat: [lat,lon], pin: [...], length_m, bearing_deg}
+let _hlBoatHalo = null;
+let _hlPinHalo = null;
+let _hlPinTick = null;
+let _hlBoatTick = null;
+let _hlBiasLabel = null;
+
+function _angleDiffDeg(a, b) {
+  const d = ((a - b + 540) % 360) - 180;
+  return d;
+}
+
+function _findReplaySampleAt(utcMs) {
+  if (!_replaySamples || !_replaySamples.length) return null;
+  // Binary search for the latest sample with ts <= utcMs.
+  let lo = 0;
+  let hi = _replaySamples.length - 1;
+  if (_replaySamples[0].ts.getTime() > utcMs) return null;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (_replaySamples[mid].ts.getTime() <= utcMs) lo = mid;
+    else hi = mid - 1;
+  }
+  return _replaySamples[lo];
+}
+
+async function loadHelmlogStartLineOverlay() {
+  if (!_map) return;
+  const r = await fetch('/api/sessions/' + SESSION_ID + '/race-start-overlay');
+  if (!r.ok) return;
+  const data = await r.json();
+  if (!data || !data.line) return;
+
+  _hlStartLineData = data.line;
+  const HELMLOG_COLOR = '#f59e0b';
+
+  // Static endpoint markers + line (always on, regardless of scrubber).
+  const boat = data.line.boat;
+  const pin = data.line.pin;
+  const boatTip = data.line.boat_end_carried_over_from_race_id
+    ? 'HelmLog boat-end (from race ' + data.line.boat_end_carried_over_from_race_id + ')'
+    : 'HelmLog boat-end ping';
+  const pinTip = data.line.pin_end_carried_over_from_race_id
+    ? 'HelmLog pin-end (from race ' + data.line.pin_end_carried_over_from_race_id + ')'
+    : 'HelmLog pin-end ping';
+  L.polyline([pin, boat], {
+    color: HELMLOG_COLOR, weight: 3, opacity: 0.9, dashArray: '8, 8',
+  }).addTo(_map).bindTooltip('HelmLog start line', { sticky: true });
+  L.circleMarker(boat, {
+    radius: 7, color: HELMLOG_COLOR, fillColor: HELMLOG_COLOR,
+    fillOpacity: 0.9, weight: 2,
+  }).addTo(_map).bindTooltip(boatTip);
+  L.circleMarker(pin, {
+    radius: 7, color: HELMLOG_COLOR, fillColor: '#fbbf24',
+    fillOpacity: 0.9, weight: 2,
+  }).addTo(_map).bindTooltip(pinTip);
+
+  // Halos behind each marker — sized/colored by which end is favoured
+  // at the current scrub time. Drawn beneath the static markers (added
+  // first so they paint underneath).
+  _hlBoatHalo = L.circleMarker(boat, {
+    radius: 0, color: HELMLOG_COLOR, fillColor: HELMLOG_COLOR,
+    fillOpacity: 0.25, weight: 0, interactive: false,
+  }).addTo(_map);
+  _hlPinHalo = L.circleMarker(pin, {
+    radius: 0, color: HELMLOG_COLOR, fillColor: '#fbbf24',
+    fillOpacity: 0.25, weight: 0, interactive: false,
+  }).addTo(_map);
+
+  // Wind ticks pointing upwind from each end — redrawn every clock tick.
+  _hlBoatTick = L.polyline([boat, boat], {
+    color: HELMLOG_COLOR, weight: 2, opacity: 0.85, interactive: false,
+  }).addTo(_map);
+  _hlPinTick = L.polyline([pin, pin], {
+    color: HELMLOG_COLOR, weight: 2, opacity: 0.85, interactive: false,
+  }).addTo(_map);
+
+  // Bias label panel below the map (re-uses the existing track-hint area
+  // styling; we add our own tiny block right under it).
+  _ensureHlBiasLabel();
+
+  // Register as a play-clock surface so it updates on every tick/seek.
+  registerSurface('hl-start-bias', function(utc) { _renderHlStartBias(utc); });
+  // Initial render at the current cursor (may be _replayStart on first load).
+  if (_playClock && _playClock.positionUtc) {
+    _renderHlStartBias(_playClock.positionUtc);
+  }
+}
+
+function _ensureHlBiasLabel() {
+  if (_hlBiasLabel) return;
+  const container = document.getElementById('track-container');
+  if (!container) return;
+  _hlBiasLabel = document.createElement('div');
+  _hlBiasLabel.id = 'hl-bias-label';
+  _hlBiasLabel.style.cssText =
+    'font-size:.78rem;color:var(--text-secondary);padding:6px 8px;'
+    + 'background:var(--bg-input);border:1px solid var(--border);'
+    + 'border-radius:4px;margin-top:6px;font-variant-numeric:tabular-nums';
+  _hlBiasLabel.innerHTML = 'Line bias: <span id="hl-bias-text">—</span>';
+  container.appendChild(_hlBiasLabel);
+}
+
+function _renderHlStartBias(utc) {
+  if (!_hlStartLineData || !_hlBoatHalo || !_hlPinHalo) return;
+  const utcMs = utc instanceof Date ? utc.getTime() : new Date(utc).getTime();
+  const sample = _findReplaySampleAt(utcMs);
+  const twd = sample && sample.twd != null ? sample.twd : null;
+  const tws = sample && sample.tws != null ? sample.tws : null;
+  const lineBearing = _hlStartLineData.bearing_deg;
+  const boat = _hlStartLineData.boat;
+  const pin = _hlStartLineData.pin;
+  const lineLen = _hlStartLineData.length_m || 100;
+
+  const labelEl = document.getElementById('hl-bias-text');
+
+  if (twd == null) {
+    if (labelEl) labelEl.textContent = '— (no wind data at this moment)';
+    if (_hlBoatTick) _hlBoatTick.setLatLngs([boat, boat]);
+    if (_hlPinTick) _hlPinTick.setLatLngs([pin, pin]);
+    if (_hlBoatHalo) _hlBoatHalo.setRadius(0);
+    if (_hlPinHalo) _hlPinHalo.setRadius(0);
+    return;
+  }
+
+  // Bias = 90 − |angle_diff(line_bearing, twd)|. Positive = pin favoured.
+  const delta = _angleDiffDeg(lineBearing, twd);
+  const bias = 90 - Math.abs(delta);
+  const favoured = Math.abs(bias) < 1 ? 'neutral' : (bias > 0 ? 'pin' : 'boat');
+
+  // Wind ticks upwind from each end (toward TWD).
+  const tickLen = Math.max(40, lineLen * 0.4);
+  const boatUp = _offsetPoint(boat[0], boat[1], twd, tickLen);
+  const pinUp = _offsetPoint(pin[0], pin[1], twd, tickLen);
+  if (_hlBoatTick) _hlBoatTick.setLatLngs([boat, boatUp]);
+  if (_hlPinTick) _hlPinTick.setLatLngs([pin, pinUp]);
+
+  // Halo on the favoured end. Size scales with bias magnitude (1°→10px, 90°→25px).
+  const haloRadius = Math.min(25, 10 + Math.abs(bias) / 6);
+  if (favoured === 'boat') {
+    _hlBoatHalo.setRadius(haloRadius);
+    _hlPinHalo.setRadius(0);
+  } else if (favoured === 'pin') {
+    _hlPinHalo.setRadius(haloRadius);
+    _hlBoatHalo.setRadius(0);
+  } else {
+    _hlBoatHalo.setRadius(0);
+    _hlPinHalo.setRadius(0);
+  }
+
+  if (labelEl) {
+    const sign = bias >= 0 ? '+' : '';
+    const twsTxt = tws != null ? ' · ' + tws.toFixed(1) + ' kt' : '';
+    labelEl.innerHTML =
+      '<strong>' + sign + bias.toFixed(0) + '°</strong> '
+      + '<span style="text-transform:uppercase;letter-spacing:.05em">'
+      + favoured + '</span> favoured · TWD ' + Math.round(twd) + '°' + twsTxt;
   }
 }
 

--- a/tests/test_race_start_overlay.py
+++ b/tests/test_race_start_overlay.py
@@ -1,0 +1,134 @@
+"""HelmLog start-line overlay endpoint for the session detail page.
+
+Exposes ping history + computed line so the frontend can draw boat/pin
+markers and a time-synced bias indicator that follows the scrubber.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+_T = datetime(2026, 4, 30, 1, 25, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_overlay_404_for_unknown_race(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get("/api/sessions/9999/race-start-overlay")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_overlay_empty_when_no_pings(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Race exists but has no pings — line is null, pings list empty."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race = await storage.start_race(
+        event="CYC", start_utc=_T, date_str="2026-04-30", race_num=1, name="R"
+    )
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race.id}/race-start-overlay")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pings"] == []
+    assert body["line"] is None
+
+
+@pytest.mark.asyncio
+async def test_overlay_line_geometry(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Line returns boat/pin coords plus bearing + length to GPS precision."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race = await storage.start_race(
+        event="CYC", start_utc=_T, date_str="2026-04-30", race_num=1, name="R"
+    )
+    # ~100 m east-west line at lat 47.65.
+    await storage.add_start_line_ping(
+        race_id=race.id,
+        end_kind="boat",
+        latitude_deg=47.65,
+        longitude_deg=-122.4000,
+        captured_at=_T,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=race.id,
+        end_kind="pin",
+        latitude_deg=47.65,
+        longitude_deg=-122.39866,  # ~100 m east
+        captured_at=_T + timedelta(seconds=10),
+        captured_by=None,
+    )
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race.id}/race-start-overlay")
+    body = r.json()
+    assert len(body["pings"]) == 2
+    line = body["line"]
+    assert line is not None
+    # ~100 m line, due east → bearing ~90°.
+    assert line["length_m"] == pytest.approx(100.0, abs=2.0)
+    assert line["bearing_deg"] == pytest.approx(90.0, abs=1.0)
+    assert line["boat_end_carried_over_from_race_id"] is None
+    assert line["pin_end_carried_over_from_race_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_overlay_flags_carried_over_ends(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the line is carried over from a prior race, surface that
+    race_id so the UI can flag the line as stale."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    date = "2026-04-30"
+    r1 = await storage.start_race("CYC", _T, date, 1, "R1")
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="boat",
+        latitude_deg=47.65,
+        longitude_deg=-122.40,
+        captured_at=_T,
+        captured_by=None,
+    )
+    await storage.add_start_line_ping(
+        race_id=r1.id,
+        end_kind="pin",
+        latitude_deg=47.6510,
+        longitude_deg=-122.40,
+        captured_at=_T,
+        captured_by=None,
+    )
+    r2 = await storage.start_race("CYC", _T + timedelta(minutes=30), date, 2, "R2")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{r2.id}/race-start-overlay")
+    body = r.json()
+    line = body["line"]
+    assert line is not None
+    assert line["boat_end_carried_over_from_race_id"] == r1.id
+    assert line["pin_end_carried_over_from_race_id"] == r1.id


### PR DESCRIPTION
## Summary

Adds boat-end and pin-end markers for HelmLog pings on the session map plus a **time-synced bias indicator** that follows the replay scrubber. As you scrub through the prestart, the favoured end pulses with a halo whose size scales with bias magnitude, and a label below the map reads e.g. \"+12° pin favoured · TWD 195° · 8.4 kt\".

Goal: build crew judgment on which end is favoured at the gun, and let you replay the prestart to see how that judgment evolved as the wind shifted.

## What changed

### Backend

- New \`GET /api/sessions/{id}/race-start-overlay\`. Returns:
  - \`pings\`: ping history (\`end_kind\`, lat/lon, ts)
  - \`line\`: latest boat + pin (with \`#702\` carry-over annotations) + computed bearing/length
- Cheap — reuses \`list_start_line_pings\` + \`get_latest_start_line\`. No new tables.

### Frontend (session.js)

- \`loadHelmlogStartLineOverlay()\` draws static boat/pin circle markers and a dashed orange line on the existing leaflet map.
- Registers an \`hl-start-bias\` play-clock surface. On every tick/seek:
  - Binary-searches \`_replaySamples\` for the TWD nearest the cursor.
  - Recomputes bias = \`90 − |Δ(line_bearing, TWD)|\` (matches \`race_start.line_metrics\`).
  - Redraws upwind ticks at each line end (toward TWD).
  - Sizes a coloured halo on the favoured end (10 px at 1° bias → 25 px at 90°).
  - Updates the bias label below the map.
- No fetch on scrub — all derived from already-loaded samples.

The widget's static map render (\`race_start_widget.js\`) is suppressed on \`/session/*\` paths so we don't paint duplicate lines on top of the new overlay.

## Why this matters

The Vakaros overlay shows wind ticks at \"gun time\" only — a single snapshot. With a time-synced overlay, the helm + tactician can replay the prestart and see exactly when the line bias swung favourable for the boat-end vs. the pin, which side the wind was on at each moment, and whether their on-the-water call matched what the data shows.

## Risk tier

**Standard**. New read-only endpoint, JS-only frontend changes, no schema, no auth changes, no migration. Cache-friendly: the overlay endpoint is not (yet) cached because it's small and infrequent. Existing replay cache untouched.

## Tests

- \`test_overlay_404_for_unknown_race\`
- \`test_overlay_empty_when_no_pings\`
- \`test_overlay_line_geometry\` — 100 m east-west line, bearing ≈ 90° within 1°
- \`test_overlay_flags_carried_over_ends\` — \`#702\` carry-over surfaces correctly

\`uv run pytest tests/test_race_start_overlay.py\`: 4 pass. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)