### PR TITLE
fix(live-race): unhide #track-layers-wrap so overlay toggles render

### DIFF
--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -132,7 +132,6 @@ body.live-race #sharing-card,
 body.live-race #match-card,
 body.live-race #exports-card,
 body.live-race #danger-zone,
-body.live-race #track-layers-wrap,
 body.live-race #session-tags-row{display:none!important}
 body.live-race .live-inst-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:6px;font-family:monospace}
 body.live-race .live-inst-item{background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:6px 8px}


### PR DESCRIPTION
## Summary
- #720 unhid `#replay-toggle-row` (Wind / Current / Boat-wind / Boat-current checkboxes) but those live inside `#track-layers-wrap`, which the strip-down still hid — so the Layers section was empty on the live page
- Drop `#track-layers-wrap` from `.live-race`'s hide list so the entire Layers section renders during a live race

## Test plan
- [ ] On corvopi-live: Layers section visible above the map; Wind / Current toggles functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)