### PR TITLE
fix(cache): include data_hash in web_cache PK

### DIFF
--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -254,15 +254,12 @@ class WebCache:
 
     async def t2_get(self, key_family: str, *, race_id: int, data_hash: str) -> object | None:
         try:
-            row = await self._read_row(key_family, race_id)
+            row = await self._read_row(key_family, race_id, data_hash)
         except Exception as exc:  # pragma: no cover - exercised via monkeypatch
             logger.warning("web cache read failed ({}): {}", key_family, exc)
             self._bump(key_family, "miss")
             return None
         if row is None:
-            self._bump(key_family, "miss")
-            return None
-        if row["data_hash"] != data_hash:
             self._bump(key_family, "miss")
             return None
         # v74+ schema: expires_utc is always present (NULL for race-keyed
@@ -274,7 +271,7 @@ class WebCache:
             except ValueError:
                 exp_dt = None
             if exp_dt is not None and exp_dt <= datetime.now(UTC):
-                await self._delete_row(key_family, race_id)
+                await self._delete_row(key_family, race_id, data_hash)
                 self._bump(key_family, "miss")
                 return None
         try:
@@ -288,7 +285,7 @@ class WebCache:
                 race_id,
                 exc,
             )
-            await self._delete_row(key_family, race_id)
+            await self._delete_row(key_family, race_id, data_hash)
             self._bump(key_family, "miss")
             return None
 
@@ -382,12 +379,14 @@ class WebCache:
     # Internal DB helpers (patched in tests to simulate failures)
     # ------------------------------------------------------------------
 
-    async def _read_row(self, key_family: str, race_id: int) -> aiosqlite.Row | None:
+    async def _read_row(
+        self, key_family: str, race_id: int, data_hash: str
+    ) -> aiosqlite.Row | None:
         db = self._storage._conn()  # noqa: SLF001
         cur = await db.execute(
             "SELECT data_hash, blob, expires_utc FROM web_cache"
-            " WHERE key_family = ? AND race_id = ?",
-            (key_family, race_id),
+            " WHERE key_family = ? AND race_id = ? AND data_hash = ?",
+            (key_family, race_id, data_hash),
         )
         return await cur.fetchone()
 
@@ -404,8 +403,7 @@ class WebCache:
         await db.execute(
             "INSERT INTO web_cache (key_family, race_id, data_hash, blob,"
             " created_utc, expires_utc) VALUES (?, ?, ?, ?, ?, ?)"
-            " ON CONFLICT(key_family, race_id) DO UPDATE SET"
-            "   data_hash = excluded.data_hash,"
+            " ON CONFLICT(key_family, race_id, data_hash) DO UPDATE SET"
             "   blob = excluded.blob,"
             "   created_utc = excluded.created_utc,"
             "   expires_utc = excluded.expires_utc",
@@ -413,11 +411,11 @@ class WebCache:
         )
         await db.commit()
 
-    async def _delete_row(self, key_family: str, race_id: int) -> None:
+    async def _delete_row(self, key_family: str, race_id: int, data_hash: str) -> None:
         db = self._storage._conn()  # noqa: SLF001
         await db.execute(
-            "DELETE FROM web_cache WHERE key_family = ? AND race_id = ?",
-            (key_family, race_id),
+            "DELETE FROM web_cache WHERE key_family = ? AND race_id = ? AND data_hash = ?",
+            (key_family, race_id, data_hash),
         )
         await db.commit()
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -203,7 +203,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 83
+_CURRENT_VERSION: int = 84
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -2024,6 +2024,27 @@ _MIGRATIONS: dict[int, str] = {
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_race_videos_unique_race_video
             ON race_videos(race_id, video_id);
+    """,
+    84: """
+        -- Add data_hash to the web_cache PK so global (race_id=0) entries
+        -- with different content hashes can coexist. Previously every
+        -- distinct cross-session overlay URL evicted the previous one
+        -- because the single (key_family, race_id) slot only held one
+        -- row per family. Cache content is fully regenerable, so we
+        -- drop the table outright rather than rewrite columns in place.
+        DROP TABLE IF EXISTS web_cache;
+        CREATE TABLE web_cache (
+            key_family  TEXT NOT NULL,
+            race_id     INTEGER NOT NULL,
+            data_hash   TEXT NOT NULL,
+            blob        TEXT NOT NULL,
+            created_utc TEXT NOT NULL,
+            expires_utc TEXT,
+            PRIMARY KEY (key_family, race_id, data_hash)
+        );
+        CREATE INDEX IF NOT EXISTS idx_web_cache_race ON web_cache(race_id);
+        CREATE INDEX IF NOT EXISTS idx_web_cache_created ON web_cache(created_utc);
+        CREATE INDEX IF NOT EXISTS idx_web_cache_expires ON web_cache(expires_utc);
     """,
 }
 

--- a/tests/test_migration_v84.py
+++ b/tests/test_migration_v84.py
@@ -1,0 +1,112 @@
+"""Tests for migration v84 — web_cache PK now includes data_hash."""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+import pytest
+
+from helmlog.storage import _MIGRATIONS, _split_migration_sql
+
+
+async def _apply_migration(db: aiosqlite.Connection, version: int) -> None:
+    for stmt in _split_migration_sql(_MIGRATIONS[version]):
+        upper = stmt.lstrip().upper()
+        is_alter_add = upper.startswith("ALTER TABLE") and "ADD COLUMN" in upper
+        if is_alter_add:
+            with contextlib.suppress(aiosqlite.OperationalError):
+                await db.execute(stmt)
+        else:
+            await db.execute(stmt)
+    await db.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (?)", (version,))
+    await db.commit()
+
+
+async def _build_db_at(version: int) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY)")
+    for v in sorted(_MIGRATIONS):
+        if v > version:
+            break
+        await _apply_migration(db, v)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_v84_pk_includes_data_hash() -> None:
+    db = await _build_db_at(84)
+    try:
+        async with db.execute("PRAGMA table_info(web_cache)") as cur:
+            cols = {r[1]: r["pk"] for r in await cur.fetchall()}
+        # data_hash is part of the PK alongside key_family and race_id.
+        assert cols["key_family"] > 0
+        assert cols["race_id"] > 0
+        assert cols["data_hash"] > 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v84_allows_distinct_hashes_for_same_global_family() -> None:
+    """The whole point of the migration: two global (race_id=0) rows with
+    the same key_family but different data_hash must coexist instead of
+    one overwriting the other."""
+    db = await _build_db_at(84)
+    try:
+        await db.execute(
+            "INSERT INTO web_cache (key_family, race_id, data_hash, blob, created_utc)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("maneuvers_overlay", 0, "hash_a", '{"a":1}', "2026-04-20T00:00:00+00:00"),
+        )
+        await db.execute(
+            "INSERT INTO web_cache (key_family, race_id, data_hash, blob, created_utc)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("maneuvers_overlay", 0, "hash_b", '{"b":2}', "2026-04-20T00:00:01+00:00"),
+        )
+        await db.commit()
+        async with db.execute(
+            "SELECT COUNT(*) FROM web_cache WHERE key_family = 'maneuvers_overlay'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 2
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v84_drops_pre_migration_rows() -> None:
+    """Cache content is best-effort and the migration drops it; downstream
+    requests rebuild on demand. Verify that v83 rows do not leak through."""
+    db = await _build_db_at(83)
+    try:
+        await db.execute(
+            "INSERT INTO web_cache (key_family, race_id, data_hash, blob, created_utc)"
+            " VALUES (?, ?, ?, ?, ?)",
+            ("session_summary", 1, "old_hash", "{}", "2026-04-20T00:00:00+00:00"),
+        )
+        await db.commit()
+        await _apply_migration(db, 84)
+        async with db.execute("SELECT COUNT(*) FROM web_cache") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_v84_migration_applied_on_fresh_db() -> None:
+    from helmlog.storage import Storage, StorageConfig
+
+    s = Storage(StorageConfig(db_path=":memory:"))
+    await s.connect()
+    try:
+        assert s._db is not None
+        async with s._db.execute("SELECT 1 FROM schema_version WHERE version = 84") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+    finally:
+        await s.close()

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -121,13 +121,21 @@ async def test_t2_stale_hash_returns_none(storage: Storage) -> None:
 
 
 @pytest.mark.asyncio
-async def test_t2_put_replaces_stale_entry(storage: Storage) -> None:
+async def test_t2_put_keeps_distinct_hashes_until_invalidation(storage: Storage) -> None:
+    """Post-v84 the PK includes data_hash, so two writes with different
+    hashes leave both rows in place. The old hash can never be looked up
+    by anyone who already has the new data — it stays until the race
+    mutation invalidation hook drops everything for the race id, or the
+    row-cap evictor sweeps it out."""
     cache = WebCache(storage)
     await cache.t2_put("session_summary", race_id=1, data_hash="abc", value={"v": 1})
     await cache.t2_put("session_summary", race_id=1, data_hash="def", value={"v": 2})
-    # Old hash is gone, new one is present
-    assert await cache.t2_get("session_summary", race_id=1, data_hash="abc") is None
+    assert await cache.t2_get("session_summary", race_id=1, data_hash="abc") == {"v": 1}
     assert await cache.t2_get("session_summary", race_id=1, data_hash="def") == {"v": 2}
+    # An invalidate flushes both.
+    await cache.invalidate(1)
+    assert await cache.t2_get("session_summary", race_id=1, data_hash="abc") is None
+    assert await cache.t2_get("session_summary", race_id=1, data_hash="def") is None
 
 
 # ---------------------------------------------------------------------------
@@ -395,3 +403,57 @@ async def test_t2_put_round_trip_preserves_json(storage: Storage) -> None:
     got = await cache.t2_get("session_track", race_id=1, data_hash="h")
     assert got == value
     assert json.dumps(got, sort_keys=True) == json.dumps(value, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# v84 — multiple distinct hashes coexist for the same global key_family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t2_global_distinct_hashes_coexist(storage: Storage) -> None:
+    """Two cross-session overlay selections with different content hashes
+    must not evict each other. Pre-v84 the (key_family, race_id=0) PK
+    held only one row, so any new selection blew away the previous
+    cached payload."""
+    cache = WebCache(storage)
+    await cache.t2_put_global(
+        "maneuvers_overlay", data_hash="h_a", value={"sel": "A"}, ttl_seconds=3600
+    )
+    await cache.t2_put_global(
+        "maneuvers_overlay", data_hash="h_b", value={"sel": "B"}, ttl_seconds=3600
+    )
+
+    a = await cache.t2_get_global("maneuvers_overlay", data_hash="h_a")
+    b = await cache.t2_get_global("maneuvers_overlay", data_hash="h_b")
+    assert a == {"sel": "A"}
+    assert b == {"sel": "B"}
+
+
+@pytest.mark.asyncio
+async def test_t2_race_keyed_distinct_hashes_coexist(storage: Storage) -> None:
+    """Race-keyed entries also benefit: writing a new hash for a race
+    that hasn't been invalidated yet leaves the prior hash readable
+    until the race-mutation hook drops everything for that race."""
+    cache = WebCache(storage)
+    await cache.t2_put("session_summary", race_id=42, data_hash="h_old", value={"v": 1})
+    await cache.t2_put("session_summary", race_id=42, data_hash="h_new", value={"v": 2})
+
+    old = await cache.t2_get("session_summary", race_id=42, data_hash="h_old")
+    new = await cache.t2_get("session_summary", race_id=42, data_hash="h_new")
+    assert old == {"v": 1}
+    assert new == {"v": 2}
+
+
+@pytest.mark.asyncio
+async def test_invalidate_race_drops_all_hashes_for_that_race(storage: Storage) -> None:
+    """Race-mutation invalidation still works as before — every cached
+    hash for the touched race id is dropped."""
+    cache = WebCache(storage)
+    await cache.t2_put("session_summary", race_id=99, data_hash="h_a", value={"v": 1})
+    await cache.t2_put("session_summary", race_id=99, data_hash="h_b", value={"v": 2})
+
+    await cache.invalidate(99)
+
+    assert await cache.t2_get("session_summary", race_id=99, data_hash="h_a") is None
+    assert await cache.t2_get("session_summary", race_id=99, data_hash="h_b") is None


### PR DESCRIPTION
## Summary
Previously \`web_cache\` PK was \`(key_family, race_id)\`, so the T2 global cache (the \`race_id=0\` sentinel from #610) held only one row per \`key_family\`. Every distinct cross-session maneuvers overlay URL evicted the previous overlay's cache row because they all shared \`(maneuvers_overlay, 0)\`.

This widens the PK to \`(key_family, race_id, data_hash)\` so distinct hashes coexist. Race-mutation \`invalidate(race_id)\` already deletes by \`race_id\` so it sweeps every hash for the touched race when a race mutates. Cache content is fully regenerable — migration v84 drops and recreates the table rather than rewriting columns in place.

\`t2_get\` now reads by exact \`(family, race, hash)\` tuple instead of fetching the row and post-comparing; \`_delete_row\` is scoped to the specific hash so eviction of a stale entry doesn't blow away unrelated rows.

## Test plan
- [x] \`uv run pytest --no-cov\` — 2497 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] New tests:
  - \`test_migration_v84.py\` — PK shape, distinct global hashes coexist, pre-migration rows are dropped.
  - \`test_t2_global_distinct_hashes_coexist\` — two overlay selections store and retrieve independently.
  - \`test_t2_race_keyed_distinct_hashes_coexist\` — same for race-keyed entries.
  - \`test_invalidate_race_drops_all_hashes_for_that_race\` — invalidation hook still scrubs everything per race.
  - \`test_t2_put_keeps_distinct_hashes_until_invalidation\` (replaces \`test_t2_put_replaces_stale_entry\`, which encoded the old size-1-slot behavior).
- [ ] After merge + Pi deploy: open the original overlay URL, then a second one, then return to the first — both should be warm hits, no rebuild.

Fixes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)