### PR TITLE
fix(results): convert local session start to venue-local date for matching

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -9,7 +9,7 @@ the same data produces zero net changes (R15, R16, R17).
 from __future__ import annotations
 
 import json
-from datetime import UTC, date, datetime, tzinfo
+from datetime import UTC, date, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -91,7 +91,10 @@ async def import_results(
 
         counts["races_upserted"] += 1
 
-    _linked, touched_sessions = await _link_regatta_races_to_local_sessions(db, regatta_id)
+    venue_tz = _resolve_venue_tz(reg.venue_tz)
+    _linked, touched_sessions = await _link_regatta_races_to_local_sessions(
+        db, regatta_id, venue_tz=venue_tz
+    )
 
     for standing in results.standings:
         boat_id = await _upsert_boat_minimal(db, standing.sail_number, boat_cache)
@@ -171,15 +174,23 @@ async def _link_regatta_races_to_local_sessions(
     db: aiosqlite.Connection,
     regatta_id: int,
     *,
+    venue_tz: tzinfo | None = None,
     force: bool = False,
 ) -> tuple[int, set[int]]:
-    """Link imported races to local race sessions on the same date.
+    """Link imported races to local race sessions on the same venue-local date.
 
-    When the number of local race-type sessions on a date is greater
-    than or equal to the number of imported races on that date, imported
-    races are zipped 1:1 with local sessions in order (imported by
-    ``race_num``, local by ``start_utc``). This handles beer-can nights
-    where race 1 and race 2 are each their own logged session.
+    The imported race's ``date`` is in the regatta's venue-local timezone
+    (e.g. STYC publishes "2026-05-04" for a Wed-night race that ends
+    near 8 PM PDT, even though the local session's ``start_utc`` reads
+    as "2026-05-05T01:27Z"). Candidate local sessions are pulled from a
+    ±1-day window and converted to venue-local date for comparison, so
+    after-midnight-UTC starts still match the published date (#734).
+
+    When the number of local race-type sessions on a venue-local date
+    is greater than or equal to the number of imported races on that
+    date, imported races are zipped 1:1 with local sessions in order
+    (imported by ``race_num``, local by ``start_utc``). This handles
+    beer-can nights where race 1 and race 2 are each their own session.
 
     Otherwise (fewer local sessions than imported races, i.e. a single
     local session covered the whole sailing day), every imported race is
@@ -192,11 +203,16 @@ async def _link_regatta_races_to_local_sessions(
     endpoint to fix up data that was linked before zip-in-order was
     implemented.
 
+    ``venue_tz`` is the regatta's local timezone (resolved via
+    ``_resolve_venue_tz``). When ``None``, falls back to system local
+    tz — which is correct on a Pi located at the venue.
+
     Returns ``(count_linked, touched_local_session_ids)`` — the second
     value is the union of every local session id written as a new link
     plus every prior link replaced by ``force=True``. Callers use it to
     drop cached session_summary blobs keyed on those session ids (#666).
     """
+    tz = venue_tz if venue_tz is not None else _resolve_venue_tz(None)
     cur = await db.execute(
         "SELECT id, date, race_num, local_session_id FROM races"
         " WHERE regatta_id = ? AND source IS NOT NULL AND source != 'live'"
@@ -218,7 +234,7 @@ async def _link_regatta_races_to_local_sessions(
     linked_count = 0
     touched: set[int] = set()
     for d, imported in by_date.items():
-        local_sessions = await _list_local_race_sessions_on_date(db, d)
+        local_sessions = await _list_local_race_sessions_on_date(db, d, tz)
         if not local_sessions:
             continue
 
@@ -253,25 +269,43 @@ async def _link_regatta_races_to_local_sessions(
 async def _list_local_race_sessions_on_date(
     db: aiosqlite.Connection,
     target_date: date,
+    venue_tz: tzinfo,
 ) -> list[int]:
-    """Return local race-type session ids whose ``date`` column is *target_date*.
+    """Return local race-type session ids whose venue-local start date is *target_date*.
 
-    Compares the stored ``date`` column directly — both helmlog's local
-    race date and the importer's race date are derived from UTC, so
-    matching on the string avoids venue-tz conversion bugs where a
-    session near midnight could shift to a different local date than
-    the imported race reports.
+    The local ``races.date`` column is derived from ``start_utc``, so
+    West-coast evening races crossing UTC midnight have a stored date
+    one day ahead of the venue-local date the importer reports. Pull a
+    ±1-day window of candidates and convert each session's
+    ``start_utc`` to venue-local date to filter — that way a 18:27 PDT
+    start (= 01:27Z next day, stored as date X+1) still matches the
+    imported race's date X.
     """
+    prev_d = (target_date - timedelta(days=1)).isoformat()
+    next_d = (target_date + timedelta(days=1)).isoformat()
     cur = await db.execute(
         "SELECT id, start_utc FROM races"
         " WHERE (source IS NULL OR source = 'live')"
         " AND session_type = 'race'"
-        " AND date = ?"
+        " AND date BETWEEN ? AND ?"
         " ORDER BY start_utc",
-        (target_date.isoformat(),),
+        (prev_d, next_d),
     )
     rows = await cur.fetchall()
-    return [r[0] for r in rows]
+    out: list[int] = []
+    for r in rows:
+        start_str = r[1]
+        if not start_str:
+            continue
+        try:
+            dt = datetime.fromisoformat(start_str)
+        except (ValueError, TypeError):
+            continue
+        if dt.tzinfo is None:
+            continue
+        if dt.astimezone(venue_tz).date() == target_date:
+            out.append(r[0])
+    return out
 
 
 async def _upsert_regatta(db: aiosqlite.Connection, reg: Regatta, now: str) -> int:

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -612,6 +612,73 @@ async def test_force_rematch_invalidates_old_and_new_live_sessions(
 
 
 @pytest.mark.asyncio
+async def test_link_matches_when_local_session_crosses_utc_midnight(
+    storage: Storage,
+) -> None:
+    """Regression for #734: a local session whose ``start_utc`` is past
+    midnight UTC but in the venue-local previous evening must still link
+    to an imported race published with the venue-local date.
+
+    Concrete example from corvopi-live: STYC publishes a Wed-night race
+    as date 2026-05-04, but the local session's start_utc is
+    2026-05-05T01:27Z (= 2026-05-04 18:27 PDT). String-compare on
+    ``races.date`` (UTC-derived → '2026-05-05') previously failed to
+    match the imported '2026-05-04' and left ``local_session_id`` NULL.
+    """
+    from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults
+
+    db = storage._conn()
+    # Local session started at 18:27 PDT on May 4 — that's 01:27 UTC on May 5.
+    # The stored ``date`` column is UTC-derived ('2026-05-05'), but the
+    # venue-local date is '2026-05-04'.
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, 'race')",
+        (
+            "Local Wed evening race",
+            "Local",
+            1,
+            "2026-05-05",
+            "2026-05-05T01:27:15+00:00",
+        ),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (local_id,) = await cur.fetchone()  # type: ignore[misc]
+    await db.commit()
+
+    # Imported race published with the venue-local date '2026-05-04'.
+    imported = RaceData(
+        source_id="cross_midnight_race",
+        race_number=4,
+        name="Race 4",
+        date="2026-05-04",
+        class_name="J/105",
+        finishes=(BoatFinish(sail_number="475", place=1),),
+    )
+    results = RegattaResults(
+        regatta=Regatta(
+            source="test",
+            source_id="cross_midnight",
+            name="Cross-midnight regatta",
+            venue_tz="America/Los_Angeles",
+        ),
+        races=(imported,),
+    )
+
+    await import_results(storage, results)
+
+    cur = await db.execute(
+        "SELECT local_session_id FROM races WHERE source = 'test' AND source_id = ?",
+        ("cross_midnight_race",),
+    )
+    row = await cur.fetchone()
+    assert row is not None
+    assert row["local_session_id"] == local_id, (
+        "imported race must auto-link via venue-local date conversion"
+    )
+
+
+@pytest.mark.asyncio
 async def test_race_with_no_date_skipped(storage: Storage) -> None:
     """R: imported race with no date is rejected, not written."""
     from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults


### PR DESCRIPTION
## Summary

- Fix `_link_regatta_races_to_local_sessions` so it matches imported races to local sessions even when the local session's `start_utc` crosses UTC midnight relative to the venue tz.
- Pull a ±1-day window of candidate sessions and convert each `start_utc` to venue-local date before comparing — fixes Wed-night PDT races whose stored `date` is the next UTC day.
- Resolve venue tz from `Regatta.venue_tz` (already on the dataclass) with the existing `_resolve_venue_tz` fallback chain (regatta tz → system local → UTC).

## Concrete example from corvopi-live

- STYC publishes the May-4 Wed-night race with `date='2026-05-04'`
- Local session 130: `start_utc='2026-05-05T01:27:15Z'` (= 2026-05-04 18:27 PDT), stored `date='2026-05-05'`
- Pre-fix string compare on `date` column: `'2026-05-04' != '2026-05-05'` → no link → results panel empty
- Post-fix: candidate's `start_utc.astimezone(LA).date() == 2026-05-04` → auto-links

## Test plan

- [x] `tests/test_results_importer.py::test_link_matches_when_local_session_crosses_utc_midnight` — new regression covering a synthetic venue_tz=LA regatta + post-midnight UTC local session
- [x] All 22 existing importer tests still pass
- [x] `ruff check`, `ruff format --check`, `mypy src/helmlog/results/importer.py` clean

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)