### PR TITLE
feat(live): smooth set/drift server-side, derived from smoothed inputs

### DIFF
--- a/src/helmlog/smoothing.py
+++ b/src/helmlog/smoothing.py
@@ -55,12 +55,18 @@ DEFAULT_TAUS: dict[str, float] = {
     "bsp_kts": 3.0,
     "heading_deg": 2.0,
     "cog_deg": 2.0,
+    # Set / drift derive from sog/cog/stw/hdg, which are themselves
+    # smoothed; applying a longer EMA on top damps residual jitter from
+    # the four-input vector subtraction (a few degrees of HDG drift can
+    # swing drift by more than a knot — see #729).
+    "set_deg": 8.0,
+    "drift_kts": 8.0,
 }
 
 # Channels whose values are bearings (0–360°) and need vector smoothing
 # rather than scalar.
 ANGLE_CHANNELS: frozenset[str] = frozenset(
-    {"twa_deg", "twd_deg", "awa_deg", "heading_deg", "cog_deg"}
+    {"twa_deg", "twd_deg", "awa_deg", "heading_deg", "cog_deg", "set_deg"}
 )
 
 # Floor on tau so a stuck-zero setting can't cause divide-by-zero or

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -520,43 +520,13 @@ function _populateRoundings() {
 // the scrubber HUD has data when pinned at the live tip.
 let _lastLiveInstruments = null;
 
-// Derive (set, drift) on the client from sog/cog/stw/hdg. Mirrors the
-// formula in src/helmlog/current.py — boat-over-ground vector minus
-// boat-through-water vector. The Python code is the source of truth;
-// we recompute here because the WS instrument snapshot only carries the
-// raw measurements and the boat-current arrow + the GAUGES "Current"
-// row need set/drift in real time.
-function _computeLiveSetDrift(d) {
-  if (!d) return null;
-  const sog = d.sog_kts, cog = d.cog_deg, stw = d.bsp_kts, hdg = d.heading_deg;
-  if (sog == null || cog == null || stw == null || hdg == null) return null;
-  if ([sog, cog, stw, hdg].some(Number.isNaN)) return null;
-  const polar = (speed, deg) => {
-    const r = deg * Math.PI / 180;
-    return [speed * Math.cos(r), speed * Math.sin(r)];
-  };
-  const [nG, eG] = polar(sog, cog);
-  const [nW, eW] = polar(stw, hdg);
-  const nC = nG - nW, eC = eG - eW;
-  const drift = Math.hypot(nC, eC);
-  if (drift < 1e-9) return {set: 0, drift: 0};
-  const set = ((Math.atan2(eC, nC) * 180 / Math.PI) % 360 + 360) % 360;
-  return {set: set, drift: drift};
-}
-
 // Push live instrument values straight into the GAUGES card so it stays
 // real-time without polling /api/instruments. Mirrors the binding inside
 // _renderHud() — but driven by the WS message instead of the scrubber.
+// Set / drift now arrive pre-computed from the server (#729) so we just
+// bind them here alongside the raw measurements.
 function _renderLiveGauges(d) {
   if (!d) return;
-  // Augment the snapshot with computed set/drift so downstream consumers
-  // (synthetic _replaySamples row, GAUGES Current row, boat-current arrow)
-  // all see the same values without recomputing.
-  const sd = _computeLiveSetDrift(d);
-  if (sd) {
-    d.set_deg = sd.set;
-    d.drift_kts = sd.drift;
-  }
   _lastLiveInstruments = d;
   const setNum = (id, val, decimals) => {
     const el = document.getElementById(id);

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -192,6 +192,11 @@ _LIVE_KEYS = (
     "aws_kts",
     "awa_deg",
     "rudder_deg",
+    # Derived current vector — computed in _recompute_set_drift from the
+    # already-smoothed sog/cog/stw/hdg, then routed through its own EMA
+    # so the gauge doesn't twitch on every input fix.
+    "set_deg",
+    "drift_kts",
 )
 
 # ---------------------------------------------------------------------------
@@ -2142,6 +2147,26 @@ class Storage:
             self._live["twd_deg"] = round(ang % 360, 1)
             self._live["twa_deg"] = round((ang - hdg + 360) % 360, 1) if hdg is not None else None
 
+    def _recompute_set_drift(self) -> None:
+        """Derive set / drift from the (already-smoothed) sog, cog, stw, hdg
+        in ``self._live``. The result is then run through the set/drift
+        smoothers so a few-degree heading wobble doesn't bounce drift by
+        a knot every tick. Mirrors ``helmlog.current.compute_set_drift``.
+        """
+        from helmlog.current import compute_set_drift
+
+        sog = self._live["sog_kts"]
+        cog = self._live["cog_deg"]
+        stw = self._live["bsp_kts"]
+        hdg = self._live["heading_deg"]
+        result = compute_set_drift(sog, cog, stw, hdg)
+        if result is None:
+            return
+        set_raw, drift_raw = result
+        sm = self._smoothing
+        self._live["set_deg"] = round(sm.update("set_deg", set_raw), 1)
+        self._live["drift_kts"] = round(sm.update("drift_kts", drift_raw), 2)
+
     def update_live(self, record: PGNRecord) -> None:
         """Update the in-memory live cache from a decoded record (no DB write).
 
@@ -2155,11 +2180,14 @@ class Storage:
             case HeadingRecord():
                 self._live["heading_deg"] = round(sm.update("heading_deg", record.heading_deg), 1)
                 self._recompute_true_wind()
+                self._recompute_set_drift()
             case SpeedRecord():
                 self._live["bsp_kts"] = round(sm.update("bsp_kts", record.speed_kts), 2)
+                self._recompute_set_drift()
             case COGSOGRecord():
                 self._live["cog_deg"] = round(sm.update("cog_deg", record.cog_deg), 1)
                 self._live["sog_kts"] = round(sm.update("sog_kts", record.sog_kts), 2)
+                self._recompute_set_drift()
             case WindRecord() if record.reference == 2:  # apparent
                 self._live["aws_kts"] = round(sm.update("aws_kts", record.wind_speed_kts), 1)
                 self._live["awa_deg"] = round(sm.update("awa_deg", record.wind_angle_deg), 1)

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -154,6 +154,40 @@ async def test_heading_smoothing_is_angle_aware(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_set_drift_derived_from_smoothed_inputs(storage: Storage) -> None:
+    """Set / drift are computed server-side from the (already-smoothed)
+    sog / cog / stw / hdg in self._live, then put through their own EMA
+    so the gauge doesn't twitch on every input. Checks that update_live
+    populates set_deg + drift_kts in the broadcast snapshot."""
+    from helmlog.nmea2000 import COGSOGRecord
+
+    await storage.refresh_smoothing()
+    # Make every smoother near-pass-through so this test can reason
+    # about steady-state values without waiting many seconds.
+    for ch in ("sog_kts", "cog_deg", "bsp_kts", "heading_deg", "set_deg", "drift_kts"):
+        storage._smoothing.set_tau(ch, 0.05)
+    base_ts = datetime(2026, 5, 2, 16, 0, 0, tzinfo=UTC)
+    # HDG = 0°, COG = 0°, STW = 5, SOG = 5 → no current.
+    storage.update_live(
+        HeadingRecord(
+            pgn=127250,
+            source_addr=0,
+            timestamp=base_ts,
+            heading_deg=0.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+    )
+    storage.update_live(SpeedRecord(pgn=128259, source_addr=0, timestamp=base_ts, speed_kts=5.0))
+    storage.update_live(
+        COGSOGRecord(pgn=129026, source_addr=0, timestamp=base_ts, cog_deg=0.0, sog_kts=5.0)
+    )
+    drift_no_current = storage._live["drift_kts"]
+    assert drift_no_current is not None
+    assert drift_no_current < 0.5  # essentially zero
+
+
+@pytest.mark.asyncio
 async def test_speed_record_is_smoothed(storage: Storage) -> None:
     """Confirms SpeedRecord (boat speed through water) is routed through
     the bsp_kts smoother — first sample seeds, second blends."""


### PR DESCRIPTION
## Summary
Follow-up to #728. The Current row twitched because the client recomputed set / drift from the live WS snapshot on every fix; small sensor mismatch (a few degrees of HDG drift, 0.1 kt of STW noise) can swing drift by over a knot — math is right, but the display is noisy.

Now set / drift are derived server-side from the already-smoothed sog / cog / stw / hdg, run through their own EMA (default tau = 8 s — longer than the inputs because the residual jitter compounds in the four-input vector subtraction), and broadcast as part of the existing instruments WS message. Admin-tuneable via the existing /admin/instruments slider page.

The client-side \`_computeLiveSetDrift\` is removed — the renderer just binds the values that arrive in the snapshot.

## Test plan
- [x] New test verifies that matched sog/cog/stw/hdg → drift ≈ 0
- [x] 127 passed across smoothing + storage + ws suites
- [ ] On corvopi-live: drift gauge stops twitching; admin slider for set_deg / drift_kts adjusts behavior live

🤖 Generated with [Claude Code](https://claude.com/claude-code)