### PR TITLE
fix(results): invalidate session_summary cache on manual link-imported

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -47,6 +47,8 @@ def compute_race_data_hash(
     start_utc: datetime,
     end_utc: datetime | None,
     row_count: int,
+    linked_imported_id: int | None = None,
+    linked_imported_results: int = 0,
 ) -> str:
     """Stable 16-char hex digest of the race's cache-relevant inputs.
 
@@ -54,12 +56,19 @@ def compute_race_data_hash(
     race row. No TTL is needed: any mutation to the underlying race flows
     through the storage invalidation hook, which drops all entries for the
     race id.
+
+    ``linked_imported_id`` and ``linked_imported_results`` fold the
+    imported-results link into the hash so ETag revalidation flips when
+    a session's results are linked, unlinked, or rewritten — otherwise
+    browsers that cached an empty-results response keep getting 304s.
     """
     payload = {
         "race_id": race_id,
         "start_utc": start_utc.isoformat(),
         "end_utc": end_utc.isoformat() if end_utc is not None else None,
         "row_count": row_count,
+        "linked_imported_id": linked_imported_id,
+        "linked_imported_results": linked_imported_results,
     }
     raw = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
@@ -102,10 +111,36 @@ async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
         win_row = await win_cur.fetchone()
         row_count = int(win_row["cnt"]) if win_row else 0
 
+    # Imported-results link: which (if any) imported race points here, and
+    # how many results it carries. Folded into the hash so ETag flips on
+    # link/unlink even though the live race row itself hasn't changed.
+    link_cur = await db.execute(
+        "SELECT id FROM races"
+        " WHERE local_session_id = ? AND source IS NOT NULL AND source != 'live'"
+        " ORDER BY COALESCE(start_utc, date) LIMIT 1",
+        (race_id,),
+    )
+    link_row = await link_cur.fetchone()
+    linked_imported_id: int | None = None
+    linked_imported_results = 0
+    if link_row is not None:
+        linked_imported_id = int(link_row["id"])
+        rr_cur = await db.execute(
+            "SELECT COUNT(*) AS cnt FROM race_results WHERE race_id = ?",
+            (linked_imported_id,),
+        )
+        rr_row = await rr_cur.fetchone()
+        linked_imported_results = int(rr_row["cnt"]) if rr_row else 0
+
     start_dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
     end_dt = datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else None
     return compute_race_data_hash(
-        race_id=race_id, start_utc=start_dt, end_utc=end_dt, row_count=row_count
+        race_id=race_id,
+        start_utc=start_dt,
+        end_utc=end_dt,
+        row_count=row_count,
+        linked_imported_id=linked_imported_id,
+        linked_imported_results=linked_imported_results,
     )
 
 

--- a/src/helmlog/routes/results.py
+++ b/src/helmlog/routes/results.py
@@ -301,12 +301,23 @@ async def api_session_link_imported(
     if not await cur.fetchone():
         raise HTTPException(404, "Session not found")
 
+    # Collect ids whose cached session_summary depends on the link before
+    # mutating: the live session itself, the new imported race, and any
+    # imported race already pointing here (whose link is about to be cleared).
+    # Without this, /history keeps serving the pre-link results: [] blob.
+    invalidation_ids: set[int] = {session_id}
+    cur = await db.execute("SELECT id FROM races WHERE local_session_id = ?", (session_id,))
+    for row in await cur.fetchall():
+        invalidation_ids.add(row[0])
+
     if imported_race_id == 0:
         await db.execute(
             "UPDATE races SET local_session_id = NULL WHERE local_session_id = ?",
             (session_id,),
         )
         await db.commit()
+        for rid in invalidation_ids:
+            await storage._invalidate_race_cache(rid)
         await audit(
             request,
             "results_session_unlink",
@@ -320,6 +331,7 @@ async def api_session_link_imported(
     )
     if not await cur.fetchone():
         raise HTTPException(404, "Imported race not found")
+    invalidation_ids.add(imported_race_id)
 
     # Clear any previous link on this session so we don't end up pointing
     # multiple imported rows at the same local session.
@@ -332,6 +344,9 @@ async def api_session_link_imported(
         (session_id, imported_race_id),
     )
     await db.commit()
+
+    for rid in invalidation_ids:
+        await storage._invalidate_race_cache(rid)
 
     await audit(
         request,

--- a/tests/test_results_rematch_web.py
+++ b/tests/test_results_rematch_web.py
@@ -152,6 +152,8 @@ async def test_link_imported_invalidates_session_summary_cache(
     pre = await admin_client.get(f"/api/sessions/{local_id}/summary")
     assert pre.status_code == 200
     assert pre.json()["results"] == []
+    pre_etag = pre.headers.get("etag")
+    assert pre_etag is not None
 
     cur = await db.execute(
         "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
@@ -173,10 +175,23 @@ async def test_link_imported_invalidates_session_summary_cache(
     )
     assert (await cur.fetchone())["n"] == 0
 
-    # Re-fetch — fresh compute now sees the linked results.
+    # Re-fetch — fresh compute now sees the linked results AND the ETag flips
+    # so a browser holding the pre-link 200 won't get a 304 with stale data.
     post = await admin_client.get(f"/api/sessions/{local_id}/summary")
     assert post.status_code == 200
     assert len(post.json()["results"]) == 1
+    post_etag = post.headers.get("etag")
+    assert post_etag is not None
+    assert post_etag != pre_etag
+
+    # Sanity: a conditional GET with the OLD ETag must NOT return 304 — the
+    # server must recognise the link change and serve the fresh payload.
+    cond = await admin_client.get(
+        f"/api/sessions/{local_id}/summary",
+        headers={"If-None-Match": pre_etag},
+    )
+    assert cond.status_code == 200
+    assert len(cond.json()["results"]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_results_rematch_web.py
+++ b/tests/test_results_rematch_web.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import httpx
@@ -87,3 +87,155 @@ async def test_rematch_unknown_regatta_returns_404(
 ) -> None:
     resp = await admin_client.post("/api/results/regattas/9999/rematch")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_link_imported_invalidates_session_summary_cache(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """Manual link-imported drops the cached session_summary blob (#739 follow-up).
+
+    Reproduces the history-page bug: a /summary fetch ran *before* the user
+    linked imported results, populating web_cache with results: []. Without
+    invalidation the history thumbnails keep serving the stale empty list.
+    """
+    db = storage._conn()
+    now = datetime.now(UTC).isoformat()
+
+    cur = await db.execute(
+        "INSERT INTO regattas (source, source_id, name, created_at)"
+        " VALUES ('clubspot', 'rg-link', 'Test Regatta', ?)",
+        (now,),
+    )
+    regatta_id = cur.lastrowid
+
+    race_date = "2026-04-09"
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, "
+        "session_type, regatta_id, source, source_id) "
+        "VALUES (?, ?, ?, ?, ?, 'race', ?, 'clubspot', 'rc-link-1')",
+        ("Imported Race", "J/105", 1, race_date, race_date, regatta_id),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (imported_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    local_start = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, ?, 'race')",
+        (
+            "Local Race",
+            "Local",
+            1,
+            race_date,
+            local_start.isoformat(),
+            (local_start + timedelta(minutes=30)).isoformat(),
+        ),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (local_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    # A boat + result so the imported race actually has something to surface.
+    cur = await db.execute(
+        "INSERT INTO boats (sail_number, name, class, last_used) VALUES ('USA 1', 'Test', '', ?)",
+        (now,),
+    )
+    boat_id = cur.lastrowid
+    await db.execute(
+        "INSERT INTO race_results (race_id, boat_id, place, dnf, dns, created_at)"
+        " VALUES (?, ?, 1, 0, 0, ?)",
+        (imported_id, boat_id, now),
+    )
+    await db.commit()
+
+    # Prime the cache with a pre-link summary (results will be empty).
+    pre = await admin_client.get(f"/api/sessions/{local_id}/summary")
+    assert pre.status_code == 200
+    assert pre.json()["results"] == []
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (local_id, "session_summary"),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+    # Link the imported race manually.
+    resp = await admin_client.post(
+        f"/api/sessions/{local_id}/link-imported",
+        data={"imported_race_id": imported_id},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Cache must be gone for the local session AND the imported race.
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (local_id, "session_summary"),
+    )
+    assert (await cur.fetchone())["n"] == 0
+
+    # Re-fetch — fresh compute now sees the linked results.
+    post = await admin_client.get(f"/api/sessions/{local_id}/summary")
+    assert post.status_code == 200
+    assert len(post.json()["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_link_imported_unlink_invalidates_cache(
+    storage: Storage, admin_client: httpx.AsyncClient
+) -> None:
+    """imported_race_id=0 (unlink) also drops the session's cached summary."""
+    db = storage._conn()
+    now = datetime.now(UTC).isoformat()
+
+    cur = await db.execute(
+        "INSERT INTO regattas (source, source_id, name, created_at)"
+        " VALUES ('clubspot', 'rg-unlink', 'Test Regatta', ?)",
+        (now,),
+    )
+    regatta_id = cur.lastrowid
+    race_date = "2026-04-16"
+    local_start = datetime.fromisoformat(race_date + "T18:00:00+00:00")
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, session_type)"
+        " VALUES (?, ?, ?, ?, ?, ?, 'race')",
+        (
+            "Local",
+            "Local",
+            1,
+            race_date,
+            local_start.isoformat(),
+            (local_start + timedelta(minutes=30)).isoformat(),
+        ),
+    )
+    cur = await db.execute("SELECT last_insert_rowid()")
+    (local_id,) = await cur.fetchone()  # type: ignore[misc]
+
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, "
+        "session_type, regatta_id, source, source_id, local_session_id) "
+        "VALUES (?, ?, ?, ?, ?, 'race', ?, 'clubspot', 'rc-unlink', ?)",
+        ("Imported", "J/105", 1, race_date, race_date, regatta_id, local_id),
+    )
+    await db.commit()
+
+    # Prime the cache with the linked summary.
+    pre = await admin_client.get(f"/api/sessions/{local_id}/summary")
+    assert pre.status_code == 200
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (local_id, "session_summary"),
+    )
+    assert (await cur.fetchone())["n"] == 1
+
+    resp = await admin_client.post(
+        f"/api/sessions/{local_id}/link-imported",
+        data={"imported_race_id": 0},
+    )
+    assert resp.status_code == 200
+
+    cur = await db.execute(
+        "SELECT COUNT(*) AS n FROM web_cache WHERE race_id = ? AND key_family = ?",
+        (local_id, "session_summary"),
+    )
+    assert (await cur.fetchone())["n"] == 0


### PR DESCRIPTION
## Summary
Two-layer fix for imported results not appearing on `/history` after a manual Link.

1. `POST /api/sessions/{id}/link-imported` now invalidates the cached `session_summary` blob (T1 + T2) for the live session, the newly-linked imported race, and any race whose previous link is being cleared.
2. `compute_race_data_hash` now folds the linked imported race id + its result count into the hash, so the ETag flips on link/unlink. Without this, browsers that cached the pre-link 200 response keep getting 304 on revalidation and serve the stale empty-results payload from disk forever.

## Context
Bug was visible after #736: imported results showed on the session detail page (uncached path) but not on `/history` (cached). The regatta-wide rematch endpoint and the importer itself already invalidated; only the per-session manual Link was missing it. And even after invalidation, browser cache held the empty-results blob keyed to an unchanged ETag.

## Test plan
- [x] `uv run pytest tests/test_results_rematch_web.py` — 4 passed
- [x] Wider sweep: `tests/test_results_importer.py tests/test_web_cache_routes.py tests/test_results_rematch_web.py` — 40 passed
- [x] Reverting the route fix: the new tests fail (regression check)
- [ ] On corvopi-live: hit `/history`, observe Wednesday-night sessions show their imported results once the page revalidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)