### PR TITLE
feat: scheduled-start auto-fires at T-15min, hands-off countdown to gun

### DIFF
--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -93,8 +93,21 @@ async def api_delete_event_rule(
 # ------------------------------------------------------------------
 
 
+#: How many seconds before the scheduled gun the system auto-starts the
+#: race + arms the race-start FSM. Pursuit starts (#714) want the helm
+#: hands-off ahead of the gun, so we lead by a full 5-4-1-0 sequence
+#: plus a margin for setup.
+SCHEDULE_LEAD_S: int = 15 * 60
+
+
 async def _schedule_fire_loop(app: FastAPI) -> None:
-    """Background task: poll for a pending scheduled start and fire when due."""
+    """Background task: poll for a pending scheduled start and fire when due.
+
+    Fires ``SCHEDULE_LEAD_S`` seconds before the configured gun time so the
+    race recording starts in time and the FSM arms automatically with
+    ``t0 = scheduled_start_utc``. The 5-4-1-0 sequence then plays out
+    against the real wall clock without any helm action.
+    """
     storage = app.state.storage
     ss = app.state.session_state
     while True:
@@ -105,16 +118,18 @@ async def _schedule_fire_loop(app: FastAPI) -> None:
                 if fire_at.tzinfo is None:
                     fire_at = fire_at.replace(tzinfo=UTC)
                 now = datetime.now(UTC)
-                if now >= fire_at:
-                    if not ss.schedule_first_check_done:
-                        # First check after startup — missed start, don't fire
+                lead_threshold = fire_at - timedelta(seconds=SCHEDULE_LEAD_S)
+                if now >= lead_threshold:
+                    if not ss.schedule_first_check_done and now > fire_at:
+                        # System was off through the lead window AND past the
+                        # gun — can't recover, drop the schedule.
                         logger.warning(
                             "Scheduled start at {} was missed — system was not running",
                             row["scheduled_start_utc"],
                         )
                         await storage.cancel_scheduled_start()
                     else:
-                        # Normal operation — fire the scheduled start
+                        # Normal operation: fire + arm with t0 = the gun.
                         current = await storage.get_current_race()
                         if current is not None:
                             await storage.cancel_scheduled_start()
@@ -124,7 +139,12 @@ async def _schedule_fire_loop(app: FastAPI) -> None:
                             )
                         else:
                             await storage.cancel_scheduled_start()
-                            await _do_scheduled_start(app, row["event"], row["session_type"])
+                            await _do_scheduled_start(
+                                app,
+                                row["event"],
+                                row["session_type"],
+                                gun_at=fire_at,
+                            )
             ss.schedule_first_check_done = True
         except asyncio.CancelledError:
             raise
@@ -133,8 +153,19 @@ async def _schedule_fire_loop(app: FastAPI) -> None:
         await asyncio.sleep(1)
 
 
-async def _do_scheduled_start(app: FastAPI, event: str, session_type: str) -> None:
-    """Fire a scheduled start — equivalent to pressing Start."""
+async def _do_scheduled_start(
+    app: FastAPI,
+    event: str,
+    session_type: str,
+    gun_at: datetime | None = None,
+) -> None:
+    """Fire a scheduled start — equivalent to pressing Start.
+
+    When *gun_at* is supplied (the schedule's authoritative gun time), the
+    race-start FSM is also armed with ``t0 = gun_at`` so the helmsman gets
+    a hands-off countdown to the actual gun. Used by the auto-fire path
+    that runs ``SCHEDULE_LEAD_S`` seconds before the gun.
+    """
     storage = app.state.storage
     ss = app.state.session_state
     from helmlog.races import build_race_name, local_today
@@ -147,6 +178,28 @@ async def _do_scheduled_start(app: FastAPI, event: str, session_type: str) -> No
     try:
         race = await storage.start_race(event, now, date_str, race_num, name, session_type)
         logger.info("Scheduled start fired: {} (id={})", race.name, race.id)
+
+        # Auto-arm the race-start FSM with the authoritative gun time so
+        # the page transitions straight into a 5-4-1-0 countdown without
+        # the helm needing to tap Arm.
+        if gun_at is not None:
+            try:
+                await storage.upsert_race_start_state(
+                    phase="armed",
+                    kind="5-4-1-0",
+                    t0_utc=gun_at,
+                    sync_offset_s=0.0,
+                    last_sync_at_utc=None,
+                    started_at_utc=None,
+                    classes_json="[]",
+                    now_utc=now,
+                )
+                logger.info(
+                    "Race-start FSM auto-armed for scheduled gun at {}",
+                    gun_at.isoformat(),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Race-start auto-arm failed for scheduled race {}: {}", name, exc)
 
         # Auto-apply sail defaults
         try:

--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -1142,21 +1142,29 @@ async function cancelSchedule() {
   await loadState();
 }
 
+function _fmtScheduleCountdown(seconds) {
+  if (seconds <= 0) return 'Starting...';
+  const days = Math.floor(seconds / 86400);
+  const hrs = Math.floor((seconds % 86400) / 3600);
+  const min = Math.floor((seconds % 3600) / 60);
+  const sec = seconds % 60;
+  if (days > 0) return `${days}d ${hrs}h ${min}m ${String(sec).padStart(2, '0')}s`;
+  if (hrs > 0) return `${hrs}h ${min}m ${String(sec).padStart(2, '0')}s`;
+  if (min > 0) return `${min}m ${String(sec).padStart(2, '0')}s`;
+  return `${sec}s`;
+}
+
 function _startScheduleCountdown(fireAt) {
   _stopScheduleCountdown();
   const el = document.getElementById('schedule-countdown-time');
   function update() {
     const diff = Math.max(0, Math.floor((fireAt - Date.now()) / 1000));
+    el.textContent = _fmtScheduleCountdown(diff);
     if (diff <= 0) {
-      el.textContent = 'Starting...';
       _stopScheduleCountdown();
-      // Poll state to pick up the new race
+      // Poll state to pick up the new race.
       setTimeout(() => loadState(), 2000);
-      return;
     }
-    const m = Math.floor(diff / 60);
-    const s = diff % 60;
-    el.textContent = `${m}:${String(s).padStart(2, '0')}`;
   }
   update();
   scheduleCountdownInterval = setInterval(update, 1000);

--- a/src/helmlog/static/race_start.js
+++ b/src/helmlog/static/race_start.js
@@ -101,25 +101,31 @@
   }
 
   function renderScheduledStart() {
-    const wrap = document.getElementById("rs-scheduled");
-    if (!wrap || !snapshot) return;
+    const schedView = document.getElementById("rs-scheduled-view");
+    const liveView = document.getElementById("rs-live-view");
+    if (!schedView || !liveView || !snapshot) return;
     const sched = snapshot.scheduled_start;
-    // Show only when there's a schedule AND the FSM hasn't been armed
-    // against it yet — once the helm arms, the live countdown is the
-    // primary surface and we hide the scheduled banner.
-    if (!sched || (snapshot.phase !== "idle" && snapshot.phase !== "abandoned")) {
-      wrap.style.display = "none";
-      return;
+    // Scheduled-pre-arm: only when a schedule is set AND the FSM is still
+    // idle. Hide the live FSM controls entirely — auto-fire at T-15min
+    // takes over without any helm action, and cancellation lives on
+    // /control to avoid accidental taps near a real start.
+    const showScheduled =
+      !!sched && (snapshot.phase === "idle" || snapshot.phase === "abandoned");
+    if (showScheduled) {
+      schedView.style.display = "";
+      liveView.style.display = "none";
+      const fireMs = new Date(sched.scheduled_start_utc).getTime();
+      document.getElementById("rs-sched-utc").textContent =
+        new Date(fireMs).toLocaleString();
+      const ev = document.getElementById("rs-sched-event");
+      ev.textContent = sched.event ? "· " + sched.event : "";
+      const remaining = (fireMs - virtualNowMs()) / 1000;
+      document.getElementById("rs-sched-countdown").textContent =
+        fmtCountdown(remaining);
+    } else {
+      schedView.style.display = "none";
+      liveView.style.display = "";
     }
-    wrap.style.display = "";
-    const fireMs = new Date(sched.scheduled_start_utc).getTime();
-    const localTime = new Date(fireMs).toLocaleString();
-    document.getElementById("rs-sched-utc").textContent = localTime;
-    const ev = document.getElementById("rs-sched-event");
-    ev.textContent = sched.event ? "· " + sched.event : "";
-    const remaining = (fireMs - virtualNowMs()) / 1000;
-    document.getElementById("rs-sched-countdown").textContent =
-      fmtCountdown(remaining);
   }
 
   function renderLineCarryover() {
@@ -246,12 +252,6 @@
 
   bind("rs-arm", () => action("/api/race-start/arm",
         { kind: "5-4-1-0", t0_utc: defaultT0Utc() }));
-  bind("rs-arm-sched", () => {
-    const sched = snapshot && snapshot.scheduled_start;
-    if (!sched) return showError("no scheduled start");
-    action("/api/race-start/arm",
-      { kind: "5-4-1-0", t0_utc: sched.scheduled_start_utc, classes: [] });
-  });
   bind("rs-sync", () => {
     if (!snapshot || !snapshot.t0_utc) return showError("arm a sequence first");
     // Sync rounds the countdown to the nearest minute. Use case: user

--- a/src/helmlog/templates/race_start.html
+++ b/src/helmlog/templates/race_start.html
@@ -45,60 +45,68 @@
   <div class="rs-phase">Phase: <strong id="rs-phase">—</strong>
     <span id="rs-sync-status"></span></div>
 
-  <div id="rs-scheduled" style="display:none;text-align:center;padding:.5rem;
-       background:var(--bg-elev,#1a1d23);border:1px solid var(--border);
-       border-radius:.5rem;font-size:.9rem;color:var(--text-secondary)">
-    <div>Scheduled start: <strong id="rs-sched-utc">—</strong>
-      <span id="rs-sched-event" style="color:var(--text-muted)"></span></div>
-    <div style="margin-top:.25rem;font-variant-numeric:tabular-nums">
-      in <strong id="rs-sched-countdown">—</strong></div>
-    <button id="rs-arm-sched" class="primary" style="margin-top:.5rem"
-      {% if not is_writer %}disabled{% endif %}>Arm 5-4-1-0 for scheduled start</button>
-  </div>
-
-  <div class="rs-clock" id="rs-clock">--:--</div>
-
-  <div class="rs-flags">
-    <div class="rs-flag-cell">
-      <div class="label">Class flag</div>
-      <div class="value" id="rs-class-flag">—</div>
+  <!-- Scheduled-pre-arm view: only visible when a schedule exists and the
+       FSM is still idle. Big d:hh:mm:ss countdown, no buttons — the
+       system auto-fires at T-15min so the helm can't accidentally arm
+       early or out-of-band. -->
+  <div id="rs-scheduled-view" style="display:none;text-align:center">
+    <div style="font-size:.9rem;color:var(--text-secondary)">
+      Scheduled start: <strong id="rs-sched-utc">—</strong>
+      <span id="rs-sched-event" style="color:var(--text-muted)"></span>
     </div>
-    <div class="rs-flag-cell">
-      <div class="label">Prep flag</div>
-      <div class="value" id="rs-prep-flag">—</div>
-    </div>
-    <div class="rs-flag-cell">
-      <div class="label">Special</div>
-      <div class="value" id="rs-special-flag">—</div>
+    <div id="rs-sched-countdown" class="rs-clock" style="color:var(--accent,#2563eb)">—</div>
+    <div style="font-size:.85rem;color:var(--text-muted)">
+      Auto-arms 15 min before the gun. Cancel from <a href="/control">/control</a>.
     </div>
   </div>
 
-  <div class="rs-grid-buttons">
-    <button id="rs-sync" class="primary" {% if not is_writer %}disabled{% endif %}>Sync to gun</button>
-    <button id="rs-arm" {% if not is_writer %}disabled{% endif %}>Arm 5-4-1-0</button>
-    <button id="rs-ping-boat" {% if not is_writer %}disabled{% endif %}>Boat-end ping</button>
-    <button id="rs-ping-pin" {% if not is_writer %}disabled{% endif %}>Pin-end ping</button>
-    <button id="rs-plus-min" {% if not is_writer %}disabled{% endif %}>+1 min</button>
-    <button id="rs-minus-min" {% if not is_writer %}disabled{% endif %}>−1 min</button>
-  </div>
+  <!-- Live FSM view: shown whenever the FSM is non-idle, or when no
+       schedule is set (so manual arm is still possible). -->
+  <div id="rs-live-view">
+    <div class="rs-clock" id="rs-clock">--:--</div>
 
-  <div class="rs-row">
-    <button id="rs-postpone" {% if not is_writer %}disabled{% endif %}>Postpone (AP)</button>
-    <button id="rs-recall" {% if not is_writer %}disabled{% endif %}>General recall</button>
-    <button id="rs-abandon" class="danger" {% if not is_writer %}disabled{% endif %}>Abandon (N)</button>
-    <button id="rs-reset" {% if not is_writer %}disabled{% endif %}>Reset</button>
-  </div>
+    <div class="rs-flags">
+      <div class="rs-flag-cell">
+        <div class="label">Class flag</div>
+        <div class="value" id="rs-class-flag">—</div>
+      </div>
+      <div class="rs-flag-cell">
+        <div class="label">Prep flag</div>
+        <div class="value" id="rs-prep-flag">—</div>
+      </div>
+      <div class="rs-flag-cell">
+        <div class="label">Special</div>
+        <div class="value" id="rs-special-flag">—</div>
+      </div>
+    </div>
 
-  <div class="rs-line">
-    <div id="rs-line-carryover" style="display:none;color:var(--warning,#f5c518);
-         font-size:.85rem;padding:.25rem 0;font-style:italic"></div>
-    <dl>
-      <dt>Line bearing</dt><dd id="rs-line-bearing">—</dd>
-      <dt>Line length</dt><dd id="rs-line-length">—</dd>
-      <dt>Bias</dt><dd id="rs-line-bias">—</dd>
-      <dt>Distance to line</dt><dd id="rs-line-dist">—</dd>
-      <dt>Time to line</dt><dd id="rs-line-time">—</dd>
-    </dl>
+    <div class="rs-grid-buttons">
+      <button id="rs-sync" class="primary" {% if not is_writer %}disabled{% endif %}>Sync to gun</button>
+      <button id="rs-arm" {% if not is_writer %}disabled{% endif %}>Arm 5-4-1-0</button>
+      <button id="rs-ping-boat" {% if not is_writer %}disabled{% endif %}>Boat-end ping</button>
+      <button id="rs-ping-pin" {% if not is_writer %}disabled{% endif %}>Pin-end ping</button>
+      <button id="rs-plus-min" {% if not is_writer %}disabled{% endif %}>+1 min</button>
+      <button id="rs-minus-min" {% if not is_writer %}disabled{% endif %}>−1 min</button>
+    </div>
+
+    <div class="rs-row">
+      <button id="rs-postpone" {% if not is_writer %}disabled{% endif %}>Postpone (AP)</button>
+      <button id="rs-recall" {% if not is_writer %}disabled{% endif %}>General recall</button>
+      <button id="rs-abandon" class="danger" {% if not is_writer %}disabled{% endif %}>Abandon (N)</button>
+      <button id="rs-reset" {% if not is_writer %}disabled{% endif %}>Reset</button>
+    </div>
+
+    <div class="rs-line">
+      <div id="rs-line-carryover" style="display:none;color:var(--warning,#f5c518);
+           font-size:.85rem;padding:.25rem 0;font-style:italic"></div>
+      <dl>
+        <dt>Line bearing</dt><dd id="rs-line-bearing">—</dd>
+        <dt>Line length</dt><dd id="rs-line-length">—</dd>
+        <dt>Bias</dt><dd id="rs-line-bias">—</dd>
+        <dt>Distance to line</dt><dd id="rs-line-dist">—</dd>
+        <dt>Time to line</dt><dd id="rs-line-time">—</dd>
+      </dl>
+    </div>
   </div>
 
   <div class="rs-error" id="rs-error"></div>

--- a/tests/test_scheduled_start_autofire.py
+++ b/tests/test_scheduled_start_autofire.py
@@ -1,0 +1,72 @@
+"""Tests for the schedule auto-fire path.
+
+When the schedule fires (T-15min before the configured gun), the system
+should: (a) create the race row, (b) cancel the schedule row, (c) auto-arm
+the race-start FSM with t0 = scheduled gun. The 5-4-1-0 sequence then
+plays out hands-off.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from helmlog.routes.races import SCHEDULE_LEAD_S, _do_scheduled_start
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+@pytest.mark.asyncio
+async def test_lead_constant_is_15min() -> None:
+    assert SCHEDULE_LEAD_S == 15 * 60
+
+
+@pytest.mark.asyncio
+async def test_do_scheduled_start_arms_fsm_when_gun_supplied(
+    storage: Storage,
+) -> None:
+    """_do_scheduled_start with gun_at: race row created + FSM armed at gun."""
+    gun = datetime.now(UTC) + timedelta(minutes=15)
+
+    # Build a stub app with the bits _do_scheduled_start touches.
+    app = MagicMock()
+    app.state.storage = storage
+    app.state.recorder = None
+    app.state.audio_config = None
+    app.state.session_state = MagicMock()
+
+    await _do_scheduled_start(app, event="R2TS", session_type="race", gun_at=gun)
+
+    # Race row exists.
+    current = await storage.get_current_race()
+    assert current is not None
+    assert current.event == "R2TS"
+
+    # FSM is armed with t0 = gun.
+    fsm = await storage.get_race_start_state()
+    assert fsm is not None
+    assert fsm["phase"] == "armed"
+    assert fsm["kind"] == "5-4-1-0"
+    assert fsm["t0_utc"] == gun.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_do_scheduled_start_no_gun_does_not_arm(storage: Storage) -> None:
+    """Without gun_at (legacy callers), _do_scheduled_start creates the race
+    but does not touch the FSM."""
+    app = MagicMock()
+    app.state.storage = storage
+    app.state.recorder = None
+    app.state.audio_config = None
+    app.state.session_state = MagicMock()
+
+    await _do_scheduled_start(app, event="TestRegatta", session_type="race")
+
+    current = await storage.get_current_race()
+    assert current is not None
+    fsm = await storage.get_race_start_state()
+    assert fsm is None


### PR DESCRIPTION
## Summary

Pursuit start workflow tightened up. Helm sets the schedule the night before; the system handles the rest.

## Behaviour

**Before**: scheduled start fired AT the gun (race row created at t0). FSM stayed idle. Helm had to remember to arm at t0 − 5min and the page showed a regular m:ss countdown only after they did.

**Now**:
- At **T − 15 min** the schedule fires. Race row is created. The race-start FSM is auto-armed with \`t0 = scheduled_gun\`.
- \`/race-start\` while a schedule is set but FSM is still idle: **single big d:hh:mm:ss countdown** to the gun. **No Arm or Sync** buttons (or any other action buttons). A small hint tells the helm cancellation lives on \`/control\`.
- Once auto-fire happens, the existing 5-4-1-0 live view replaces the scheduled-pre-arm view smoothly.
- \`/control\`'s existing schedule-countdown panel now renders d:hh:mm:ss (was m:ss only) — useful when the schedule is hours or days out.

The race row's \`start_utc\` gets gun-anchored to \`t0\` when the FSM transitions to \`started\` (existing \`#644\` behaviour), so the session is anchored to the actual gun moment, not the T-15min fire moment.

## What changed

- \`routes/races.py\`:
  - \`SCHEDULE_LEAD_S = 15 × 60\` constant.
  - \`_schedule_fire_loop\` triggers at \`now ≥ gun − SCHEDULE_LEAD_S\`.
  - \`_do_scheduled_start(..., gun_at=...)\` arms the FSM via \`storage.upsert_race_start_state\` after starting the race.
  - "Missed start" path now requires \`now > scheduled_gun\` before dropping the row, so a system that comes up inside the lead window still fires correctly.
- \`templates/race_start.html\`: split layout into \`#rs-scheduled-view\` (countdown only) and \`#rs-live-view\` (existing FSM controls). JS toggles based on \`scheduled_start && phase === 'idle'\`.
- \`static/race_start.js\`: existing \`fmtCountdown\` already produces d:hh:mm:ss; just routes the scheduled-pre-arm view through it. Removes the obsolete \"Arm 5-4-1-0 for scheduled start\" button binding.
- \`static/home.js\`: \`_startScheduleCountdown\` now formats d:hh:mm:ss instead of m:ss.

## Risk tier

**Standard**. \`routes/races.py\` schedule logic + JS-only UI. No schema, no auth changes, no migration.

## Tests

- \`SCHEDULE_LEAD_S\` is 900s.
- \`_do_scheduled_start\` with \`gun_at\` creates the race row AND arms the FSM at the gun.
- Without \`gun_at\` (legacy) the race row is created and the FSM stays idle.

\`uv run pytest tests/test_scheduled_start*.py tests/test_race_start_web.py\`: 52 pass. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)