### PR TITLE
fix(live): boat-current arrow + GAUGES Current row during live race

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -520,11 +520,43 @@ function _populateRoundings() {
 // the scrubber HUD has data when pinned at the live tip.
 let _lastLiveInstruments = null;
 
+// Derive (set, drift) on the client from sog/cog/stw/hdg. Mirrors the
+// formula in src/helmlog/current.py — boat-over-ground vector minus
+// boat-through-water vector. The Python code is the source of truth;
+// we recompute here because the WS instrument snapshot only carries the
+// raw measurements and the boat-current arrow + the GAUGES "Current"
+// row need set/drift in real time.
+function _computeLiveSetDrift(d) {
+  if (!d) return null;
+  const sog = d.sog_kts, cog = d.cog_deg, stw = d.bsp_kts, hdg = d.heading_deg;
+  if (sog == null || cog == null || stw == null || hdg == null) return null;
+  if ([sog, cog, stw, hdg].some(Number.isNaN)) return null;
+  const polar = (speed, deg) => {
+    const r = deg * Math.PI / 180;
+    return [speed * Math.cos(r), speed * Math.sin(r)];
+  };
+  const [nG, eG] = polar(sog, cog);
+  const [nW, eW] = polar(stw, hdg);
+  const nC = nG - nW, eC = eG - eW;
+  const drift = Math.hypot(nC, eC);
+  if (drift < 1e-9) return {set: 0, drift: 0};
+  const set = ((Math.atan2(eC, nC) * 180 / Math.PI) % 360 + 360) % 360;
+  return {set: set, drift: drift};
+}
+
 // Push live instrument values straight into the GAUGES card so it stays
 // real-time without polling /api/instruments. Mirrors the binding inside
 // _renderHud() — but driven by the WS message instead of the scrubber.
 function _renderLiveGauges(d) {
   if (!d) return;
+  // Augment the snapshot with computed set/drift so downstream consumers
+  // (synthetic _replaySamples row, GAUGES Current row, boat-current arrow)
+  // all see the same values without recomputing.
+  const sd = _computeLiveSetDrift(d);
+  if (sd) {
+    d.set_deg = sd.set;
+    d.drift_kts = sd.drift;
+  }
   _lastLiveInstruments = d;
   const setNum = (id, val, decimals) => {
     const el = document.getElementById(id);
@@ -555,6 +587,8 @@ function _renderLiveGauges(d) {
   setNum('hud-cog', d.cog_deg, 0);
   setSigned('hud-heel', d.heel_deg, 1);
   setSigned('hud-trim', d.trim_deg, 1);
+  setDeg('hud-set', d.set_deg);
+  setNum('hud-drift', d.drift_kts, 2);
 }
 
 // Throttle for live overlay rebuilds — wind/current arrow layers iterate


### PR DESCRIPTION
## Summary
The WS `instruments` snapshot only carries raw measurements (sog / cog / stw / hdg, etc.) — the derived set / drift live in \`current.py\` and only flow through the replay endpoint. During a live race the synthetic \`_replaySamples\` row pushed by #725 therefore had \`set=undefined\` / \`drift=undefined\`, so:
- \`_windowedSetDrift\` returned null and the boat-current arrow on the overlay silently disappeared even with the Boat current toggle on
- the GAUGES card's CURRENT row stayed at "—"

Now we compute set / drift on the client (\`_computeLiveSetDrift\`) using the same vector-difference formula as \`helmlog.current.compute_set_drift\`, augment \`_lastLiveInstruments\` before stashing, and bind the values to \`hud-set\` / \`hud-drift\`. The synthetic samples now carry set/drift, which feeds both the boat overlay arrow and the live current overlay rebuild.

## Test plan
- [ ] On corvopi-live: with **Boat current** toggle on, the orange set/drift arrow on the boat overlay populates and updates per fix
- [ ] GAUGES card → CURRENT row shows live SET / DRIFT values
- [ ] Numbers match the existing replay-time values (sanity check vs the same race after end_utc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)