### PR TITLE
feat: show scheduled start on /race-start (pursuit-start use case)

### DIFF
--- a/src/helmlog/routes/race_start.py
+++ b/src/helmlog/routes/race_start.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -264,6 +267,31 @@ async def _build_snapshot(request: Request, state: SequenceState) -> dict[str, A
         },
         "line_metrics": metrics_payload,
         "race_id": race_id,
+        "scheduled_start": await _scheduled_start_payload(storage),
+    }
+
+
+async def _scheduled_start_payload(storage: Storage) -> dict[str, Any] | None:
+    """Surface the active scheduled-start row (if any) so /race-start can
+    display the upcoming gun and offer an "Arm for scheduled start" button.
+
+    Use case: pursuit starts where each boat's gun depends on rating —
+    the helm sets the schedule the night before, and the page shows the
+    countdown without anyone needing to remember to arm at the right
+    moment.
+    """
+    row = await storage.get_scheduled_start()
+    if row is None:
+        return None
+    fire_at = datetime.fromisoformat(row["scheduled_start_utc"])
+    if fire_at.tzinfo is None:
+        fire_at = fire_at.replace(tzinfo=UTC)
+    seconds_until = max(0, int((fire_at - datetime.now(UTC)).total_seconds()))
+    return {
+        "scheduled_start_utc": fire_at.isoformat(),
+        "event": row["event"],
+        "session_type": row["session_type"],
+        "seconds_until_start": seconds_until,
     }
 
 

--- a/src/helmlog/static/race_start.js
+++ b/src/helmlog/static/race_start.js
@@ -87,6 +87,41 @@
     }
   }
 
+  function fmtCountdown(seconds) {
+    const sign = seconds < 0 ? "−" : "";
+    const abs = Math.abs(Math.floor(seconds));
+    const days = Math.floor(abs / 86400);
+    const hrs = Math.floor((abs % 86400) / 3600);
+    const min = Math.floor((abs % 3600) / 60);
+    const sec = abs % 60;
+    if (days > 0) return sign + days + "d " + hrs + "h " + min + "m";
+    if (hrs > 0) return sign + hrs + "h " + min + "m " + sec + "s";
+    if (min > 0) return sign + min + "m " + sec + "s";
+    return sign + sec + "s";
+  }
+
+  function renderScheduledStart() {
+    const wrap = document.getElementById("rs-scheduled");
+    if (!wrap || !snapshot) return;
+    const sched = snapshot.scheduled_start;
+    // Show only when there's a schedule AND the FSM hasn't been armed
+    // against it yet — once the helm arms, the live countdown is the
+    // primary surface and we hide the scheduled banner.
+    if (!sched || (snapshot.phase !== "idle" && snapshot.phase !== "abandoned")) {
+      wrap.style.display = "none";
+      return;
+    }
+    wrap.style.display = "";
+    const fireMs = new Date(sched.scheduled_start_utc).getTime();
+    const localTime = new Date(fireMs).toLocaleString();
+    document.getElementById("rs-sched-utc").textContent = localTime;
+    const ev = document.getElementById("rs-sched-event");
+    ev.textContent = sched.event ? "· " + sched.event : "";
+    const remaining = (fireMs - virtualNowMs()) / 1000;
+    document.getElementById("rs-sched-countdown").textContent =
+      fmtCountdown(remaining);
+  }
+
   function renderLineCarryover() {
     const el = document.getElementById("rs-line-carryover");
     if (!el || !snapshot || !snapshot.start_line) return;
@@ -151,6 +186,7 @@
       renderPhase();
       renderFlags();
       renderClock();
+      renderScheduledStart();
       renderLineMetrics(snapshot.line_metrics);
       showError("");
     } catch (e) {
@@ -187,6 +223,7 @@
       renderPhase();
       renderFlags();
       renderClock();
+      renderScheduledStart();
       renderLineMetrics(snapshot.line_metrics);
     } catch (e) {
       showError(e.message);
@@ -209,6 +246,12 @@
 
   bind("rs-arm", () => action("/api/race-start/arm",
         { kind: "5-4-1-0", t0_utc: defaultT0Utc() }));
+  bind("rs-arm-sched", () => {
+    const sched = snapshot && snapshot.scheduled_start;
+    if (!sched) return showError("no scheduled start");
+    action("/api/race-start/arm",
+      { kind: "5-4-1-0", t0_utc: sched.scheduled_start_utc, classes: [] });
+  });
   bind("rs-sync", () => {
     if (!snapshot || !snapshot.t0_utc) return showError("arm a sequence first");
     // Sync rounds the countdown to the nearest minute. Use case: user
@@ -256,6 +299,9 @@
   // 2 s × handful of devices the load is negligible and the flow is
   // robust to disconnect.
   setInterval(renderClock, 250);
+  // Tick the scheduled-start countdown alongside the main clock so the
+  // helm sees the seconds drop without waiting for the 2 s state poll.
+  setInterval(renderScheduledStart, 1000);
   setInterval(refreshState, 2000);
 
   refreshState();

--- a/src/helmlog/templates/race_start.html
+++ b/src/helmlog/templates/race_start.html
@@ -45,6 +45,17 @@
   <div class="rs-phase">Phase: <strong id="rs-phase">—</strong>
     <span id="rs-sync-status"></span></div>
 
+  <div id="rs-scheduled" style="display:none;text-align:center;padding:.5rem;
+       background:var(--bg-elev,#1a1d23);border:1px solid var(--border);
+       border-radius:.5rem;font-size:.9rem;color:var(--text-secondary)">
+    <div>Scheduled start: <strong id="rs-sched-utc">—</strong>
+      <span id="rs-sched-event" style="color:var(--text-muted)"></span></div>
+    <div style="margin-top:.25rem;font-variant-numeric:tabular-nums">
+      in <strong id="rs-sched-countdown">—</strong></div>
+    <button id="rs-arm-sched" class="primary" style="margin-top:.5rem"
+      {% if not is_writer %}disabled{% endif %}>Arm 5-4-1-0 for scheduled start</button>
+  </div>
+
   <div class="rs-clock" id="rs-clock">--:--</div>
 
   <div class="rs-flags">

--- a/tests/test_race_start_web.py
+++ b/tests/test_race_start_web.py
@@ -77,6 +77,30 @@ async def test_state_returns_idle_initially(storage: Storage) -> None:
     assert body["phase"] == "idle"
     assert body["t0_utc"] is None
     assert body["start_line"]["is_complete"] is False
+    # No schedule by default.
+    assert body["scheduled_start"] is None
+
+
+@pytest.mark.asyncio
+async def test_state_surfaces_scheduled_start(storage: Storage) -> None:
+    """When a scheduled start row exists, /api/race-start/state exposes it
+    so the page can render the upcoming-gun banner + arm button. Pursuit
+    starts (helm sets the gun the night before) drove this addition."""
+    fire_at = datetime.now(UTC) + timedelta(hours=22)
+    await storage.schedule_start(fire_at, event="R2TS", session_type="race")
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get("/api/race-start/state")
+    body = r.json()
+    sched = body["scheduled_start"]
+    assert sched is not None
+    assert sched["event"] == "R2TS"
+    assert sched["session_type"] == "race"
+    # seconds_until_start ≈ 22 h within a couple seconds for test latency.
+    assert sched["seconds_until_start"] > 22 * 3600 - 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Pursuit start tomorrow for Race to the Straits — each boat's gun depends on rating. The helm sets the schedule the night before via \`/api/races/schedule\`, but \`/race-start\` showed \"idle\" with no hint of the upcoming gun. Now the page surfaces the scheduled time + a live countdown + a one-tap **Arm 5-4-1-0 for scheduled start** button.

## What changed

- \`/api/race-start/state\` returns \`scheduled_start: { scheduled_start_utc, event, session_type, seconds_until_start }\` when \`storage.get_scheduled_start()\` has a row, else \`null\`. No new tables — reuses the existing \`scheduled_starts\` row that \`/api/races/schedule\` already writes.
- \`/race-start\` page renders a banner (visible only when phase is idle/abandoned and a schedule exists) showing local-time scheduled gun, event, countdown, and the Arm button. Hides as soon as the helm arms.
- Countdown ticks at 1 Hz client-side so seconds drop smoothly between the 2 s state polls.

## Why this matters for tomorrow

Race to the Straits has rolling pursuit guns. Without this surface, the helm has to either: (a) remember to arm at exactly t0 − 5 min, or (b) walk through the schedule UI. With it, they open the page, see "Scheduled start: 13:42 PDT · in 22h 14m · Arm 5-4-1-0 for scheduled start", and can arm with one tap when the time is right (or just leave it and hit arm at t0 − 5).

## Risk tier

**Standard**. Snapshot field addition + UI block. No schema, no auth changes, no migration.

## Tests

- \`test_state_returns_idle_initially\` — \`scheduled_start\` is null without a schedule row
- \`test_state_surfaces_scheduled_start\` — sets a schedule 22 h out, asserts the snapshot reports it with the right event + remaining seconds

\`uv run pytest tests/test_race_start_web.py\`: 29 pass. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)