### PR TITLE
fix(results): filter imports to races containing the boat's own sail

### DIFF
--- a/src/helmlog/results/importer.py
+++ b/src/helmlog/results/importer.py
@@ -28,6 +28,44 @@ if TYPE_CHECKING:
     from helmlog.storage import Storage
 
 
+def _own_sail_number() -> str | None:
+    """Return the Pi's own sail number from boat identity, or None.
+
+    Wraps every conceivable failure (no identity, malformed json, missing
+    attr) and returns None — callers fall back to importing every race
+    when the sail is unknown.
+    """
+    try:
+        from helmlog.federation import load_identity
+
+        _, card = load_identity()
+        sail = card.sail_number
+    except Exception:  # noqa: BLE001
+        return None
+    sail = (sail or "").strip()
+    return sail or None
+
+
+def _filter_races_for_own_sail(
+    races: tuple[RaceData, ...],
+    own_sail: str | None,
+) -> tuple[RaceData, ...]:
+    """Drop races whose finishes don't contain *own_sail*.
+
+    STYC publishes a separate race row per division for each race
+    number, and helmlog's value comes from the one division the boat
+    actually competed in — every other division is noise. Filter to
+    races that actually contain the own sail.
+
+    If *own_sail* is unknown OR every race lacks it (spectator regatta),
+    return *races* unchanged so we don't accidentally drop everything.
+    """
+    if not own_sail:
+        return races
+    kept = tuple(r for r in races if any(f.sail_number == own_sail for f in r.finishes))
+    return kept if kept else races
+
+
 def _assign_places(finishes: tuple[BoatFinish, ...]) -> list[tuple[int, BoatFinish]]:
     """Assign unique 1-based place numbers.
 
@@ -53,8 +91,18 @@ async def import_results(
     results: RegattaResults,
     *,
     user_id: int | None = None,
+    own_sail: str | None = None,
 ) -> dict[str, int]:
     """Upsert a ``RegattaResults`` into the database.
+
+    When the boat's own sail number is known (loaded from
+    ``boat_identity`` if not explicitly provided), races that don't
+    contain that sail are filtered out before persisting — STYC and
+    similar sources publish every division for every race-night, and
+    most are irrelevant to the boat running this Pi (#735). The filter
+    only applies when at least one race contains the own sail; if the
+    sail is absent from the entire regatta (e.g. an admin imported a
+    spectator regatta), every race is persisted as before.
 
     Returns a summary dict with counts: ``races_upserted``,
     ``results_upserted``, ``boats_upserted``, ``standings_upserted``.
@@ -69,11 +117,22 @@ async def import_results(
         "standings_upserted": 0,
     }
 
+    if own_sail is None:
+        own_sail = _own_sail_number()
+    races_to_import = _filter_races_for_own_sail(results.races, own_sail)
+    if own_sail and len(races_to_import) < len(results.races):
+        logger.info(
+            "Filtered {} → {} races for own sail {!r} (skipped foreign divisions)",
+            len(results.races),
+            len(races_to_import),
+            own_sail,
+        )
+
     regatta_id = await _upsert_regatta(db, reg, now)
 
     boat_cache: dict[str, int] = {}
 
-    for race_data in results.races:
+    for race_data in races_to_import:
         if not race_data.date:
             logger.warning(
                 "Skipping race {} — no date (provider returned null)",

--- a/tests/test_results_importer.py
+++ b/tests/test_results_importer.py
@@ -612,6 +612,109 @@ async def test_force_rematch_invalidates_old_and_new_live_sessions(
 
 
 @pytest.mark.asyncio
+async def test_filter_drops_races_without_own_sail(storage: Storage) -> None:
+    """Regression for #735: STYC publishes 10 division-races per race-num.
+    With own_sail known, only races containing that sail are persisted.
+    """
+    from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults
+
+    own = RaceData(
+        source_id="own_div",
+        race_number=1,
+        name="Race 1",
+        date="2026-05-04",
+        class_name="Flying Sails Div 6",
+        finishes=(
+            BoatFinish(sail_number="475", place=1),
+            BoatFinish(sail_number="403", place=2),
+        ),
+    )
+    foreign = RaceData(
+        source_id="foreign_div",
+        race_number=1,
+        name="Race 1",
+        date="2026-05-04",
+        class_name="Flying Sails Div 2",
+        finishes=(BoatFinish(sail_number="34", place=1),),
+    )
+    results = RegattaResults(
+        regatta=Regatta(source="test", source_id="filter_t1", name="Test"),
+        races=(own, foreign),
+    )
+
+    counts = await import_results(storage, results, own_sail="475")
+    assert counts["races_upserted"] == 1, "foreign division must be filtered out"
+
+    db = storage._conn()
+    cur = await db.execute(
+        "SELECT source_id FROM races WHERE source = 'test' ORDER BY source_id",
+    )
+    rows = await cur.fetchall()
+    assert [r["source_id"] for r in rows] == ["own_div"]
+
+
+@pytest.mark.asyncio
+async def test_filter_keeps_all_when_sail_absent_from_regatta(storage: Storage) -> None:
+    """If the own sail isn't in *any* race (spectator regatta), don't
+    silently drop everything — fall back to importing every race."""
+    from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults
+
+    foreign1 = RaceData(
+        source_id="foreign_a",
+        race_number=1,
+        name="Race 1",
+        date="2026-05-04",
+        class_name="Class A",
+        finishes=(BoatFinish(sail_number="34", place=1),),
+    )
+    foreign2 = RaceData(
+        source_id="foreign_b",
+        race_number=2,
+        name="Race 2",
+        date="2026-05-04",
+        class_name="Class B",
+        finishes=(BoatFinish(sail_number="153", place=1),),
+    )
+    results = RegattaResults(
+        regatta=Regatta(source="test", source_id="filter_t2", name="Test"),
+        races=(foreign1, foreign2),
+    )
+
+    counts = await import_results(storage, results, own_sail="475")
+    assert counts["races_upserted"] == 2, "fall back to all races when own sail absent"
+
+
+@pytest.mark.asyncio
+async def test_filter_skipped_when_no_own_sail(storage: Storage) -> None:
+    """No identity → no filter, every race imported (back-compat)."""
+    from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults
+
+    a = RaceData(
+        source_id="a_div",
+        race_number=1,
+        name="Race 1",
+        date="2026-05-04",
+        class_name="Class A",
+        finishes=(BoatFinish(sail_number="475", place=1),),
+    )
+    b = RaceData(
+        source_id="b_div",
+        race_number=1,
+        name="Race 1",
+        date="2026-05-04",
+        class_name="Class B",
+        finishes=(BoatFinish(sail_number="34", place=1),),
+    )
+    results = RegattaResults(
+        regatta=Regatta(source="test", source_id="filter_t3", name="Test"),
+        races=(a, b),
+    )
+
+    counts = await import_results(storage, results, own_sail=None)
+    assert counts["races_upserted"] == 2
+
+
+@pytest.mark.asyncio
 async def test_race_with_no_date_skipped(storage: Storage) -> None:
     """R: imported race with no date is rejected, not written."""
     from helmlog.results.base import BoatFinish, RaceData, Regatta, RegattaResults


### PR DESCRIPTION
## Summary

- Filter imported races at the importer to only those whose finishes contain the Pi's own sail number, loaded from `boat_identity`.
- Drops the 9-of-10 foreign division-races that STYC publishes for every race-night where Corvo only competes in one.
- Falls back to importing every race when the own sail is absent from the entire regatta (spectator regattas) or when no identity is configured.

## Concrete impact on corvopi-live

Before: regatta 5 has 40 imported races (4 race-nums × 10 divisions). Corvo (sail 475) appears in 4 of them; the other 36 clutter the admin UI and confuse auto-linking.

After: only the 4 races containing sail 475 are persisted on next import.

## Tests

- [x] `test_filter_drops_races_without_own_sail` — own sail set, only matching races persisted
- [x] `test_filter_keeps_all_when_sail_absent_from_regatta` — own sail set, sail not in any race → fall back to importing all
- [x] `test_filter_skipped_when_no_own_sail` — no identity → import every race (back-compat)
- [x] All 24 existing importer tests still pass
- [x] `ruff check`, `ruff format --check`, `mypy src/helmlog/results/importer.py` clean

## Cleanup of pre-existing rows

Not in this PR — after merge + import re-run on corvopi-live, an admin can run the cleanup query from #735 to drop the 36 stale foreign-division rows.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)