### PR TITLE
docs(ideation): promote IDX-034 + IDX-038 to issue #757

### DIFF
--- a/docs/ideation-log.md
+++ b/docs/ideation-log.md
@@ -2148,7 +2148,8 @@ data-licensing policy (co-op data is view-only, no bulk export).
 
 - **Date captured:** 2026-04-06
 - **Origin:** Conversation about needing offline analysis when the boat's Pi isn't online, plus backup
-- **Status:** `raw`
+- **Status:** `promoted`
+- **Promoted to:** combined with IDX-038 into issue #757 (off-Pi viewing & analysis — replication + read-only mode); this entry covers Phase 0 (read-only mode) + Phase 1 (`helmlog sync` to owner-controlled hosts)
 - **Related:** SQLite storage (`storage.py`), audio recording (`audio.py`), ArUco images, federation
 
 **Description:**
@@ -2455,7 +2456,8 @@ make HelmLog the helm/tactician's primary start tool.
   reachable over Tailscale. The aspiration: turn the Pi into a pure
   data-gathering appliance and serve the historical/replay UI from
   always-on cloud infrastructure.
-- **Status:** `raw`
+- **Status:** `promoted`
+- **Promoted to:** combined with IDX-034 into issue #757 (off-Pi viewing & analysis — replication + read-only mode); this entry covers Phase 2 (cloud-hosted viewer, layered on the Phase 1 sync primitive)
 - **Related:** **IDX-034** (Pi → Mac/test-Pi DB replication — narrower
   precursor of the same plumbing), IDX-007 (centralized-vs-federated
   tension, already settled in favor of centralized for the social feed),


### PR DESCRIPTION
## Summary

- Mark IDX-034 (Pi → Mac/test-Pi DB replication) and IDX-038 (cloud-hosted race viewer) as `promoted` in the ideation log
- Both now point to issue #757, which combines them into a single phased tracking issue (off-Pi viewing & analysis — replication + read-only mode)

## Test plan

- [x] No code changes; docs-only edit to `docs/ideation-log.md`
- [x] Promote workflow: ideation-log-only changes are exempt from `RELEASES.md` requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)