### PR TITLE
fix(perf): cache aligned overlay series in enrich payload

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -500,7 +500,12 @@ _ENRICH_PAD_S = 60  # seconds of instrument data to load beyond the session wind
 # v7: distance_loss_m switches from entry-COG projection to the single
 #     ladder-axis projection (upwind for tacks, downwind for gybes).
 #     Positive = ground lost toward the mark. (#619 follow-up.)
-ENRICH_CACHE_VERSION = 7
+# v8: per-maneuver overlay arrays (overlay_bsp, overlay_heading_rate_deg_s,
+#     overlay_twa) are precomputed at enrichment time so the cross-session
+#     overlay endpoint serves from cache instead of rescanning instrument
+#     tables for every request. Untagged sessions with multi-hour windows
+#     made the previous reload path take 20+ s on a Pi.
+ENRICH_CACHE_VERSION = 8
 
 
 def _bucket_positions_per_second(
@@ -790,6 +795,15 @@ async def enrich_session_maneuvers(
     tws.sort(key=lambda p: p[0])
     twd.sort(key=lambda p: p[0])
 
+    # Per-second lookup tables for the overlay alignment below. ``hdg_by_sec``
+    # is already populated above (it's also used for TWD→TWA conversion).
+    bsp_by_sec: dict[str, float] = {}
+    for ts_b, bv in bsp:
+        bsp_by_sec.setdefault(ts_b.isoformat()[:19], bv)
+    twa_by_sec: dict[str, float] = {}
+    for ts_t, tv in twa:
+        twa_by_sec.setdefault(ts_t.isoformat()[:19], tv)
+
     # Video sync for deep-links. Pick the first race video.
     video_cur = await db.execute(
         "SELECT video_id, sync_utc, sync_offset_s, duration_s, youtube_url"
@@ -951,6 +965,23 @@ async def enrich_session_maneuvers(
             d["video_offset_s"] = None
             d["youtube_url"] = None
 
+        # Aligned per-maneuver overlay series (#619 follow-up). Pre-aligning
+        # here means the cross-session overlay endpoint can serve straight
+        # from the maneuver_cache row instead of re-scanning headings/speeds/
+        # winds for every request. Aligned to ``head_to_wind_ts`` over the
+        # fixed ``_OVERLAY_AXIS`` (-20..+30 s); maneuvers without an HTW
+        # (roundings, stalled tacks) get None and are surfaced as excluded
+        # by the overlay endpoint.
+        htw_ts = metrics.head_to_wind_ts
+        if htw_ts is not None:
+            d["overlay_bsp"] = _align_series_at_htw(bsp_by_sec, htw_ts)
+            d["overlay_heading_rate_deg_s"] = _heading_rate_series(hdg_by_sec, htw_ts)
+            d["overlay_twa"] = _align_series_at_htw(twa_by_sec, htw_ts)
+        else:
+            d["overlay_bsp"] = None
+            d["overlay_heading_rate_deg_s"] = None
+            d["overlay_twa"] = None
+
         enriched.append(d)
 
     rank_maneuvers(enriched)
@@ -1084,9 +1115,10 @@ async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]
     missing TWA) are excluded and their ``"<sid>:<mid>"`` string appended
     to ``excluded_ids`` so the UI can show a notice.
 
-    Per-session instrument data is loaded via ``enrich_session_maneuvers``
-    (cached), then aligned here to the fixed overlay axis. No new
-    storage round-trips for repeat calls on the same session ids.
+    The aligned per-maneuver series are precomputed at enrichment time and
+    stored on each maneuver's cached payload (see
+    :func:`enrich_session_maneuvers` and :data:`ENRICH_CACHE_VERSION`), so
+    this function makes no fresh range-scans on the instrument tables.
     """
     if not pairs:
         return {"axis_s": _OVERLAY_AXIS, "channels": [], "maneuvers": [], "excluded_ids": []}
@@ -1109,12 +1141,6 @@ async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]
         session_name = race.name
         session_slug = race.slug or ""
 
-        # Load instrument series once per session for the overlay alignment.
-        series = await _load_session_instrument_series(storage, session_id)
-        hdg_by_sec = series["hdg"]
-        bsp_by_sec = series["bsp"]
-        twa_by_sec = series["twa"]
-
         for m in enriched:
             if m.get("id") not in wanted_ids:
                 continue
@@ -1123,9 +1149,10 @@ async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]
             if not htw_raw:
                 excluded.append(key)
                 continue
-            try:
-                htw_ts = _parse_iso(str(htw_raw))
-            except (ValueError, TypeError):
+            bsp_aligned = m.get("overlay_bsp")
+            hr_aligned = m.get("overlay_heading_rate_deg_s")
+            twa_aligned = m.get("overlay_twa")
+            if bsp_aligned is None or hr_aligned is None or twa_aligned is None:
                 excluded.append(key)
                 continue
 
@@ -1144,10 +1171,10 @@ async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]
                     "rank": m.get("rank"),
                     "loss_percentile": m.get("loss_percentile"),
                     "head_to_wind_ts": m.get("head_to_wind_ts"),
-                    # Aligned time-series for the line charts.
-                    "bsp": _align_series_at_htw(bsp_by_sec, htw_ts),
-                    "heading_rate_deg_s": _heading_rate_series(hdg_by_sec, htw_ts),
-                    "twa": _align_series_at_htw(twa_by_sec, htw_ts),
+                    # Precomputed aligned series for the line charts.
+                    "bsp": bsp_aligned,
+                    "heading_rate_deg_s": hr_aligned,
+                    "twa": twa_aligned,
                     # Wind-up track + ghost reference for the overlay SVG.
                     "track": m.get("track"),
                     "track_vakaros": m.get("track_vakaros"),
@@ -1187,82 +1214,6 @@ async def build_maneuvers_overlay(storage: Storage, pairs: list[tuple[int, int]]
         "maneuvers": out,
         "excluded_ids": excluded,
     }
-
-
-async def _load_session_instrument_series(
-    storage: Storage, session_id: int
-) -> dict[str, dict[str, float]]:
-    """Load per-second hdg / bsp / twa dicts for a session, keyed by
-    ``ts.isoformat()[:19]``. Uses the same race_id-scoped-with-fallback
-    pattern as ``enrich_session_maneuvers`` and builds the folded TWA
-    the same way."""
-    db = storage._conn()
-    race_cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
-    race_row = await race_cur.fetchone()
-    if race_row is None:
-        return {"hdg": {}, "bsp": {}, "twa": {}}
-
-    start = _parse_iso(race_row["start_utc"])
-    end = _parse_iso(race_row["end_utc"]) if race_row["end_utc"] else start + timedelta(hours=24)
-    start_pad = start - timedelta(seconds=_ENRICH_PAD_S)
-    end_pad = end + timedelta(seconds=_ENRICH_PAD_S)
-
-    async def _load(table: str) -> list[dict[str, Any]]:
-        data = await storage.query_range(table, start_pad, end_pad, race_id=session_id)
-        if not data:
-            data = await storage.query_range(table, start_pad, end_pad)
-        return data
-
-    headings_raw = await _load("headings")
-    speeds_raw = await _load("speeds")
-    winds_raw = await _load("winds")
-    cogsog_raw: list[dict[str, Any]] = []
-    if not headings_raw or not speeds_raw:
-        cogsog_raw = await _load("cogsog")
-
-    def _sec(ts_str: str) -> str:
-        return str(ts_str)[:19]
-
-    hdg_by_sec: dict[str, float] = {}
-    if headings_raw:
-        for r in headings_raw:
-            hdg_by_sec.setdefault(_sec(r["ts"]), float(r["heading_deg"]))
-    elif cogsog_raw:
-        for r in cogsog_raw:
-            hdg_by_sec.setdefault(_sec(r["ts"]), float(r["cog_deg"]))
-
-    bsp_by_sec: dict[str, float] = {}
-    if speeds_raw:
-        for r in speeds_raw:
-            bsp_by_sec.setdefault(_sec(r["ts"]), float(r["speed_kts"]))
-    elif cogsog_raw:
-        for r in cogsog_raw:
-            bsp_by_sec.setdefault(_sec(r["ts"]), float(r["sog_kts"]))
-
-    twa_by_sec: dict[str, float] = {}
-    for r in winds_raw:
-        ref_raw = r.get("reference")
-        if ref_raw is None:
-            continue
-        try:
-            ref = int(ref_raw)
-        except (TypeError, ValueError):
-            continue
-        if ref not in (0, 4):
-            continue
-        sec = _sec(r["ts"])
-        if ref == 0:
-            signed = float(r["wind_angle_deg"])
-            folded = abs(signed) % 360.0
-            twa_by_sec.setdefault(sec, folded if folded <= 180.0 else 360.0 - folded)
-        else:
-            twd_val = float(r["wind_angle_deg"]) % 360.0
-            hv = hdg_by_sec.get(sec)
-            if hv is not None:
-                raw = (twd_val - hv + 360.0) % 360.0
-                twa_by_sec.setdefault(sec, raw if raw <= 180.0 else 360.0 - raw)
-
-    return {"hdg": hdg_by_sec, "bsp": bsp_by_sec, "twa": twa_by_sec}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_overlay_endpoint.py
+++ b/tests/test_overlay_endpoint.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport
 from helmlog.analysis.maneuvers import (
     ENRICH_CACHE_VERSION,
     build_maneuvers_overlay,
+    enrich_session_maneuvers,
 )
 
 if TYPE_CHECKING:
@@ -193,6 +194,49 @@ class TestBuildManeuversOverlay:
         # t=0 index is 20 (position of 0 in [-20..30]).
         assert bsp[20] is not None
         assert abs(bsp[20] - 6.0) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_overlay_served_from_cache_without_instrument_rescan(
+        self, storage: Storage
+    ) -> None:
+        """The aligned series live on the cached enriched payload, so
+        ``build_maneuvers_overlay`` must keep working after the
+        instrument tables are wiped — proving it does not re-scan them
+        per request. Regression guard for the slow cold path that
+        rebuilt headings/speeds/winds for every overlay request."""
+        await _seed_session(storage, session_id=10, name="cached", htw_offsets_s=[60])
+        # Prime the maneuver_cache with v8 enrichment.
+        await enrich_session_maneuvers(storage, 10)
+
+        db = storage._conn()
+        for table in ("headings", "speeds", "winds", "positions"):
+            await db.execute(f"DELETE FROM {table}")  # noqa: S608
+        await db.commit()
+
+        payload = await build_maneuvers_overlay(storage, [(10, 1000)])
+        assert len(payload["maneuvers"]) == 1
+        m = payload["maneuvers"][0]
+        assert len(m["bsp"]) == 51
+        # Steady BSP=6.0 was seeded; the cache holds the aligned values.
+        assert m["bsp"][20] is not None
+        assert abs(m["bsp"][20] - 6.0) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_enriched_payload_contains_overlay_arrays(self, storage: Storage) -> None:
+        """The enrichment step is the single producer of the aligned
+        overlay arrays; ``build_maneuvers_overlay`` only forwards them.
+        Verify the contract directly so the producer can't quietly
+        drop fields without breaking this test."""
+        await _seed_session(storage, session_id=11, name="enr", htw_offsets_s=[60])
+        enriched, _ = await enrich_session_maneuvers(storage, 11)
+        assert len(enriched) == 1
+        m = enriched[0]
+        assert isinstance(m["overlay_bsp"], list) and len(m["overlay_bsp"]) == 51
+        assert (
+            isinstance(m["overlay_heading_rate_deg_s"], list)
+            and len(m["overlay_heading_rate_deg_s"]) == 51
+        )
+        assert isinstance(m["overlay_twa"], list) and len(m["overlay_twa"]) == 51
 
 
 class TestOverlayEndpoint:


### PR DESCRIPTION
## Summary
- The cross-session maneuvers overlay endpoint cold-path took ~27 s on a Pi because `build_maneuvers_overlay` called `_load_session_instrument_series` for every session, scanning `headings/speeds/winds` on every request — even though `enrich_session_maneuvers` already loaded the same rows and was cached.
- Pre-aligning the per-maneuver `bsp / heading_rate_deg_s / twa` arrays at enrichment time and stashing them on the cached row turns the cold overlay into a handful of `maneuver_cache` reads. Bumps `ENRICH_CACHE_VERSION` to 8 so `backfill_stale_maneuver_cache` rebuilds entries on next service start. Deletes the now-unused `_load_session_instrument_series`.
- Net diff: −93 / +88 lines.

## Profiled cold path on `corvopi-live` (issue #751)
| Step | Before |
|---|---|
| `resolve_race_data_hash` × 5 | 51 ms |
| `enrich_session_maneuvers` × 5 (cached) | 17 ms |
| **`_load_session_instrument_series` × 5** | **21,902 ms** |
| Total `build_maneuvers_overlay` | 23,903 ms |

Session 126 (RTTS, 22.4 h window, instrument tables untagged) drove ~16 s of that on its own; this PR removes the entire row.

## Test plan
- [x] `uv run pytest -x -q --no-cov` — 2490 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — clean (113 files)
- [x] New tests:
  - `test_overlay_served_from_cache_without_instrument_rescan` — primes cache, wipes instrument tables, verifies the overlay payload still rebuilds correctly from the cached enriched row.
  - `test_enriched_payload_contains_overlay_arrays` — pins the contract on the producer side.
- [ ] After merge + Pi deploy: re-time the original URL and confirm cold-cache request drops from ~27 s to under a second.

## Follow-ups not in this PR
- T2 global cache PK is `(key_family, race_id=0)` so different overlay selections evict each other. Worth fixing separately to keep multiple overlays warm at once.
- Backfill `race_id` on instrument tables and start tagging on writes — would speed up every range query, not just overlay.

Fixes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)