### PR TITLE
feat(live): WS push + drop duplicate instruments + distance widgets

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -309,7 +309,6 @@ async function init() {
   // than flashing them on screen and yanking them away.
   if (cfg.dataset.live === '1') {
     document.body.classList.add('live-race');
-    document.getElementById('live-instruments-card').style.display = '';
   }
 
   // If a deep-link query string targets a specific moment, start opening
@@ -384,20 +383,25 @@ function _maybeOpenDeepLinkMoment() {
 // ---------------------------------------------------------------------------
 
 const _LIVE_REFRESH_MS = 15000;
-const _LIVE_INSTRUMENT_MS = 2000;
 let _liveInterval = null;
-let _liveInstrumentInterval = null;
-let _liveInstTickInterval = null;
 let _liveWs = null;
 let _liveLastRefresh = 0;
 let _livePhotoUrl = null;
+let _liveWsBackoffMs = 1000;
+let _liveWsRetryTimer = null;
+let _liveGotPositionViaWs = false;
 
 async function _liveRefreshOnce() {
+  // Polling fallback. Only invoked if the WS is dead — once a position
+  // arrives over the socket, _liveGotPositionViaWs flips and this stops
+  // re-fetching the track endpoint (the expensive part on cellular).
   const now = Date.now();
   if (now - _liveLastRefresh < _LIVE_REFRESH_MS - 500) return;
   _liveLastRefresh = now;
   try {
-    await Promise.all([loadTrack(), loadVideos(), _refreshLivePhoto()]);
+    const tasks = [loadVideos(), _refreshLivePhoto()];
+    if (!_liveGotPositionViaWs) tasks.push(loadTrack());
+    await Promise.all(tasks);
   } catch (e) { /* non-fatal */ }
 }
 
@@ -427,44 +431,178 @@ async function _refreshLivePhoto() {
   } catch (e) { /* non-fatal */ }
 }
 
-async function _refreshLiveInstruments() {
+// Haversine distance in nautical miles between two [lat, lng] points.
+// Used by the live distance gauges and the boat→start straight-line
+// computation. 3440.065 nm is the Earth's mean radius in nm.
+function _haversineNm(a, b) {
+  const toRad = (d) => d * Math.PI / 180;
+  const dLat = toRad(b[0] - a[0]);
+  const dLon = toRad(b[1] - a[1]);
+  const lat1 = toRad(a[0]);
+  const lat2 = toRad(b[0]);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * 3440.065 * Math.asin(Math.sqrt(h));
+}
+
+// Cumulative track length (nm) from start_utc to the latest fix. Iterates
+// _trackData.latLngs and sums Haversine legs from the first point at or
+// after race start_utc.
+let _gunLatLngIdx = -1;
+function _recomputeDistanceSailed() {
+  if (!_trackData || !_trackData.latLngs.length || !_session || !_session.start_utc) return;
+  const startMs = new Date(_session.start_utc).getTime();
+  if (_gunLatLngIdx < 0) {
+    for (let i = 0; i < _trackData.timestamps.length; i++) {
+      if (_trackData.timestamps[i].getTime() >= startMs) { _gunLatLngIdx = i; break; }
+    }
+    if (_gunLatLngIdx < 0) return; // no post-gun fixes yet
+  }
+  let total = 0;
+  for (let i = _gunLatLngIdx + 1; i < _trackData.latLngs.length; i++) {
+    total += _haversineNm(_trackData.latLngs[i - 1], _trackData.latLngs[i]);
+  }
+  const el = document.getElementById('hud-dist-sailed');
+  if (el) el.textContent = total.toFixed(2);
+}
+
+// Course distance: start → rounding₁ → … → rounding_n → boat. With no
+// roundings yet (the live-race case — detector only runs at race-end),
+// degrades to start → boat. _roundings is populated lazily from the
+// maneuvers endpoint once it's been run.
+let _roundings = []; // [{ts, lat, lon}]
+function _recomputeCourseDistance() {
+  if (!_trackData || !_trackData.latLngs.length || !_session || !_session.start_utc) return;
+  if (_gunLatLngIdx < 0) return;
+  const startLatLng = _trackData.latLngs[_gunLatLngIdx];
+  const boat = _trackData.latLngs[_trackData.latLngs.length - 1];
+  let total = 0;
+  let prev = startLatLng;
+  for (const r of _roundings) {
+    const here = [r.lat, r.lon];
+    total += _haversineNm(prev, here);
+    prev = here;
+  }
+  total += _haversineNm(prev, boat);
+  const el = document.getElementById('hud-dist-line');
+  if (el) el.textContent = total.toFixed(2);
+}
+
+// Resolve roundings from the maneuvers list to (lat, lon) by snapping
+// each rounding's ts to the nearest position in _trackData. Stored in
+// _roundings so the course-distance compute can iterate them. Refreshes
+// any time _maneuvers or _trackData changes.
+function _populateRoundings() {
+  if (typeof _maneuvers === 'undefined' || !_maneuvers || !_trackData) {
+    _roundings = [];
+    return;
+  }
+  const tsList = _trackData.timestamps;
+  if (!tsList.length) { _roundings = []; return; }
+  const out = [];
+  for (const m of _maneuvers) {
+    if (m.type !== 'rounding') continue;
+    const tsMs = new Date(m.ts.endsWith('Z') || m.ts.includes('+') ? m.ts : m.ts + 'Z').getTime();
+    let bestIdx = -1, bestDt = Infinity;
+    for (let i = 0; i < tsList.length; i++) {
+      const dt = Math.abs(tsList[i].getTime() - tsMs);
+      if (dt < bestDt) { bestDt = dt; bestIdx = i; }
+    }
+    if (bestIdx >= 0) {
+      const ll = _trackData.latLngs[bestIdx];
+      out.push({ts: m.ts, lat: ll[0], lon: ll[1]});
+    }
+  }
+  _roundings = out;
+}
+
+// Push live instrument values straight into the GAUGES card so it stays
+// real-time without polling /api/instruments. Mirrors the binding inside
+// _renderHud() — but driven by the WS message instead of the scrubber.
+function _renderLiveGauges(d) {
+  if (!d) return;
+  const setNum = (id, val, decimals) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = (val != null && !Number.isNaN(val)) ? Number(val).toFixed(decimals) : '—';
+  };
+  const setDeg = (id, val) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (val == null || Number.isNaN(val)) { el.textContent = '—'; return; }
+    const wrapped = ((Math.round(val) % 360) + 360) % 360;
+    el.textContent = wrapped + '°';
+  };
+  const setSigned = (id, val, decimals) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (val == null || Number.isNaN(val)) { el.textContent = '—'; return; }
+    const sign = Number(val) >= 0 ? '+' : '';
+    el.textContent = sign + Number(val).toFixed(decimals) + '°';
+  };
+  setNum('hud-stw', d.bsp_kts, 2);
+  setNum('hud-sog', d.sog_kts, 2);
+  setNum('hud-tws', d.tws_kts, 1);
+  setNum('hud-aws', d.aws_kts, 1);
+  setDeg('hud-twd', d.twd_deg);
+  setDeg('hud-twa', d.twa_deg);
+  setDeg('hud-awa', d.awa_deg);
+  setNum('hud-hdg', d.heading_deg, 0);
+  setNum('hud-cog', d.cog_deg, 0);
+  setSigned('hud-heel', d.heel_deg, 1);
+  setSigned('hud-trim', d.trim_deg, 1);
+}
+
+// Append a position fix to the polyline + casing and refresh distances.
+// No-op if the fix is older than the last one we have (out-of-order
+// arrival, e.g. on reconnect after a brief disconnect).
+function _appendLivePosition(payload) {
+  if (!_trackData || !payload || payload.lat == null || payload.lon == null) return;
+  const ts = new Date(payload.ts.endsWith('Z') || payload.ts.includes('+') ? payload.ts : payload.ts + 'Z');
+  const last = _trackData.timestamps[_trackData.timestamps.length - 1];
+  if (last && ts <= last) return;
+  _trackData.latLngs.push([payload.lat, payload.lon]);
+  _trackData.timestamps.push(ts);
+  if (_trackData.line) _trackData.line.setLatLngs(_trackData.latLngs);
+  if (_trackData.casing) _trackData.casing.setLatLngs(_trackData.latLngs);
+  _liveGotPositionViaWs = true;
+  _recomputeDistanceSailed();
+  _recomputeCourseDistance();
+}
+
+function _handleLiveWsMessage(ev) {
+  let msg;
+  try { msg = JSON.parse(ev.data); } catch (e) { return; }
+  if (msg.type === 'position') {
+    _appendLivePosition(msg.data);
+  } else if (msg.type === 'instruments') {
+    _renderLiveGauges(msg.data);
+  }
+}
+
+function _connectLiveWs() {
   try {
-    const r = await fetch('/api/instruments');
-    if (!r.ok) return;
-    const d = await r.json();
-    const set = (id, val, decimals) => {
-      const el = document.getElementById(id);
-      if (el) el.textContent = val != null ? Number(val).toFixed(decimals) : '—';
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    _liveWs = new WebSocket(`${proto}//${location.host}/ws/live`);
+    _liveWs.onmessage = _handleLiveWsMessage;
+    _liveWs.onopen = () => { _liveWsBackoffMs = 1000; };
+    _liveWs.onclose = () => {
+      _liveWs = null;
+      // Reconnect with exponential backoff capped at 30 s. The polling
+      // fallback in _liveRefreshOnce() takes over (re-fetching the full
+      // track) until the socket comes back.
+      _liveGotPositionViaWs = false;
+      if (_liveWsRetryTimer) clearTimeout(_liveWsRetryTimer);
+      _liveWsRetryTimer = setTimeout(_connectLiveWs, _liveWsBackoffMs);
+      _liveWsBackoffMs = Math.min(_liveWsBackoffMs * 2, 30000);
     };
-    set('liv-sog', d.sog_kts, 1);
-    set('liv-cog', d.cog_deg, 0);
-    set('liv-hdg', d.heading_deg, 0);
-    set('liv-bsp', d.bsp_kts, 1);
-    set('liv-aws', d.aws_kts, 1);
-    set('liv-awa', d.awa_deg, 0);
-    set('liv-tws', d.tws_kts, 1);
-    set('liv-twa', d.twa_deg, 0);
-    set('liv-twd', d.twd_deg, 0);
-    set('liv-rdr', d.rudder_deg, 1);
-  } catch (e) { /* non-fatal */ }
+    _liveWs.onerror = () => { try { _liveWs.close(); } catch (e) {} };
+  } catch (e) { /* fallback to polling */ }
 }
 
 function _startLiveRefresh() {
   if (_liveInterval) return;
   _liveInterval = setInterval(_liveRefreshOnce, _LIVE_REFRESH_MS);
-  _liveInstrumentInterval = setInterval(_refreshLiveInstruments, _LIVE_INSTRUMENT_MS);
-  _liveInstTickInterval = setInterval(() => {
-    const el = document.getElementById('live-inst-time');
-    if (el) el.textContent = new Date().toISOString().substring(11, 19) + ' UTC';
-  }, 1000);
-  _refreshLiveInstruments();
   _refreshLivePhoto();
-  try {
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    _liveWs = new WebSocket(`${proto}//${location.host}/ws/live`);
-    _liveWs.onmessage = () => { _liveRefreshOnce(); };
-    _liveWs.onclose = () => { _liveWs = null; };
-  } catch (e) { /* polling covers the fallback */ }
+  _connectLiveWs();
 }
 
 // ---------------------------------------------------------------------------
@@ -635,6 +773,11 @@ async function loadTrack() {
   const cursor = L.marker([0, 0], {icon: cursorIcon, interactive: false});
 
   _trackData = {latLngs, timestamps, line, casing, cursor};
+  // Reset the gun-index cache so the next compute walks from scratch.
+  _gunLatLngIdx = -1;
+  _recomputeDistanceSailed();
+  _populateRoundings();
+  _recomputeCourseDistance();
 
   // Map is a consumer: render the cursor at the requested UTC. We use a
   // continuous interpolated position (not the nearest sample index) so the
@@ -5280,6 +5423,9 @@ async function loadManeuvers() {
   // Roundings are now loaded — refresh laylines so they anchor on the
   // mark positions from this fetch (handles re-detection too).
   if (typeof _drawAllLaylines === 'function') _drawAllLaylines();
+  // Refresh the course-distance gauge using the new rounding set.
+  _populateRoundings();
+  _recomputeCourseDistance();
 }
 
 function _manKey(m, idx) {

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2056,10 +2056,19 @@ class Storage:
         self._pending: int = 0
         self._last_flush: float = 0.0
         self._session_active: bool = False
+        # Active race id, if any. Maintained by start_race / end_race. Used
+        # to tag WS position broadcasts so clients can filter by race.
+        self._active_race_id: int | None = None
         self._live: dict[str, float | None] = dict.fromkeys(_LIVE_KEYS)
         self._live_tw_ref: int | None = None
         self._live_tw_angle_raw: float | None = None
         self._on_live_update: Callable[[dict[str, float | None]], None] | None = None
+        # Position broadcasts go on a separate callback because they're a
+        # different message shape (per-fix lat/lon/ts) and we throttle them
+        # to 1 Hz on the wire — GPS can arrive at 5–10 Hz and we don't need
+        # that granularity for the live polyline.
+        self._on_position_update: Callable[[dict[str, Any]], None] | None = None
+        self._last_position_broadcast: float = 0.0
         self._last_rudder_write: float = 0.0
         self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
@@ -2151,12 +2160,35 @@ class Storage:
             case AttitudeRecord():
                 self._live["heel_deg"] = round(record.heel_deg, 1)
                 self._live["trim_deg"] = round(record.trim_deg, 1)
+            case PositionRecord():
+                # Don't fire the instruments callback for position records —
+                # they go on the separate position channel below. Throttle
+                # to 1 Hz on the wire because GPS may arrive at 5–10 Hz.
+                now = time.monotonic()
+                if (
+                    self._on_position_update is not None
+                    and (now - self._last_position_broadcast) >= 1.0
+                ):
+                    self._last_position_broadcast = now
+                    self._on_position_update(
+                        {
+                            "ts": record.timestamp.isoformat(),
+                            "lat": record.latitude_deg,
+                            "lon": record.longitude_deg,
+                            "race_id": self._active_race_id,
+                        }
+                    )
+                return
         if self._on_live_update is not None:
             self._on_live_update(dict(self._live))
 
     def set_live_callback(self, cb: Callable[[dict[str, float | None]], None]) -> None:
         """Register a callback invoked on every live instrument update."""
         self._on_live_update = cb
+
+    def set_position_callback(self, cb: Callable[[dict[str, Any]], None]) -> None:
+        """Register a callback invoked on each new GPS fix (1 Hz throttled)."""
+        self._on_position_update = cb
 
     def live_instruments(self) -> dict[str, float | None]:
         """Return a snapshot of the current in-memory instrument cache."""
@@ -2196,6 +2228,7 @@ class Storage:
                 self._read_db = None
         current = await self.get_current_race()
         self._session_active = current is not None
+        self._active_race_id = current.id if current is not None else None
 
     async def close(self) -> None:
         """Flush any buffered writes and close the database connections."""
@@ -3609,6 +3642,7 @@ class Storage:
         await self._invalidate_race_cache(cur.lastrowid)
         logger.info("Race started: {} (id={}) type={}", name, cur.lastrowid, session_type)
         self._session_active = True
+        self._active_race_id = cur.lastrowid
         return _Race(
             id=cur.lastrowid,
             name=name,
@@ -3631,6 +3665,8 @@ class Storage:
         await db.commit()
         await self._invalidate_race_cache(race_id)
         self._session_active = False
+        if self._active_race_id == race_id:
+            self._active_race_id = None
         logger.info("Race {} ended at {}", race_id, end_utc.isoformat())
 
     async def set_race_start_utc(self, race_id: int, start_utc: datetime) -> None:

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -133,11 +133,6 @@ body.live-race #match-card,
 body.live-race #exports-card,
 body.live-race #danger-zone,
 body.live-race #session-tags-row{display:none!important}
-body.live-race .live-inst-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:6px;font-family:monospace}
-body.live-race .live-inst-item{background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:6px 8px}
-body.live-race .live-inst-label{font-size:.65rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary)}
-body.live-race .live-inst-value{font-size:1.1rem;color:var(--text-primary)}
-body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margin-left:2px}
 </style>
 {% endblock %}
 
@@ -302,6 +297,15 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
           <span><span style="color:var(--text-secondary);font-size:.7rem">DRIFT</span> <span id="hud-drift" style="font-size:1.1rem;color:var(--text-primary)">—</span></span>
         </div>
       </div>
+      <div class="replay-gauge" data-gauge="distance" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px">
+        <div style="font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--text-secondary);margin-bottom:2px">Distance</div>
+        <div style="display:grid;grid-template-columns:auto 1fr;gap:1px 10px;font-family:monospace;align-items:baseline">
+          <span style="color:var(--text-secondary);font-size:.7rem" title="Cumulative track length since the gun">SAILED</span>
+          <span><span id="hud-dist-sailed" style="font-size:1.1rem;color:var(--text-primary)">—</span> <span style="color:var(--text-secondary);font-size:.7rem">nm</span></span>
+          <span style="color:var(--text-secondary);font-size:.7rem" title="Straight-line distance: start → roundings → boat (start → boat if no roundings yet)">COURSE</span>
+          <span><span id="hud-dist-line" style="font-size:1.1rem;color:var(--text-primary)">—</span> <span style="color:var(--text-secondary);font-size:.7rem">nm</span></span>
+        </div>
+      </div>
     </div>
     </div>
   </div>
@@ -331,25 +335,6 @@ body.live-race .live-inst-unit{font-size:.7rem;color:var(--text-secondary);margi
   </div>
   <div id="track-hint" style="font-size:.72rem;color:var(--text-secondary);margin-top:4px"></div>
   <div id="vakaros-line-info" style="display:none;font-size:.78rem;color:var(--text-secondary);margin-top:6px;font-family:monospace"></div>
-</div>
-
-<div id="live-instruments-card" class="card" style="display:none">
-  <div class="section-title" style="display:flex;justify-content:space-between;align-items:center">
-    <span>Instruments</span>
-    <span id="live-inst-time" style="font-family:monospace;font-size:.72rem;color:var(--text-secondary);text-transform:none;letter-spacing:normal">--:--:-- UTC</span>
-  </div>
-  <div class="live-inst-grid">
-    <div class="live-inst-item"><div class="live-inst-label">BSP</div><div><span class="live-inst-value" id="liv-bsp">&mdash;</span><span class="live-inst-unit">kts</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">TWS</div><div><span class="live-inst-value" id="liv-tws">&mdash;</span><span class="live-inst-unit">kts</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">TWA</div><div><span class="live-inst-value" id="liv-twa">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">HDG</div><div><span class="live-inst-value" id="liv-hdg">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">COG</div><div><span class="live-inst-value" id="liv-cog">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">SOG</div><div><span class="live-inst-value" id="liv-sog">&mdash;</span><span class="live-inst-unit">kts</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">AWS</div><div><span class="live-inst-value" id="liv-aws">&mdash;</span><span class="live-inst-unit">kts</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">AWA</div><div><span class="live-inst-value" id="liv-awa">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">TWD</div><div><span class="live-inst-value" id="liv-twd">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-    <div class="live-inst-item"><div class="live-inst-label">RDR</div><div><span class="live-inst-value" id="liv-rdr">&mdash;</span><span class="live-inst-unit">&deg;</span></div></div>
-  </div>
 </div>
 
 <div id="wind-field-card" class="card" style="display:none">

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -309,4 +309,19 @@ def create_app(
 
     storage.set_live_callback(_on_live_update)
 
+    def _on_position_update(payload: dict) -> None:  # type: ignore[type-arg]
+        """Sync callback from Storage.update_live() for PositionRecord → broadcast.
+
+        Throttled to 1 Hz inside Storage so the wire stays predictable
+        regardless of GPS fix rate. Frontend appends each fix to its track
+        polyline so the live page extends in real time without polling.
+        """
+        try:
+            loop = _asyncio.get_running_loop()
+            loop.create_task(broadcast(app.state.ws_clients, {"type": "position", "data": payload}))
+        except RuntimeError:
+            pass
+
+    storage.set_position_callback(_on_position_update)
+
     return app

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 from starlette.testclient import TestClient
 
-from helmlog.nmea2000 import HeadingRecord
+from helmlog.nmea2000 import HeadingRecord, PositionRecord
 from helmlog.web import create_app
 
 if TYPE_CHECKING:
@@ -64,6 +64,82 @@ async def test_live_callback_fires_on_update(storage: Storage) -> None:
 
     assert len(received) == 1
     assert received[0]["heading_deg"] == 245.3
+
+
+@pytest.mark.asyncio
+async def test_position_callback_fires_for_position_record(storage: Storage) -> None:
+    """update_live(PositionRecord) routes to the position callback, not the
+    instrument callback. Wire format is {ts, lat, lon, race_id}."""
+    received: list[dict] = []  # type: ignore[type-arg]
+
+    def cb(payload: dict) -> None:  # type: ignore[type-arg]
+        received.append(payload)
+
+    storage.set_position_callback(cb)
+    record = PositionRecord(
+        pgn=129025,
+        source_addr=0,
+        timestamp=datetime(2026, 5, 2, 16, 30, 0, tzinfo=UTC),
+        latitude_deg=47.65,
+        longitude_deg=-122.40,
+    )
+    storage.update_live(record)
+
+    assert len(received) == 1
+    assert received[0]["lat"] == 47.65
+    assert received[0]["lon"] == -122.40
+    assert received[0]["ts"].startswith("2026-05-02T16:30:00")
+
+
+@pytest.mark.asyncio
+async def test_position_broadcasts_throttled_to_1hz(storage: Storage) -> None:
+    """Multiple position records inside the same second collapse to one
+    broadcast — GPS at 5–10 Hz must not flood the wire."""
+    received: list[dict] = []  # type: ignore[type-arg]
+
+    def cb(payload: dict) -> None:  # type: ignore[type-arg]
+        received.append(payload)
+
+    storage.set_position_callback(cb)
+    base = datetime(2026, 5, 2, 16, 30, 0, tzinfo=UTC)
+    for i in range(5):
+        storage.update_live(
+            PositionRecord(
+                pgn=129025,
+                source_addr=0,
+                timestamp=base.replace(microsecond=i * 100_000),
+                latitude_deg=47.65 + i * 0.0001,
+                longitude_deg=-122.40,
+            )
+        )
+    # Five fixes within the same monotonic second → only the first reaches
+    # the wire. The throttle is monotonic-clock-based so this assertion is
+    # tight and not flaky.
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_position_record_does_not_fire_instrument_callback(storage: Storage) -> None:
+    """A PositionRecord must not also trigger the instruments broadcast — it
+    has no instrument fields and would just spam an unchanged snapshot."""
+    inst_calls: list[dict] = []  # type: ignore[type-arg]
+    pos_calls: list[dict] = []  # type: ignore[type-arg]
+
+    storage.set_live_callback(lambda d: inst_calls.append(d))
+    storage.set_position_callback(lambda p: pos_calls.append(p))
+
+    storage.update_live(
+        PositionRecord(
+            pgn=129025,
+            source_addr=0,
+            timestamp=datetime(2026, 5, 2, 16, 31, 0, tzinfo=UTC),
+            latitude_deg=47.65,
+            longitude_deg=-122.40,
+        )
+    )
+
+    assert len(pos_calls) == 1
+    assert len(inst_calls) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Replaces the 15 s `/api/sessions/{id}/track` polling and 2 s `/api/instruments` polling in live-race mode with WebSocket pushes over the existing `/ws/live` socket. Drops the duplicate `#live-instruments-card`. Adds two live-updating distance gauges.

Per [issue #723](https://github.com/weaties/helmlog/issues/723) the bandwidth target is roughly:
- Today (polling): ~19 MB / viewer / hour
- After this PR: ~440 KB / viewer / hour

A meaningful win for the Pi's Mint Mobile uplink during a 2 hour race with a few viewers.

## Backend
- `Storage.update_live()` matches `PositionRecord` and fires a separate `_on_position_update` callback with `{ts, lat, lon, race_id}`, throttled to 1 Hz on the wire.
- New `_active_race_id` field on Storage, maintained by `start_race` / `end_race` and restored on connect, so position broadcasts can be tagged with the current race id.
- `web.py` registers a `_on_position_update` handler that wraps each payload as `{type: \"position\", data: ...}` and fans it out via the existing broadcast helper.

## Frontend (`session.js` + `session.html`)
- New `_appendLivePosition` handler extends `_trackData.latLngs` and `timestamps` on each fix, then calls `setLatLngs` on both the bright dashed line and the dark casing.
- New `_renderLiveGauges` writes WS instrument values directly into the GAUGES card hud-* elements.
- WS reconnect with exponential backoff (1 s → 30 s cap). Polling fallback re-engages while the socket is down.
- Drops `#live-instruments-card` HTML + CSS; removes `_refreshLiveInstruments` polling.
- Two new replay-gauge cards: SAILED (cumulative track length from gun) and COURSE (start → roundings → boat; falls back to start → boat when no roundings have been detected — the live-race case, since the maneuver detector runs at race-end).

## Tests
- `test_position_callback_fires_for_position_record`
- `test_position_broadcasts_throttled_to_1hz`
- `test_position_record_does_not_fire_instrument_callback`
- Broader sweep (test_ws + test_storage + test_web + test_session_track_prestart + test_web_cache + test_races): 373 passed locally.

## Test plan
- [x] New WS unit tests fail before the storage change, pass after
- [x] Lint + typecheck clean on changed files
- [x] Existing live-race regressions (track grows, scrubber spans, layers visible) all still pass
- [ ] On corvopi-live during a live race: track polyline grows in real time without polling, GAUGES card numbers update per fix, SAILED + COURSE gauges populate and update, page survives a brief network drop and reconnects
- [ ] Verify the polling fallback fires correctly if the socket is closed (e.g. cellular flicker)

## Out of scope
- Live rounding detection (the maneuver detector still only runs at race-end). Once a race ends and detection runs, the COURSE gauge auto-updates via the maneuvers endpoint refresh.
- Auth on `/ws/live` — separate concern, the existing instrument socket has the same posture.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)