### PR TITLE
fix(storage): tag race_id on live instrument writes

### DIFF
--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -3181,51 +3181,67 @@ class Storage:
     async def _write_heading(self, r: HeadingRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO headings (ts, source_addr, heading_deg, deviation_deg, variation_deg)"
-            " VALUES (?, ?, ?, ?, ?)",
-            (_ts(r.timestamp), r.source_addr, r.heading_deg, r.deviation_deg, r.variation_deg),
+            "INSERT INTO headings (ts, source_addr, heading_deg, deviation_deg, variation_deg,"
+            " race_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                _ts(r.timestamp),
+                r.source_addr,
+                r.heading_deg,
+                r.deviation_deg,
+                r.variation_deg,
+                self._active_race_id,
+            ),
         )
 
     async def _write_speed(self, r: SpeedRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
-            (_ts(r.timestamp), r.source_addr, r.speed_kts),
+            "INSERT INTO speeds (ts, source_addr, speed_kts, race_id) VALUES (?, ?, ?, ?)",
+            (_ts(r.timestamp), r.source_addr, r.speed_kts, self._active_race_id),
         )
 
     async def _write_depth(self, r: DepthRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO depths (ts, source_addr, depth_m, offset_m) VALUES (?, ?, ?, ?)",
-            (_ts(r.timestamp), r.source_addr, r.depth_m, r.offset_m),
+            "INSERT INTO depths (ts, source_addr, depth_m, offset_m, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (_ts(r.timestamp), r.source_addr, r.depth_m, r.offset_m, self._active_race_id),
         )
 
     async def _write_position(self, r: PositionRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
-            " VALUES (?, ?, ?, ?)",
-            (_ts(r.timestamp), r.source_addr, r.latitude_deg, r.longitude_deg),
+            "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (
+                _ts(r.timestamp),
+                r.source_addr,
+                r.latitude_deg,
+                r.longitude_deg,
+                self._active_race_id,
+            ),
         )
 
     async def _write_cogsog(self, r: COGSOGRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO cogsog (ts, source_addr, cog_deg, sog_kts) VALUES (?, ?, ?, ?)",
-            (_ts(r.timestamp), r.source_addr, r.cog_deg, r.sog_kts),
+            "INSERT INTO cogsog (ts, source_addr, cog_deg, sog_kts, race_id)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (_ts(r.timestamp), r.source_addr, r.cog_deg, r.sog_kts, self._active_race_id),
         )
 
     async def _write_wind(self, r: WindRecord) -> None:
         db = self._conn()
         await db.execute(
-            "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference)"
-            " VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference,"
+            " race_id) VALUES (?, ?, ?, ?, ?, ?)",
             (
                 _ts(r.timestamp),
                 r.source_addr,
                 r.wind_speed_kts,
                 r.wind_angle_deg,
                 r.reference,
+                self._active_race_id,
             ),
         )
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -382,6 +382,86 @@ _START2 = datetime(2025, 8, 10, 14, 5, 30, tzinfo=UTC)
 _END1 = datetime(2025, 8, 10, 14, 5, 0, tzinfo=UTC)
 
 
+class TestRaceIdTagging:
+    """Live instrument writes should pick up the active race_id (#755)."""
+
+    async def _hdg(self, ts: datetime) -> HeadingRecord:
+        return HeadingRecord(
+            pgn=PGN_VESSEL_HEADING,
+            source_addr=5,
+            timestamp=ts,
+            heading_deg=42.0,
+            deviation_deg=None,
+            variation_deg=None,
+        )
+
+    async def _pos(self, ts: datetime) -> PositionRecord:
+        return PositionRecord(
+            pgn=PGN_POSITION_RAPID,
+            source_addr=5,
+            timestamp=ts,
+            latitude_deg=37.0,
+            longitude_deg=-122.0,
+        )
+
+    async def test_writes_outside_race_have_null_race_id(self, storage: Storage) -> None:
+        before = _START1 - timedelta(seconds=30)
+        await storage.write(await self._hdg(before))
+        await storage.write(await self._pos(before))
+        rows = await storage.query_range("headings", before, before + timedelta(seconds=1))
+        assert rows[0]["race_id"] is None
+        rows = await storage.query_range("positions", before, before + timedelta(seconds=1))
+        assert rows[0]["race_id"] is None
+
+    async def test_writes_during_active_race_are_tagged(self, storage: Storage) -> None:
+        race = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+        during = _START1 + timedelta(seconds=10)
+        await storage.write(await self._hdg(during))
+        await storage.write(await self._pos(during))
+
+        for table in ("headings", "positions"):
+            rows = await storage.query_range(table, during, during + timedelta(seconds=1))
+            assert len(rows) == 1
+            assert rows[0]["race_id"] == race.id
+
+    async def test_writes_after_end_race_are_untagged_again(self, storage: Storage) -> None:
+        race = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+        await storage.end_race(race.id, _END1)
+        after = _END1 + timedelta(seconds=10)
+        await storage.write(await self._hdg(after))
+        rows = await storage.query_range("headings", after, after + timedelta(seconds=1))
+        assert rows[0]["race_id"] is None
+
+    async def test_query_range_can_scope_by_race_id_for_tagged_writes(
+        self, storage: Storage
+    ) -> None:
+        """End-to-end: tagging plus race_id filter on query_range returns
+        only the tagged rows. Pre-#755 every instrument row was untagged,
+        so this query path was a no-op for live data.
+
+        Tagging is based on whether a race is active *at write time*, not
+        the record timestamp — sailing data streams in live and we don't
+        retroactively tag earlier buffered rows when the race starts.
+        """
+        # Pre-race write: untagged because no race is active yet.
+        before = _START1 - timedelta(seconds=10)
+        await storage.write(await self._pos(before))
+        # Race active: write gets tagged.
+        race = await storage.start_race("BallardCup", _START1, _DATE, 1, "20250810-BallardCup-1")
+        during = _START1 + timedelta(seconds=10)
+        await storage.write(await self._pos(during))
+
+        # Wide time window catches both rows; race_id filter keeps just one.
+        rows = await storage.query_range(
+            "positions",
+            before - timedelta(seconds=1),
+            during + timedelta(seconds=1),
+            race_id=race.id,
+        )
+        assert len(rows) == 1
+        assert rows[0]["race_id"] == race.id
+
+
 class TestSessionGate:
     async def test_session_active_false_initially(self, storage: Storage) -> None:
         assert storage.session_active is False


### PR DESCRIPTION
## Summary
Live instrument writers in \`storage.py\` (\`_write_heading\`, \`_write_speed\`, \`_write_position\`, \`_write_cogsog\`, \`_write_wind\`, \`_write_depth\`) omitted \`race_id\` from their INSERTs despite the column and indexes existing. On \`corvopi-live\`, every row across these tables had \`race_id IS NULL\` (e.g. 11.2 M wind rows, all untagged), so range-by-race \`query_range()\` calls silently fell back to time-window scans. The synthesize/replay path (\`_write_*\` siblings around line 4115) was already tagging correctly — this is just the live path catching up.

This PR addresses **part A** of #755. The historical-backfill part (UPDATE millions of rows by joining on race time windows) is critical-tier per CLAUDE.md (storage migration) and stays open in #755 for a future spec/TDD pass.

## Behavior
Tagging is based on whether a race is active *at write time* (\`self._active_race_id\`, already maintained by \`start_race\`/\`end_race\`). Records flush as they arrive, so we don't retroactively tag earlier buffered rows when a race starts mid-stream. Outside an active race, \`race_id\` stays NULL — same as today.

## Test plan
- [x] \`uv run pytest --no-cov\` — 2501 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] New tests in \`tests/test_storage.py::TestRaceIdTagging\`:
  - \`test_writes_outside_race_have_null_race_id\`
  - \`test_writes_during_active_race_are_tagged\`
  - \`test_writes_after_end_race_are_untagged_again\`
  - \`test_query_range_can_scope_by_race_id_for_tagged_writes\` — end-to-end with the wide-time-window + race_id filter pattern that was the original motivation.
- [ ] After Pi deploy: confirm new instrument rows during an active race carry the race id (\`SELECT COUNT(*) FROM positions WHERE race_id IS NOT NULL\` should grow as new sessions are sailed).

Addresses #755 (forward-tagging part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)