### PR TITLE
feat(live): hot-refresh leeway_k on boat-settings write

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -9174,6 +9174,11 @@ class Storage:
             )
             ids.append(cur.lastrowid or 0)
         await db.commit()
+        # Hot-reload the cached leeway coefficient if it was just written —
+        # admin tuning takes effect on the live broadcast immediately
+        # without a service restart (#730 follow-up).
+        if any(e["parameter"] == "leeway_coefficient" for e in entries):
+            await self.refresh_leeway_k()
         return ids
 
     async def list_boat_settings(self, race_id: int | None) -> list[dict[str, Any]]:

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -154,6 +154,24 @@ async def test_heading_smoothing_is_angle_aware(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_boat_settings_hot_refreshes_leeway_k(storage: Storage) -> None:
+    """Writing leeway_coefficient via create_boat_settings should
+    immediately update the cached storage._leeway_k — admin tunes the
+    coefficient and the next live broadcast picks it up, no restart."""
+    from datetime import UTC, datetime
+
+    # Default after connect is 10.0 (no boat_settings rows yet).
+    assert storage._leeway_k == 10.0
+    ts = datetime.now(UTC).isoformat()
+    await storage.create_boat_settings(
+        race_id=None,
+        entries=[{"ts": ts, "parameter": "leeway_coefficient", "value": "13.5"}],
+        source="manual",
+    )
+    assert storage._leeway_k == 13.5
+
+
+@pytest.mark.asyncio
 async def test_set_drift_derived_from_smoothed_inputs(storage: Storage) -> None:
     """Set / drift are computed server-side from the (already-smoothed)
     sog / cog / stw / hdg in self._live, then put through their own EMA


### PR DESCRIPTION
## Summary
Follow-up to #730. Admin tunes \`leeway_coefficient\` via the boat-settings UI; the change now applies to the live WS broadcast immediately without a service restart.

\`create_boat_settings\` calls \`refresh_leeway_k()\` in the same transaction whenever any entry has \`parameter == 'leeway_coefficient'\`.

## Test
- \`test_create_boat_settings_hot_refreshes_leeway_k\` — write the setting, assert \`storage._leeway_k\` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)