### PR TITLE
feat(live): EMA smoothing on wind + speed (admin-configurable)

### DIFF
--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -572,3 +572,66 @@ async def admin_cache_stats_reset(
         cache.reset_stats()
     await audit(request, action="cache_stats_reset")
     return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Instrument smoothing (#727)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/admin/instrument-smoothing", response_class=JSONResponse, include_in_schema=False)
+async def admin_instrument_smoothing_get(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Return the currently-effective tau (seconds) for each smoothed
+    channel. Falls back to defaults when a channel hasn't been overridden
+    in app_settings."""
+    from helmlog.smoothing import DEFAULT_TAUS, parse_tau
+
+    storage = get_storage(request)
+    out: dict[str, dict[str, float]] = {}
+    for channel, default in DEFAULT_TAUS.items():
+        raw = await storage.get_setting(f"smoothing.{channel}.tau_s")
+        out[channel] = {"tau_s": parse_tau(raw, default), "default": default}
+    return JSONResponse(out)
+
+
+@router.put("/api/admin/instrument-smoothing", status_code=204, include_in_schema=False)
+async def admin_instrument_smoothing_put(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Persist new tau values for one or more channels then refresh the
+    live smoothers. Body: ``{channel: tau_seconds, ...}``. Unknown
+    channels are rejected; tau<=0 or NaN are rejected."""
+    from helmlog.smoothing import DEFAULT_TAUS
+
+    storage = get_storage(request)
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Body must be an object")
+    for channel, tau in body.items():
+        if channel not in DEFAULT_TAUS:
+            raise HTTPException(status_code=400, detail=f"Unknown channel: {channel}")
+        try:
+            v = float(tau)
+        except (TypeError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=f"{channel}: not a number") from e
+        if not (v > 0) or v != v:  # rejects 0, negatives, NaN
+            raise HTTPException(status_code=400, detail=f"{channel}: tau must be > 0")
+        await storage.set_setting(f"smoothing.{channel}.tau_s", str(v))
+    await storage.refresh_smoothing()
+    await audit(request, action="instrument_smoothing_update", detail=str(body))
+    return Response(status_code=204)
+
+
+@router.get("/admin/instruments", response_class=HTMLResponse, include_in_schema=False)
+async def admin_instruments_page(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Admin page with a slider per smoothed channel."""
+    return templates.TemplateResponse(
+        request, "admin/instruments.html", tpl_ctx(request, "/admin/instruments")
+    )

--- a/src/helmlog/smoothing.py
+++ b/src/helmlog/smoothing.py
@@ -1,0 +1,187 @@
+"""Exponential moving average smoothing for live instrument values.
+
+Server-side smoothing applied in ``Storage.update_live`` so the WS
+broadcast and the in-memory ``self._live`` cache reflect a smoothed
+value. SQLite writes are unaffected — the historical replay path still
+sees raw samples and can do its own averaging if it wants to.
+
+The math
+--------
+Variable-dt EMA so smoothing behaves consistently regardless of how
+often instrument records arrive::
+
+    alpha = dt / (tau + dt)
+    smoothed = alpha * raw + (1 - alpha) * smoothed_prev
+
+``tau`` is the time constant in seconds — roughly the lag the user will
+see. With ``tau=5`` the smoothed signal reaches ~63 % of a step input
+after 5 s and ~95 % after 15 s.
+
+Angles
+------
+Bearings (TWD, TWA, AWA, COG, HDG) wrap at 360°, so a naive scalar EMA
+crosses the wrap boundary by going the long way around. ``AngleEma``
+smooths the (sin, cos) components separately and reconstructs the
+direction with ``atan2`` — the same convention used by the wind/current
+overlays.
+
+Configuration
+-------------
+Time constants live in the ``app_settings`` table under keys of the
+form ``smoothing.<channel>.tau_s`` so admins can tune them without
+restarting the service. ``SmoothingConfig.from_storage`` loads the
+current values; ``refresh`` re-reads them and rebuilds the smoothers
+in place (preserving the last smoothed value so a tau change doesn't
+glitch the gauges).
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+
+from loguru import logger
+
+# Default time constants (seconds). Overrideable via app_settings rows
+# named ``smoothing.<channel>.tau_s``.
+DEFAULT_TAUS: dict[str, float] = {
+    "tws_kts": 5.0,
+    "twa_deg": 5.0,
+    "twd_deg": 5.0,
+    "aws_kts": 5.0,
+    "awa_deg": 5.0,
+    "sog_kts": 3.0,
+    "bsp_kts": 3.0,
+    "heading_deg": 2.0,
+    "cog_deg": 2.0,
+}
+
+# Channels whose values are bearings (0–360°) and need vector smoothing
+# rather than scalar.
+ANGLE_CHANNELS: frozenset[str] = frozenset(
+    {"twa_deg", "twd_deg", "awa_deg", "heading_deg", "cog_deg"}
+)
+
+# Floor on tau so a stuck-zero setting can't cause divide-by-zero or
+# pass-through behaviour (defeats the purpose of smoothing).
+_MIN_TAU_S: float = 0.05
+
+
+@dataclass
+class Ema:
+    """Scalar exponential moving average with variable dt."""
+
+    tau_s: float
+    value: float | None = None
+    last_t: float | None = None
+
+    def update(self, raw: float, t: float | None = None) -> float:
+        now = t if t is not None else time.monotonic()
+        tau = max(self.tau_s, _MIN_TAU_S)
+        if self.value is None or self.last_t is None:
+            self.value = raw
+            self.last_t = now
+            return raw
+        dt = now - self.last_t
+        if dt <= 0:
+            return self.value
+        alpha = dt / (tau + dt)
+        self.value = alpha * raw + (1 - alpha) * self.value
+        self.last_t = now
+        return self.value
+
+
+@dataclass
+class AngleEma:
+    """Vector EMA on (sin, cos) so wrap-around at 360° is handled cleanly."""
+
+    tau_s: float
+    _sin: float | None = None
+    _cos: float | None = None
+    last_t: float | None = None
+
+    def update(self, raw_deg: float, t: float | None = None) -> float:
+        now = t if t is not None else time.monotonic()
+        tau = max(self.tau_s, _MIN_TAU_S)
+        rad = math.radians(raw_deg)
+        s_raw, c_raw = math.sin(rad), math.cos(rad)
+        if self._sin is None or self._cos is None or self.last_t is None:
+            self._sin, self._cos = s_raw, c_raw
+            self.last_t = now
+            return raw_deg % 360.0
+        dt = now - self.last_t
+        if dt <= 0:
+            out = math.degrees(math.atan2(self._sin, self._cos)) % 360.0
+            return out
+        alpha = dt / (tau + dt)
+        self._sin = alpha * s_raw + (1 - alpha) * self._sin
+        self._cos = alpha * c_raw + (1 - alpha) * self._cos
+        self.last_t = now
+        return math.degrees(math.atan2(self._sin, self._cos)) % 360.0
+
+
+@dataclass
+class SmoothingConfig:
+    """Container for per-channel smoothers, kept in Storage."""
+
+    smoothers: dict[str, Ema | AngleEma] = field(default_factory=dict)
+
+    @classmethod
+    def from_taus(cls, taus: dict[str, float]) -> SmoothingConfig:
+        cfg = cls()
+        for ch, tau in taus.items():
+            cfg.smoothers[ch] = AngleEma(tau_s=tau) if ch in ANGLE_CHANNELS else Ema(tau_s=tau)
+        return cfg
+
+    def update(self, channel: str, raw: float) -> float:
+        """Push a raw value through the smoother. Channels with no
+        configured smoother also pass through — useful for fields like
+        rudder/heel where smoothing isn't wanted. Caller handles None at
+        the boundary so the return type stays float.
+        """
+        sm = self.smoothers.get(channel)
+        if sm is None:
+            return raw
+        try:
+            return sm.update(float(raw))
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("smoothing update failed for {}: {}", channel, exc)
+            return raw
+
+    def set_tau(self, channel: str, tau_s: float) -> None:
+        """Update the time constant for ``channel`` in place — keeps the
+        last smoothed value so the gauge doesn't glitch on a setting change.
+        """
+        sm = self.smoothers.get(channel)
+        if sm is None:
+            self.smoothers[channel] = (
+                AngleEma(tau_s=tau_s) if channel in ANGLE_CHANNELS else Ema(tau_s=tau_s)
+            )
+        else:
+            sm.tau_s = max(tau_s, _MIN_TAU_S)
+
+
+def parse_tau(raw: str | None, default: float) -> float:
+    """Parse a tau value from the app_settings table. Falls back to default
+    on any malformed input — the live path can't tolerate exceptions.
+    """
+    if raw is None:
+        return default
+    try:
+        v = float(raw)
+        if v <= 0 or math.isnan(v) or math.isinf(v):
+            return default
+        return v
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "ANGLE_CHANNELS",
+    "DEFAULT_TAUS",
+    "AngleEma",
+    "Ema",
+    "SmoothingConfig",
+    "parse_tau",
+]

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2069,6 +2069,12 @@ class Storage:
         # that granularity for the live polyline.
         self._on_position_update: Callable[[dict[str, Any]], None] | None = None
         self._last_position_broadcast: float = 0.0
+        # Per-channel smoothing applied to live broadcast values (#727).
+        # Loaded from app_settings during connect(); refresh_smoothing()
+        # picks up admin tau changes without restarting the service.
+        from helmlog.smoothing import DEFAULT_TAUS, SmoothingConfig
+
+        self._smoothing: SmoothingConfig = SmoothingConfig.from_taus(DEFAULT_TAUS)
         self._last_rudder_write: float = 0.0
         self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
@@ -2137,23 +2143,33 @@ class Storage:
             self._live["twa_deg"] = round((ang - hdg + 360) % 360, 1) if hdg is not None else None
 
     def update_live(self, record: PGNRecord) -> None:
-        """Update the in-memory live cache from a decoded record (no DB write)."""
+        """Update the in-memory live cache from a decoded record (no DB write).
+
+        Wind / speed / heading values pass through ``self._smoothing`` so
+        the gauges don't jitter on every CAN tick. The smoothed value is
+        what gets stored in ``self._live`` and broadcast over the WS;
+        SQLite still records the raw record (see ``write``).
+        """
+        sm = self._smoothing
         match record:
             case HeadingRecord():
-                self._live["heading_deg"] = round(record.heading_deg, 1)
+                self._live["heading_deg"] = round(sm.update("heading_deg", record.heading_deg), 1)
                 self._recompute_true_wind()
             case SpeedRecord():
-                self._live["bsp_kts"] = round(record.speed_kts, 2)
+                self._live["bsp_kts"] = round(sm.update("bsp_kts", record.speed_kts), 2)
             case COGSOGRecord():
-                self._live["cog_deg"] = round(record.cog_deg, 1)
-                self._live["sog_kts"] = round(record.sog_kts, 2)
+                self._live["cog_deg"] = round(sm.update("cog_deg", record.cog_deg), 1)
+                self._live["sog_kts"] = round(sm.update("sog_kts", record.sog_kts), 2)
             case WindRecord() if record.reference == 2:  # apparent
-                self._live["aws_kts"] = round(record.wind_speed_kts, 1)
-                self._live["awa_deg"] = round(record.wind_angle_deg, 1)
+                self._live["aws_kts"] = round(sm.update("aws_kts", record.wind_speed_kts), 1)
+                self._live["awa_deg"] = round(sm.update("awa_deg", record.wind_angle_deg), 1)
             case WindRecord() if record.reference in (0, 4):  # true
-                self._live["tws_kts"] = round(record.wind_speed_kts, 1)
+                self._live["tws_kts"] = round(sm.update("tws_kts", record.wind_speed_kts), 1)
                 self._live_tw_ref = record.reference
-                self._live_tw_angle_raw = record.wind_angle_deg
+                # Smoothed angle feeds the recompute below so TWD/TWA come
+                # out smoothed too. Vector EMA handles 0/360 wrap.
+                channel = "twd_deg" if record.reference == 4 else "twa_deg"
+                self._live_tw_angle_raw = sm.update(channel, record.wind_angle_deg)
                 self._recompute_true_wind()
             case RudderRecord():
                 self._live["rudder_deg"] = round(record.rudder_angle_deg, 1)
@@ -2189,6 +2205,25 @@ class Storage:
     def set_position_callback(self, cb: Callable[[dict[str, Any]], None]) -> None:
         """Register a callback invoked on each new GPS fix (1 Hz throttled)."""
         self._on_position_update = cb
+
+    async def refresh_smoothing(self) -> dict[str, float]:
+        """Reload per-channel time constants from ``app_settings`` and apply
+        them to the live smoothers without losing accumulated state.
+
+        Returns the effective tau map so the caller (admin API) can echo
+        back what's now in force. Settings keys are
+        ``smoothing.<channel>.tau_s``; missing or malformed values fall
+        back to ``DEFAULT_TAUS``.
+        """
+        from helmlog.smoothing import DEFAULT_TAUS, parse_tau
+
+        out: dict[str, float] = {}
+        for channel, default in DEFAULT_TAUS.items():
+            raw = await self.get_setting(f"smoothing.{channel}.tau_s")
+            tau = parse_tau(raw, default)
+            self._smoothing.set_tau(channel, tau)
+            out[channel] = tau
+        return out
 
     def live_instruments(self) -> dict[str, float | None]:
         """Return a snapshot of the current in-memory instrument cache."""
@@ -2229,6 +2264,7 @@ class Storage:
         current = await self.get_current_race()
         self._session_active = current is not None
         self._active_race_id = current.id if current is not None else None
+        await self.refresh_smoothing()
 
     async def close(self) -> None:
         """Flush any buffered writes and close the database connections."""

--- a/src/helmlog/templates/admin/instruments.html
+++ b/src/helmlog/templates/admin/instruments.html
@@ -1,0 +1,151 @@
+{% extends "base.html" %}
+{% block title %}HelmLog — Instrument Smoothing{% endblock %}
+{% block extra_css %}
+<style>
+h1{font-size:1.3rem;font-weight:700;color:var(--accent);margin-bottom:12px}
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:16px}
+.row{display:grid;grid-template-columns:140px 1fr 70px 80px;gap:12px;align-items:center;padding:6px 0;border-bottom:1px solid var(--border)}
+.row:last-child{border-bottom:none}
+.label{font-size:.85rem;color:var(--text-primary)}
+.label .desc{font-size:.7rem;color:var(--text-secondary);display:block;margin-top:1px}
+input[type=range]{width:100%}
+.value{font-family:monospace;font-size:.85rem;color:var(--text-primary);text-align:right}
+.value .unit{color:var(--text-secondary);font-size:.7rem;margin-left:2px}
+.default{font-size:.7rem;color:var(--text-secondary);text-align:right}
+.default a{color:var(--accent);text-decoration:none;cursor:pointer}
+.actions{margin-top:14px;display:flex;gap:8px;align-items:center}
+button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:6px 14px;font-size:.85rem;cursor:pointer}
+button:disabled{opacity:.5;cursor:not-allowed}
+.status{font-size:.78rem;color:var(--text-secondary)}
+.status.ok{color:var(--success)}
+.status.err{color:var(--danger)}
+.help{font-size:.78rem;color:var(--text-secondary);margin:8px 0 16px}
+</style>
+{% endblock %}
+{% block content %}
+<h1>Instrument Smoothing</h1>
+<div class="card">
+  <p class="help">
+    Time constants (tau, in seconds) for the live wind / speed gauges.
+    Higher = smoother but laggier. Changes take effect immediately —
+    no restart needed. The historical record in SQLite is unaffected;
+    only the live broadcast is smoothed.
+  </p>
+  <div id="smoothing-rows">Loading…</div>
+  <div class="actions">
+    <button id="smoothing-save-btn" disabled>Save</button>
+    <button id="smoothing-reset-btn" type="button" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">Reset all to defaults</button>
+    <span id="smoothing-status" class="status"></span>
+  </div>
+</div>
+
+<script>
+const _channels = [
+  ['tws_kts',     'TWS',       'True wind speed'],
+  ['twa_deg',     'TWA',       'True wind angle (boat-relative)'],
+  ['twd_deg',     'TWD',       'True wind direction (compass)'],
+  ['aws_kts',     'AWS',       'Apparent wind speed'],
+  ['awa_deg',     'AWA',       'Apparent wind angle'],
+  ['bsp_kts',     'STW',       'Boat speed through water'],
+  ['sog_kts',     'SOG',       'Speed over ground'],
+  ['heading_deg', 'HDG',       'Magnetic heading'],
+  ['cog_deg',     'COG',       'Course over ground'],
+];
+let _initial = {};
+let _dirty = {};
+
+function _render(state) {
+  const root = document.getElementById('smoothing-rows');
+  root.innerHTML = _channels.map(([key, label, desc]) => {
+    const cur = state[key] || {tau_s: 5, default: 5};
+    const isDirty = _dirty[key] != null;
+    const tau = isDirty ? _dirty[key] : cur.tau_s;
+    return `
+      <div class="row" data-channel="${key}">
+        <div class="label">${label}<span class="desc">${desc}</span></div>
+        <input type="range" min="0.5" max="30" step="0.5" value="${tau}" data-channel="${key}">
+        <div class="value"><span data-tau-display="${key}">${Number(tau).toFixed(1)}</span><span class="unit">s</span></div>
+        <div class="default"><a data-reset="${key}">${cur.default.toFixed(1)}s</a></div>
+      </div>`;
+  }).join('');
+  // Wire input + reset handlers
+  root.querySelectorAll('input[type=range]').forEach(inp => {
+    inp.addEventListener('input', e => {
+      const k = e.target.dataset.channel;
+      const v = Number(e.target.value);
+      _dirty[k] = v;
+      document.querySelector(`[data-tau-display="${k}"]`).textContent = v.toFixed(1);
+      _setDirtyState();
+    });
+  });
+  root.querySelectorAll('[data-reset]').forEach(a => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      const k = e.target.dataset.reset;
+      const def = state[k].default;
+      _dirty[k] = def;
+      _render(_initial);
+      _setDirtyState();
+    });
+  });
+}
+
+function _setDirtyState() {
+  const anyDirty = Object.keys(_dirty).some(k => _dirty[k] !== _initial[k].tau_s);
+  document.getElementById('smoothing-save-btn').disabled = !anyDirty;
+}
+
+function _setStatus(msg, kind) {
+  const el = document.getElementById('smoothing-status');
+  el.textContent = msg;
+  el.className = 'status' + (kind ? ' ' + kind : '');
+}
+
+async function _load() {
+  const r = await fetch('/api/admin/instrument-smoothing');
+  if (!r.ok) { _setStatus('Failed to load', 'err'); return; }
+  _initial = await r.json();
+  _dirty = {};
+  _render(_initial);
+  _setDirtyState();
+  _setStatus('');
+}
+
+async function _save() {
+  const body = {};
+  Object.keys(_dirty).forEach(k => {
+    if (_dirty[k] !== _initial[k].tau_s) body[k] = _dirty[k];
+  });
+  if (!Object.keys(body).length) return;
+  _setStatus('Saving…');
+  const r = await fetch('/api/admin/instrument-smoothing', {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const t = await r.text();
+    _setStatus('Save failed: ' + t, 'err');
+    return;
+  }
+  _setStatus('Saved', 'ok');
+  await _load();
+}
+
+async function _resetAll() {
+  const body = {};
+  _channels.forEach(([k]) => { body[k] = _initial[k].default; });
+  const r = await fetch('/api/admin/instrument-smoothing', {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
+  });
+  if (r.ok) { _setStatus('Reset to defaults', 'ok'); await _load(); }
+  else { _setStatus('Reset failed', 'err'); }
+}
+
+document.getElementById('smoothing-save-btn').addEventListener('click', _save);
+document.getElementById('smoothing-reset-btn').addEventListener('click', _resetAll);
+_load();
+</script>
+{% endblock %}

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -30,6 +30,7 @@
     <a href="/admin/cameras" class="admin-link{% if active_page == "/admin/cameras" %} active{% endif %}">Cameras</a>
     <a href="/admin/aruco" class="admin-link{% if active_page == "/admin/aruco" %} active{% endif %}">ArUco</a>
     <a href="/admin/devices" class="admin-link{% if active_page == "/admin/devices" %} active{% endif %}">Devices</a>
+    <a href="/admin/instruments" class="admin-link{% if active_page == "/admin/instruments" %} active{% endif %}">Instruments</a>
     <a href="/admin/network" class="admin-link{% if active_page == "/admin/network" %} active{% endif %}">Network</a>
     <a href="/admin/events" class="admin-link{% if active_page == "/admin/events" %} active{% endif %}">Events</a>
     <a href="/admin/settings" class="admin-link{% if active_page == "/admin/settings" %} active{% endif %}">Settings</a>

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -1,0 +1,168 @@
+"""Admin API + storage integration for instrument smoothing (#727)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from helmlog.nmea2000 import HeadingRecord, SpeedRecord, WindRecord
+from helmlog.smoothing import DEFAULT_TAUS
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+@pytest_asyncio.fixture
+async def admin_client(  # type: ignore[misc]
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> httpx.AsyncClient:
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_get_returns_defaults_when_unset(admin_client: httpx.AsyncClient) -> None:
+    """Fresh DB → endpoint reports DEFAULT_TAUS for every channel."""
+    r = await admin_client.get("/api/admin/instrument-smoothing")
+    assert r.status_code == 200
+    body = r.json()
+    for channel, default in DEFAULT_TAUS.items():
+        assert channel in body
+        assert body[channel]["tau_s"] == default
+        assert body[channel]["default"] == default
+
+
+@pytest.mark.asyncio
+async def test_put_persists_and_get_reflects(admin_client: httpx.AsyncClient) -> None:
+    """Setting a channel via PUT → GET returns the new value."""
+    r = await admin_client.put(
+        "/api/admin/instrument-smoothing",
+        json={"tws_kts": 8.0, "twa_deg": 7.5},
+    )
+    assert r.status_code == 204
+    body = (await admin_client.get("/api/admin/instrument-smoothing")).json()
+    assert body["tws_kts"]["tau_s"] == 8.0
+    assert body["twa_deg"]["tau_s"] == 7.5
+    # Untouched channels stay at default.
+    assert body["sog_kts"]["tau_s"] == DEFAULT_TAUS["sog_kts"]
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_unknown_channel(admin_client: httpx.AsyncClient) -> None:
+    r = await admin_client.put("/api/admin/instrument-smoothing", json={"bogus_channel": 5.0})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_invalid_tau(admin_client: httpx.AsyncClient) -> None:
+    """tau<=0 and non-numeric strings fail with 400. NaN is exercised by
+    the unit tests in test_smoothing.py — httpx itself rejects
+    out-of-range floats during JSON encode, so we can't drive that path
+    through a real HTTP call here."""
+    for bad in [0, -1, "not-a-number"]:
+        r = await admin_client.put("/api/admin/instrument-smoothing", json={"tws_kts": bad})
+        assert r.status_code == 400, f"tau={bad!r} should have been rejected"
+
+
+@pytest.mark.asyncio
+async def test_put_applies_to_live_storage(
+    admin_client: httpx.AsyncClient, storage: Storage
+) -> None:
+    """After PUT, ``storage.update_live`` uses the new tau immediately —
+    no service restart, no manual reload."""
+    await admin_client.put("/api/admin/instrument-smoothing", json={"tws_kts": 0.5})
+    # The smoother for tws_kts now has tau=0.5.
+    sm = storage._smoothing.smoothers["tws_kts"]
+    assert sm.tau_s == 0.5
+
+
+@pytest.mark.asyncio
+async def test_smoothed_value_is_blend_of_history(storage: Storage) -> None:
+    """update_live(WindRecord) feeds raw through the EMA — successive calls
+    blend rather than slamming to the latest raw value."""
+    await storage.refresh_smoothing()
+    storage._smoothing.set_tau("tws_kts", 5.0)
+    base_ts = datetime(2026, 5, 2, 16, 0, 0, tzinfo=UTC)
+    storage.update_live(
+        WindRecord(
+            pgn=130306,
+            source_addr=0,
+            timestamp=base_ts,
+            wind_speed_kts=10.0,
+            wind_angle_deg=45.0,
+            reference=4,
+        )
+    )
+    # First sample seeds the smoother at 10.0.
+    assert storage._live["tws_kts"] == 10.0
+    storage.update_live(
+        WindRecord(
+            pgn=130306,
+            source_addr=0,
+            timestamp=base_ts,
+            wind_speed_kts=20.0,
+            wind_angle_deg=45.0,
+            reference=4,
+        )
+    )
+    # Second sample at near-zero dt → smoothed value barely moves.
+    assert storage._live["tws_kts"] is not None
+    assert storage._live["tws_kts"] < 15.0  # not slammed to 20
+
+
+@pytest.mark.asyncio
+async def test_heading_smoothing_is_angle_aware(storage: Storage) -> None:
+    """Heading smoother uses vector EMA — successive 359° → 1° samples
+    don't swing the smoothed value through 180°."""
+    await storage.refresh_smoothing()
+    storage._smoothing.set_tau("heading_deg", 1.0)
+    base_ts = datetime(2026, 5, 2, 16, 0, 0, tzinfo=UTC)
+    storage.update_live(
+        HeadingRecord(
+            pgn=127250,
+            source_addr=0,
+            timestamp=base_ts,
+            heading_deg=359.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+    )
+    storage.update_live(
+        HeadingRecord(
+            pgn=127250,
+            source_addr=0,
+            timestamp=base_ts,
+            heading_deg=1.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+    )
+    # Result should be close to 0° / 360°, not anywhere near 180°.
+    val = storage._live["heading_deg"]
+    assert val is not None
+    norm = ((val + 180) % 360) - 180
+    assert abs(norm) < 30, f"heading EMA crossed 360 the long way: got {val}°"
+
+
+@pytest.mark.asyncio
+async def test_speed_record_is_smoothed(storage: Storage) -> None:
+    """Confirms SpeedRecord (boat speed through water) is routed through
+    the bsp_kts smoother — first sample seeds, second blends."""
+    await storage.refresh_smoothing()
+    storage._smoothing.set_tau("bsp_kts", 5.0)
+    base_ts = datetime(2026, 5, 2, 16, 0, 0, tzinfo=UTC)
+    storage.update_live(SpeedRecord(pgn=128259, source_addr=0, timestamp=base_ts, speed_kts=5.0))
+    assert storage._live["bsp_kts"] == 5.0
+    storage.update_live(SpeedRecord(pgn=128259, source_addr=0, timestamp=base_ts, speed_kts=15.0))
+    val = storage._live["bsp_kts"]
+    assert val is not None
+    assert val < 10.0  # blended, not slammed

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -1,0 +1,145 @@
+"""Unit tests for instrument-value smoothing (#727)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from helmlog.smoothing import (
+    DEFAULT_TAUS,
+    AngleEma,
+    Ema,
+    SmoothingConfig,
+    parse_tau,
+)
+
+
+def test_ema_first_sample_passes_through() -> None:
+    """First raw value seeds the smoother — there's nothing to blend with yet."""
+    e = Ema(tau_s=5.0)
+    assert e.update(10.0, t=0.0) == 10.0
+
+
+def test_ema_step_response_approaches_target() -> None:
+    """tau=1s: after ~5 tau the smoothed value is within 1% of a step input."""
+    e = Ema(tau_s=1.0)
+    e.update(0.0, t=0.0)
+    # Step to 10.0 sustained at 0.1 s cadence.
+    last = 0.0
+    for i in range(1, 60):  # 6 s ≈ 6 tau
+        last = e.update(10.0, t=i * 0.1)
+    assert last == pytest.approx(10.0, abs=0.1)
+
+
+def test_ema_short_tau_responds_faster_than_long_tau() -> None:
+    """Sanity: tau=1s tracks a step faster than tau=10s at the same dt."""
+    fast = Ema(tau_s=1.0)
+    slow = Ema(tau_s=10.0)
+    fast.update(0.0, t=0.0)
+    slow.update(0.0, t=0.0)
+    for i in range(1, 11):  # 1 s of step input at 0.1 s cadence
+        fast.update(10.0, t=i * 0.1)
+        slow.update(10.0, t=i * 0.1)
+    assert fast.value > slow.value > 0
+
+
+def test_ema_clamps_min_tau() -> None:
+    """tau=0 is treated as a tiny positive number — no divide-by-zero, but
+    the smoother still applies non-trivial smoothing if dt is very small."""
+    e = Ema(tau_s=0.0)
+    e.update(0.0, t=0.0)
+    out = e.update(10.0, t=1.0)  # large dt → alpha near 1, fast catch-up
+    assert out == pytest.approx(10.0, abs=0.5)
+
+
+def test_ema_zero_dt_returns_previous_value() -> None:
+    """Two updates at the same monotonic time → smoothed value unchanged."""
+    e = Ema(tau_s=5.0)
+    e.update(10.0, t=0.0)
+    out = e.update(20.0, t=0.0)
+    assert out == 10.0
+
+
+def test_angle_ema_handles_wrap_at_360() -> None:
+    """Smoothing 359° → 1° must not swing through 180° — the vector form
+    crosses the wrap boundary directly. Average lands near 0°."""
+    a = AngleEma(tau_s=1.0)
+    a.update(359.0, t=0.0)
+    out = a.update(1.0, t=1.0)  # alpha=0.5
+    # Expected: vector mean of unit vectors at 359° and 1° is ~0°.
+    # Allow some slack for the alpha ≈ 0.5 weighting.
+    norm = ((out + 180) % 360) - 180
+    assert abs(norm) < 5.0, f"angle EMA crossed 360 the long way: got {out}°"
+
+
+def test_angle_ema_180_opposite_inputs_average_to_one_end() -> None:
+    """Two opposite directions (0° and 180°) average to drift back toward
+    one of them rather than collapsing to zero magnitude. The exact value
+    depends on alpha; we just check it stays in 0..360 and isn't NaN."""
+    a = AngleEma(tau_s=1.0)
+    a.update(0.0, t=0.0)
+    out = a.update(180.0, t=1.0)
+    assert 0.0 <= out < 360.0
+    assert not math.isnan(out)
+
+
+def test_smoothing_config_dispatches_angle_vs_scalar() -> None:
+    """Channels listed in ANGLE_CHANNELS get an AngleEma; others get Ema."""
+    cfg = SmoothingConfig.from_taus({"tws_kts": 5.0, "twa_deg": 5.0})
+    assert isinstance(cfg.smoothers["tws_kts"], Ema)
+    assert isinstance(cfg.smoothers["twa_deg"], AngleEma)
+
+
+def test_smoothing_config_passes_through_unknown_channel() -> None:
+    """A channel without a smoother (e.g. rudder_deg) just returns the raw."""
+    cfg = SmoothingConfig.from_taus({"tws_kts": 5.0})
+    assert cfg.update("rudder_deg", 12.5) == 12.5
+
+
+def test_set_tau_preserves_state() -> None:
+    """Changing tau on the fly must not glitch the gauge — the last
+    smoothed value is preserved, only the time constant changes."""
+    cfg = SmoothingConfig.from_taus({"tws_kts": 5.0})
+    cfg.update("tws_kts", 10.0)  # seeds the EMA at 10
+    cfg.set_tau("tws_kts", 1.0)
+    sm = cfg.smoothers["tws_kts"]
+    assert isinstance(sm, Ema)
+    assert sm.value == 10.0
+    assert sm.tau_s == 1.0
+
+
+def test_set_tau_creates_smoother_for_unknown_channel() -> None:
+    """set_tau on a channel without a smoother creates one (admin can
+    configure smoothing for a previously-unsmoothed channel)."""
+    cfg = SmoothingConfig()
+    cfg.set_tau("twa_deg", 5.0)
+    assert isinstance(cfg.smoothers["twa_deg"], AngleEma)
+    cfg.set_tau("tws_kts", 5.0)
+    assert isinstance(cfg.smoothers["tws_kts"], Ema)
+
+
+def test_default_taus_cover_expected_channels() -> None:
+    """The hard-coded defaults include every channel the GAUGES card binds."""
+    expected = {
+        "tws_kts",
+        "twa_deg",
+        "twd_deg",
+        "aws_kts",
+        "awa_deg",
+        "sog_kts",
+        "bsp_kts",
+        "heading_deg",
+        "cog_deg",
+    }
+    assert expected.issubset(DEFAULT_TAUS.keys())
+
+
+def test_parse_tau_handles_malformed_input() -> None:
+    """parse_tau falls back to default for None, garbage, NaN, and <=0."""
+    assert parse_tau(None, 5.0) == 5.0
+    assert parse_tau("not-a-number", 5.0) == 5.0
+    assert parse_tau("nan", 5.0) == 5.0
+    assert parse_tau("0", 5.0) == 5.0
+    assert parse_tau("-1.5", 5.0) == 5.0
+    assert parse_tau("3.5", 5.0) == 3.5


### PR DESCRIPTION
## Summary
The live wind and speed gauges jittered on every CAN tick. Now each smoothed channel routes through a per-channel EMA in \`Storage.update_live\`, with vector smoothing for bearings (TWA / TWD / AWA / HDG / COG) so 0/360 wrap is handled cleanly. Time constants live in \`app_settings\` and are admin-tuneable from \`/admin/instruments\` without restarting the service. SQLite still records raw values; only the in-memory live snapshot and the WS broadcast are smoothed.

Closes #727.

## Architecture
- New module \`smoothing.py\`: \`Ema\`, \`AngleEma\`, \`SmoothingConfig\`, \`parse_tau\`, \`DEFAULT_TAUS\`. Variable-dt formula: \`alpha = dt / (tau + dt)\`.
- \`Storage._smoothing\` populated from \`DEFAULT_TAUS\` at init, refreshed from \`app_settings\` during \`connect()\` and via \`refresh_smoothing()\`.
- \`update_live\` routes wind / speed / heading / cog through the smoother; heel / trim / rudder pass raw.
- \`GET/PUT /api/admin/instrument-smoothing\` + \`/admin/instruments\` slider page (linked in admin nav next to Devices).

## Defaults
| Channel | Tau (s) |
|---|---|
| TWS / TWA / TWD / AWS / AWA | 5 |
| STW / SOG | 3 |
| HDG / COG | 2 |

## Tests
- \`tests/test_smoothing.py\` — 13 unit tests on the EMA math, including 360°-wrap and zero-dt edge cases.
- \`tests/test_instrument_smoothing_admin.py\` — 7 integration tests for GET / PUT, validation, persistence-then-reload, and that update_live produces blended values.
- 134 passed in the broader sweep (smoothing + instrument-smoothing-admin + storage + ws + session-track-prestart).

## Test plan
- [x] Unit + integration tests green
- [x] \`ruff\` + \`mypy\` clean
- [ ] On corvopi-live: gauges visibly less jittery; \`/admin/instruments\` loads, sliders save, no-restart reload works
- [ ] Verify SQLite still has raw values (replay query unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)