### PR TITLE
fix(track): live track grows past start_utc during active race

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -82,7 +82,10 @@ async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
     start_iso = str(race["start_utc"])
     end_iso = str(race["end_utc"]) if race["end_utc"] is not None else None
 
-    # Row count: prefer race_id tagging, fall back to time window.
+    # Row count: prefer race_id tagging, fall back to time window. For an
+    # active race (end_iso is None), use "now" as the upper bound so the
+    # count grows as positions stream in — otherwise the hash would be
+    # frozen and the cache would serve stale track blobs forever.
     rid_cur = await db.execute(
         "SELECT COUNT(*) AS cnt FROM positions WHERE race_id = ?", (race_id,)
     )
@@ -91,7 +94,7 @@ async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
     if n_tagged > 0:
         row_count = n_tagged
     else:
-        window_end = end_iso or start_iso
+        window_end = end_iso or datetime.now(UTC).isoformat()
         win_cur = await db.execute(
             "SELECT COUNT(*) AS cnt FROM positions WHERE ts >= ? AND ts <= ?",
             (start_iso, window_end),

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -332,7 +332,7 @@ async def _compute_session_track(storage: Storage, session_id: int) -> dict[str,
     the race doesn't exist — the HTTP path surfaces that; the warmer
     catches and logs it.
     """
-    from datetime import datetime, timedelta
+    from datetime import UTC, datetime, timedelta
 
     db = storage._conn()
     cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
@@ -340,7 +340,11 @@ async def _compute_session_track(storage: Storage, session_id: int) -> dict[str,
     if row is None:
         raise HTTPException(status_code=404, detail="Race not found")
     start_utc = row["start_utc"]
-    end_utc = row["end_utc"] or start_utc
+    # Active race (end_utc IS NULL): bound the upper window at "now" so live
+    # positions written after the gun appear on the map. Falling back to
+    # start_utc here would collapse the window and freeze the track at the
+    # gun (the bug behind this regression).
+    end_utc = row["end_utc"] or datetime.now(UTC).isoformat()
 
     # Prestart cutoff: start_utc shifted back by the configured window.
     try:

--- a/tests/test_session_track_prestart.py
+++ b/tests/test_session_track_prestart.py
@@ -175,6 +175,75 @@ async def test_replay_samples_extend_into_prestart(
 
 
 @pytest.mark.asyncio
+async def test_track_includes_post_gun_for_active_race(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """While the race is in progress (end_utc IS NULL), the track must
+    include positions written *after* start_utc — not just the prestart
+    prefix. Regression: the bounded query collapsed to [start, start]
+    when end_utc was NULL, so live tracks froze at the gun."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race = await storage.start_race(
+        event="CYC", start_utc=_GUN, date_str="2026-04-30", race_num=1, name="R"
+    )
+    db = storage._conn()
+    # 3 prestart fixes + 4 post-gun fixes, all unscoped (race_id IS NULL),
+    # which is what the SK reader produces during an active race.
+    for offset_s in (-180, -120, -60, 30, 60, 120, 180):
+        ts = (_GUN + timedelta(seconds=offset_s)).isoformat()
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
+            " VALUES (?, ?, ?, ?)",
+            (ts, 0, 47.65, -122.40),
+        )
+    await db.commit()
+    # Note: NO end_race call — race is still active.
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race.id}/track")
+    assert r.status_code == 200
+    body = r.json()
+    timestamps = body["features"][0]["properties"]["timestamps"]
+    start_iso = _GUN.isoformat().replace("+00:00", "Z")
+    pre = [t for t in timestamps if t < start_iso]
+    post = [t for t in timestamps if t >= start_iso]
+    assert len(pre) == 3, f"prestart fixes missing: {timestamps}"
+    assert len(post) == 4, f"post-gun fixes missing: {timestamps}"
+
+
+@pytest.mark.asyncio
+async def test_data_hash_changes_during_active_race(storage: Storage) -> None:
+    """resolve_race_data_hash must move as new positions stream into an
+    active race — otherwise the cache key never changes and stale track
+    blobs are served indefinitely. Regression for the same #707 bug."""
+    from helmlog.cache import resolve_race_data_hash
+
+    race = await storage.start_race(
+        event="CYC", start_utc=_GUN, date_str="2026-04-30", race_num=1, name="R"
+    )
+    db = storage._conn()
+
+    async def insert_position(ts_iso: str) -> None:
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
+            " VALUES (?, ?, ?, ?)",
+            (ts_iso, 0, 47.65, -122.40),
+        )
+        await db.commit()
+
+    # First fix during the race.
+    await insert_position((_GUN + timedelta(seconds=10)).isoformat())
+    h1 = await resolve_race_data_hash(storage, race.id)
+    # Second fix arriving 30s later — hash MUST change.
+    await insert_position((_GUN + timedelta(seconds=40)).isoformat())
+    h2 = await resolve_race_data_hash(storage, race.id)
+    assert h1 != h2, "data_hash unchanged as positions stream in — cache will never invalidate"
+
+
+@pytest.mark.asyncio
 async def test_track_window_falls_back_when_no_race_id_tagged(
     storage: Storage, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `_compute_session_track` and `resolve_race_data_hash` both fell back to `start_utc` when `end_utc IS NULL`, which (a) clipped the track query at the gun and (b) froze the cache data_hash for the duration of the race
- Both now use `datetime.now(UTC).isoformat()` as the upper bound when the race is active, so the window and the cache hash grow as positions arrive
- Live page on corvopi-live (race 126, 2026-05-02) was stuck at 20 minutes of prestart and not extending — verified the bug end-to-end before patching

## Test plan
- [x] New unit tests fail before the fix and pass after
  - `test_track_includes_post_gun_for_active_race`
  - `test_data_hash_changes_during_active_race`
- [x] Existing prestart + cache suites still green (`test_session_track_prestart`, `test_web_cache`, `test_web_cache_routes`, `test_web_cache_stats_warm`, `test_web_cache_list_detail`, `test_external_cache`, `test_races`) — 126 passed
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files
- [ ] Post-deploy on corvopi-live: confirm `/api/sessions/126/track` blob's last_ts advances past `start_utc` and matches the most recent position write

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)