### PR TITLE
fix(replay): scrubber + overlays + gauges work during live race

### DIFF
--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -456,7 +456,9 @@ async def _compute_session_summary(storage: Storage, session_id: int) -> dict[st
     if race is None:
         raise HTTPException(status_code=404, detail="Race not found")
     start_utc = race["start_utc"]
-    end_utc = race["end_utc"] or start_utc
+    # Active race: use "now" so the post-gun positions and wind samples are
+    # included in the summary. Falling back to start_utc would clip them.
+    end_utc = race["end_utc"] or datetime.now(UTC).isoformat()
 
     rid_cur = await db.execute(
         "SELECT COUNT(*) as cnt FROM positions WHERE race_id = ?", (session_id,)
@@ -1241,7 +1243,11 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
     if row is None:
         raise HTTPException(status_code=404, detail="Race not found")
     start_utc = row["start_utc"]
-    end_utc = row["end_utc"] or row["start_utc"]
+    # Active race (end_utc IS NULL): use "now" as the upper bound so the
+    # scrubber range and the instrument-sample queries cover everything up
+    # to the current moment. Falling back to start_utc would collapse the
+    # window to the prestart prefix only.
+    end_utc = row["end_utc"] or datetime.now(UTC).isoformat()
 
     # Replay scrubber spans the prestart prefix too — same window the track
     # is extended by (#707 / prestart-scrub). Instrument series queries use

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -112,10 +112,12 @@
 #video-course-overlay{top:6px;right:6px}
 #video-maneuver-overlay{bottom:6px;left:6px}
 /* Live-race strip-down (#664) — while a race is in progress and this page
-   is served at /, collapse to: photo, track, instruments, boat setup, notes.
-   Everything else is forcibly hidden even if its loader calls display=''. */
+   is served at /, collapse to: photo, track + replay (scrubber + overlays
+   + gauges), wind field, instruments, boat setup, notes. Heavy debrief
+   cards (video, polar, results, audio, etc.) stay hidden. The replay
+   surfaces are kept so a shore observer can scrub and toggle wind /
+   current overlays during the race. */
 body.live-race #video-container,
-body.live-race #wind-field-card,
 body.live-race #polar-card,
 body.live-race #videos-card,
 body.live-race #analysis-card,
@@ -131,8 +133,6 @@ body.live-race #match-card,
 body.live-race #exports-card,
 body.live-race #danger-zone,
 body.live-race #track-layers-wrap,
-body.live-race #replay-toggle-row,
-body.live-race #replay-gauges-wrap,
 body.live-race #session-tags-row{display:none!important}
 body.live-race .live-inst-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:6px;font-family:monospace}
 body.live-race .live-inst-item{background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:6px 8px}

--- a/tests/test_session_track_prestart.py
+++ b/tests/test_session_track_prestart.py
@@ -215,6 +215,42 @@ async def test_track_includes_post_gun_for_active_race(
 
 
 @pytest.mark.asyncio
+async def test_replay_samples_extend_past_gun_for_active_race(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """During a live race the replay scrubber must cover post-gun samples
+    too — otherwise the scrubber range collapses to the prestart prefix
+    and the gauges have no in-race data to show."""
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    race = await storage.start_race(
+        event="CYC", start_utc=_GUN, date_str="2026-04-30", race_num=1, name="R"
+    )
+    db = storage._conn()
+    # Mix of pre-gun and post-gun speed samples; race is still active.
+    for offset_s in (-300, -120, -10, 5, 60, 200):
+        ts = (_GUN + timedelta(seconds=offset_s)).isoformat()
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 0, 4.5),
+        )
+    await db.commit()
+    # Note: NO end_race call — race is still active.
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(f"/api/sessions/{race.id}/replay")
+    assert r.status_code == 200
+    body = r.json()
+    sample_ts = [s["ts"] for s in body["samples"]]
+    pre_gun = [t for t in sample_ts if t < body["start_utc"]]
+    post_gun = [t for t in sample_ts if t >= body["start_utc"]]
+    assert len(pre_gun) >= 3, f"prestart samples missing: {sample_ts}"
+    assert len(post_gun) >= 3, f"post-gun samples missing: {sample_ts}"
+
+
+@pytest.mark.asyncio
 async def test_data_hash_changes_during_active_race(storage: Storage) -> None:
     """resolve_race_data_hash must move as new positions stream into an
     active race — otherwise the cache key never changes and stale track


### PR DESCRIPTION
## Summary
- `_compute_session_replay` and `_compute_session_summary` had the same `end_utc IS NULL` fallback bug as #717 — the scrubber and summary clipped at the gun. Both now use `datetime.now(UTC).isoformat()` for active races.
- Drops `#replay-toggle-row`, `#replay-gauges-wrap`, `#wind-field-card` from the `.live-race` strip-down so a shore-side observer can scrub, toggle wind/current overlays, and watch the gauges during a live race. Heavy debrief cards (video, polar, results, audio, maneuvers, etc.) stay hidden.
- Surfaced today watching corvo105 mid-race after #718 landed: track grew correctly, but scrubber stopped at the gun and overlays/gauges were missing.

## Test plan
- [x] New regression test `test_replay_samples_extend_past_gun_for_active_race` fails before fix, passes after
- [x] Existing prestart + cache + race suites all green (115 passed)
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files
- [ ] Post-deploy on corvopi-live: scrubber on race 126 spans prestart → now; Wind/Current overlay checkboxes visible and functional; gauges display live values

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)