### PR TITLE
fix(admin): save boat default color scheme on click (#747)

### DIFF
--- a/src/helmlog/templates/admin/settings.html
+++ b/src/helmlog/templates/admin/settings.html
@@ -56,11 +56,11 @@
 <div class="card">
   <div class="label">Color Scheme — Boat Default</div>
   <div id="cs-status" class="status"></div>
-  <p style="font-size:.82rem;color:var(--text-secondary);margin-bottom:12px">Applies to all crew who haven't set a personal override. Select a preset or create a custom scheme below.</p>
+  <p style="font-size:.82rem;color:var(--text-secondary);margin-bottom:12px">Applies to all crew who haven't set a personal override. Click a preset or custom scheme to make it the boat default.</p>
 
   <div class="cs-grid" id="preset-grid">
     {% for p in preset_schemes %}
-    <div class="cs-preset{% if boat_default == p.id %} selected{% endif %}" id="preset-{{ p.id }}" onclick="selectScheme('{{ p.id }}')">
+    <div class="cs-preset{% if boat_default == p.id %} selected{% endif %}" id="preset-{{ p.id }}" onclick="setDefault('{{ p.id }}')">
       <div class="cs-swatch" id="swatch-{{ p.id }}"></div>
       <div>{{ p.name }}</div>
     </div>
@@ -79,7 +79,7 @@
       </div>
       <span style="flex:1;font-size:.85rem">{{ cs.name }}</span>
       <button class="btn{% if boat_default == 'custom:' ~ cs.id|string %} btn-primary{% endif %}"
-              onclick="selectScheme('custom:{{ cs.id }}')" style="padding:4px 10px;font-size:.78rem">
+              onclick="setDefault('custom:{{ cs.id }}')" style="padding:4px 10px;font-size:.78rem">
         {% if boat_default == 'custom:' ~ cs.id|string %}Default ✓{% else %}Set default{% endif %}
       </button>
       <button class="btn btn-reset" onclick="deleteCustom({{ cs.id }})">Delete</button>
@@ -94,7 +94,6 @@
     </span>
   </div>
   <div class="btn-row">
-    <button class="btn btn-primary" onclick="saveDefault()">Save Default</button>
     <button class="btn btn-reset" onclick="clearDefault()">Clear (use system default)</button>
   </div>
 </div>
@@ -138,27 +137,18 @@ const PRESET_COLORS = {
   'daylight_amber': {bg:'#FFFDE7', text:'#3E2723', accent:'#FF8F00'},
 };
 
-let selectedScheme = '{{ boat_default }}';
-
 // Populate swatch backgrounds
 Object.entries(PRESET_COLORS).forEach(([id, c]) => {
   const sw = document.getElementById('swatch-'+id);
   if (sw) sw.style.background = `linear-gradient(135deg, ${c.bg} 50%, ${c.text} 50%)`;
 });
 
-function selectScheme(id) {
-  selectedScheme = id;
-  document.querySelectorAll('.cs-preset').forEach(el => el.classList.remove('selected'));
-  const el = document.getElementById('preset-'+id);
-  if (el) el.classList.add('selected');
-}
-
-async function saveDefault() {
+async function setDefault(id) {
   const r = await fetch('/api/color-schemes/default', {
     method:'PUT', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({scheme_id: selectedScheme})
+    body: JSON.stringify({scheme_id: id})
   });
-  if (r.ok) { showCsStatus('Default saved — reload to see the change','ok'); setTimeout(()=>location.reload(),1200); }
+  if (r.ok) { showCsStatus('Default saved — reloading…','ok'); setTimeout(()=>location.reload(),600); }
   else { const d = await r.json().catch(()=>({})); showCsStatus(d.detail||'Save failed','err'); }
 }
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -267,6 +267,25 @@ async def test_api_set_boat_default_unknown_scheme_422(client: httpx.AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_api_set_boat_default_custom_scheme(client: httpx.AsyncClient) -> None:
+    """PUT /api/color-schemes/default with a custom scheme id persists (regression #747).
+
+    The admin/settings page now triggers this PUT directly on click instead of
+    staging the selection in JS. This guards the path the new click handler hits.
+    """
+    create = await client.post(
+        "/api/color-schemes",
+        json={"name": "Corvo", "bg": "#000000", "text_color": "#FFD600", "accent": "#FFD600"},
+    )
+    assert create.status_code == 201
+    sid = create.json()["id"]
+    resp = await client.put("/api/color-schemes/default", json={"scheme_id": f"custom:{sid}"})
+    assert resp.status_code == 200
+    list_resp = await client.get("/api/color-schemes")
+    assert list_resp.json()["boat_default"] == f"custom:{sid}"
+
+
+@pytest.mark.asyncio
 async def test_api_delete_custom_scheme(client: httpx.AsyncClient) -> None:
     """DELETE /api/color-schemes/{id} removes the scheme."""
     create = await client.post(


### PR DESCRIPTION
## Summary

- Settings page split boat-default selection into two steps (stage in JS → click separate "Save Default" button). For custom schemes, the staging step had **zero visible feedback** because the `.selected` highlight only attached to `.cs-preset` elements, so users reasonably concluded "it didn't take".
- Make every scheme tile/button issue `PUT /api/color-schemes/default` directly and reload. Drop the redundant "Save Default" button (the "Clear" button stays).
- Add a regression test for the custom-scheme PUT path the new click handler hits — the existing test only covered the preset path.

Closes #747

## Test plan

- [x] `uv run pytest tests/test_themes.py tests/test_settings.py` — 44 passed
- [x] `uv run ruff check src/helmlog/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [ ] Manual: on `/admin/settings`, click a preset tile → reloads with that preset as default; click a custom row's "Set default" → reloads with that scheme as default; click "Clear" → reverts to system default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)