### PR TITLE
fix(deploy): skip unreadable /home dirs in _uv_bin lookup

### DIFF
--- a/src/helmlog/deploy.py
+++ b/src/helmlog/deploy.py
@@ -82,23 +82,36 @@ def _uv_bin() -> str:
     """Return the full path to the uv binary.
 
     Under systemd, ~/.local/bin is not in PATH, so we resolve it explicitly.
+    The systemd unit overrides HOME (e.g. ``HOME=/var/cache/helmlog``) so
+    ``Path.home()`` does not point at the deploy user's home — we must check
+    the repo owner's home dir explicitly.
     """
     found = shutil.which("uv")
     if found:
         return found
-    # Common install location on Pi (installed by setup.sh for the deploy user)
-    home_local = Path.home() / ".local" / "bin" / "uv"
-    if home_local.exists():
-        return str(home_local)
-    # helmlog service account fallback
-    svc_local = Path("/home/helmlog/.local/bin/uv")
-    if svc_local.exists():
-        return str(svc_local)
-    # Search common home dirs on the Pi
-    for user_dir in Path("/home").iterdir():
+    candidates = [
+        Path.home() / ".local" / "bin" / "uv",
+        Path(f"/home/{_repo_owner()}/.local/bin/uv"),
+        Path("/home/helmlog/.local/bin/uv"),
+    ]
+    for candidate in candidates:
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        except PermissionError:
+            continue
+    # Last-ditch search across /home — skip dirs we can't read.
+    try:
+        user_dirs = list(Path("/home").iterdir())
+    except (PermissionError, OSError):
+        user_dirs = []
+    for user_dir in user_dirs:
         candidate = user_dir / ".local" / "bin" / "uv"
-        if candidate.exists():
-            return str(candidate)
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        except PermissionError:
+            continue
     return "uv"  # last resort — let it fail with a clear error
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -12,6 +13,8 @@ from helmlog.deploy import DeployConfig, in_deploy_window
 from helmlog.web import create_app
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from helmlog.storage import Storage
 
 
@@ -74,6 +77,60 @@ class TestDeployWindow:
         hour = datetime.now(UTC).hour
         expected = hour >= 22 or hour < 6
         assert in_deploy_window(config) is expected
+
+
+class TestUvBin:
+    def test_finds_uv_in_owner_home_when_path_home_misses(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When systemd HOME=/var/cache/helmlog has no uv, the owner home is consulted."""
+        import helmlog.deploy as deploy_mod
+
+        fake_owner_home = tmp_path / "owner"
+        owner_uv = fake_owner_home / ".local" / "bin" / "uv"
+        owner_uv.parent.mkdir(parents=True)
+        owner_uv.write_text("#!/bin/sh\nexit 0\n")
+        owner_uv.chmod(0o755)
+
+        empty_home = tmp_path / "empty_systemd_home"
+        empty_home.mkdir()
+
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(self: Path) -> Iterator[Path]:
+            if str(self) == "/home":
+                return iter([fake_owner_home])
+            return original_iterdir(self)
+
+        monkeypatch.setattr(deploy_mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(deploy_mod.Path, "home", staticmethod(lambda: empty_home))
+        monkeypatch.setattr(deploy_mod, "_repo_owner", lambda: "no_such_user_xyz")
+        monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+
+        assert deploy_mod._uv_bin() == str(owner_uv)
+
+    def test_does_not_raise_when_home_iter_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable /home (PermissionError on iterdir) must not crash _uv_bin."""
+        import helmlog.deploy as deploy_mod
+
+        empty_home = tmp_path / "empty"
+        empty_home.mkdir()
+
+        monkeypatch.setattr(deploy_mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(deploy_mod.Path, "home", staticmethod(lambda: empty_home))
+        monkeypatch.setattr(deploy_mod, "_repo_owner", lambda: "nonexistent_user_xyz")
+
+        def boom_iterdir(self: Path) -> Iterator[Path]:
+            if str(self) == "/home":
+                raise PermissionError("simulated")
+            return iter(())
+
+        monkeypatch.setattr(Path, "iterdir", boom_iterdir)
+
+        # Falls through to the "uv" sentinel instead of raising.
+        assert deploy_mod._uv_bin() == "uv"
 
 
 class TestRepoOwner:


### PR DESCRIPTION
## Summary
- Deploy page on the Pi was failing with `[Errno 13] Permission denied: '/home/helmlog-backup/.local/bin/uv'`.
- The systemd unit runs as `helmlog` with `HOME=/var/cache/helmlog`, so `Path.home()` doesn't point at the deploy user. `_uv_bin()` fell through to a `/home` iteration and picked `helmlog-backup` (alphabetically before `weaties`) — a dir the service user can't traverse, so the subsequent `subprocess` raised on exec.
- Now consult the repo owner's home (`/home/weaties` here) explicitly, require X_OK on each candidate, and tolerate `PermissionError` when listing/probing `/home`.

## Test plan
- [x] `uv run pytest tests/test_deploy.py --no-cov` (33 passed)
- [x] `uv run ruff check src/helmlog/deploy.py tests/test_deploy.py`
- [x] `uv run mypy src/helmlog/deploy.py`
- [ ] Verify on `corvopi-live` that the deploy page loads without the uv error after merge + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)