### PR TITLE
fix: scheduled-start input accepts seconds (pursuit-start precision)

### DIFF
--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -1105,10 +1105,12 @@ function toggleSchedulePanel() {
   const panel = document.getElementById('schedule-panel');
   panel.classList.toggle('hidden');
   if (!panel.classList.contains('hidden')) {
-    // Pre-fill with a time 5 minutes from now
+    // Pre-fill with a time 5 minutes from now, second-precise (the input
+    // has step="1" so seconds are editable for pursuit-start times).
     const d = new Date(Date.now() + 5 * 60000);
     const pad = n => String(n).padStart(2, '0');
-    const local = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    const local = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`
+      + `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
     document.getElementById('schedule-time').value = local;
   }
 }

--- a/src/helmlog/templates/home.html
+++ b/src/helmlog/templates/home.html
@@ -168,7 +168,7 @@
   <div class="label">Schedule Start Time</div>
   <div class="field">
     <label for="schedule-time">Start time (local)</label>
-    <input id="schedule-time" type="datetime-local" style="width:100%;padding:4px 0;background:transparent;color:var(--text-primary)"/>
+    <input id="schedule-time" type="datetime-local" step="1" style="width:100%;padding:4px 0;background:transparent;color:var(--text-primary)"/>
   </div>
   <div style="display:flex;gap:8px;margin-top:8px">
     <button class="btn btn-primary" onclick="submitSchedule()" style="flex:1">Schedule</button>


### PR DESCRIPTION
## Summary

Pursuit starts hand out gun times with second precision (e.g. 13:42:**17**). The \`datetime-local\` input on \`/control\` defaulted to minute-only granularity, silently truncating the user's seconds input.

## Changes

- \`step=\"1\"\` on the schedule \`<input>\` so the browser picker exposes a seconds field.
- Pre-fill writes \`YYYY-MM-DDTHH:MM:SS\` so the editable seconds field isn't blank.
- Backend (\`datetime.fromisoformat\`) already accepted any precision; no API change.

## Risk tier

**Trivial**. UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)