### PR TITLE
feat(analysis): cross-session maneuver compare — 3 best + 3 median (#741)

### DIFF
--- a/src/helmlog/analysis/compare.py
+++ b/src/helmlog/analysis/compare.py
@@ -1,0 +1,202 @@
+"""Cross-session maneuver compare — best/median selection (#741).
+
+A coaching tool: given a pool of enriched maneuvers (the output of
+:func:`helmlog.analysis.maneuvers.enrich_maneuvers_for_ids`), pick the
+3 best by some success metric and the 3 closest to the median, so the
+coach can compare top performers vs typical performers side-by-side.
+
+All current candidate metrics (``distance_loss_m``, ``time_to_recover_s``,
+``vmg_loss_kts``, ...) follow a smaller-is-better convention; ``pick_best``
+sorts ascending. Items missing the chosen metric are excluded from ranking.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+# Filterable maneuver-type values exposed by the API. Internally, ``rounding``
+# maneuvers carry a ``details.rounding_kind`` of ``"weather"`` / ``"leeward"``
+# (or absent for legacy rows), so the two split out at the filter layer.
+ROUNDING_TYPES = {"weather_rounding", "leeward_rounding"}
+
+
+def _recency_key(m: dict[str, Any]) -> str:
+    """Sort key for tie-breaking — newer session_start_utc wins.
+
+    ISO-8601 strings sort lexicographically in chronological order, so a
+    plain string compare suffices. Missing values sort earliest.
+    """
+    return str(m.get("session_start_utc") or "")
+
+
+def _matches_type(m: dict[str, Any], maneuver_type: str) -> bool:
+    if maneuver_type in ROUNDING_TYPES:
+        if m.get("type") != "rounding":
+            return False
+        kind = (m.get("details") or {}).get("rounding_kind")
+        wanted = "weather" if maneuver_type == "weather_rounding" else "leeward"
+        return kind == wanted
+    return m.get("type") == maneuver_type
+
+
+def filter_pool(
+    items: list[dict[str, Any]],
+    *,
+    maneuver_type: str | None = None,
+    tws_min: float | None = None,
+    tws_max: float | None = None,
+) -> list[dict[str, Any]]:
+    """Filter an enriched-maneuver pool by type and entry-TWS range.
+
+    TWS range is inclusive on both ends. Items missing ``entry_tws`` are
+    dropped only when a TWS range is supplied — when no range is set, they
+    pass through (the caller didn't ask to filter on wind).
+    """
+    out = []
+    for m in items:
+        if maneuver_type is not None and not _matches_type(m, maneuver_type):
+            continue
+        if tws_min is not None or tws_max is not None:
+            tws = m.get("entry_tws")
+            if tws is None:
+                continue
+            if tws_min is not None and tws < tws_min:
+                continue
+            if tws_max is not None and tws > tws_max:
+                continue
+        out.append(m)
+    return out
+
+
+def pick_best(
+    items: list[dict[str, Any]],
+    *,
+    metric: str,
+    n: int = 3,
+) -> list[dict[str, Any]]:
+    """Return up to ``n`` maneuvers with the smallest ``metric`` values.
+
+    Items where ``metric`` is None are excluded. Ties are broken by session
+    recency (most recent first), so a current-form best beats an old best.
+    """
+    rankable = [m for m in items if m.get(metric) is not None]
+    rankable.sort(key=lambda m: (float(m[metric]), _negate(_recency_key(m))))
+    return rankable[:n]
+
+
+def pick_median(
+    items: list[dict[str, Any]],
+    *,
+    metric: str,
+    n: int = 3,
+    exclude_ids: set[int] | None = None,
+) -> list[dict[str, Any]]:
+    """Return up to ``n`` maneuvers whose ``metric`` is closest to the median.
+
+    The median is computed from the ``metric`` values of items not excluded
+    and not None — so the median represents typical performance of the pool
+    that's available to fill the median slots. Ties on distance-to-median
+    are broken by session recency (most recent first).
+
+    ``exclude_ids`` lets the caller hand in the ids already chosen by
+    :func:`pick_best` so the best and median sets don't overlap.
+    """
+    excluded = exclude_ids or set()
+    rankable = [m for m in items if m.get(metric) is not None and m.get("id") not in excluded]
+    if not rankable:
+        return []
+
+    values = [float(m[metric]) for m in rankable]
+    median = statistics.median(values)
+
+    rankable.sort(key=lambda m: (abs(float(m[metric]) - median), _negate(_recency_key(m))))
+    return rankable[:n]
+
+
+def assemble_compare_set(
+    items: list[dict[str, Any]],
+    *,
+    metric: str,
+    n: int = 3,
+) -> dict[str, Any]:
+    """Top-level: split a filtered pool into ``best`` and ``median`` cells.
+
+    The two sets are disjoint — anything chosen as best is excluded from the
+    median pool, so a coach reviewing the page never sees the same maneuver
+    in two cells. Returns the metric's median value (across the full pool)
+    so the UI can label the median row with the actual number coaches are
+    comparing against.
+    """
+    rankable_values = [float(m[metric]) for m in items if m.get(metric) is not None]
+    median_value: float | None = statistics.median(rankable_values) if rankable_values else None
+
+    best = pick_best(items, metric=metric, n=n)
+    best_ids = {m["id"] for m in best if m.get("id") is not None}
+    median = pick_median(items, metric=metric, n=n, exclude_ids=best_ids)
+
+    return {
+        "best": best,
+        "median": median,
+        "median_value": median_value,
+        "pool_size": len(items),
+    }
+
+
+async def list_maneuver_pairs(
+    storage: Storage,
+    *,
+    maneuver_type: str | None = None,
+) -> list[tuple[int, int]]:
+    """Return all ``(session_id, maneuver_id)`` pairs across the boat's DB.
+
+    Filtering by tack / gybe is pushed to SQL via the ``type`` column. The
+    rounding split (``weather_rounding`` vs ``leeward_rounding``) reads the
+    ``details`` JSON in-Python because SQLite has no first-class JSON path
+    operator on this schema. Roundings without a ``rounding_kind`` are
+    skipped under the rounding filters — they cannot be classified.
+    """
+    db = storage._read_conn()
+    if maneuver_type in ROUNDING_TYPES:
+        cursor = await db.execute(
+            "SELECT session_id, id, details FROM maneuvers WHERE type = 'rounding'"
+        )
+        rows = await cursor.fetchall()
+        wanted = "weather" if maneuver_type == "weather_rounding" else "leeward"
+        out: list[tuple[int, int]] = []
+        for r in rows:
+            details_raw = r[2]
+            if not details_raw:
+                continue
+            try:
+                details = json.loads(details_raw)
+            except (TypeError, ValueError):
+                continue
+            if details.get("rounding_kind") == wanted:
+                out.append((int(r[0]), int(r[1])))
+        return out
+
+    if maneuver_type is None:
+        cursor = await db.execute("SELECT session_id, id FROM maneuvers")
+    else:
+        cursor = await db.execute(
+            "SELECT session_id, id FROM maneuvers WHERE type = ?",
+            (maneuver_type,),
+        )
+    rows = await cursor.fetchall()
+    return [(int(r[0]), int(r[1])) for r in rows]
+
+
+def _negate(s: str) -> tuple[int, ...]:
+    """Sort-key adapter: invert a string's ordering so newer (lex-greater)
+    sorts first when used as a secondary tiebreaker on ascending sorts.
+
+    ISO-8601 timestamps as plain strings sort old → new ascending. We want
+    new → old as a *tie-break under* an ascending primary key, so we map
+    each character to its negated codepoint. Cheap and total over any str.
+    """
+    return tuple(-ord(c) for c in s)

--- a/src/helmlog/analysis/compare.py
+++ b/src/helmlog/analysis/compare.py
@@ -50,12 +50,22 @@ def filter_pool(
     maneuver_type: str | None = None,
     tws_min: float | None = None,
     tws_max: float | None = None,
+    direction: str | None = None,
+    gun_by_session: dict[int, str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Filter an enriched-maneuver pool by type and entry-TWS range.
+    """Filter an enriched-maneuver pool by type, entry-TWS, direction, and
+    pre/post-start cut-off.
 
     TWS range is inclusive on both ends. Items missing ``entry_tws`` are
-    dropped only when a TWS range is supplied — when no range is set, they
-    pass through (the caller didn't ask to filter on wind).
+    dropped only when a TWS range is supplied.
+
+    ``direction`` follows the convention in ``routes/sessions.py``:
+    ``is_ps = turn_angle_deg < 0`` (so PS matches negative turn, SP matches
+    non-negative). Items without a turn angle are dropped when set.
+
+    ``gun_by_session`` enables the post-start cut: ``{session_id: gun_iso}``;
+    items whose ``ts`` is before their session's gun are dropped. Sessions
+    not in the dict pass through (no gun = no cut).
     """
     out = []
     for m in items:
@@ -69,8 +79,58 @@ def filter_pool(
                 continue
             if tws_max is not None and tws > tws_max:
                 continue
+        if direction is not None:
+            ang = m.get("turn_angle_deg")
+            if ang is None:
+                continue
+            is_ps = ang < 0
+            if direction == "PS" and not is_ps:
+                continue
+            if direction == "SP" and is_ps:
+                continue
+        if gun_by_session:
+            sid = m.get("session_id")
+            gun = gun_by_session.get(sid) if isinstance(sid, int) else None
+            if gun and str(m.get("ts") or "") < gun:
+                continue
         out.append(m)
     return out
+
+
+async def load_gun_times(
+    storage: Storage,
+    session_ids: list[int],
+) -> dict[int, str]:
+    """Compute each session's effective race gun (latest Vakaros race_start
+    event inside the session window, falling back to ``start_utc``).
+
+    Mirrors the query used by ``GET /api/maneuvers`` in routes/sessions.py
+    so the post-start filter on this endpoint and the existing maneuvers
+    browser cut at the same instant.
+    """
+    if not session_ids:
+        return {}
+    db = storage._read_conn()
+    placeholders = ",".join("?" * len(session_ids))
+    cursor = await db.execute(
+        f"""
+        SELECT r.id AS session_id,
+               COALESCE(
+                 (SELECT MAX(vre.ts)
+                    FROM vakaros_race_events vre
+                   WHERE vre.session_id = r.vakaros_session_id
+                     AND vre.event_type = 'race_start'
+                     AND vre.ts BETWEEN r.start_utc
+                                    AND COALESCE(r.end_utc, r.start_utc)),
+                 r.start_utc
+               ) AS gun_utc
+          FROM races r
+         WHERE r.id IN ({placeholders})
+        """,
+        session_ids,
+    )
+    rows = await cursor.fetchall()
+    return {int(r[0]): str(r[1]) for r in rows if r[1] is not None}
 
 
 def pick_best(

--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -403,25 +403,33 @@ _CONSISTENT_STDEV_FRAC = 0.5
 _CONSISTENT_ABS_SPREAD_M = 3.0
 
 
-def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def rank_maneuvers(
+    items: list[dict[str, Any]],
+    *,
+    metric: str | None = None,
+) -> list[dict[str, Any]]:
     """Attach a ``rank`` label and ``loss_percentile`` in-place (#616).
 
-    Ranking is by ``distance_loss_m`` when available, else ``loss_kts``.
-    When the set's loss spread is too small to be meaningful (low
-    relative stdev OR small absolute range), every rankable item gets
-    rank ``consistent`` instead of the quartile split. Otherwise top
-    quartile (lowest loss) → ``good``, bottom quartile → ``bad``,
-    middle half → ``avg``. Entries with no loss data get rank ``None``.
+    Ranking is by ``metric`` when supplied, else ``distance_loss_m`` falling
+    back to ``loss_kts``. When the set's loss spread is too small to be
+    meaningful (low relative stdev OR — for ``distance_loss_m`` only — small
+    absolute range), every rankable item gets rank ``consistent`` instead
+    of the quartile split. Otherwise top quartile (lowest value) → ``good``,
+    bottom quartile → ``bad``, middle half → ``avg``. Entries with no value
+    for the chosen metric get rank ``None``.
 
-    ``loss_percentile`` is the 0–100 within-set rank (lowest loss = 0)
-    on every rankable item, regardless of bucket. The UI renders it
-    as a tooltip number so a user can see the underlying ordering
-    even when the bucket label is ``consistent``.
+    ``loss_percentile`` is the 0–100 within-set rank (lowest value = 0)
+    on every rankable item, regardless of bucket. The UI renders it as a
+    tooltip number so a user can see the underlying ordering even when the
+    bucket label is ``consistent``.
     """
     if not items:
         return items
 
     def _key(m: dict[str, Any]) -> float | None:
+        if metric is not None:
+            v = m.get(metric)
+            return float(v) if v is not None else None
         v = m.get("distance_loss_m")
         if v is not None:
             return float(v)
@@ -449,10 +457,11 @@ def rank_maneuvers(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     stdev_loss = statistics.pstdev(losses) if n > 1 else 0.0
     relative_passes = median_loss > 0 and (stdev_loss / median_loss) >= _CONSISTENT_STDEV_FRAC
     # The 3 m floor is unit-specific (GPS positional noise on
-    # ``distance_loss_m``). When falling back to ``loss_kts`` we can't
-    # apply it — knots aren't meters — so only the relative test gates
-    # the spread call on those rows.
-    using_distance = all(m.get("distance_loss_m") is not None for m in sorted_items)
+    # ``distance_loss_m``). For any other metric (knots, seconds) it would
+    # be meaningless, so only the relative test gates those rows.
+    using_distance = metric is None and all(
+        m.get("distance_loss_m") is not None for m in sorted_items
+    )
     absolute_passes = (not using_distance) or spread >= _CONSISTENT_ABS_SPREAD_M
 
     if not (relative_passes and absolute_passes):

--- a/src/helmlog/routes/analysis.py
+++ b/src/helmlog/routes/analysis.py
@@ -555,14 +555,19 @@ async def api_maneuver_compare(
     metric: str = Query("distance_loss_m"),
     tws_min: float | None = Query(None, ge=0),
     tws_max: float | None = Query(None, ge=0),
+    direction: str | None = Query(None),
+    post_start: bool = Query(False),
     n: int = Query(3, ge=1, le=10),
     user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
 ) -> JSONResponse:
     """Coaching tool: 3 best + 3 median maneuvers across all sessions (#741).
 
-    Filters all stored maneuvers by ``type`` and entry-TWS range, ranks the
-    pool by ``metric`` (smaller is better), and returns the best ``n`` plus
-    the ``n`` closest to the median for side-by-side video/track review.
+    Filters all stored maneuvers by ``type``, entry-TWS range, tack/gybe
+    ``direction`` (PS|SP), and an optional pre-start cut (``post_start=1``
+    drops maneuvers that happened before the session's race gun, computed
+    the same way as ``GET /api/maneuvers``). Ranks the pool by ``metric``
+    (smaller is better) and returns the best ``n`` plus the ``n`` closest
+    to the median for side-by-side video/track review.
     """
     if maneuver_type not in _COMPARE_TYPES:
         raise HTTPException(422, f"type must be one of {sorted(_COMPARE_TYPES)}")
@@ -570,6 +575,8 @@ async def api_maneuver_compare(
         raise HTTPException(422, f"metric must be one of {sorted(_COMPARE_METRICS)}")
     if tws_min is not None and tws_max is not None and tws_min > tws_max:
         raise HTTPException(422, "tws_min must be <= tws_max")
+    if direction is not None and direction not in ("PS", "SP"):
+        raise HTTPException(422, "direction must be PS or SP")
 
     storage = get_storage(request)
 
@@ -577,16 +584,25 @@ async def api_maneuver_compare(
         assemble_compare_set,
         filter_pool,
         list_maneuver_pairs,
+        load_gun_times,
     )
     from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids  # noqa: PLC0415
 
     pairs = await list_maneuver_pairs(storage, maneuver_type=maneuver_type)
     enriched, video_sync = await enrich_maneuvers_for_ids(storage, pairs)
+
+    gun_by_session: dict[int, str] | None = None
+    if post_start:
+        session_ids = sorted({sid for sid, _ in pairs})
+        gun_by_session = await load_gun_times(storage, session_ids)
+
     pool = filter_pool(
         enriched,
         maneuver_type=maneuver_type,
         tws_min=tws_min,
         tws_max=tws_max,
+        direction=direction,
+        gun_by_session=gun_by_session,
     )
     result = assemble_compare_set(pool, metric=metric, n=n)
 
@@ -595,7 +611,8 @@ async def api_maneuver_compare(
         "analysis.maneuver_compare",
         detail=(
             f"type={maneuver_type} metric={metric}"
-            f" tws=[{tws_min},{tws_max}] pool={result['pool_size']}"
+            f" tws=[{tws_min},{tws_max}] dir={direction}"
+            f" post_start={int(post_start)} pool={result['pool_size']}"
         ),
         user=user,
     )
@@ -606,6 +623,8 @@ async def api_maneuver_compare(
                 "metric": metric,
                 "tws_min": tws_min,
                 "tws_max": tws_max,
+                "direction": direction,
+                "post_start": post_start,
                 "n": n,
             },
             **result,

--- a/src/helmlog/routes/analysis.py
+++ b/src/helmlog/routes/analysis.py
@@ -4,13 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
 from helmlog.auth import require_auth
 from helmlog.routes._helpers import audit, get_storage
 
 router = APIRouter()
+
+# Allowed metric names (smaller-is-better) for the maneuver-compare endpoint.
+# Each maps to a key on the enriched-maneuver dict produced by
+# ``analysis.maneuvers.enrich_maneuvers_for_ids``.
+_COMPARE_METRICS: set[str] = {
+    "distance_loss_m",
+    "time_to_recover_s",
+    "time_to_head_to_wind_s",
+    "loss_kts",
+}
+# Allowed maneuver-type values for the compare endpoint. Roundings are
+# split into weather / leeward via the ``details.rounding_kind`` discriminator.
+_COMPARE_TYPES: set[str] = {
+    "tack",
+    "gybe",
+    "weather_rounding",
+    "leeward_rounding",
+}
 
 
 @router.get("/api/analysis/models")
@@ -528,3 +546,69 @@ async def api_analysis_ab_compare(
         user=user,
     )
     return JSONResponse({"session_id": session_id, "panels": panels})
+
+
+@router.get("/api/analysis/maneuver-compare")
+async def api_maneuver_compare(
+    request: Request,
+    maneuver_type: str = Query(..., alias="type"),
+    metric: str = Query("distance_loss_m"),
+    tws_min: float | None = Query(None, ge=0),
+    tws_max: float | None = Query(None, ge=0),
+    n: int = Query(3, ge=1, le=10),
+    user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
+) -> JSONResponse:
+    """Coaching tool: 3 best + 3 median maneuvers across all sessions (#741).
+
+    Filters all stored maneuvers by ``type`` and entry-TWS range, ranks the
+    pool by ``metric`` (smaller is better), and returns the best ``n`` plus
+    the ``n`` closest to the median for side-by-side video/track review.
+    """
+    if maneuver_type not in _COMPARE_TYPES:
+        raise HTTPException(422, f"type must be one of {sorted(_COMPARE_TYPES)}")
+    if metric not in _COMPARE_METRICS:
+        raise HTTPException(422, f"metric must be one of {sorted(_COMPARE_METRICS)}")
+    if tws_min is not None and tws_max is not None and tws_min > tws_max:
+        raise HTTPException(422, "tws_min must be <= tws_max")
+
+    storage = get_storage(request)
+
+    from helmlog.analysis.compare import (  # noqa: PLC0415
+        assemble_compare_set,
+        filter_pool,
+        list_maneuver_pairs,
+    )
+    from helmlog.analysis.maneuvers import enrich_maneuvers_for_ids  # noqa: PLC0415
+
+    pairs = await list_maneuver_pairs(storage, maneuver_type=maneuver_type)
+    enriched, video_sync = await enrich_maneuvers_for_ids(storage, pairs)
+    pool = filter_pool(
+        enriched,
+        maneuver_type=maneuver_type,
+        tws_min=tws_min,
+        tws_max=tws_max,
+    )
+    result = assemble_compare_set(pool, metric=metric, n=n)
+
+    await audit(
+        request,
+        "analysis.maneuver_compare",
+        detail=(
+            f"type={maneuver_type} metric={metric}"
+            f" tws=[{tws_min},{tws_max}] pool={result['pool_size']}"
+        ),
+        user=user,
+    )
+    return JSONResponse(
+        {
+            "filters": {
+                "type": maneuver_type,
+                "metric": metric,
+                "tws_min": tws_min,
+                "tws_max": tws_max,
+                "n": n,
+            },
+            **result,
+            "video_sync_by_session": {str(sid): vs for sid, vs in video_sync.items()},
+        }
+    )

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -205,6 +205,28 @@ async def maneuvers_browser_page(request: Request) -> Response:
     )
 
 
+@router.get(
+    "/maneuvers/compare",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def maneuver_best_vs_median_page(request: Request) -> Response:
+    """Best vs median maneuver picker for coaching review (#741).
+
+    Filter form → /api/analysis/maneuver-compare → links to /compare and
+    /maneuvers/overlay so the existing video-grid and track-overlay pages
+    do the heavy rendering.
+    """
+    get_storage(request)
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "maneuver_compare.html",
+        tpl_ctx(request, "/maneuvers", user_role=user_role),
+    )
+
+
 @router.get("/maneuvers/overlay", response_class=HTMLResponse, include_in_schema=False)
 async def maneuvers_overlay_page(request: Request) -> Response:
     """Time-aligned multi-maneuver overlay chart (#619).

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -206,7 +206,29 @@ async def maneuvers_browser_page(request: Request) -> Response:
 
 
 @router.get(
-    "/maneuvers/compare",
+    "/analysis",
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)
+async def analysis_hub_page(request: Request) -> Response:
+    """Coach-facing landing page listing cross-session analysis tools (#741).
+
+    Distinct from /admin/analysis — that surface manages the AnalysisPlugin
+    framework (install, default, co-op catalog). This page is the entry
+    point for actually *running* coach analyses.
+    """
+    get_storage(request)
+    user: dict[str, Any] | None = getattr(request.state, "user", None)
+    user_role = user.get("role", "viewer") if user else "viewer"
+    return templates.TemplateResponse(
+        request,
+        "analysis_hub.html",
+        tpl_ctx(request, "/analysis", user_role=user_role),
+    )
+
+
+@router.get(
+    "/analysis/maneuver-compare",
     response_class=HTMLResponse,
     include_in_schema=False,
 )
@@ -223,7 +245,7 @@ async def maneuver_best_vs_median_page(request: Request) -> Response:
     return templates.TemplateResponse(
         request,
         "maneuver_compare.html",
-        tpl_ctx(request, "/maneuvers", user_role=user_role),
+        tpl_ctx(request, "/analysis", user_role=user_role),
     )
 
 

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -2067,6 +2067,14 @@ async def api_maneuver_browse_regattas(
     return JSONResponse({"regattas": regattas})
 
 
+_BROWSE_RANK_METRICS: set[str] = {
+    "distance_loss_m",
+    "time_to_recover_s",
+    "time_to_head_to_wind_s",
+    "loss_kts",
+}
+
+
 @router.get("/api/maneuvers/browse")
 async def api_maneuver_browse(
     request: Request,
@@ -2083,6 +2091,7 @@ async def api_maneuver_browse(
     session_limit: int = 20,
     tags: str | None = None,
     tag_mode: str = "and",
+    rank_by: str | None = None,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
     """Cross-session maneuver browser feed (#584).
@@ -2112,6 +2121,11 @@ async def api_maneuver_browse(
         raise HTTPException(status_code=422, detail="direction must be PS|SP")
     if session_type is not None and session_type not in ("race", "practice"):
         raise HTTPException(status_code=422, detail="session_type must be race|practice")
+    if rank_by is not None and rank_by not in _BROWSE_RANK_METRICS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"rank_by must be one of {sorted(_BROWSE_RANK_METRICS)}",
+        )
 
     # Parse optional multi-band wind filter. Each band is "min-max" (e.g.
     # "8-10") or "min-" for an open-ended upper bound (e.g. "15-" for 15+
@@ -2338,11 +2352,22 @@ async def api_maneuver_browse(
 
             filtered = [m for m in filtered if _tag_match(m)]
 
+    # Re-rank the filtered set against the requested metric. The cached
+    # rank attached during enrichment is always distance_loss_m-based, so
+    # rank_by recomputes the good/avg/bad/consistent buckets across the
+    # *visible* set only — comparing a tight wind band to itself, not to
+    # the boat's all-time distribution.
+    if rank_by is not None:
+        from helmlog.analysis.maneuvers import rank_maneuvers
+
+        rank_maneuvers(filtered, metric=rank_by)
+
     return JSONResponse(
         {
             "maneuvers": filtered,
             "session_ids": resolved_session_ids,
             "available_tags": available_tags,
+            "rank_by": rank_by or "distance_loss_m",
         }
     )
 

--- a/src/helmlog/static/maneuvers.js
+++ b/src/helmlog/static/maneuvers.js
@@ -31,6 +31,8 @@ const state = {
   direction: null,         // 'PS'|'SP'|null
   postStart: false,        // drop pre-gun maneuvers when true
   twsBands: new Set(),     // indices into TWS_BANDS — empty = any
+  twsMin: null,            // typed wind range floor; null = unset
+  twsMax: null,            // typed wind range ceiling; null = unset
   hasVideo: false,
   tagFilter: new Set(),    // tag ids
   tagMode: 'and',          // 'and'|'or'
@@ -38,6 +40,11 @@ const state = {
   maneuvers: [],
   selected: new Set(),     // composite keys "sid:mid"
   loading: false,
+  rankBy: 'distance_loss_m', // metric driving the server-side Rank column
+  // Multi-column sort: ordered list of { key, dir }. Click toggles
+  // asc → desc → off; shift-click appends as secondary. Empty = natural
+  // (server) order, which is chronological ascending.
+  sortKeys: [],
 };
 
 // ---------------------------------------------------------------------------
@@ -46,6 +53,7 @@ const state = {
 
 (async function init() {
   renderPills();
+  _wireHeaderClicks();
   await Promise.all([loadRegattas(), loadSessions()]);
   await reload();
 })();
@@ -180,6 +188,37 @@ function mvToggleTws(i) {
   reload();
 }
 function mvClearTws() { state.twsBands.clear(); renderPills(); reload(); }
+
+function _parseTwsField(id) {
+  const raw = (document.getElementById(id).value || '').trim();
+  if (raw === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+let _twsRangeDebounce = null;
+function mvOnTwsRangeChange() {
+  // Debounce typing so each keystroke doesn't fire a fetch.
+  state.twsMin = _parseTwsField('mv-tws-min');
+  state.twsMax = _parseTwsField('mv-tws-max');
+  clearTimeout(_twsRangeDebounce);
+  _twsRangeDebounce = setTimeout(reload, 250);
+}
+
+function mvClearTwsRange() {
+  document.getElementById('mv-tws-min').value = '';
+  document.getElementById('mv-tws-max').value = '';
+  state.twsMin = null;
+  state.twsMax = null;
+  reload();
+}
+
+function mvOnRankByChange() {
+  const sel = document.getElementById('mv-rank-by');
+  state.rankBy = sel ? sel.value : 'distance_loss_m';
+  reload();
+}
+
 function mvSetPhase(on) { state.postStart = !!on; renderPills(); reload(); }
 function mvSetSessionType(t) {
   state.sessionType = t;
@@ -219,8 +258,13 @@ async function reload() {
       });
       params.set('tws_bands', bands.join(','));
     }
+    if (state.twsMin != null) params.set('tws_min', String(state.twsMin));
+    if (state.twsMax != null) params.set('tws_max', String(state.twsMax));
     if (state.hasVideo) params.set('has_video', '1');
     if (state.postStart) params.set('post_start', '1');
+    if (state.rankBy && state.rankBy !== 'distance_loss_m') {
+      params.set('rank_by', state.rankBy);
+    }
     if (state.tagFilter.size) {
       params.set('tags', [...state.tagFilter].join(','));
       params.set('tag_mode', state.tagMode);
@@ -246,6 +290,116 @@ function mvReload() {
   reload();
 }
 
+// ---------------------------------------------------------------------------
+// Multi-column sort
+// ---------------------------------------------------------------------------
+
+function _sortValue(m, key) {
+  // Synthesized keys we expose as sort targets that don't map 1:1 to a
+  // field on the maneuver dict.
+  if (key === 'turn_angle_abs') {
+    return m.turn_angle_deg == null ? null : Math.abs(Number(m.turn_angle_deg));
+  }
+  if (key === 'direction') {
+    // Map turn-angle sign to its label, then sort lex (PS < SP).
+    return m.turn_angle_deg == null ? null
+      : (m.turn_angle_deg < 0 ? 'PS' : 'SP');
+  }
+  if (key === 'session_start_utc') {
+    return m.session_start_utc || '';
+  }
+  const v = m[key];
+  return v === undefined ? null : v;
+}
+
+function _compareForSort(a, b, key, dir, numeric) {
+  const va = _sortValue(a, key);
+  const vb = _sortValue(b, key);
+  // Nulls always sort to the end, regardless of direction — keeps "no
+  // data" rows from polluting the top when you sort ascending.
+  if (va == null && vb == null) return 0;
+  if (va == null) return 1;
+  if (vb == null) return -1;
+  let cmp;
+  if (numeric) {
+    cmp = Number(va) - Number(vb);
+  } else {
+    cmp = String(va).localeCompare(String(vb));
+  }
+  return dir === 'desc' ? -cmp : cmp;
+}
+
+function _sortedManeuvers() {
+  if (!state.sortKeys.length) return state.maneuvers;
+  // Stable sort: walk the keys in priority order, breaking ties downstream.
+  const out = state.maneuvers.slice();
+  // We need to know numeric vs lex for each key — pull from the header DOM
+  // so the truth lives next to the column it describes.
+  const numericByKey = {};
+  document.querySelectorAll('th.mv-sortable').forEach(th => {
+    numericByKey[th.dataset.sort] = th.dataset.numeric === '1';
+  });
+  out.sort((a, b) => {
+    for (const sk of state.sortKeys) {
+      const c = _compareForSort(a, b, sk.key, sk.dir, !!numericByKey[sk.key]);
+      if (c !== 0) return c;
+    }
+    return 0;
+  });
+  return out;
+}
+
+function mvOnHeaderClick(ev, key) {
+  const existing = state.sortKeys.findIndex(k => k.key === key);
+  if (ev.shiftKey) {
+    // Add or cycle a secondary key without clearing others.
+    if (existing === -1) {
+      state.sortKeys.push({ key, dir: 'asc' });
+    } else if (state.sortKeys[existing].dir === 'asc') {
+      state.sortKeys[existing].dir = 'desc';
+    } else {
+      state.sortKeys.splice(existing, 1);
+    }
+  } else {
+    // Plain click — replace the whole sort with this key, cycling dir
+    // if it was already the only key.
+    if (state.sortKeys.length === 1 && state.sortKeys[0].key === key) {
+      if (state.sortKeys[0].dir === 'asc') state.sortKeys[0].dir = 'desc';
+      else state.sortKeys = [];
+    } else {
+      state.sortKeys = [{ key, dir: 'asc' }];
+    }
+  }
+  _renderHeaderIndicators();
+  renderResults();
+}
+
+function _renderHeaderIndicators() {
+  document.querySelectorAll('th.mv-sortable').forEach(th => {
+    const key = th.dataset.sort;
+    const idx = state.sortKeys.findIndex(k => k.key === key);
+    // Strip any existing indicator span.
+    const existing = th.querySelector('.mv-sort-indicator');
+    if (existing) existing.remove();
+    if (idx === -1) return;
+    const sk = state.sortKeys[idx];
+    const arrow = sk.dir === 'asc' ? '↑' : '↓';
+    const label = state.sortKeys.length > 1
+      ? arrow + (idx + 1)  // show priority when there are multiple keys
+      : arrow;
+    const span = document.createElement('span');
+    span.className = 'mv-sort-indicator';
+    span.textContent = label;
+    th.appendChild(span);
+  });
+}
+
+function _wireHeaderClicks() {
+  document.querySelectorAll('th.mv-sortable').forEach(th => {
+    th.addEventListener('click', (ev) => mvOnHeaderClick(ev, th.dataset.sort));
+  });
+}
+
 function renderResults() {
   const tbody = document.getElementById('mv-tbody');
   const empty = document.getElementById('mv-empty');
@@ -260,7 +414,7 @@ function renderResults() {
   }
   empty.style.display = 'none';
 
-  tbody.innerHTML = state.maneuvers.map(m => {
+  tbody.innerHTML = _sortedManeuvers().map(m => {
     const k = m.session_id + ':' + m.id;
     const sel = state.selected.has(k);
     const date = (m.session_start_utc || '').slice(0, 10);

--- a/src/helmlog/templates/analysis_hub.html
+++ b/src/helmlog/templates/analysis_hub.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Analysis — HelmLog{% endblock %}
+
+{% block extra_css %}
+<style>
+.ah-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:12px;margin-top:14px}
+.ah-card{display:block;text-decoration:none;color:inherit;border:1px solid var(--border);border-radius:6px;padding:14px 16px;background:var(--bg-secondary)}
+.ah-card:hover{border-color:var(--accent);background:var(--bg-input)}
+.ah-card h2{font-size:.95rem;font-weight:600;margin:0 0 6px;color:var(--accent)}
+.ah-card p{font-size:.8rem;color:var(--text-secondary);margin:0;line-height:1.45}
+.ah-section{font-size:.72rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);margin:18px 0 4px}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1 style="margin-bottom:6px">Analysis</h1>
+<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:6px">
+  Cross-session tools for reviewing performance and finding patterns.
+</div>
+
+<div class="ah-section">Maneuvers</div>
+<div class="ah-grid">
+  <a class="ah-card" href="/analysis/maneuver-compare">
+    <h2>Best vs Median Maneuvers</h2>
+    <p>Pull the 3 best and 3 typical maneuvers matching your filters (type, wind range, direction, post-start), then open a side-by-side video / track comparison.</p>
+  </a>
+  <a class="ah-card" href="/maneuvers">
+    <h2>Maneuver Browser</h2>
+    <p>Browse every detected maneuver across sessions, filter by wind / direction / phase / tags, then hand-pick a set to overlay or compare.</p>
+  </a>
+</div>
+{% endblock %}

--- a/src/helmlog/templates/maneuver_compare.html
+++ b/src/helmlog/templates/maneuver_compare.html
@@ -1,0 +1,206 @@
+{% extends "base.html" %}
+{% block title %}Best vs Median Maneuvers — HelmLog{% endblock %}
+
+{% block extra_css %}
+<style>
+.mc-form{display:flex;flex-wrap:wrap;gap:12px;align-items:flex-end;margin-bottom:12px}
+.mc-form label{display:flex;flex-direction:column;font-size:.72rem;color:var(--text-secondary);gap:4px}
+.mc-form select,.mc-form input[type=number]{background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:5px 8px;font-size:.85rem;min-width:120px}
+.mc-form button{background:var(--accent-strong);color:var(--bg-primary);border:none;border-radius:4px;padding:7px 16px;font-size:.85rem;font-weight:600;cursor:pointer}
+.mc-form button:disabled{opacity:.4;cursor:not-allowed}
+.mc-summary{display:flex;gap:18px;flex-wrap:wrap;font-size:.78rem;color:var(--text-secondary);margin-bottom:10px}
+.mc-summary b{color:var(--text-primary)}
+.mc-section-title{font-size:.78rem;text-transform:uppercase;letter-spacing:.06em;color:var(--text-secondary);margin:14px 0 6px}
+.mc-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:8px}
+.mc-card{border:1px solid var(--border);border-radius:4px;padding:8px 10px;background:var(--bg-secondary);font-size:.78rem}
+.mc-card .mc-date{color:var(--text-secondary);font-size:.7rem}
+.mc-card .mc-metric{font-size:1.1rem;font-weight:600;margin:4px 0}
+.mc-card .mc-meta{color:var(--text-secondary);font-size:.72rem;line-height:1.4}
+.mc-card .mc-yt{color:var(--accent);text-decoration:none;font-size:.72rem}
+.mc-actions{margin:14px 0;display:flex;gap:10px;flex-wrap:wrap}
+.mc-actions a{background:var(--accent);color:var(--bg-primary);border:none;border-radius:4px;padding:7px 14px;font-size:.85rem;font-weight:600;text-decoration:none}
+.mc-empty{padding:18px;text-align:center;color:var(--text-secondary);font-size:.85rem;border:1px dashed var(--border);border-radius:4px}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1 style="margin-bottom:6px">Best vs Median Maneuvers</h1>
+<div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:14px">
+  Pull the 3 best and 3 typical maneuvers matching your filters, then open a side-by-side video / track comparison.
+</div>
+
+<div class="card">
+  <form id="mc-form" class="mc-form" onsubmit="mcSubmit(event)">
+    <label>Maneuver type
+      <select id="mc-type" required>
+        <option value="tack">Tack</option>
+        <option value="gybe">Gybe</option>
+        <option value="weather_rounding">Weather rounding</option>
+        <option value="leeward_rounding">Leeward rounding</option>
+      </select>
+    </label>
+    <label>Success metric
+      <select id="mc-metric" required>
+        <option value="distance_loss_m">Distance lost (m)</option>
+        <option value="time_to_recover_s">Recovery time (s)</option>
+        <option value="time_to_head_to_wind_s">Time to head-to-wind (s)</option>
+        <option value="loss_kts">Speed loss (kt)</option>
+      </select>
+    </label>
+    <label>TWS min (kt)
+      <input id="mc-tws-min" type="number" step="0.5" min="0" placeholder="e.g. 8" style="max-width:100px"/>
+    </label>
+    <label>TWS max (kt)
+      <input id="mc-tws-max" type="number" step="0.5" min="0" placeholder="e.g. 12" style="max-width:100px"/>
+    </label>
+    <label>Per group
+      <input id="mc-n" type="number" min="1" max="6" value="3" style="max-width:70px"/>
+    </label>
+    <button type="submit" id="mc-submit">Find</button>
+  </form>
+</div>
+
+<div id="mc-status" style="margin-top:12px"></div>
+<div id="mc-results" style="margin-top:12px"></div>
+
+<script>
+const _METRIC_LABELS = {
+  distance_loss_m: 'Distance lost',
+  time_to_recover_s: 'Recovery time',
+  time_to_head_to_wind_s: 'Time to HTW',
+  loss_kts: 'Speed loss'
+};
+const _METRIC_UNITS = {
+  distance_loss_m: 'm',
+  time_to_recover_s: 's',
+  time_to_head_to_wind_s: 's',
+  loss_kts: 'kt'
+};
+
+function _qs(p){
+  const u = new URLSearchParams(window.location.search);
+  return u.get(p);
+}
+
+function _esc(s){
+  return String(s == null ? '' : s)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+function _fmtMetric(v, unit){
+  if (v == null) return '—';
+  return Number(v).toFixed(unit === 'm' ? 1 : 1) + ' ' + unit;
+}
+
+function _renderCard(m, metric){
+  const unit = _METRIC_UNITS[metric] || '';
+  const date = (m.session_start_utc || '').slice(0,10);
+  const tws = m.entry_tws == null ? '—' : Number(m.entry_tws).toFixed(1) + ' kt';
+  const turn = m.turn_angle_deg == null ? '—' : Math.abs(Number(m.turn_angle_deg)).toFixed(0) + '°';
+  const yt = m.youtube_url
+    ? '<a class="mc-yt" href="' + _esc(m.youtube_url) + '" target="_blank" rel="noopener">▶ YouTube</a>'
+    : '<span style="color:var(--text-secondary);opacity:.5">no video</span>';
+  return ''
+    + '<div class="mc-card">'
+    + '<div class="mc-date">' + _esc(date) + ' · ' + _esc(m.session_name || '') + '</div>'
+    + '<div class="mc-metric">' + _fmtMetric(m[metric], unit) + '</div>'
+    + '<div class="mc-meta">'
+    +   'TWS ' + tws + ' · turn ' + turn
+    +   '<br/>entry BSP ' + (m.entry_bsp == null ? '—' : Number(m.entry_bsp).toFixed(1) + ' kt')
+    +   ' · exit BSP ' + (m.exit_bsp == null ? '—' : Number(m.exit_bsp).toFixed(1) + ' kt')
+    + '</div>'
+    + '<div style="margin-top:6px">' + yt + '</div>'
+    + '</div>';
+}
+
+function _idTuple(m){
+  return m.session_id + ':' + m.id;
+}
+
+async function mcSubmit(e){
+  e.preventDefault();
+  const params = new URLSearchParams();
+  params.set('type', document.getElementById('mc-type').value);
+  params.set('metric', document.getElementById('mc-metric').value);
+  const tmin = document.getElementById('mc-tws-min').value;
+  const tmax = document.getElementById('mc-tws-max').value;
+  if (tmin) params.set('tws_min', tmin);
+  if (tmax) params.set('tws_max', tmax);
+  params.set('n', document.getElementById('mc-n').value || '3');
+
+  // Persist filters in the URL for shareable permalinks.
+  const newUrl = window.location.pathname + '?' + params.toString();
+  window.history.replaceState({}, '', newUrl);
+
+  const status = document.getElementById('mc-status');
+  const results = document.getElementById('mc-results');
+  const submit = document.getElementById('mc-submit');
+  submit.disabled = true;
+  status.innerHTML = '<div style="color:var(--text-secondary);font-size:.78rem">Loading…</div>';
+  results.innerHTML = '';
+
+  try {
+    const resp = await fetch('/api/analysis/maneuver-compare?' + params.toString());
+    if (!resp.ok) {
+      let msg = 'Request failed (' + resp.status + ')';
+      try { const j = await resp.json(); if (j.detail) msg += ': ' + j.detail; } catch(_){}
+      status.innerHTML = '<div style="color:var(--danger);font-size:.85rem">' + _esc(msg) + '</div>';
+      return;
+    }
+    const data = await resp.json();
+    _render(data);
+  } catch (err) {
+    status.innerHTML = '<div style="color:var(--danger);font-size:.85rem">' + _esc(err.message || err) + '</div>';
+  } finally {
+    submit.disabled = false;
+  }
+}
+
+function _render(data){
+  const status = document.getElementById('mc-status');
+  const results = document.getElementById('mc-results');
+  const metric = data.filters.metric;
+  const unit = _METRIC_UNITS[metric] || '';
+
+  status.innerHTML = ''
+    + '<div class="mc-summary">'
+    +   '<span>Pool: <b>' + data.pool_size + '</b> maneuvers</span>'
+    +   '<span>Median ' + _METRIC_LABELS[metric] + ': <b>' + _fmtMetric(data.median_value, unit) + '</b></span>'
+    + '</div>';
+
+  if (!data.best.length && !data.median.length) {
+    results.innerHTML = '<div class="mc-empty">No maneuvers match these filters. Widen the wind range or pick a different type.</div>';
+    return;
+  }
+
+  // Build the side-by-side comparison link.
+  const allIds = data.best.map(_idTuple).concat(data.median.map(_idTuple));
+  const compareHref = '/compare?ids=' + encodeURIComponent(allIds.join(','));
+  const overlayHref = '/maneuvers/overlay?ids=' + encodeURIComponent(allIds.join(','));
+
+  results.innerHTML = ''
+    + '<div class="mc-actions">'
+    +   '<a href="' + compareHref + '">Open side-by-side videos</a>'
+    +   '<a href="' + overlayHref + '" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">Open track overlay</a>'
+    + '</div>'
+    + '<div class="mc-section-title">Best ' + data.best.length + ' (lowest ' + _METRIC_LABELS[metric] + ')</div>'
+    + '<div class="mc-grid">' + data.best.map(m => _renderCard(m, metric)).join('') + '</div>'
+    + (data.median.length
+        ? '<div class="mc-section-title">Median ' + data.median.length + ' (typical ' + _METRIC_LABELS[metric] + ')</div>'
+          + '<div class="mc-grid">' + data.median.map(m => _renderCard(m, metric)).join('') + '</div>'
+        : ''
+      );
+}
+
+// Hydrate filters from the URL on first load (permalink support).
+(function(){
+  const t = _qs('type'); if (t) document.getElementById('mc-type').value = t;
+  const m = _qs('metric'); if (m) document.getElementById('mc-metric').value = m;
+  const tmin = _qs('tws_min'); if (tmin) document.getElementById('mc-tws-min').value = tmin;
+  const tmax = _qs('tws_max'); if (tmax) document.getElementById('mc-tws-max').value = tmax;
+  const n = _qs('n'); if (n) document.getElementById('mc-n').value = n;
+  if (t) document.getElementById('mc-form').dispatchEvent(new Event('submit', {cancelable:true}));
+})();
+</script>
+{% endblock %}

--- a/src/helmlog/templates/maneuver_compare.html
+++ b/src/helmlog/templates/maneuver_compare.html
@@ -24,6 +24,9 @@
 {% endblock %}
 
 {% block content %}
+<div style="font-size:.74rem;margin-bottom:4px">
+  <a href="/analysis" style="color:var(--text-secondary);text-decoration:none">← Analysis</a>
+</div>
 <h1 style="margin-bottom:6px">Best vs Median Maneuvers</h1>
 <div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:14px">
   Pull the 3 best and 3 typical maneuvers matching your filters, then open a side-by-side video / track comparison.

--- a/src/helmlog/templates/maneuver_compare.html
+++ b/src/helmlog/templates/maneuver_compare.html
@@ -107,6 +107,19 @@ function _fmtMetric(v, unit){
   return Number(v).toFixed(unit === 'm' ? 1 : 1) + ' ' + unit;
 }
 
+function _sessionDeepLink(m){
+  // Build /session/{id}/{slug}?t=<offset-seconds> so the session page
+  // seeks to the maneuver moment on load (uses the existing ?t= mechanism
+  // already wired up in session.js _applyDeepLink).
+  if (!m.session_id || !m.session_start_utc || !m.ts) return null;
+  const start = Date.parse(m.session_start_utc);
+  const at = Date.parse(m.ts);
+  if (isNaN(start) || isNaN(at)) return null;
+  const offsetSec = Math.max(0, Math.floor((at - start) / 1000));
+  const slug = m.session_slug ? '/' + encodeURIComponent(m.session_slug) : '';
+  return '/session/' + m.session_id + slug + '?t=' + offsetSec;
+}
+
 function _renderCard(m, metric){
   const unit = _METRIC_UNITS[metric] || '';
   const date = (m.session_start_utc || '').slice(0,10);
@@ -115,6 +128,10 @@ function _renderCard(m, metric){
   const yt = m.youtube_url
     ? '<a class="mc-yt" href="' + _esc(m.youtube_url) + '" target="_blank" rel="noopener">▶ YouTube</a>'
     : '<span style="color:var(--text-secondary);opacity:.5">no video</span>';
+  const deepLink = _sessionDeepLink(m);
+  const sessionLink = deepLink
+    ? '<a class="mc-yt" href="' + _esc(deepLink) + '" target="_blank" rel="noopener">View in session →</a>'
+    : '';
   return ''
     + '<div class="mc-card">'
     + '<div class="mc-date">' + _esc(date) + ' · ' + _esc(m.session_name || '') + '</div>'
@@ -124,7 +141,10 @@ function _renderCard(m, metric){
     +   '<br/>entry BSP ' + (m.entry_bsp == null ? '—' : Number(m.entry_bsp).toFixed(1) + ' kt')
     +   ' · exit BSP ' + (m.exit_bsp == null ? '—' : Number(m.exit_bsp).toFixed(1) + ' kt')
     + '</div>'
-    + '<div style="margin-top:6px">' + yt + '</div>'
+    + '<div style="margin-top:6px;display:flex;gap:10px;flex-wrap:wrap">'
+    +   yt
+    +   (sessionLink ? sessionLink : '')
+    + '</div>'
     + '</div>';
 }
 
@@ -198,8 +218,8 @@ function _render(data){
 
   results.innerHTML = ''
     + '<div class="mc-actions">'
-    +   '<a href="' + compareHref + '">Open side-by-side videos</a>'
-    +   '<a href="' + overlayHref + '" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">Open track overlay</a>'
+    +   '<a href="' + compareHref + '" target="_blank" rel="noopener">Open side-by-side videos</a>'
+    +   '<a href="' + overlayHref + '" target="_blank" rel="noopener" style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border)">Open track overlay</a>'
     + '</div>'
     + '<div class="mc-section-title">Best ' + data.best.length + ' (lowest ' + _METRIC_LABELS[metric] + ')</div>'
     + '<div class="mc-grid">' + data.best.map(m => _renderCard(m, metric)).join('') + '</div>'

--- a/src/helmlog/templates/maneuver_compare.html
+++ b/src/helmlog/templates/maneuver_compare.html
@@ -53,6 +53,17 @@
     <label>TWS max (kt)
       <input id="mc-tws-max" type="number" step="0.5" min="0" placeholder="e.g. 12" style="max-width:100px"/>
     </label>
+    <label>Direction
+      <select id="mc-direction">
+        <option value="">Either</option>
+        <option value="PS">P→S</option>
+        <option value="SP">S→P</option>
+      </select>
+    </label>
+    <label style="flex-direction:row;align-items:center;gap:6px">
+      <input type="checkbox" id="mc-post-start"/>
+      Post-start only
+    </label>
     <label>Per group
       <input id="mc-n" type="number" min="1" max="6" value="3" style="max-width:70px"/>
     </label>
@@ -127,6 +138,9 @@ async function mcSubmit(e){
   const tmax = document.getElementById('mc-tws-max').value;
   if (tmin) params.set('tws_min', tmin);
   if (tmax) params.set('tws_max', tmax);
+  const dir = document.getElementById('mc-direction').value;
+  if (dir) params.set('direction', dir);
+  if (document.getElementById('mc-post-start').checked) params.set('post_start', '1');
   params.set('n', document.getElementById('mc-n').value || '3');
 
   // Persist filters in the URL for shareable permalinks.
@@ -199,6 +213,8 @@ function _render(data){
   const m = _qs('metric'); if (m) document.getElementById('mc-metric').value = m;
   const tmin = _qs('tws_min'); if (tmin) document.getElementById('mc-tws-min').value = tmin;
   const tmax = _qs('tws_max'); if (tmax) document.getElementById('mc-tws-max').value = tmax;
+  const dir = _qs('direction'); if (dir) document.getElementById('mc-direction').value = dir;
+  if (_qs('post_start')) document.getElementById('mc-post-start').checked = true;
   const n = _qs('n'); if (n) document.getElementById('mc-n').value = n;
   if (t) document.getElementById('mc-form').dispatchEvent(new Event('submit', {cancelable:true}));
 })();

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -52,7 +52,7 @@
 <div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:12px">
   Browse maneuvers across sessions, filter by wind, then compare videos side-by-side.
   &middot;
-  <a href="/maneuvers/compare" style="color:var(--accent)">Best vs median picker →</a>
+  <a href="/analysis/maneuver-compare" style="color:var(--accent)">Best vs median picker →</a>
 </div>
 
 <div class="card">

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -51,6 +51,8 @@
 <h1 style="margin-bottom:8px">Maneuvers</h1>
 <div style="font-size:.78rem;color:var(--text-secondary);margin-bottom:12px">
   Browse maneuvers across sessions, filter by wind, then compare videos side-by-side.
+  &middot;
+  <a href="/maneuvers/compare" style="color:var(--accent)">Best vs median picker →</a>
 </div>
 
 <div class="card">

--- a/src/helmlog/templates/maneuvers.html
+++ b/src/helmlog/templates/maneuvers.html
@@ -22,6 +22,9 @@
 .mv-table{width:100%;border-collapse:collapse;font-size:.78rem}
 .mv-table th,.mv-table td{padding:5px 8px;text-align:left;border-bottom:1px solid var(--border)}
 .mv-table th{font-size:.7rem;font-weight:600;color:var(--text-secondary);background:var(--bg-input);text-transform:uppercase;letter-spacing:.03em;position:sticky;top:0}
+.mv-table th.mv-sortable{cursor:pointer;user-select:none}
+.mv-table th.mv-sortable:hover{color:var(--text-primary)}
+.mv-table th .mv-sort-indicator{display:inline-block;margin-left:4px;font-size:.65rem;color:var(--accent);vertical-align:middle}
 .mv-table tbody tr{cursor:pointer}
 .mv-table tbody tr:hover{background:var(--bg-input)}
 .mv-table tbody tr.selected{background:rgba(var(--accent-rgb,100,140,200),.12)}
@@ -91,9 +94,19 @@
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">Race phase</div>
         <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-phase-pills"></div>
         <div style="font-size:.72rem;color:var(--text-secondary);margin:10px 0 4px">
-          Wind (TWS kts) <span style="opacity:.6">— click multiple to combine</span>
+          Wind (TWS kts) <span style="opacity:.6">— click pills, type a range, or both</span>
         </div>
-        <div style="display:flex;gap:4px;flex-wrap:wrap" id="mv-tws-pills"></div>
+        <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center" id="mv-tws-pills"></div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:4px">
+          <input type="number" id="mv-tws-min" step="0.5" min="0" placeholder="min"
+            style="width:70px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.8rem"
+            oninput="mvOnTwsRangeChange()"/>
+          <span style="font-size:.78rem;color:var(--text-secondary)">to</span>
+          <input type="number" id="mv-tws-max" step="0.5" min="0" placeholder="max"
+            style="width:70px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.8rem"
+            oninput="mvOnTwsRangeChange()"/>
+          <button type="button" class="mv-pill" onclick="mvClearTwsRange()" style="font-size:.7rem">clear range</button>
+        </div>
       </div>
     </div>
   </div>
@@ -104,6 +117,16 @@
     <strong id="mv-count">0 maneuvers</strong>
     <span id="mv-selected-count" style="font-size:.75rem;color:var(--text-secondary)"></span>
     <span class="spacer"></span>
+    <label style="font-size:.72rem;color:var(--text-secondary);display:flex;align-items:center;gap:5px">
+      Rank by
+      <select id="mv-rank-by" onchange="mvOnRankByChange()"
+        style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;padding:3px 6px;font-size:.78rem">
+        <option value="distance_loss_m">Distance lost</option>
+        <option value="time_to_recover_s">Recovery time</option>
+        <option value="time_to_head_to_wind_s">Time to HTW</option>
+        <option value="loss_kts">Speed loss</option>
+      </select>
+    </label>
     <button id="mv-overlay-btn" onclick="mvOpenOverlay()" disabled>Overlay Selected</button>
     <button id="mv-compare-btn" onclick="mvOpenCompare()" disabled>Compare Selected</button>
   </div>
@@ -113,16 +136,16 @@
       <thead>
         <tr>
           <th style="width:28px"><input type="checkbox" id="mv-check-all" onchange="mvToggleAll(this.checked)"/></th>
-          <th>Session</th>
-          <th>Time</th>
-          <th>Type</th>
-          <th>Dir</th>
-          <th class="mv-num">TWS</th>
-          <th class="mv-num" title="Turn angle in degrees (heading change through the maneuver)">&Delta;&deg;</th>
-          <th class="mv-num">Duration</th>
-          <th class="mv-num" title="Turn phase (entry &rarr; head-to-wind). Long turn = helm slow.">Turn</th>
-          <th class="mv-num" title="Recovery phase (head-to-wind &rarr; exit). Long recovery = trim slow.">Recovery</th>
-          <th>Rank</th>
+          <th class="mv-sortable" data-sort="session_start_utc" title="Click to sort, shift-click to add as secondary sort">Session</th>
+          <th class="mv-sortable" data-sort="ts">Time</th>
+          <th class="mv-sortable" data-sort="type">Type</th>
+          <th class="mv-sortable" data-sort="direction" title="Direction P&rarr;S or S&rarr;P">Dir</th>
+          <th class="mv-num mv-sortable" data-sort="entry_tws" data-numeric="1">TWS</th>
+          <th class="mv-num mv-sortable" data-sort="turn_angle_abs" data-numeric="1" title="Turn angle in degrees (heading change through the maneuver)">&Delta;&deg;</th>
+          <th class="mv-num mv-sortable" data-sort="duration_sec" data-numeric="1">Duration</th>
+          <th class="mv-num mv-sortable" data-sort="time_to_head_to_wind_s" data-numeric="1" title="Turn phase (entry &rarr; head-to-wind). Long turn = helm slow.">Turn</th>
+          <th class="mv-num mv-sortable" data-sort="time_to_recover_s" data-numeric="1" title="Recovery phase (head-to-wind &rarr; exit). Long recovery = trim slow.">Recovery</th>
+          <th class="mv-sortable" data-sort="loss_percentile" data-numeric="1" title="Sorts by underlying percentile; label reflects chosen Rank by metric">Rank</th>
           <th>Video</th>
           <th>Tags</th>
         </tr>

--- a/tests/test_analysis_compare.py
+++ b/tests/test_analysis_compare.py
@@ -1,0 +1,374 @@
+"""Tests for analysis/compare.py — best/median selection helpers (#741)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from helmlog.analysis.compare import (
+    assemble_compare_set,
+    filter_pool,
+    list_maneuver_pairs,
+    pick_best,
+    pick_median,
+)
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+def _m(
+    *,
+    mid: int,
+    metric_value: float | None,
+    session_start: str = "2026-01-01T00:00:00+00:00",
+    mtype: str = "tack",
+    entry_tws: float | None = 10.0,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal enriched-maneuver dict for tests."""
+    out: dict[str, Any] = {
+        "id": mid,
+        "type": mtype,
+        "distance_loss_m": metric_value,
+        "entry_tws": entry_tws,
+        "session_start_utc": session_start,
+    }
+    if extra:
+        out.update(extra)
+    return out
+
+
+class TestPickBest:
+    def test_returns_n_lowest_values(self) -> None:
+        items = [
+            _m(mid=1, metric_value=10.0),
+            _m(mid=2, metric_value=2.0),
+            _m(mid=3, metric_value=8.0),
+            _m(mid=4, metric_value=4.0),
+            _m(mid=5, metric_value=6.0),
+        ]
+        result = pick_best(items, metric="distance_loss_m", n=3)
+        assert [m["id"] for m in result] == [2, 4, 5]
+
+    def test_skips_items_with_none_metric(self) -> None:
+        items = [
+            _m(mid=1, metric_value=None),
+            _m(mid=2, metric_value=2.0),
+            _m(mid=3, metric_value=4.0),
+        ]
+        result = pick_best(items, metric="distance_loss_m", n=3)
+        assert [m["id"] for m in result] == [2, 3]
+
+    def test_n_larger_than_pool_returns_all(self) -> None:
+        items = [_m(mid=1, metric_value=5.0), _m(mid=2, metric_value=3.0)]
+        result = pick_best(items, metric="distance_loss_m", n=5)
+        assert [m["id"] for m in result] == [2, 1]
+
+    def test_empty_pool_returns_empty(self) -> None:
+        assert pick_best([], metric="distance_loss_m", n=3) == []
+
+    def test_all_none_returns_empty(self) -> None:
+        items = [_m(mid=1, metric_value=None), _m(mid=2, metric_value=None)]
+        assert pick_best(items, metric="distance_loss_m", n=3) == []
+
+    def test_ties_broken_by_recency_newer_first(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, session_start="2026-01-01T00:00:00+00:00"),
+            _m(mid=2, metric_value=2.0, session_start="2026-03-01T00:00:00+00:00"),
+            _m(mid=3, metric_value=5.0),
+        ]
+        result = pick_best(items, metric="distance_loss_m", n=2)
+        assert [m["id"] for m in result] == [2, 1]
+
+    def test_alternative_metric_field(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, extra={"time_to_recover_s": 30.0}),
+            _m(mid=2, metric_value=10.0, extra={"time_to_recover_s": 5.0}),
+        ]
+        result = pick_best(items, metric="time_to_recover_s", n=1)
+        assert [m["id"] for m in result] == [2]
+
+
+class TestPickMedian:
+    def test_picks_n_closest_to_median(self) -> None:
+        # values: 1, 2, 3, 4, 5, 6, 7  → median = 4
+        # closest 3: 4, 3 (or 5), 5 (or 3)
+        items = [_m(mid=i, metric_value=float(i)) for i in range(1, 8)]
+        result = pick_median(items, metric="distance_loss_m", n=3)
+        ids = sorted(m["id"] for m in result)
+        assert ids == [3, 4, 5]
+
+    def test_even_count_uses_average_of_middle_two(self) -> None:
+        # values: 2, 4, 6, 8 → median = 5; closest are 4 and 6 (distance 1)
+        items = [
+            _m(mid=1, metric_value=2.0),
+            _m(mid=2, metric_value=4.0),
+            _m(mid=3, metric_value=6.0),
+            _m(mid=4, metric_value=8.0),
+        ]
+        result = pick_median(items, metric="distance_loss_m", n=2)
+        ids = sorted(m["id"] for m in result)
+        assert ids == [2, 3]
+
+    def test_skips_none_metric(self) -> None:
+        items = [
+            _m(mid=1, metric_value=None),
+            _m(mid=2, metric_value=2.0),
+            _m(mid=3, metric_value=4.0),
+            _m(mid=4, metric_value=6.0),
+        ]
+        result = pick_median(items, metric="distance_loss_m", n=3)
+        ids = {m["id"] for m in result}
+        assert ids == {2, 3, 4}
+
+    def test_empty_returns_empty(self) -> None:
+        assert pick_median([], metric="distance_loss_m", n=3) == []
+
+    def test_single_item_returns_that_item(self) -> None:
+        items = [_m(mid=1, metric_value=4.0)]
+        result = pick_median(items, metric="distance_loss_m", n=3)
+        assert [m["id"] for m in result] == [1]
+
+    def test_tie_in_distance_to_median_broken_by_recency(self) -> None:
+        # values: 2, 4, 6 → median = 4; both 2 and 6 are distance-2 from median
+        items = [
+            _m(mid=1, metric_value=2.0, session_start="2026-01-01T00:00:00+00:00"),
+            _m(mid=2, metric_value=4.0, session_start="2026-02-01T00:00:00+00:00"),
+            _m(mid=3, metric_value=6.0, session_start="2026-03-01T00:00:00+00:00"),
+        ]
+        result = pick_median(items, metric="distance_loss_m", n=2)
+        # 4 is closest (dist 0); tie between 2 and 6 broken by recency → 6 wins
+        assert [m["id"] for m in result] == [2, 3]
+
+    def test_excludes_items_already_in_best_set(self) -> None:
+        # When passed an exclusion id-set, the median picker must skip them
+        # so the best/median sets don't overlap.
+        items = [_m(mid=i, metric_value=float(i)) for i in range(1, 8)]
+        # Pretend ids {1, 2} are the "best" — median should not include them.
+        result = pick_median(items, metric="distance_loss_m", n=3, exclude_ids={1, 2})
+        assert all(m["id"] not in {1, 2} for m in result)
+        # Remaining values 3..7, median = 5; closest 3 are 4, 5, 6.
+        ids = sorted(m["id"] for m in result)
+        assert ids == [4, 5, 6]
+
+
+class TestFilterPool:
+    def test_filters_by_type(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, mtype="tack"),
+            _m(mid=2, metric_value=2.0, mtype="gybe"),
+            _m(mid=3, metric_value=2.0, mtype="tack"),
+        ]
+        result = filter_pool(items, maneuver_type="tack")
+        assert {m["id"] for m in result} == {1, 3}
+
+    def test_filters_by_tws_range_inclusive(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, entry_tws=7.9),
+            _m(mid=2, metric_value=2.0, entry_tws=8.0),
+            _m(mid=3, metric_value=2.0, entry_tws=10.0),
+            _m(mid=4, metric_value=2.0, entry_tws=12.0),
+            _m(mid=5, metric_value=2.0, entry_tws=12.1),
+        ]
+        result = filter_pool(items, tws_min=8.0, tws_max=12.0)
+        assert {m["id"] for m in result} == {2, 3, 4}
+
+    def test_drops_items_missing_tws_when_range_set(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, entry_tws=None),
+            _m(mid=2, metric_value=2.0, entry_tws=10.0),
+        ]
+        result = filter_pool(items, tws_min=8.0, tws_max=12.0)
+        assert {m["id"] for m in result} == {2}
+
+    def test_no_filters_returns_pool_unchanged(self) -> None:
+        items = [_m(mid=1, metric_value=2.0), _m(mid=2, metric_value=2.0)]
+        result = filter_pool(items)
+        assert len(result) == 2
+
+    def test_combined_type_and_tws_filter(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, mtype="tack", entry_tws=10.0),
+            _m(mid=2, metric_value=2.0, mtype="tack", entry_tws=20.0),
+            _m(mid=3, metric_value=2.0, mtype="gybe", entry_tws=10.0),
+        ]
+        result = filter_pool(items, maneuver_type="tack", tws_min=8.0, tws_max=12.0)
+        assert {m["id"] for m in result} == {1}
+
+
+class TestRoundingTypes:
+    """Roundings are stored as type='rounding' with a discriminator in details."""
+
+    def test_filter_weather_rounding(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                mtype="rounding",
+                extra={"details": {"rounding_kind": "weather"}},
+            ),
+            _m(
+                mid=2,
+                metric_value=2.0,
+                mtype="rounding",
+                extra={"details": {"rounding_kind": "leeward"}},
+            ),
+            _m(mid=3, metric_value=2.0, mtype="tack"),
+        ]
+        result = filter_pool(items, maneuver_type="weather_rounding")
+        assert {m["id"] for m in result} == {1}
+
+    def test_filter_leeward_rounding(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                mtype="rounding",
+                extra={"details": {"rounding_kind": "weather"}},
+            ),
+            _m(
+                mid=2,
+                metric_value=2.0,
+                mtype="rounding",
+                extra={"details": {"rounding_kind": "leeward"}},
+            ),
+        ]
+        result = filter_pool(items, maneuver_type="leeward_rounding")
+        assert {m["id"] for m in result} == {2}
+
+
+class TestAssembleCompareSet:
+    def test_returns_best_and_median_disjoint(self) -> None:
+        # 10 maneuvers with metric values 1..10. Best 3 = {1,2,3}.
+        # Median of full set = 5.5; closest 3 from remaining = {5, 6, 4}.
+        items = [_m(mid=i, metric_value=float(i)) for i in range(1, 11)]
+        result = assemble_compare_set(items, metric="distance_loss_m", n=3)
+        best_ids = {m["id"] for m in result["best"]}
+        median_ids = {m["id"] for m in result["median"]}
+        assert best_ids == {1, 2, 3}
+        assert best_ids.isdisjoint(median_ids)
+        assert len(result["median"]) == 3
+        assert result["pool_size"] == 10
+        assert result["median_value"] == pytest.approx(5.5)
+
+    def test_pool_too_small_returns_what_it_has(self) -> None:
+        items = [_m(mid=1, metric_value=1.0), _m(mid=2, metric_value=2.0)]
+        result = assemble_compare_set(items, metric="distance_loss_m", n=3)
+        # Both go to "best"; "median" is empty since exclude eats remainder.
+        assert len(result["best"]) == 2
+        assert len(result["median"]) == 0
+        assert result["pool_size"] == 2
+
+    def test_empty_pool(self) -> None:
+        result = assemble_compare_set([], metric="distance_loss_m", n=3)
+        assert result["best"] == []
+        assert result["median"] == []
+        assert result["pool_size"] == 0
+        assert result["median_value"] is None
+
+
+_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _seed_session_with_maneuvers(
+    storage: Storage,
+    *,
+    session_id: int,
+    name: str,
+    maneuvers: list[tuple[str, str | None]],
+) -> None:
+    """Insert a session and a list of (type, rounding_kind) maneuvers."""
+    db = storage._conn()
+    start = _TS + timedelta(hours=session_id)
+    end = start + timedelta(minutes=30)
+    await db.execute(
+        "INSERT INTO races"
+        " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            session_id,
+            name,
+            "test-event",
+            session_id,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    for i, (mtype, rounding_kind) in enumerate(maneuvers):
+        ts = (start + timedelta(seconds=60 + i * 10)).isoformat()
+        details = None
+        if rounding_kind is not None:
+            import json
+
+            details = json.dumps({"rounding_kind": rounding_kind})
+        await db.execute(
+            "INSERT INTO maneuvers"
+            " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+            "  vmg_loss_kts, tws_bin, twa_bin, details)"
+            " VALUES (?, ?, ?, ?, 10.0, 1.0, NULL, 10, 40, ?)",
+            (session_id, mtype, ts, ts, details),
+        )
+    await db.commit()
+
+
+class TestListManeuverPairs:
+    @pytest.mark.asyncio
+    async def test_returns_all_pairs_when_no_filter(self, storage: Storage) -> None:
+        await _seed_session_with_maneuvers(
+            storage,
+            session_id=1,
+            name="s1",
+            maneuvers=[("tack", None), ("gybe", None)],
+        )
+        await _seed_session_with_maneuvers(
+            storage,
+            session_id=2,
+            name="s2",
+            maneuvers=[("tack", None)],
+        )
+        pairs = await list_maneuver_pairs(storage)
+        # Pairs are (session_id, maneuver_id). 3 maneuvers total.
+        assert len(pairs) == 3
+        assert {p[0] for p in pairs} == {1, 2}
+
+    @pytest.mark.asyncio
+    async def test_filter_by_type_tack(self, storage: Storage) -> None:
+        await _seed_session_with_maneuvers(
+            storage,
+            session_id=1,
+            name="s1",
+            maneuvers=[("tack", None), ("gybe", None), ("tack", None)],
+        )
+        pairs = await list_maneuver_pairs(storage, maneuver_type="tack")
+        assert len(pairs) == 2
+
+    @pytest.mark.asyncio
+    async def test_filter_weather_rounding_uses_rounding_kind(self, storage: Storage) -> None:
+        await _seed_session_with_maneuvers(
+            storage,
+            session_id=1,
+            name="s1",
+            maneuvers=[
+                ("rounding", "weather"),
+                ("rounding", "leeward"),
+                ("tack", None),
+            ],
+        )
+        weather = await list_maneuver_pairs(storage, maneuver_type="weather_rounding")
+        leeward = await list_maneuver_pairs(storage, maneuver_type="leeward_rounding")
+        assert len(weather) == 1
+        assert len(leeward) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_db_returns_empty(self, storage: Storage) -> None:
+        pairs = await list_maneuver_pairs(storage)
+        assert pairs == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_analysis_compare.py
+++ b/tests/test_analysis_compare.py
@@ -11,6 +11,7 @@ from helmlog.analysis.compare import (
     assemble_compare_set,
     filter_pool,
     list_maneuver_pairs,
+    load_gun_times,
     pick_best,
     pick_median,
 )
@@ -153,6 +154,117 @@ class TestPickMedian:
         # Remaining values 3..7, median = 5; closest 3 are 4, 5, 6.
         ids = sorted(m["id"] for m in result)
         assert ids == [4, 5, 6]
+
+
+class TestDirectionFilter:
+    """Tack/gybe direction follows the convention in routes/sessions.py:
+    ``is_ps = turn_angle_deg < 0`` (PS = negative turn, SP = non-negative)."""
+
+    def test_filter_ps_keeps_negative_turn(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, extra={"turn_angle_deg": -90.0}),
+            _m(mid=2, metric_value=2.0, extra={"turn_angle_deg": 90.0}),
+            _m(mid=3, metric_value=2.0, extra={"turn_angle_deg": -45.0}),
+        ]
+        result = filter_pool(items, direction="PS")
+        assert {m["id"] for m in result} == {1, 3}
+
+    def test_filter_sp_keeps_non_negative_turn(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, extra={"turn_angle_deg": -90.0}),
+            _m(mid=2, metric_value=2.0, extra={"turn_angle_deg": 90.0}),
+            _m(mid=3, metric_value=2.0, extra={"turn_angle_deg": 0.0}),
+        ]
+        result = filter_pool(items, direction="SP")
+        assert {m["id"] for m in result} == {2, 3}
+
+    def test_no_direction_filter_keeps_all(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, extra={"turn_angle_deg": -90.0}),
+            _m(mid=2, metric_value=2.0, extra={"turn_angle_deg": 90.0}),
+        ]
+        result = filter_pool(items)
+        assert len(result) == 2
+
+    def test_drops_items_missing_turn_angle_when_direction_set(self) -> None:
+        items = [
+            _m(mid=1, metric_value=2.0, extra={"turn_angle_deg": None}),
+            _m(mid=2, metric_value=2.0, extra={"turn_angle_deg": -90.0}),
+        ]
+        result = filter_pool(items, direction="PS")
+        assert {m["id"] for m in result} == {2}
+
+
+class TestPostStartFilter:
+    """post_start drops maneuvers whose ts < the session's gun_utc."""
+
+    def test_drops_pre_gun_maneuvers(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                extra={
+                    "session_id": 100,
+                    "ts": "2026-04-01T11:55:00+00:00",  # before gun
+                },
+            ),
+            _m(
+                mid=2,
+                metric_value=2.0,
+                extra={
+                    "session_id": 100,
+                    "ts": "2026-04-01T12:05:00+00:00",  # after gun
+                },
+            ),
+        ]
+        gun_by_session = {100: "2026-04-01T12:00:00+00:00"}
+        result = filter_pool(items, gun_by_session=gun_by_session)
+        assert {m["id"] for m in result} == {2}
+
+    def test_keeps_maneuvers_at_or_after_gun(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                extra={
+                    "session_id": 100,
+                    "ts": "2026-04-01T12:00:00+00:00",  # exactly at gun
+                },
+            ),
+        ]
+        gun_by_session = {100: "2026-04-01T12:00:00+00:00"}
+        result = filter_pool(items, gun_by_session=gun_by_session)
+        assert {m["id"] for m in result} == {1}
+
+    def test_keeps_maneuver_when_session_has_no_gun(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                extra={
+                    "session_id": 200,
+                    "ts": "2026-04-01T11:55:00+00:00",
+                },
+            ),
+        ]
+        # Session 200 not in the gun map → no post-start filter applies.
+        gun_by_session: dict[int, str] = {100: "2026-04-01T12:00:00+00:00"}
+        result = filter_pool(items, gun_by_session=gun_by_session)
+        assert {m["id"] for m in result} == {1}
+
+    def test_no_gun_dict_disables_post_start(self) -> None:
+        items = [
+            _m(
+                mid=1,
+                metric_value=2.0,
+                extra={
+                    "session_id": 100,
+                    "ts": "2026-04-01T11:55:00+00:00",
+                },
+            ),
+        ]
+        result = filter_pool(items)
+        assert len(result) == 1
 
 
 class TestFilterPool:
@@ -368,6 +480,27 @@ class TestListManeuverPairs:
     async def test_empty_db_returns_empty(self, storage: Storage) -> None:
         pairs = await list_maneuver_pairs(storage)
         assert pairs == []
+
+
+class TestLoadGunTimes:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_start_utc(self, storage: Storage) -> None:
+        """When there's no Vakaros race_start event, gun = race.start_utc."""
+        await _seed_session_with_maneuvers(storage, session_id=1, name="s1", maneuvers=[])
+        gun_map = await load_gun_times(storage, [1])
+        # The seed function uses _TS + 1h as start; just check it's populated.
+        assert 1 in gun_map
+        assert gun_map[1].startswith("2026-04-01T13:")  # _TS + 1h
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_skipped(self, storage: Storage) -> None:
+        gun_map = await load_gun_times(storage, [999])
+        assert gun_map == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_session_list(self, storage: Storage) -> None:
+        gun_map = await load_gun_times(storage, [])
+        assert gun_map == {}
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis_compare_route.py
+++ b/tests/test_analysis_compare_route.py
@@ -180,6 +180,86 @@ async def test_compare_empty_pool_returns_zero_counts(
 
 
 @pytest.mark.asyncio
+async def test_compare_rejects_unknown_direction(
+    client: httpx.AsyncClient,
+) -> None:
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "loss_kts", "direction": "leftways"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compare_post_start_excludes_pre_gun(
+    client: httpx.AsyncClient, storage: Storage
+) -> None:
+    """Two tacks in one session — one before the race start_utc, one after.
+    With post_start=1 only the post-gun tack survives.
+    """
+    db = storage._conn()
+    start = _BASE_TS
+    end = start + timedelta(minutes=30)
+    await db.execute(
+        "INSERT INTO races"
+        " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            1,
+            "race1",
+            "evt",
+            1,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+    # Two maneuver rows: one 5min before start_utc, one 5min after.
+    await db.execute(
+        "INSERT INTO maneuvers"
+        " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+        "  vmg_loss_kts, tws_bin, twa_bin, details)"
+        " VALUES (?, ?, ?, ?, 10.0, 1.0, NULL, 12, 40, NULL)",
+        (
+            1,
+            "tack",
+            (start - timedelta(minutes=5)).isoformat(),
+            (start - timedelta(minutes=4)).isoformat(),
+        ),
+    )
+    await db.execute(
+        "INSERT INTO maneuvers"
+        " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+        "  vmg_loss_kts, tws_bin, twa_bin, details)"
+        " VALUES (?, ?, ?, ?, 10.0, 2.0, NULL, 12, 40, NULL)",
+        (
+            1,
+            "tack",
+            (start + timedelta(minutes=5)).isoformat(),
+            (start + timedelta(minutes=6)).isoformat(),
+        ),
+    )
+    await db.commit()
+
+    # Without post_start: both maneuvers in pool.
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "loss_kts"},
+    )
+    assert resp.json()["pool_size"] == 2
+
+    # With post_start=1: only the post-gun tack.
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "loss_kts", "post_start": "1"},
+    )
+    data = resp.json()
+    assert data["pool_size"] == 1
+    assert data["filters"]["post_start"] is True
+
+
+@pytest.mark.asyncio
 async def test_compare_page_renders(client: httpx.AsyncClient) -> None:
     """The /maneuvers/compare page renders the filter form."""
     resp = await client.get("/maneuvers/compare")
@@ -192,3 +272,6 @@ async def test_compare_page_renders(client: httpx.AsyncClient) -> None:
     assert 'value="gybe"' in body
     assert 'value="weather_rounding"' in body
     assert 'value="leeward_rounding"' in body
+    # Direction + post-start filters are present.
+    assert 'id="mc-direction"' in body
+    assert 'id="mc-post-start"' in body

--- a/tests/test_analysis_compare_route.py
+++ b/tests/test_analysis_compare_route.py
@@ -133,6 +133,12 @@ async def test_compare_returns_best_and_median_disjoint(
     # Best 3 should be the 3 lowest loss values.
     best_losses = sorted(m["loss_kts"] for m in data["best"])
     assert best_losses == [1.0, 2.0, 3.0]
+    # Each cell carries the fields the UI deep-link needs to build
+    # /session/{id}/{slug}?t=<offset>: session_id, session_start_utc, ts.
+    for m in data["best"]:
+        assert m.get("session_id") is not None
+        assert m.get("session_start_utc") is not None
+        assert m.get("ts") is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_analysis_compare_route.py
+++ b/tests/test_analysis_compare_route.py
@@ -1,0 +1,194 @@
+"""Tests for the /api/analysis/maneuver-compare HTTP route (#741)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+@pytest_asyncio.fixture
+async def client(storage: Storage, monkeypatch: pytest.MonkeyPatch) -> httpx.AsyncClient:  # type: ignore[misc]
+    monkeypatch.setenv("AUTH_DISABLED", "true")
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+_BASE_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _seed_session(
+    storage: Storage,
+    *,
+    session_id: int,
+    name: str,
+    base_offset_h: int,
+    distance_loss_m: float,
+) -> None:
+    """Seed one session with one tack — distance_loss_m derived from the
+    geometry of the seeded positions, not directly stored. We approximate
+    by adjusting the position drift so the enriched value lands near the
+    target. Good enough for ordering tests.
+    """
+    db = storage._conn()
+    start = _BASE_TS + timedelta(hours=base_offset_h)
+    end = start + timedelta(seconds=180)
+    await db.execute(
+        "INSERT INTO races"
+        " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            session_id,
+            name,
+            "test-event",
+            session_id,
+            start.date().isoformat(),
+            "race",
+            start.isoformat(),
+            end.isoformat(),
+        ),
+    )
+
+    # 180s of 1Hz instrument data with a tack at t=90.
+    for i in range(181):
+        ts = (start + timedelta(seconds=i)).isoformat()
+        hdg = 10.0 if i < 90 else 280.0
+        bsp = 6.0 if i < 85 or i > 100 else 3.0
+        await db.execute(
+            "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+            (ts, 0x05, hdg),
+        )
+        await db.execute(
+            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+            (ts, 0x05, bsp),
+        )
+        await db.execute(
+            "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference)"
+            " VALUES (?, ?, ?, ?, 0)",
+            (ts, 0x05, 12.0, 40.0),
+        )
+        # Position drift roughly along entry COG so enrichment can compute loss.
+        await db.execute(
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
+            " VALUES (?, ?, ?, ?)",
+            (ts, 0x05, 37.0 + i * 1e-5, -122.0),
+        )
+
+    # Stored maneuver row at t=90.
+    await db.execute(
+        "INSERT INTO maneuvers"
+        " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+        "  vmg_loss_kts, tws_bin, twa_bin, details)"
+        " VALUES (?, ?, ?, ?, 10.0, ?, NULL, 12, 40, NULL)",
+        (
+            session_id,
+            "tack",
+            (start + timedelta(seconds=90)).isoformat(),
+            (start + timedelta(seconds=100)).isoformat(),
+            distance_loss_m,  # piggyback as loss_kts so our metric ranking can fire
+        ),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_compare_returns_best_and_median_disjoint(
+    client: httpx.AsyncClient, storage: Storage
+) -> None:
+    # Seven sessions with monotonically increasing loss_kts.
+    for i, loss in enumerate([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], start=1):
+        await _seed_session(
+            storage,
+            session_id=i,
+            name=f"s{i}",
+            base_offset_h=i * 2,
+            distance_loss_m=loss,
+        )
+
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "loss_kts", "n": 3},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filters"]["type"] == "tack"
+    assert data["filters"]["metric"] == "loss_kts"
+    assert data["pool_size"] == 7
+    assert len(data["best"]) == 3
+    assert len(data["median"]) == 3
+    best_ids = {m["id"] for m in data["best"]}
+    median_ids = {m["id"] for m in data["median"]}
+    assert best_ids.isdisjoint(median_ids)
+    # Best 3 should be the 3 lowest loss values.
+    best_losses = sorted(m["loss_kts"] for m in data["best"])
+    assert best_losses == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.asyncio
+async def test_compare_rejects_unknown_type(client: httpx.AsyncClient) -> None:
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "loop-de-loop", "metric": "distance_loss_m"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compare_rejects_unknown_metric(client: httpx.AsyncClient) -> None:
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "vibe_score"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compare_rejects_inverted_tws_range(
+    client: httpx.AsyncClient,
+) -> None:
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "tack", "metric": "loss_kts", "tws_min": 12, "tws_max": 8},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compare_empty_pool_returns_zero_counts(
+    client: httpx.AsyncClient,
+) -> None:
+    resp = await client.get(
+        "/api/analysis/maneuver-compare",
+        params={"type": "gybe", "metric": "loss_kts"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pool_size"] == 0
+    assert data["best"] == []
+    assert data["median"] == []
+
+
+@pytest.mark.asyncio
+async def test_compare_page_renders(client: httpx.AsyncClient) -> None:
+    """The /maneuvers/compare page renders the filter form."""
+    resp = await client.get("/maneuvers/compare")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Best vs Median Maneuvers" in body
+    assert 'id="mc-form"' in body
+    # All four maneuver types are filter options.
+    assert 'value="tack"' in body
+    assert 'value="gybe"' in body
+    assert 'value="weather_rounding"' in body
+    assert 'value="leeward_rounding"' in body

--- a/tests/test_analysis_compare_route.py
+++ b/tests/test_analysis_compare_route.py
@@ -261,8 +261,8 @@ async def test_compare_post_start_excludes_pre_gun(
 
 @pytest.mark.asyncio
 async def test_compare_page_renders(client: httpx.AsyncClient) -> None:
-    """The /maneuvers/compare page renders the filter form."""
-    resp = await client.get("/maneuvers/compare")
+    """The /analysis/maneuver-compare page renders the filter form."""
+    resp = await client.get("/analysis/maneuver-compare")
     assert resp.status_code == 200
     body = resp.text
     assert "Best vs Median Maneuvers" in body
@@ -275,3 +275,15 @@ async def test_compare_page_renders(client: httpx.AsyncClient) -> None:
     # Direction + post-start filters are present.
     assert 'id="mc-direction"' in body
     assert 'id="mc-post-start"' in body
+
+
+@pytest.mark.asyncio
+async def test_analysis_hub_page_renders(client: httpx.AsyncClient) -> None:
+    """The /analysis hub lists the available coach analyses."""
+    resp = await client.get("/analysis")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Analysis" in body
+    # Both tools should be linked.
+    assert 'href="/analysis/maneuver-compare"' in body
+    assert 'href="/maneuvers"' in body

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -1195,3 +1195,54 @@ class TestRankManeuvers:
         ranked = rank_maneuvers(items)
         worst = max(ranked, key=lambda m: m["loss_kts"] or 0)
         assert worst["rank"] == "bad"
+
+    def test_explicit_metric_recovery_time(self) -> None:
+        """Passing metric='time_to_recover_s' should rank by that field
+        instead of the distance_loss_m fallback."""
+        items = [
+            {"type": "tack", "distance_loss_m": 100.0, "time_to_recover_s": 1.0},
+            {"type": "tack", "distance_loss_m": 90.0, "time_to_recover_s": 5.0},
+            {"type": "tack", "distance_loss_m": 80.0, "time_to_recover_s": 10.0},
+            {"type": "tack", "distance_loss_m": 70.0, "time_to_recover_s": 30.0},
+            {"type": "tack", "distance_loss_m": 60.0, "time_to_recover_s": 50.0},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 80.0},
+            {"type": "tack", "distance_loss_m": 40.0, "time_to_recover_s": 120.0},
+            {"type": "tack", "distance_loss_m": 30.0, "time_to_recover_s": 200.0},
+        ]
+        rank_maneuvers(items, metric="time_to_recover_s")
+        # Worst distance_loss has the FASTEST recovery → should be 'good'
+        # under the recovery metric, even though it has the most distance loss.
+        fastest_recovery = next(m for m in items if m["time_to_recover_s"] == 1.0)
+        slowest_recovery = next(m for m in items if m["time_to_recover_s"] == 200.0)
+        assert fastest_recovery["rank"] == "good"
+        assert slowest_recovery["rank"] == "bad"
+
+    def test_unknown_metric_falls_back_to_default(self) -> None:
+        """An unknown metric name should not crash; items get rank=None."""
+        items = [
+            {"type": "tack", "distance_loss_m": 1.0, "loss_kts": 0.1},
+            {"type": "tack", "distance_loss_m": 2.0, "loss_kts": 0.5},
+        ]
+        rank_maneuvers(items, metric="not_a_real_field")
+        # No items have a non-None value for 'not_a_real_field' → all unranked.
+        assert all(m["rank"] is None for m in items)
+
+    def test_metric_skips_absolute_floor_for_non_distance(self) -> None:
+        """The 3m absolute spread floor only gates distance_loss_m ranking.
+        For other metrics, only the relative-stdev test applies."""
+        # Tight cluster of recovery times — 0.5s spread — would fail the
+        # absolute floor (3m) if it were applied. But it isn't, so the
+        # relative test gets to decide.
+        items = [
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.0},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.1},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.2},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.3},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.4},
+            {"type": "tack", "distance_loss_m": 50.0, "time_to_recover_s": 5.5},
+        ]
+        rank_maneuvers(items, metric="time_to_recover_s")
+        # stdev/median ≈ 0.17/5.25 ≈ 0.03, below the 0.5 threshold,
+        # so the spread-aware path should label everything 'consistent'.
+        labels = {m["rank"] for m in items}
+        assert labels == {"consistent"}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4064,6 +4064,49 @@ async def test_maneuver_browse_rejects_bad_direction(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
+async def test_maneuver_browse_rejects_bad_rank_by(storage: Storage) -> None:
+    """Unknown rank_by metric returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/maneuvers/browse?rank_by=vibes")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_default_rank_by_in_response(
+    storage: Storage,
+) -> None:
+    """Response carries rank_by so the client knows which metric is rendered."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="RankDefault", count=2)
+        resp = await client.get(f"/api/maneuvers/browse?session_ids={race_id}")
+    assert resp.status_code == 200
+    assert resp.json()["rank_by"] == "distance_loss_m"
+
+
+@pytest.mark.asyncio
+async def test_maneuver_browse_accepts_rank_by_alternative(
+    storage: Storage,
+) -> None:
+    """A valid alternate metric round-trips and labels the response."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        race_id, _ = await _seed_maneuvers(storage, client, event="RankAlt", count=2)
+        resp = await client.get(
+            f"/api/maneuvers/browse?session_ids={race_id}&rank_by=time_to_recover_s"
+        )
+    assert resp.status_code == 200
+    assert resp.json()["rank_by"] == "time_to_recover_s"
+
+
+@pytest.mark.asyncio
 async def test_maneuver_browse_sessions_filters_by_session_type(storage: Storage) -> None:
     """session_type=race hides practice sessions from the picker (and vice versa)."""
     app = create_app(storage)


### PR DESCRIPTION
## Summary

- Coaching tool to surface the **3 best** and **3 closest-to-median** maneuvers across all of a boat's sessions, filtered by type + entry-TWS + success metric
- Filter page at `/maneuvers/compare` hands off to the existing `/compare` (video grid) and `/maneuvers/overlay` (track overlay) pages, so this is a thin selector built on top of mature infrastructure
- `analysis/compare.py` is pure helpers (`filter_pool`, `pick_best`, `pick_median`, `assemble_compare_set`) plus one cross-session DB query, all ~200 lines

## How it works

1. Coach picks maneuver type (tack / gybe / weather rounding / leeward rounding), TWS range, and success metric (`distance_loss_m`, `time_to_recover_s`, `time_to_head_to_wind_s`, `loss_kts` — all smaller-is-better)
2. `GET /api/analysis/maneuver-compare?...` loads every matching maneuver across the boat's DB, enriches via the existing per-session cache, and returns 6 picks (best 3 + median 3, disjoint sets, ties broken by recency)
3. UI shows a 6-card preview + 'Open side-by-side videos' / 'Open track overlay' buttons that deep-link into `/compare` and `/maneuvers/overlay`

## Test plan

- [x] 28 unit tests for `compare.py` helpers — empty pools, all-None metrics, ties, recency tie-breaks, rounding-kind discriminator, TWS range edges
- [x] 5 route tests including 422 validation cases and a multi-session integration test that seeds 7 races worth of instrument data and asserts disjoint best/median sets ordered by metric
- [x] Page-renders smoke test for `/maneuvers/compare`
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (114 source files)
- [x] Full `uv run pytest` — 2512 passed, 2 skipped, no failures
- [ ] Manual browser test — flagging this for the human reviewer; the JS interactions (form submit, render, permalink hydration) aren't exercised by automated tests

## Notes

- **Do not merge** — per the issue request, leaving this for review before landing
- Closes #741
- No schema changes; no auth or peer-API surface touched. Medium-tier per `docs/risk-tiers.md`
- Open questions raised in the issue (inline-tag from each card; entry-TWS vs averaged; pre-classifying rounding kinds upstream) are not addressed here — left for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)