### PR TITLE
fix(live): bucket-and-average position fixes per second

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2073,7 +2073,18 @@ class Storage:
         # to 1 Hz on the wire — GPS can arrive at 5–10 Hz and we don't need
         # that granularity for the live polyline.
         self._on_position_update: Callable[[dict[str, Any]], None] | None = None
-        self._last_position_broadcast: float = 0.0
+        # Per-second position bucket (#732). The SK reader records every fix
+        # with source_addr=0 even when Signal K is multiplexing two physical
+        # GPS antennas (~3 m apart on Corvo), so consecutive raw fixes
+        # zig-zag between antennas. We accumulate every fix in the current
+        # whole-second bucket; when the second ticks over, the bucket's
+        # mean lat/lon is broadcast as one position. Mirrors the per-second
+        # mean averaging in routes.sessions._compute_session_track so the
+        # live polyline reads the same as the historical track.
+        self._position_bucket_key: str | None = None
+        self._position_bucket_lats: list[float] = []
+        self._position_bucket_lons: list[float] = []
+        self._position_bucket_first_ts: str | None = None
         # Per-channel smoothing applied to live broadcast values (#727).
         # Loaded from app_settings during connect(); refresh_smoothing()
         # picks up admin tau changes without restarting the service.
@@ -2215,23 +2226,36 @@ class Storage:
                 # set/drift whenever it changes.
                 self._recompute_set_drift()
             case PositionRecord():
-                # Don't fire the instruments callback for position records —
-                # they go on the separate position channel below. Throttle
-                # to 1 Hz on the wire because GPS may arrive at 5–10 Hz.
-                now = time.monotonic()
-                if (
-                    self._on_position_update is not None
-                    and (now - self._last_position_broadcast) >= 1.0
-                ):
-                    self._last_position_broadcast = now
-                    self._on_position_update(
-                        {
-                            "ts": record.timestamp.isoformat(),
-                            "lat": record.latitude_deg,
-                            "lon": record.longitude_deg,
-                            "race_id": self._active_race_id,
-                        }
-                    )
+                # Position records bypass the instruments callback and go
+                # on the separate position channel. We bucket all fixes
+                # within each whole-second key and broadcast the mean
+                # lat/lon when the bucket rolls over (see __init__ for
+                # rationale — collapses dual-antenna zig-zag).
+                ts_iso = record.timestamp.isoformat()
+                key = ts_iso[:19]  # truncate to whole-second precision
+                if self._position_bucket_key is None:
+                    self._position_bucket_key = key
+                    self._position_bucket_first_ts = ts_iso
+                if key != self._position_bucket_key:
+                    # Bucket rolled over — emit the previous second's mean.
+                    if self._position_bucket_lats and self._on_position_update is not None:
+                        n = len(self._position_bucket_lats)
+                        avg_lat = sum(self._position_bucket_lats) / n
+                        avg_lon = sum(self._position_bucket_lons) / n
+                        self._on_position_update(
+                            {
+                                "ts": self._position_bucket_first_ts,
+                                "lat": avg_lat,
+                                "lon": avg_lon,
+                                "race_id": self._active_race_id,
+                            }
+                        )
+                    self._position_bucket_key = key
+                    self._position_bucket_first_ts = ts_iso
+                    self._position_bucket_lats = []
+                    self._position_bucket_lons = []
+                self._position_bucket_lats.append(record.latitude_deg)
+                self._position_bucket_lons.append(record.longitude_deg)
                 return
         if self._on_live_update is not None:
             self._on_live_update(dict(self._live))

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -67,60 +67,77 @@ async def test_live_callback_fires_on_update(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
-async def test_position_callback_fires_for_position_record(storage: Storage) -> None:
-    """update_live(PositionRecord) routes to the position callback, not the
-    instrument callback. Wire format is {ts, lat, lon, race_id}."""
+async def test_position_broadcast_buckets_per_second_and_emits_mean(
+    storage: Storage,
+) -> None:
+    """Same-second fixes accumulate; the bucket emits its mean only when
+    the next second arrives. Mirrors the per-second mean averaging in
+    routes.sessions._compute_session_track so the live polyline reads
+    the same as the historical track (#732)."""
     received: list[dict] = []  # type: ignore[type-arg]
+    storage.set_position_callback(received.append)
 
-    def cb(payload: dict) -> None:  # type: ignore[type-arg]
-        received.append(payload)
-
-    storage.set_position_callback(cb)
-    record = PositionRecord(
-        pgn=129025,
-        source_addr=0,
-        timestamp=datetime(2026, 5, 2, 16, 30, 0, tzinfo=UTC),
-        latitude_deg=47.65,
-        longitude_deg=-122.40,
-    )
-    storage.update_live(record)
-
-    assert len(received) == 1
-    assert received[0]["lat"] == 47.65
-    assert received[0]["lon"] == -122.40
-    assert received[0]["ts"].startswith("2026-05-02T16:30:00")
-
-
-@pytest.mark.asyncio
-async def test_position_broadcasts_throttled_to_1hz(storage: Storage) -> None:
-    """Multiple position records inside the same second collapse to one
-    broadcast — GPS at 5–10 Hz must not flood the wire."""
-    received: list[dict] = []  # type: ignore[type-arg]
-
-    def cb(payload: dict) -> None:  # type: ignore[type-arg]
-        received.append(payload)
-
-    storage.set_position_callback(cb)
+    # 5 fixes in the same second, alternating between two GPS antennas
+    # 3 m apart in latitude (the dual-antenna zig-zag this fix targets).
     base = datetime(2026, 5, 2, 16, 30, 0, tzinfo=UTC)
-    for i in range(5):
+    lats = [47.6500, 47.6500 + 3e-5, 47.6500, 47.6500 + 3e-5, 47.6500]
+    for i, lat in enumerate(lats):
         storage.update_live(
             PositionRecord(
                 pgn=129025,
                 source_addr=0,
                 timestamp=base.replace(microsecond=i * 100_000),
-                latitude_deg=47.65 + i * 0.0001,
+                latitude_deg=lat,
                 longitude_deg=-122.40,
             )
         )
-    # Five fixes within the same monotonic second → only the first reaches
-    # the wire. The throttle is monotonic-clock-based so this assertion is
-    # tight and not flaky.
+    # No broadcast yet — the second hasn't rolled over.
+    assert received == []
+
+    # Tick into the next whole second → the previous bucket's mean fires.
+    storage.update_live(
+        PositionRecord(
+            pgn=129025,
+            source_addr=0,
+            timestamp=base.replace(second=1),
+            latitude_deg=47.66,
+            longitude_deg=-122.40,
+        )
+    )
     assert len(received) == 1
+    # Mean of the 5 alternating-antenna fixes lands midway between them.
+    assert received[0]["lat"] == pytest.approx(47.6500 + 1.2e-5, abs=1e-9)
+    assert received[0]["lon"] == pytest.approx(-122.40, abs=1e-9)
+    # Timestamp is the first fix of the bucket.
+    assert received[0]["ts"].startswith("2026-05-02T16:30:00")
+
+
+@pytest.mark.asyncio
+async def test_position_broadcast_one_message_per_second(storage: Storage) -> None:
+    """Three buckets across three seconds → exactly two broadcasts (the
+    first two; the third is still accumulating). Confirms cadence."""
+    received: list[dict] = []  # type: ignore[type-arg]
+    storage.set_position_callback(received.append)
+
+    base = datetime(2026, 5, 2, 16, 30, 0, tzinfo=UTC)
+    for sec in range(3):
+        for sub in range(4):
+            storage.update_live(
+                PositionRecord(
+                    pgn=129025,
+                    source_addr=0,
+                    timestamp=base.replace(second=sec, microsecond=sub * 100_000),
+                    latitude_deg=47.65 + sec * 0.001,
+                    longitude_deg=-122.40,
+                )
+            )
+    # Two complete buckets + one in-flight bucket.
+    assert len(received) == 2
 
 
 @pytest.mark.asyncio
 async def test_position_record_does_not_fire_instrument_callback(storage: Storage) -> None:
-    """A PositionRecord must not also trigger the instruments broadcast — it
+    """A PositionRecord must not trigger the instruments broadcast — it
     has no instrument fields and would just spam an unchanged snapshot."""
     inst_calls: list[dict] = []  # type: ignore[type-arg]
     pos_calls: list[dict] = []  # type: ignore[type-arg]
@@ -128,16 +145,27 @@ async def test_position_record_does_not_fire_instrument_callback(storage: Storag
     storage.set_live_callback(lambda d: inst_calls.append(d))
     storage.set_position_callback(lambda p: pos_calls.append(p))
 
+    base = datetime(2026, 5, 2, 16, 31, 0, tzinfo=UTC)
+    # First fix seeds the bucket — no broadcast yet.
     storage.update_live(
         PositionRecord(
             pgn=129025,
             source_addr=0,
-            timestamp=datetime(2026, 5, 2, 16, 31, 0, tzinfo=UTC),
+            timestamp=base,
             latitude_deg=47.65,
             longitude_deg=-122.40,
         )
     )
-
+    # Second-second fix flushes the previous bucket.
+    storage.update_live(
+        PositionRecord(
+            pgn=129025,
+            source_addr=0,
+            timestamp=base.replace(second=1),
+            latitude_deg=47.66,
+            longitude_deg=-122.40,
+        )
+    )
     assert len(pos_calls) == 1
     assert len(inst_calls) == 0
 


### PR DESCRIPTION
## Summary
The live polyline drew a 3 m zig-zag along straight runs. Root cause: dual-GPS-antenna multiplexing — \`update_live\`'s 1 Hz throttle picked the first fix in each second, alternating between the two antennas. Fix mirrors what \`_compute_session_track\` already does for the historical track: bucket every fix in the current whole-second key and broadcast the mean when the second rolls over. Live polyline now reads identically to the historical view.

## Tradeoff
~1 s of added latency to the live cursor (broadcast lands when the second rolls over, not on the first fix). Acceptable for an observer feed; matches what the historical track shows on page reload anyway.

## Test plan
- [x] New unit tests on the bucket-and-flush semantics
- [x] 136 passed across ws + storage + smoothing + race suites
- [x] Lint + typecheck clean
- [ ] On corvopi-live: live polyline along a steady run draws as a smooth line, not a zig-zag

🤖 Generated with [Claude Code](https://claude.com/claude-code)