### PR TITLE
analysis: scripts + /debrief + /ocs-check skills

### DIFF
--- a/.claude/skills/debrief/SKILL.md
+++ b/.claude/skills/debrief/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: debrief
+description: Run a focused per-race debrief and attach the summary as a moment on the session. TRIGGER when the user says "debrief race N", "debrief that race", "/debrief", "post-race analysis", or asks for analysis of a single specific race. DO NOT trigger for season-wide reviews (that's a manual run of scripts/analysis/full_analysis.py), broad questions about boat performance, or non-race sessions.
+---
+
+# /debrief — per-race performance debrief
+
+Generate a concise debrief for a single race and persist it on the
+session in the helmlog UI as a moment, so the crew can see it next time
+they open the session detail page.
+
+## Usage
+
+- `/debrief` — debrief the most recent **completed race** (`session_type='race'`,
+  `end_utc IS NOT NULL`, `start_utc != end_utc`).
+- `/debrief <race-id>` — debrief a specific race by `races.id`.
+- `/debrief latest practice` — same shape, but for the most recent practice.
+
+## Inputs
+
+- DB: live on `weaties@corvopi-live:/home/weaties/helmlog/data/logger.db`.
+  Read-only access via SSH + sqlite3. Do **not** copy the DB locally —
+  query in place to keep the analysis grounded in the latest data.
+- Backup DB (when corvopi-live is unreachable): `~/Backups/helmlog/<latest>/data/logger.db`.
+
+## Steps
+
+1. **Resolve the race.** If no ID was given, find the latest race:
+   ```sql
+   SELECT id, name, date, start_utc, end_utc, vakaros_session_id
+   FROM races
+   WHERE session_type='race' AND end_utc IS NOT NULL AND start_utc != end_utc
+   ORDER BY start_utc DESC LIMIT 1;
+   ```
+   Confirm with the user before proceeding (`Debriefing race {id}: {name} on {date}. Continue?`).
+
+2. **Run the analyses for this race only.** Use `scripts/analysis/`
+   helpers but constrain to the single race window
+   (`start_utc → end_utc`, or post-gun if the Vakaros gun event exists).
+   Compute:
+
+   - **Finish:** Corvo's place + points from `race_results` joined via
+     `local_session_id`. If no place is recorded yet, say so.
+   - **Conditions:** mean TWS, TWS range, mean TWA upwind / downwind.
+   - **Heel:** mean abs heel (from `attitudes`) — note if not present.
+   - **VMG percentages:** % of seconds at ≥90% best-VMG (vs the
+     season's polar baseline).
+   - **Shifts:** good/bad/neutral tack count from the maneuvers table
+     using the 90–150s pre/post window approach in
+     `scripts/analysis/full_analysis.py`.
+   - **Start:** dist@gun, SOG@gun, TTL, favored end, what end Corvo
+     went to, tack at gun. Use the helpers in
+     `scripts/analysis/start_quality.py`.
+   - **OCS:** if the start analysis flags this race as OCS-returned,
+     call it out and apply the `ocs` tag (see /ocs-check).
+   - **Crew weight:** lookup default crew (1,070 lb on Corvo as of May
+     2026) — note if a per-race override exists in `crew_defaults`.
+
+3. **Synthesize the debrief.** A short markdown summary, ~250–400
+   words, with this structure:
+
+   ```markdown
+   ## Result
+   {place + points + boat conditions in one sentence}
+
+   ## Start
+   - Distance from line at gun: {x} m
+   - SOG at gun: {y} kt
+   - Time to clear line: {z} s {(OCS — returned)}
+   - Favored end: {boat/pin/square}, bias {n°}
+   - We went to: {boat/mid/pin} — {got favored ✓ / wrong end ✗}
+   - Tack at gun: {stbd/port}
+
+   ## Speed (post-gun)
+   - Upwind VMG: {p}% of best-ever in similar conditions
+   - Downwind VMG: {q}% of best-ever
+   - Mean heel: {h}° (or "not recorded")
+
+   ## Shifts
+   - Tacked on header: {g}, on lift: {b}, neutral: {n}
+
+   ## What we did well / what to look at
+   {1-2 bullets each, drawn from the data — be specific, cite
+   numbers, and tie to the season patterns where relevant
+   (e.g., "we sailed 135° TWA in 7 kt — the season optimum is 145°,
+   the same gap we've seen all spring")}
+   ```
+
+4. **Attach to the session.** Insert the debrief as a moment on the
+   session via direct SQL on the live DB (the API requires a session
+   cookie that's awkward to wire up from the Mac).
+
+   ```sql
+   -- Run as: ssh weaties@corvopi-live "sqlite3 /home/weaties/helmlog/data/logger.db <<EOF ... EOF"
+   BEGIN;
+
+   -- Create the moment, anchored at the gun (or start_utc + 5min if no gun)
+   INSERT INTO moments (
+     session_id, subject, anchor_kind, anchor_t_start,
+     resolved, source, created_by, created_at, updated_at
+   )
+   VALUES (
+     {race_id},
+     'Post-race debrief — {short summary, e.g. "5th, OCS recovery, 65% UP"}',
+     'timestamp',
+     '{gun_iso}',
+     0, 'auto', 1,  -- created_by user 1 = Dan; adjust if needed
+     '{now_iso}', '{now_iso}'
+   );
+
+   -- Capture the new ID and write the body as a comment
+   INSERT INTO comments (moment_id, author, body, created_at)
+   VALUES (last_insert_rowid(), 1, '{markdown body}', '{now_iso}');
+
+   COMMIT;
+   ```
+
+   The full markdown debrief goes in the **comment body** (rich text
+   supported); the moment **subject** stays a one-line summary so the
+   moment list is scannable.
+
+5. **Report the URL.** Tell the user the moment was created and give
+   them the deep link:
+   `https://corvo105.helmlog.org/session/{race_id}/{slug}?moment={moment_id}`
+   (or just `/session/{id}/{slug}` if the `?moment=` deep-link param
+   doesn't exist on the session detail page).
+
+## Conventions
+
+- The debrief comment should be **honest and specific**, not flattering.
+  Cite numbers. Reference the season patterns where they apply.
+- Wind angles always shown as **TWA (AWA ~xxx°)** — the crew sees AWA
+  on the gauges. AWA derived from BSP at the cell using the formula in
+  `scripts/analysis/awa_table.py`.
+- Don't speculate about competitor behavior — the data is from one boat
+  only. If you suspect an issue (e.g., "got rolled by Moose"), phrase it
+  as a question for the crew, not an assertion.
+- If `vakaros_session_id` is null OR `vakaros_line_positions` has no
+  endpoints for this race, mark the start section as "no line data —
+  skip" rather than computing bogus distances.
+
+## DO NOT
+
+- Do not modify any other tables (e.g., don't auto-update settings).
+- Do not create more than one debrief moment per race. Check first:
+  ```sql
+  SELECT id FROM moments WHERE session_id={race_id} AND source='auto'
+   AND subject LIKE 'Post-race debrief%' LIMIT 1;
+  ```
+  If one exists, ask the user before creating another (offer to UPDATE
+  the comment body instead).
+- Do not run this against practice sessions unless explicitly asked.
+- Do not write to the DB if the user hasn't confirmed in step 1.
+
+## Why this skill (and not a script)
+
+- The exact analysis varies — sometimes we want OCS detail, sometimes
+  current matters, sometimes shifts. A skill lets us synthesize the
+  prose layer.
+- The "attach to session" step needs context to write a useful subject
+  line, which a script can't do generically.
+- Scripts in `scripts/analysis/` do the underlying number-crunching;
+  this skill is the orchestrator + writer.

--- a/.claude/skills/debrief/SKILL.md
+++ b/.claude/skills/debrief/SKILL.md
@@ -56,7 +56,78 @@ they open the session detail page.
    - **Crew weight:** lookup default crew (1,070 lb on Corvo as of May
      2026) — note if a per-race override exists in `crew_defaults`.
 
-3. **Synthesize the debrief.** A short markdown summary, ~250–400
+3. **Pull and analyze the audio transcripts.** Each race has audio in
+   one or more `audio_sessions` rows linked by `race_id`:
+
+   - `session_type='race'` — the on-water mic capture (helm + crew chatter)
+   - `session_type='debrief'` — post-race recorded debrief (only present
+     for some races)
+
+   Both can have multiple sibling rows when more than one mic was
+   running (different `capture_group_id` per session_type, ordered by
+   `capture_ordinal`). For each audio_session, check `transcripts.status`:
+
+   ```sql
+   SELECT a.id, a.session_type, a.capture_ordinal, t.id AS transcript_id,
+          t.status, length(t.text) AS text_len
+   FROM audio_sessions a
+   LEFT JOIN transcripts t ON t.audio_session_id = a.id
+   WHERE a.race_id = {race_id}
+   ORDER BY a.session_type, a.capture_ordinal;
+   ```
+
+   Status handling:
+
+   - **`done`** with non-empty text → fetch `text` and `segments_json`
+     (the latter has speaker labels + timestamps) and feed into the
+     analysis below.
+   - **`running` or `pending`** → note that transcript is in progress,
+     skip the analysis section, tell the user to re-run /debrief once
+     it completes (typical wait: 1–5 min for a race, 30s–2min for a
+     debrief).
+   - **No transcript row exists** for an audio_session → kick off
+     transcription via the helmlog API:
+     ```
+     curl -X POST -b ~/.helmlog-cookie \
+          https://corvo105.helmlog.org/api/audio/{audio_session_id}/transcribe
+     ```
+     This returns 202 Accepted and the worker on the user's Mac
+     (com.helmlog.transcribe-worker, Tailscale 100.127.219.117:8321)
+     picks up the job. **The auth cookie file must exist; if it
+     doesn't, prompt the user to log in once and save it.**
+   - **`error`** → show the error_msg field, don't auto-retry. Suggest
+     the user retranscribes manually if appropriate.
+
+   **What to look for in the transcript:**
+
+   - **Tactical calls vs reactions.** Sailing language is brief —
+     "pressure right!", "two boat lengths", "tack", "hold". A good
+     race has crisp anticipatory calls; a bad race has lots of
+     reactive "watch out!" or "we got rolled" comments.
+   - **Specific moments worth flagging back into the analysis:**
+     - Mark roundings (counted)
+     - Tacks/jibes (count vs the maneuvers table — should match)
+     - OCS recall calls ("come back!", "we're over!") — cross-reference
+       with the OCS detection
+     - Pressure/wind callouts ("big puff coming", "lift on the right")
+     - Boat-on-boat ("Moose to leeward", "got rolled by LiftOff")
+     - Sail trim ("more vang", "kite collapse", "we're stalled")
+   - **Tone trajectory.** Compare debrief audio (post-race calm
+     reflection) to race audio (in-the-moment reactions). The debrief
+     usually surfaces what went wrong in the team's own words —
+     prioritize quoting the crew's own language over your own
+     speculation.
+   - **Segment-level speaker tracking.** `segments_json` has
+     `speaker` labels (or anonymized IDs); per-position quotes are more
+     useful than aggregate. If `position_name` is set on
+     `transcript_segments`, group by position (helm/main/pit/bow/tac).
+
+   **Add a TRANSCRIPT section to the debrief synthesized in step 4**
+   (not as a transcription dump — as a curated 3–6 bullet list of
+   notable callouts with timestamps, drawn from the actual transcript
+   text). Always cite a specific quote and timestamp.
+
+4. **Synthesize the debrief.** A short markdown summary, ~250–400
    words, with this structure:
 
    ```markdown
@@ -79,14 +150,27 @@ they open the session detail page.
    ## Shifts
    - Tacked on header: {g}, on lift: {b}, neutral: {n}
 
+   ## From the transcript
+   {3-6 bullets of notable callouts with timestamps and speakers,
+   drawn from the actual transcript text. Always quote — don't
+   paraphrase. Example:
+     - 02:14:55 (helm): "we're getting rolled by Moose"
+     - 02:18:30 (tac): "pressure on the right, hold this tack"
+   If the transcript is in progress: "Transcript still processing
+   ({status}); re-run /debrief in a few minutes for transcript notes."
+   If no audio captured for this race: "No race audio recorded."}
+
    ## What we did well / what to look at
-   {1-2 bullets each, drawn from the data — be specific, cite
-   numbers, and tie to the season patterns where relevant
-   (e.g., "we sailed 135° TWA in 7 kt — the season optimum is 145°,
-   the same gap we've seen all spring")}
+   {1-2 bullets each, drawn from BOTH the data AND the transcript —
+   be specific, cite numbers, tie to the season patterns where
+   relevant (e.g., "we sailed 135° TWA in 7 kt — the season optimum
+   is 145°, the same gap we've seen all spring") and to the crew's
+   own words from the transcript ("the helm called out 'we're slow'
+   at 02:30 — the data shows we were 0.5 kt below polar at that
+   moment")}
    ```
 
-4. **Attach to the session.** Insert the debrief as a moment on the
+6. **Attach to the session.** Insert the debrief as a moment on the
    session via direct SQL on the live DB (the API requires a session
    cookie that's awkward to wire up from the Mac).
 
@@ -119,7 +203,7 @@ they open the session detail page.
    supported); the moment **subject** stays a one-line summary so the
    moment list is scannable.
 
-5. **Report the URL.** Tell the user the moment was created and give
+7. **Report the URL.** Tell the user the moment was created and give
    them the deep link:
    `https://corvo105.helmlog.org/session/{race_id}/{slug}?moment={moment_id}`
    (or just `/session/{id}/{slug}` if the `?moment=` deep-link param
@@ -151,6 +235,14 @@ they open the session detail page.
   the comment body instead).
 - Do not run this against practice sessions unless explicitly asked.
 - Do not write to the DB if the user hasn't confirmed in step 1.
+- Do not paraphrase transcript content. If you quote a crewmember,
+  use their exact words and timestamp. If you can't find a clean
+  quote that supports a claim, drop the claim instead of inventing
+  one.
+- Do not include the full transcript text in the debrief — it'll be
+  thousands of words. Curate to 3–6 high-signal callouts.
+- Do not auto-trigger transcription for sessions with `error` status —
+  the user may have a reason (e.g., bad audio).
 
 ## Why this skill (and not a script)
 

--- a/.claude/skills/ocs-check/SKILL.md
+++ b/.claude/skills/ocs-check/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ocs-check
+description: Detect OCS (over-the-line at gun, returned to clear) races against the live DB and apply the 'ocs' tag to any newly identified ones. TRIGGER when the user asks "check for OCS", "did we OCS", "tag OCS races", "/ocs-check", or after a race day to find any starts that should be marked OCS. Auto-trigger when running /debrief on a race that hasn't been OCS-checked yet.
+---
+
+# /ocs-check — auto-detect and tag OCS races
+
+Run the OCS detection logic from `scripts/analysis/ocs_detect.py`
+against the live `corvopi-live` database, identify any races where
+the boat was over the line at the gun and returned to clear, and
+apply the `ocs` tag to those sessions.
+
+## Usage
+
+- `/ocs-check` — scan all completed races (not yet OCS-checked) and
+  tag any new OCS-returned ones.
+- `/ocs-check <race-id>` — scan one specific race.
+- `/ocs-check --since YYYY-MM-DD` — only scan races on or after a date.
+
+## Inputs
+
+- DB: live on `weaties@corvopi-live:/home/weaties/helmlog/data/logger.db`.
+  All reads via SSH + sqlite3; tags are inserted via SQL on the same
+  DB (the helmlog `tags` API would work too, but direct SQL is
+  simpler and doesn't need auth).
+
+## Steps
+
+1. **Resolve the race set.** Default: every race session
+   (`session_type='race'`, `end_utc IS NOT NULL`, `start_utc != end_utc`,
+   `name NOT LIKE '%RTTS%'`) with a Vakaros gun event AND
+   `vakaros_line_positions` endpoints, that has not already been
+   tagged `ocs`.
+
+2. **Run the detection.** For each candidate race, follow the algorithm
+   in `scripts/analysis/ocs_detect.py`:
+
+   a. Find the gun: latest `vakaros_race_events` row with
+      `event_type='race_start'` between `start_utc` and `end_utc`.
+
+   b. Find the most recent line endpoints (boat + pin) at or before
+      the gun from `vakaros_line_positions`. If either is missing, skip
+      the race with a "no line data" note.
+
+   c. Compute the boat's "side of line" each second across the window
+      `[gun-90s, gun+300s]` using a cross-product on lat/lon-projected
+      coords (use `latlon_to_xy` and `side_of_line` in
+      `scripts/analysis/start_quality.py`).
+
+   d. **pre_side** = majority side over `[gun-60s, gun-10s]` (need ≥5
+      samples non-zero).
+
+   e. **at_gun_side** = majority side over `[gun-3s, gun+3s]` (need ≥2
+      samples).
+
+   f. **returned** = at any point in `[gun+5s, gun+300s]`, side ==
+      pre_side.
+
+   g. Classify:
+      - `clean` — pre_side == at_gun_side
+      - `OCS — returned` — pre_side != at_gun_side AND returned
+      - `OCS? (no return)` — pre_side != at_gun_side AND not returned
+
+   The "OCS? (no return)" cases are usually false positives from
+   pre-start positioning noise (boat happens to be on race side at
+   gun without an actual OCS) — do **not** auto-tag these. List them
+   for manual review.
+
+3. **Apply tags for confirmed OCS races.** For each `OCS — returned`
+   race that doesn't already have the tag:
+
+   ```sql
+   INSERT INTO entity_tags (tag_id, entity_type, entity_id, created_at, source)
+   SELECT (SELECT id FROM tags WHERE name='ocs'), 'session', {race_id},
+          '{now_iso}', 'auto'
+   WHERE NOT EXISTS (
+     SELECT 1 FROM entity_tags
+     WHERE tag_id=(SELECT id FROM tags WHERE name='ocs')
+       AND entity_type='session' AND entity_id={race_id}
+   );
+
+   UPDATE tags SET usage_count = (
+     SELECT COUNT(*) FROM entity_tags WHERE tag_id=tags.id
+   ), last_used_at='{now_iso}' WHERE name='ocs';
+   ```
+
+   The `ocs` tag already exists (id 20, color #dc2626). Don't create it.
+
+4. **Report.** Print a summary table:
+
+   ```
+   OCS scan complete. {N} races scanned.
+
+   Newly tagged as OCS:
+     - 2026-04-14  20260414-Ballard cup 1-1 (https://corvo105.helmlog.org/session/35/...)
+     - 2026-04-19  20260419-PSSR-2          (https://...)
+
+   Already tagged (no change):
+     - {date  name}
+
+   No line data (skipped):
+     - {date  name}
+
+   OCS? (no return — review manually, NOT tagged):
+     - {date  name}
+   ```
+
+## DO NOT
+
+- Do not auto-tag the "no return" cases (high false-positive rate;
+  they need a human to look at the track).
+- Do not delete or modify existing OCS tags.
+- Do not bump `usage_count` if no new tags were inserted.
+- Do not run against practice sessions or RTTS-style long-distance
+  races.
+
+## Pre-existing OCS tags (as of 2026-05-12)
+
+- session 35 (4/14 Ballard Cup 1-1)
+- session 55 (4/19 PSSR-2)
+
+If those are missing from the live DB when the skill runs, something
+got cleared — confirm with the user before re-tagging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ ignore = []
 [tool.ruff.lint.per-file-ignores]
 "src/helmlog/web.py" = ["E501"]  # HTML strings contain long lines that can't be wrapped
 "src/helmlog/routes/*.py" = ["E501"]  # HTML strings inherited from web.py split
+# Standalone post-race analysis scripts — written ad-hoc for one-off
+# end-of-season debriefs. Not production code; not type-annotated.
+"scripts/analysis/*.py" = ["ANN", "E501", "B", "E7", "SIM", "C401", "F401", "F541", "I001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["helmlog"]

--- a/scripts/analysis/README.md
+++ b/scripts/analysis/README.md
@@ -1,0 +1,119 @@
+# Race-data analysis scripts
+
+Standalone Python scripts that read the HelmLog SQLite (`data/logger.db`)
+and produce post-race performance analysis. None of these are wired into
+the live web app — they're offline tools for end-of-season debriefs.
+
+The original write-up that drove these (Spring 2026 review for Corvo 105)
+lives outside the repo at `/Users/dweatbrook/Backups/helmlog/_analysis/`.
+The scripts themselves are kept here so they don't get lost.
+
+## Configuration
+
+All scripts share two env vars (with sensible defaults):
+
+| Env var | Default | What |
+|---|---|---|
+| `HELMLOG_DB` | `data/logger.db` | Path to the SQLite database |
+| `HELMLOG_OUT_DIR` | `.` | Where PNG outputs land (used by `polar_plot.py` and `start_quality.py`) |
+
+You can also pass the DB path as `argv[1]` for any script.
+
+## Scripts
+
+### `full_analysis.py` — VMG / shifts / current
+
+Per-race breakdown:
+
+- Downwind / upwind polar (mean BSP × |cos(TWA)|) per TWS bin
+- Shift-tack hit rate (using TWD before/after each tack)
+- Current set/drift from steady-leg detection (race + practice)
+- Per-race scorecard (% of seconds at ≥90% best-VMG)
+
+Uses Vakaros `race_start` events as the effective gun where available;
+falls back to `start_utc + 5 min`. Excludes practice sessions and
+RTTS-style long-distance races from the VMG/shift sections.
+
+```
+HELMLOG_DB=path/to/logger.db uv run python scripts/analysis/full_analysis.py
+```
+
+### `polar_plot.py` — TWA + AWA polar diagrams + heatmap
+
+Generates three PNGs:
+
+- `polar.png` — observed mean BSP per TWA, faceted by TWS bin (TWA on
+  the angular axis). Upwind and downwind rendered as separate segments
+  with a 90° beam-reach gap (we don't race there).
+- `polar_awa.png` — same data, AWA on the angular axis (what the
+  apparent-wind gauge would actually read).
+- `polar_heatmap.png` — grid of mean BSP per (TWS, TWA).
+
+Requires `matplotlib` and `numpy` (in the project venv).
+
+```
+HELMLOG_OUT_DIR=out/ uv run python scripts/analysis/polar_plot.py
+```
+
+### `awa_table.py` — TWA → AWA conversion table
+
+Helper for human-readable TWA/AWA cross-reference. Computes
+`AWA = atan2(TWS·sin(TWA), TWS·cos(TWA) + BSP)` for every (TWS, TWA)
+cell in the dataset, plus a "common targets" lookup (light-up,
+heavy-down, etc.).
+
+### `current_and_shifts.py` — earlier current + shift work
+
+Largely superseded by `full_analysis.py` but has slightly different
+shift-window logic. Kept for reference.
+
+### `ocs_detect.py` — OCS race detection
+
+For each race with a Vakaros `race_start` event AND `vakaros_line_positions`
+endpoints, classify as:
+
+- **clean** — boat on pre-start side at gun
+- **OCS — RETURNED** — boat on race side at gun, then crossed back to
+  pre-start side
+- **OCS? (no return)** — boat on race side at gun, no documented return
+  (likely false positive from pre-start positioning noise)
+
+The "pre-start side" is determined by majority side of the boat 60–10 sec
+before the gun.
+
+### `start_quality.py` — start matrix + trend chart + favored-end + tack
+
+Computes per race:
+
+- **dist_at_gun** — signed perpendicular distance from line at gun
+  (positive = over the line)
+- **SOG at gun** — boat speed (GPS-based, calibration-immune)
+- **TTL** — time from gun to first sustained race-side crossing (or
+  re-crossing, for OCS races)
+- **Favored end** — line bias from TWD vs line bearing; reports which
+  end was favored, the bias in degrees, and whether the boat went there
+- **Tack at gun** — starboard / port from the boat-relative TWA
+- **Pre-start trajectory** — position-along-line at gun-3min through gun
+
+Outputs `start_quality_trend.png`. The hardcoded `ocs_ids = {35, 55}`
+fallback is for backups taken before the `ocs` tags were added on
+corvopi-live; remove it when reading from a fresh backup or from the live
+DB.
+
+```
+HELMLOG_OUT_DIR=out/ uv run python scripts/analysis/start_quality.py
+```
+
+## Design notes
+
+- Scripts are intentionally standalone — no shared library — because
+  they evolved iteratively during a single debrief session. If we run
+  these monthly, factor out the common bits (`load_aligned`, gun
+  resolution, `latlon_to_xy`, line geometry).
+- DB reads are read-only; safe to run against the live `helmlog run`
+  process via WAL.
+- `tests/` doesn't cover these scripts. They're treated as one-shot
+  analysis tools, not production code.
+- All TWA/AWA conventions: TWA folded to `[0, 180]` (absolute), with
+  separate "tack" labels for port/starboard. Wind reference IDs:
+  `0 = boat-referenced TWA`, `4 = north-referenced TWD`, `2 = apparent`.

--- a/scripts/analysis/awa_table.py
+++ b/scripts/analysis/awa_table.py
@@ -1,0 +1,168 @@
+"""Compute the (TWA, TWS, BSP) -> AWA conversion table from race data.
+
+For every (TWS bin, TWA bin) cell with enough samples, compute AWA using:
+    AWA = atan2( TWS · sin(TWA), TWS · cos(TWA) + BSP )
+
+Both TWA and AWA in degrees absolute (folded to [0, 180]).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+
+
+def fold(a):
+    a = abs(a) % 360
+    return 360 - a if a > 180 else a
+
+
+def twa_to_awa(twa_deg: float, tws_kt: float, bsp_kt: float) -> float:
+    twa = math.radians(twa_deg)
+    x = tws_kt * math.sin(twa)
+    y = tws_kt * math.cos(twa) + bsp_kt
+    awa = math.degrees(math.atan2(x, y))
+    return fold(awa)
+
+
+def get_effective_start(conn, race):
+    if race["vakaros_session_id"] is not None:
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events WHERE session_id=?"
+            " AND event_type='race_start' AND ts BETWEEN ? AND ?"
+            " ORDER BY ts DESC LIMIT 1",
+            (race["vakaros_session_id"], race["start_utc"], race["end_utc"]),
+        ).fetchone()
+        if gun:
+            return gun["ts"]
+    return (datetime.fromisoformat(race["start_utc"]) + timedelta(minutes=5)).isoformat()
+
+
+def load_aligned(conn, start, end):
+    sp = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(speed_kts) FROM speeds"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hd = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heading_deg) FROM headings"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    wb, wn = {}, {}
+    for r in conn.execute(
+        "SELECT substr(ts,1,19), reference, AVG(wind_speed_kts), AVG(wind_angle_deg)"
+        " FROM winds WHERE ts BETWEEN ? AND ? AND reference IN (0,4)"
+        " GROUP BY substr(ts,1,19), reference",
+        (start, end),
+    ):
+        (wb if r[1] == 0 else wn)[r[0]] = (r[2], r[3])
+    out = []
+    for k, bsp in sp.items():
+        if k in wb:
+            tws, raw = wb[k]
+            signed = ((raw + 180) % 360) - 180
+        elif k in wn and k in hd:
+            tws, twd_n = wn[k]
+            signed = ((twd_n - hd[k] + 180) % 360) - 180
+        else:
+            continue
+        twa = fold(signed)
+        out.append((tws, twa, bsp))
+    return out
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, start_utc, end_utc, vakaros_session_id FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND session_type='race' AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    samples = []
+    for r in races:
+        start = get_effective_start(conn, r)
+        for tws, twa, bsp in load_aligned(conn, start, r["end_utc"]):
+            if 1.5 < tws < 35 and bsp > 0.2 and 30 <= twa <= 180:
+                samples.append((tws, twa, bsp))
+
+    cells = defaultdict(list)  # (tws_b, twa_b) -> [bsp]
+    for tws, twa, bsp in samples:
+        cells[(int(math.floor(tws)), int(math.floor(twa / 5) * 5))].append(bsp)
+
+    print("=" * 80)
+    print("TWA → AWA conversion (using mean BSP at each cell, ≥30 samples)")
+    print("=" * 80)
+    print(f"{'TWS':>5} {'TWA':>5} {'mean BSP':>9} {'→ AWA':>8} {'n':>5}")
+    print("-" * 50)
+    # Print useful cells: TWS 5-18, TWA 30-175 step 5
+    for tws_b in range(4, 21):
+        for twa_b in range(30, 181, 5):
+            v = cells.get((tws_b, twa_b), [])
+            if len(v) >= 30:
+                mean_bsp = statistics.mean(v)
+                tws_mid = tws_b + 0.5
+                twa_mid = twa_b + 2.5
+                awa = twa_to_awa(twa_mid, tws_mid, mean_bsp)
+                print(
+                    f"{tws_b:>3}-{tws_b + 1:<2} {twa_b:>5} {mean_bsp:>9.2f} {awa:>8.0f} {len(v):>5}"
+                )
+
+    # ============================================================
+    # Useful summary: for each (TWS, TWA point of interest), give AWA
+    # ============================================================
+    print()
+    print("=" * 80)
+    print("Quick lookup — common targets")
+    print("=" * 80)
+    targets = [
+        # (label, tws_min, tws_max, twa)
+        ("Light upwind sail", 4, 8, 60),  # what we sail
+        ("Light upwind own-best", 4, 8, 45),  # own optimum
+        ("Light downwind sail", 5, 10, 130),  # what we sail
+        ("Light downwind own-best", 5, 10, 150),  # own optimum
+        ("Mod upwind sail", 9, 13, 50),
+        ("Mod upwind own-best", 9, 13, 40),
+        ("Mod downwind sail", 11, 15, 150),
+        ("Mod downwind own-best", 11, 15, 160),
+        ("Heavy upwind", 14, 18, 40),
+        ("Heavy downwind", 14, 18, 155),
+    ]
+    print(f"{'scenario':<26} {'TWS':>5} {'TWA':>5} {'BSP':>5} {'AWA':>5}")
+    print("-" * 60)
+    for label, tws_lo, tws_hi, twa in targets:
+        bsps = []
+        for tws_b in range(tws_lo, tws_hi + 1):
+            twa_b = int(math.floor(twa / 5) * 5)
+            v = cells.get((tws_b, twa_b), [])
+            if v:
+                bsps.extend(v)
+        if not bsps:
+            print(f"{label:<26} {tws_lo}-{tws_hi:<3} {twa:>5}  no data")
+            continue
+        mean_bsp = statistics.mean(bsps)
+        tws_mid = (tws_lo + tws_hi) / 2
+        awa = twa_to_awa(twa, tws_mid, mean_bsp)
+        print(f"{label:<26} {tws_lo}-{tws_hi:<3} {twa:>5} {mean_bsp:>5.2f} {awa:>5.0f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/current_and_shifts.py
+++ b/scripts/analysis/current_and_shifts.py
@@ -1,0 +1,364 @@
+"""Current set/drift + wind-shift-catching analysis.
+
+CURRENT (set/drift): Vector difference between motion-through-water (BSP @ HDG)
+and motion-over-ground (SOG @ COG) is the current vector. Averaged over each
+race when both signals are present.
+
+SHIFT-CATCHING: For every tack/jibe maneuver in the maneuvers table, we look at
+the TWD trend in the 90s before vs 90s after the maneuver. A tack into the new
+breeze direction (i.e. tack on a header) is "good"; tack away from the shift
+("tack on a lift") is "bad".
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+
+
+def fold(a):
+    a = abs(a) % 360
+    return 360 - a if a > 180 else a
+
+
+def angle_diff(a, b):
+    """Signed difference a - b normalized to (-180, 180]."""
+    d = (a - b + 540) % 360 - 180
+    return d
+
+
+def vec_subtract(speed1, dir1, speed2, dir2):
+    """Return (mag, dir) of vector1 - vector2 where dirs are deg from N."""
+    x = speed1 * math.sin(math.radians(dir1)) - speed2 * math.sin(math.radians(dir2))
+    y = speed1 * math.cos(math.radians(dir1)) - speed2 * math.cos(math.radians(dir2))
+    mag = math.hypot(x, y)
+    deg = (math.degrees(math.atan2(x, y)) + 360) % 360
+    return mag, deg
+
+
+def load_aligned(conn, start, end):
+    sp = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(speed_kts) FROM speeds"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    cg = {
+        r[0]: (r[1], r[2])
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(cog_deg), AVG(sog_kts) FROM cogsog"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hd = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heading_deg) FROM headings"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    wb, wn = {}, {}
+    for r in conn.execute(
+        "SELECT substr(ts,1,19), reference, AVG(wind_speed_kts), AVG(wind_angle_deg)"
+        " FROM winds WHERE ts BETWEEN ? AND ? AND reference IN (0,4)"
+        " GROUP BY substr(ts,1,19), reference",
+        (start, end),
+    ):
+        (wb if r[1] == 0 else wn)[r[0]] = (r[2], r[3])
+    out = []
+    for k, bsp in sp.items():
+        if k in wb:
+            tws, raw = wb[k]
+            signed = ((raw + 180) % 360) - 180
+        elif k in wn and k in hd:
+            tws, twd_n = wn[k]
+            signed = ((twd_n - hd[k] + 180) % 360) - 180
+        else:
+            continue
+        twa = fold(signed)
+        cog, sog = cg.get(k, (None, None))
+        hdg = hd.get(k)
+        # TWD (north-referenced) = (heading + signed-twa) mod 360, or use ref=4
+        if k in wn:
+            twd = wn[k][1] % 360
+        elif hdg is not None:
+            twd = (hdg + signed) % 360
+        else:
+            twd = None
+        out.append(
+            {
+                "k": k,
+                "bsp": bsp,
+                "sog": sog,
+                "cog": cog,
+                "hdg": hdg,
+                "tws": tws,
+                "twa": twa,
+                "twd": twd,
+                "tack": "starboard" if signed >= 0 else "port",
+                "vmg": bsp * math.cos(math.radians(twa)),
+            }
+        )
+    return out
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, session_type, start_utc, end_utc FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc AND session_type='race'"
+            "   AND name NOT LIKE '%RTTS%'"  # exclude double-handed long-distance
+            " ORDER BY start_utc"
+        )
+    )
+    print(f"{len(races)} races (RTTS excluded)\n")
+
+    # ============================================================
+    # CURRENT — set/drift per race
+    # ============================================================
+    print("=" * 90)
+    print("CURRENT (set/drift) per race")
+    print("Vector: (SOG @ COG) - (BSP @ HDG). Aggregated over the race.")
+    print("Set = direction the current is FLOWING TOWARD (deg from N).")
+    print("=" * 90)
+    print(f"{'date':<11} {'race':<40} {'sec':>5} {'drift kt':>8} {'set °':>6} {'TWS':>5}")
+    print("-" * 80)
+    current_per_race = {}
+    for r in races:
+        rs = load_aligned(conn, r["start_utc"], r["end_utc"])
+        # Need bsp + hdg + sog + cog all present, and BSP>1 (moving)
+        valid = [
+            x
+            for x in rs
+            if x["bsp"] > 1.0
+            and x["sog"] is not None
+            and x["cog"] is not None
+            and x["hdg"] is not None
+            and x["tws"] is not None
+        ]
+        if len(valid) < 60:
+            continue
+        # Per-second current vector: (SOG, COG) - (BSP, HDG)
+        xs, ys = [], []
+        for x in valid:
+            cx = x["sog"] * math.sin(math.radians(x["cog"])) - x["bsp"] * math.sin(
+                math.radians(x["hdg"])
+            )
+            cy = x["sog"] * math.cos(math.radians(x["cog"])) - x["bsp"] * math.cos(
+                math.radians(x["hdg"])
+            )
+            # Filter out absurd values (instrument glitches)
+            mag = math.hypot(cx, cy)
+            if mag < 4.0:  # current rarely > 4 kt in race areas
+                xs.append(cx)
+                ys.append(cy)
+        if len(xs) < 60:
+            continue
+        mean_cx = sum(xs) / len(xs)
+        mean_cy = sum(ys) / len(ys)
+        drift = math.hypot(mean_cx, mean_cy)
+        set_deg = (math.degrees(math.atan2(mean_cx, mean_cy)) + 360) % 360
+        avg_tws = statistics.mean([x["tws"] for x in valid])
+        current_per_race[r["id"]] = {
+            "drift": drift,
+            "set": set_deg,
+            "name": r["name"],
+            "date": r["date"],
+        }
+        print(
+            f"{r['date']:<11} {r['name']:<40} {len(xs):>5} "
+            f"{drift:>8.2f} {set_deg:>6.0f} {avg_tws:>5.1f}"
+        )
+
+    # ============================================================
+    # SHIFT-CATCHING — for every tack, was it on a header or a lift?
+    # ============================================================
+    print()
+    print("=" * 90)
+    print("SHIFT-CATCHING — for every tack, what was the wind doing?")
+    print("=" * 90)
+    print("Method: compare median TWD in 60-30s BEFORE the tack to TWD in 30-60s AFTER.")
+    print("If the boat tacked INTO the new wind (turned toward where the wind shifted")
+    print("TO), that's catching a header — good. If it tacked AWAY, that's tacking on")
+    print("a lift — bad.")
+    print()
+
+    # All tacks with timestamps — race sessions only, exclude RTTS
+    tacks = list(
+        conn.execute(
+            "SELECT m.id, m.session_id, m.ts, m.duration_sec, r.name AS race_name"
+            " FROM maneuvers m"
+            " JOIN races r ON r.id = m.session_id"
+            " WHERE m.type = 'tack' AND r.session_type='race'"
+            "   AND r.name NOT LIKE '%RTTS%' AND r.end_utc IS NOT NULL"
+            " ORDER BY m.ts"
+        )
+    )
+
+    # For each tack, look at TWD WAY before (90-150s) vs WAY after (90-150s) — gives
+    # the sensor time to settle out of the tack disturbance, and reduces the chance
+    # that a sensor-lag artifact looks like a real shift.
+    classified = []
+    shift_magnitudes = []
+    for t in tacks:
+        ts = datetime.fromisoformat(t["ts"])
+        b_start = (ts - timedelta(seconds=150)).isoformat()
+        b_end = (ts - timedelta(seconds=90)).isoformat()
+        a_start = (ts + timedelta(seconds=90)).isoformat()
+        a_end = (ts + timedelta(seconds=150)).isoformat()
+
+        # Get TWD before (median over 30s window) — use ref=4 (TWD direct) if available,
+        # else compute from heading + signed TWA at ref=0.
+        def median_twd(start, end):
+            twds = []
+            for r in conn.execute(
+                "SELECT wind_angle_deg FROM winds WHERE reference=4 AND ts BETWEEN ? AND ?",
+                (start, end),
+            ):
+                twds.append(r["wind_angle_deg"] % 360)
+            if twds:
+                return statistics.median(twds)
+            # Fall back to ref=0 (TWA boat-referenced) + heading
+            wb_rows = conn.execute(
+                "SELECT ts, wind_angle_deg FROM winds WHERE reference=0 AND ts BETWEEN ? AND ?",
+                (start, end),
+            ).fetchall()
+            if not wb_rows:
+                return None
+            for w in wb_rows:
+                ts_key = w["ts"][:19]
+                hdg_row = conn.execute(
+                    "SELECT heading_deg FROM headings WHERE ts >= ? AND ts < ? LIMIT 1",
+                    (ts_key, ts_key + ":99"),
+                ).fetchone()
+                if hdg_row is None:
+                    continue
+                signed = ((w["wind_angle_deg"] + 180) % 360) - 180
+                twds.append((hdg_row["heading_deg"] + signed) % 360)
+            return statistics.median(twds) if twds else None
+
+        # Heading before & after
+        def median_hdg(start, end):
+            rows = conn.execute(
+                "SELECT heading_deg FROM headings WHERE ts BETWEEN ? AND ?", (start, end)
+            ).fetchall()
+            return statistics.median([r["heading_deg"] for r in rows]) if rows else None
+
+        twd_before = median_twd(b_start, b_end)
+        twd_after = median_twd(a_start, a_end)
+        hdg_before = median_hdg(b_start, b_end)
+        hdg_after = median_hdg(a_start, a_end)
+
+        if None in (twd_before, twd_after, hdg_before, hdg_after):
+            continue
+
+        # Heading change — sign tells us direction of tack
+        hdg_change = angle_diff(hdg_after, hdg_before)
+        # TWD change — sign tells us direction of shift
+        twd_change = angle_diff(twd_after, twd_before)
+
+        # Only count if heading change is meaningful (a real tack: 60-180°)
+        if abs(hdg_change) < 60 or abs(hdg_change) > 180:
+            continue
+
+        # Sign convention:
+        # - If hdg_change > 0 (boat turned right/clockwise) and twd_change > 0
+        #   (wind clocked right too), the tack was AWAY from the shift = bad
+        # - If hdg_change > 0 and twd_change < 0 (wind backed left) — tacked
+        #   INTO the new wind = good (caught a header)
+        # Use a meaningful threshold (10°) — below that, it's noise
+        if abs(twd_change) < 10:
+            verdict = "neutral"
+        elif (hdg_change > 0 and twd_change < 0) or (hdg_change < 0 and twd_change > 0):
+            verdict = "good (tacked on header)"
+        else:
+            verdict = "bad (tacked on lift)"
+
+        classified.append(
+            {
+                "race_id": t["session_id"],
+                "race_name": t["race_name"],
+                "ts": t["ts"],
+                "twd_change": twd_change,
+                "hdg_change": hdg_change,
+                "verdict": verdict,
+            }
+        )
+        shift_magnitudes.append(abs(twd_change))
+
+    # Aggregate
+    print(
+        f"Classified {len(classified)} tacks across {len(set(c['race_id'] for c in classified))} races."
+    )
+    print(f"Median wind shift magnitude per tack: {statistics.median(shift_magnitudes):.1f}°")
+    print(f"Mean shift magnitude per tack:        {statistics.mean(shift_magnitudes):.1f}°")
+    counts = defaultdict(int)
+    for c in classified:
+        counts[c["verdict"]] += 1
+    total = sum(counts.values())
+    print()
+    print(
+        f"  Good (tacked on a header ≥10°):  {counts['good (tacked on header)']:>3} "
+        f"({100 * counts['good (tacked on header)'] / total:.0f}%)"
+    )
+    print(
+        f"  Bad  (tacked on a lift ≥10°):    {counts['bad (tacked on lift)']:>3} "
+        f"({100 * counts['bad (tacked on lift)'] / total:.0f}%)"
+    )
+    print(
+        f"  Neutral (shift <10°):            {counts['neutral']:>3} "
+        f"({100 * counts['neutral'] / total:.0f}%)"
+    )
+    sg = counts["good (tacked on header)"] + counts["bad (tacked on lift)"]
+    if sg > 0:
+        hit_rate = counts["good (tacked on header)"] / sg
+        print(f"\n  Shift-tack hit rate (when there WAS a shift): {hit_rate * 100:.0f}%")
+        print(f"  (50% would be random chance; 60-70% is good club racing.)")
+
+    # Per-race breakdown
+    print()
+    print("Per race:")
+    print(f"{'date':<11} {'race':<40} {'tacks':>5} {'good':>4} {'bad':>4} {'neut':>4}")
+    print("-" * 75)
+    by_race = defaultdict(
+        lambda: {
+            "good (tacked on header)": 0,
+            "bad (tacked on lift)": 0,
+            "neutral": 0,
+            "name": "",
+            "date": "",
+        }
+    )
+    for c in classified:
+        b = by_race[c["race_id"]]
+        b[c["verdict"]] += 1
+        b["name"] = c["race_name"] or ""
+    for rid, b in sorted(by_race.items()):
+        race_row = next((r for r in races if r["id"] == rid), None)
+        if race_row is None:
+            continue
+        total_r = b["good (tacked on header)"] + b["bad (tacked on lift)"] + b["neutral"]
+        if total_r < 2:
+            continue
+        print(
+            f"{race_row['date']:<11} {b['name']:<40} {total_r:>5} "
+            f"{b['good (tacked on header)']:>4} "
+            f"{b['bad (tacked on lift)']:>4} {b['neutral']:>4}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/full_analysis.py
+++ b/scripts/analysis/full_analysis.py
@@ -1,0 +1,580 @@
+"""Consolidated downwind/upwind/shift/current analysis.
+
+Improvements vs prior scripts:
+  1. Uses Vakaros race_start as the effective gun when available (skips
+     pre-start maneuvering that previously polluted the dataset). Falls back
+     to start_utc + 5min for races without a Vakaros gun.
+  2. VMG + shift analysis: races only, RTTS excluded, post-gun only.
+  3. Current: includes practice sessions, but only counts "long sustained
+     legs" (heading stable ±15° peak-to-peak for ≥60s, BSP > 2 kt) — this
+     gives a much cleaner current vector by avoiding tacks/jibes/roundings.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+
+
+def fold(a):
+    a = abs(a) % 360
+    return 360 - a if a > 180 else a
+
+
+def angle_diff(a, b):
+    return (a - b + 540) % 360 - 180
+
+
+def hdg_spread(values):
+    """Peak-to-peak spread of headings (handling 359→0 wraparound)."""
+    if len(values) < 2:
+        return 0.0
+    # Convert to unit vectors, find min/max angle relative to mean
+    xs = [math.sin(math.radians(v)) for v in values]
+    ys = [math.cos(math.radians(v)) for v in values]
+    mean_dir = math.degrees(math.atan2(sum(xs) / len(xs), sum(ys) / len(ys)))
+    deltas = [abs(angle_diff(v, mean_dir)) for v in values]
+    return 2 * max(deltas)
+
+
+def load_aligned(conn, start, end):
+    sp = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(speed_kts) FROM speeds"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    cg = {
+        r[0]: (r[1], r[2])
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(cog_deg), AVG(sog_kts) FROM cogsog"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hd = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heading_deg) FROM headings"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    wb, wn = {}, {}
+    for r in conn.execute(
+        "SELECT substr(ts,1,19), reference, AVG(wind_speed_kts), AVG(wind_angle_deg)"
+        " FROM winds WHERE ts BETWEEN ? AND ? AND reference IN (0,4)"
+        " GROUP BY substr(ts,1,19), reference",
+        (start, end),
+    ):
+        (wb if r[1] == 0 else wn)[r[0]] = (r[2], r[3])
+    out = []
+    for k, bsp in sp.items():
+        if k in wb:
+            tws, raw = wb[k]
+            signed = ((raw + 180) % 360) - 180
+        elif k in wn and k in hd:
+            tws, twd_n = wn[k]
+            signed = ((twd_n - hd[k] + 180) % 360) - 180
+        else:
+            continue
+        twa = fold(signed)
+        cog, sog = cg.get(k, (None, None))
+        hdg = hd.get(k)
+        twd = wn[k][1] % 360 if k in wn else ((hdg + signed) % 360 if hdg is not None else None)
+        out.append(
+            {
+                "k": k,
+                "bsp": bsp,
+                "sog": sog,
+                "cog": cog,
+                "hdg": hdg,
+                "tws": tws,
+                "twa": twa,
+                "twd": twd,
+                "tack": "starboard" if signed >= 0 else "port",
+                "vmg": bsp * math.cos(math.radians(twa)),
+            }
+        )
+    out.sort(key=lambda r: r["k"])
+    return out
+
+
+def get_effective_start(conn, race):
+    """Return the actual gun time for a race.
+
+    Prefers Vakaros race_start event; falls back to start_utc + 5min when
+    Vakaros gun is unavailable. The +5min skip approximates the typical race
+    start sequence so we don't include pre-start maneuvering.
+    """
+    if race["vakaros_session_id"] is not None:
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events"
+            " WHERE session_id=? AND event_type='race_start'"
+            "   AND ts BETWEEN ? AND ?"
+            " ORDER BY ts DESC LIMIT 1",
+            (race["vakaros_session_id"], race["start_utc"], race["end_utc"]),
+        ).fetchone()
+        if gun is not None:
+            return gun["ts"], "vakaros"
+    # Fallback: start_utc + 5min
+    db_start = datetime.fromisoformat(race["start_utc"])
+    return (db_start + timedelta(minutes=5)).isoformat(), "fallback+5min"
+
+
+def detect_steady_legs(rows, min_duration_s=60, max_hdg_spread=15.0, min_bsp=2.0):
+    """Yield (start_idx, end_idx) of contiguous steady-heading segments.
+
+    Steady = heading peak-to-peak within max_hdg_spread, BSP > min_bsp.
+    Useful for clean current measurement (no maneuvers, no drifting).
+    """
+    n = len(rows)
+    if n < min_duration_s:
+        return
+    # Sliding window: try to extend each starting point
+    i = 0
+    while i < n - min_duration_s:
+        # Skip rows missing required fields
+        if rows[i]["hdg"] is None or rows[i]["bsp"] < min_bsp or rows[i]["sog"] is None:
+            i += 1
+            continue
+        j = i + 1
+        # Extend while heading still steady and BSP still > min
+        while j < n:
+            if rows[j]["hdg"] is None or rows[j]["bsp"] < min_bsp or rows[j]["sog"] is None:
+                break
+            window = [rows[k]["hdg"] for k in range(i, j + 1) if rows[k]["hdg"] is not None]
+            if hdg_spread(window) > max_hdg_spread:
+                break
+            j += 1
+        # Did the segment last long enough?
+        if j - i >= min_duration_s:
+            yield (i, j)
+            i = j  # skip past — non-overlapping segments
+        else:
+            i += 1
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+
+    # Race sessions for VMG/shift analysis (RTTS excluded)
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, session_type, start_utc, end_utc, vakaros_session_id"
+            " FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND session_type='race' AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    # ALL sessions (race + practice, RTTS excluded) — used only for current analysis
+    all_sessions = list(
+        conn.execute(
+            "SELECT id, name, date, session_type, start_utc, end_utc, vakaros_session_id"
+            " FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    print(f"VMG/shift analysis: {len(races)} race sessions (practice + RTTS excluded)")
+    print(f"Current analysis:   {len(all_sessions)} sessions (race + practice; RTTS excluded)")
+    print()
+
+    # Pre-compute effective starts for each race
+    starts_info = {}
+    for r in races:
+        start, src = get_effective_start(conn, r)
+        starts_info[r["id"]] = (start, src)
+    n_vakaros = sum(1 for s, src in starts_info.values() if src == "vakaros")
+    print(
+        f"Effective start: {n_vakaros}/{len(races)} via Vakaros gun, "
+        f"{len(races) - n_vakaros} via start_utc+5min fallback"
+    )
+    print()
+
+    # ============================================================
+    # Build VMG datasets (post-gun only)
+    # ============================================================
+    rows_dn, rows_up = [], []
+    per_race_rows = {}
+    for r in races:
+        start, _ = starts_info[r["id"]]
+        rs = load_aligned(conn, start, r["end_utc"])
+        per_race_rows[r["id"]] = rs
+        for x in rs:
+            if x["bsp"] < 0.5 or not (1.5 < x["tws"] < 35):
+                continue
+            if 90 <= x["twa"] <= 180:
+                rows_dn.append(x)
+            elif 30 <= x["twa"] < 90:
+                rows_up.append(x)
+    print(f"Downwind seconds (post-gun): {len(rows_dn):,} ({len(rows_dn) / 3600:.1f} h)")
+    print(f"Upwind seconds (post-gun):   {len(rows_up):,} ({len(rows_up) / 3600:.1f} h)")
+    print()
+
+    # ============================================================
+    # 1. DOWNWIND POLAR (post-gun, races only, no RTTS)
+    # ============================================================
+    print("=" * 90)
+    print("DOWNWIND POLAR — races only, post-gun, RTTS excluded")
+    print("=" * 90)
+    bin_dn = defaultdict(list)
+    for r in rows_dn:
+        bin_dn[(int(math.floor(r["tws"])), int(math.floor(r["twa"] / 5) * 5))].append(r["bsp"])
+
+    print(
+        f"{'TWS':>5} {'samples':>8} {'med TWA':>7}  "
+        f"{'OPTIMAL TWA':>22} {'opt VMG':>8} {'we sail':>14} {'gap':>6}"
+    )
+    print("-" * 88)
+    for tws in range(4, 22):
+        relevant = [r for r in rows_dn if int(math.floor(r["tws"])) == tws]
+        if len(relevant) < 60:
+            continue
+        twas = sorted([r["twa"] for r in relevant])
+        med_twa = twas[len(twas) // 2]
+        cands = []
+        for ab in range(95, 180, 5):
+            v = bin_dn.get((tws, ab), [])
+            if len(v) >= 60:
+                m = statistics.mean(v)
+                cands.append((ab, m, m * abs(math.cos(math.radians(ab + 2.5))), len(v)))
+        if not cands:
+            continue
+        opt = max(cands, key=lambda c: c[2])
+        med_b = int(math.floor(med_twa / 5) * 5)
+        med_v = bin_dn.get((tws, med_b), [])
+        med_vmg = (
+            statistics.mean(med_v) * abs(math.cos(math.radians(med_b + 2.5)))
+            if len(med_v) >= 30
+            else float("nan")
+        )
+        print(
+            f"{tws:>3}-{tws + 1:<2} {len(relevant):>8} {med_twa:>7.1f}  "
+            f"{opt[0]:>4}° (n={opt[3]:>3}) BSP {opt[1]:.2f}  {opt[2]:>8.2f}  "
+            f"{med_b}° ({med_vmg:.2f})  {opt[2] - med_vmg:>+6.2f}"
+        )
+
+    # ============================================================
+    # 2. UPWIND POLAR (post-gun)
+    # ============================================================
+    print()
+    print("=" * 90)
+    print("UPWIND POLAR — races only, post-gun, RTTS excluded")
+    print("=" * 90)
+    bin_up = defaultdict(list)
+    for r in rows_up:
+        bin_up[(int(math.floor(r["tws"])), int(math.floor(r["twa"] / 5) * 5))].append(r["bsp"])
+
+    print(
+        f"{'TWS':>5} {'samples':>8} {'med TWA':>7}  "
+        f"{'OPTIMAL TWA':>22} {'opt VMG':>8} {'we sail':>14} {'gap':>6}"
+    )
+    print("-" * 88)
+    for tws in range(4, 22):
+        relevant = [r for r in rows_up if int(math.floor(r["tws"])) == tws]
+        if len(relevant) < 60:
+            continue
+        twas = sorted([r["twa"] for r in relevant])
+        med_twa = twas[len(twas) // 2]
+        cands = []
+        for ab in range(30, 90, 5):
+            v = bin_up.get((tws, ab), [])
+            if len(v) >= 60:
+                m = statistics.mean(v)
+                cands.append((ab, m, m * abs(math.cos(math.radians(ab + 2.5))), len(v)))
+        if not cands:
+            continue
+        opt = max(cands, key=lambda c: c[2])
+        med_b = int(math.floor(med_twa / 5) * 5)
+        med_v = bin_up.get((tws, med_b), [])
+        med_vmg = (
+            statistics.mean(med_v) * abs(math.cos(math.radians(med_b + 2.5)))
+            if len(med_v) >= 30
+            else float("nan")
+        )
+        print(
+            f"{tws:>3}-{tws + 1:<2} {len(relevant):>8} {med_twa:>7.1f}  "
+            f"{opt[0]:>4}° (n={opt[3]:>3}) BSP {opt[1]:.2f}  {opt[2]:>8.2f}  "
+            f"{med_b}° ({med_vmg:.2f})  {opt[2] - med_vmg:>+6.2f}"
+        )
+
+    # ============================================================
+    # 3. SHIFT-CATCHING (post-gun, races only)
+    # ============================================================
+    print()
+    print("=" * 90)
+    print("SHIFT-CATCHING (post-gun, races only)")
+    print("=" * 90)
+    classified = []
+    shift_mags = []
+    for race in races:
+        start, _ = starts_info[race["id"]]
+        end = race["end_utc"]
+        # Tacks within the post-gun window
+        tacks = list(
+            conn.execute(
+                "SELECT id, ts, duration_sec FROM maneuvers"
+                " WHERE type='tack' AND session_id=? AND ts BETWEEN ? AND ?"
+                " ORDER BY ts",
+                (race["id"], start, end),
+            )
+        )
+        for t in tacks:
+            ts = datetime.fromisoformat(t["ts"])
+            b_start = (ts - timedelta(seconds=150)).isoformat()
+            b_end = (ts - timedelta(seconds=90)).isoformat()
+            a_start = (ts + timedelta(seconds=90)).isoformat()
+            a_end = (ts + timedelta(seconds=150)).isoformat()
+
+            def median_twd(s, e):
+                # Try ref=4 first
+                rows = conn.execute(
+                    "SELECT wind_angle_deg FROM winds WHERE reference=4 AND ts BETWEEN ? AND ?",
+                    (s, e),
+                ).fetchall()
+                if rows:
+                    return statistics.median([r["wind_angle_deg"] % 360 for r in rows])
+                # Fall back to ref=0 + heading
+                wb_rows = conn.execute(
+                    "SELECT ts, wind_angle_deg FROM winds WHERE reference=0 AND ts BETWEEN ? AND ?",
+                    (s, e),
+                ).fetchall()
+                twds = []
+                for w in wb_rows:
+                    hdg_row = conn.execute(
+                        "SELECT heading_deg FROM headings WHERE ts >= ? AND ts < ? LIMIT 1",
+                        (w["ts"][:19], w["ts"][:19] + ":99"),
+                    ).fetchone()
+                    if hdg_row is None:
+                        continue
+                    signed = ((w["wind_angle_deg"] + 180) % 360) - 180
+                    twds.append((hdg_row["heading_deg"] + signed) % 360)
+                return statistics.median(twds) if twds else None
+
+            def median_hdg(s, e):
+                rows = conn.execute(
+                    "SELECT heading_deg FROM headings WHERE ts BETWEEN ? AND ?", (s, e)
+                ).fetchall()
+                return statistics.median([r["heading_deg"] for r in rows]) if rows else None
+
+            twd_b = median_twd(b_start, b_end)
+            twd_a = median_twd(a_start, a_end)
+            hdg_b = median_hdg(b_start, b_end)
+            hdg_a = median_hdg(a_start, a_end)
+            if None in (twd_b, twd_a, hdg_b, hdg_a):
+                continue
+            hc = angle_diff(hdg_a, hdg_b)
+            tc = angle_diff(twd_a, twd_b)
+            if abs(hc) < 60 or abs(hc) > 180:
+                continue
+            shift_mags.append(abs(tc))
+            if abs(tc) < 10:
+                v = "neutral"
+            elif (hc > 0 and tc < 0) or (hc < 0 and tc > 0):
+                v = "good"
+            else:
+                v = "bad"
+            classified.append(
+                {
+                    "race_id": race["id"],
+                    "race_name": race["name"],
+                    "ts": t["ts"],
+                    "twd_change": tc,
+                    "verdict": v,
+                }
+            )
+
+    if classified:
+        print(
+            f"{len(classified)} tacks classified across "
+            f"{len(set(c['race_id'] for c in classified))} races."
+        )
+        print(f"Median wind shift around tacks: {statistics.median(shift_mags):.1f}°")
+        cnt = defaultdict(int)
+        for c in classified:
+            cnt[c["verdict"]] += 1
+        tot = sum(cnt.values())
+        print(f"  Good (tacked on header ≥10°): {cnt['good']:>3} ({100 * cnt['good'] / tot:.0f}%)")
+        print(f"  Bad  (tacked on lift ≥10°):   {cnt['bad']:>3} ({100 * cnt['bad'] / tot:.0f}%)")
+        print(
+            f"  Neutral (shift <10°):         {cnt['neutral']:>3} ({100 * cnt['neutral'] / tot:.0f}%)"
+        )
+        sg = cnt["good"] + cnt["bad"]
+        if sg > 0:
+            print(f"  Hit rate (when there WAS a shift): {100 * cnt['good'] / sg:.0f}%")
+
+    # ============================================================
+    # 4. CURRENT — long sustained legs across ALL sessions (race + practice)
+    # ============================================================
+    print()
+    print("=" * 90)
+    print("CURRENT — derived from sustained steady-heading legs ≥60s, ANY session")
+    print("Includes practice sessions (longer beats give cleaner current vectors).")
+    print("=" * 90)
+    print(f"{'date':<11} {'session':<40} {'legs':>4} {'leg-sec':>7} {'drift kt':>8} {'set °':>6}")
+    print("-" * 80)
+    current_per_session = []
+    for s in all_sessions:
+        rs = load_aligned(conn, s["start_utc"], s["end_utc"])
+        # Detect steady legs
+        all_xs, all_ys, total_secs, n_legs = [], [], 0, 0
+        for i0, i1 in detect_steady_legs(rs):
+            xs, ys = [], []
+            for k in range(i0, i1):
+                x = rs[k]
+                if x["sog"] is None or x["cog"] is None or x["hdg"] is None or x["bsp"] is None:
+                    continue
+                cx = x["sog"] * math.sin(math.radians(x["cog"])) - x["bsp"] * math.sin(
+                    math.radians(x["hdg"])
+                )
+                cy = x["sog"] * math.cos(math.radians(x["cog"])) - x["bsp"] * math.cos(
+                    math.radians(x["hdg"])
+                )
+                if math.hypot(cx, cy) < 4.0:
+                    xs.append(cx)
+                    ys.append(cy)
+            if len(xs) >= 60:
+                # Average current vector for this leg
+                lcx = sum(xs) / len(xs)
+                lcy = sum(ys) / len(ys)
+                # Each leg contributes its leg-mean weighted by duration
+                all_xs.extend([lcx] * len(xs))
+                all_ys.extend([lcy] * len(xs))
+                total_secs += len(xs)
+                n_legs += 1
+        if n_legs == 0:
+            continue
+        mcx = sum(all_xs) / len(all_xs)
+        mcy = sum(all_ys) / len(all_ys)
+        drift = math.hypot(mcx, mcy)
+        set_d = (math.degrees(math.atan2(mcx, mcy)) + 360) % 360
+        current_per_session.append(
+            {
+                "id": s["id"],
+                "name": s["name"],
+                "date": s["date"],
+                "type": s["session_type"],
+                "n_legs": n_legs,
+                "secs": total_secs,
+                "drift": drift,
+                "set": set_d,
+            }
+        )
+        marker = "(P)" if s["session_type"] == "practice" else "   "
+        print(
+            f"{s['date']:<11} {marker} {s['name']:<37} {n_legs:>4} "
+            f"{total_secs:>7} {drift:>8.2f} {set_d:>6.0f}"
+        )
+    print()
+    print("(P) = practice session")
+
+    # ============================================================
+    # 5. PER-RACE SCORECARD (post-gun, races only)
+    # ============================================================
+    print()
+    print("=" * 90)
+    print("PER-RACE SCORECARD — downwind/upwind ≥90% of best-VMG, shift hit rate")
+    print("(All metrics are post-gun; pre-start excluded.)")
+    print("=" * 90)
+
+    # Build optimum VMG per TWS for each mode
+    opt_dn = {}
+    for tws in range(4, 22):
+        cands = []
+        for ab in range(95, 180, 5):
+            v = bin_dn.get((tws, ab), [])
+            if len(v) >= 60:
+                m = statistics.mean(v)
+                cands.append(m * abs(math.cos(math.radians(ab + 2.5))))
+        if cands:
+            opt_dn[tws] = max(cands)
+    opt_up = {}
+    for tws in range(4, 22):
+        cands = []
+        for ab in range(30, 90, 5):
+            v = bin_up.get((tws, ab), [])
+            if len(v) >= 60:
+                m = statistics.mean(v)
+                cands.append(m * abs(math.cos(math.radians(ab + 2.5))))
+        if cands:
+            opt_up[tws] = max(cands)
+
+    # Aggregate shifts per race
+    shifts_per_race = defaultdict(lambda: {"good": 0, "bad": 0, "neutral": 0})
+    for c in classified:
+        shifts_per_race[c["race_id"]][c["verdict"]] += 1
+
+    summary = []
+    for r in races:
+        rs = per_race_rows[r["id"]]
+        dn = [x for x in rs if 90 <= x["twa"] <= 180 and x["bsp"] > 0.5 and 1.5 < x["tws"] < 35]
+        up = [x for x in rs if 30 <= x["twa"] < 90 and x["bsp"] > 1.0 and 1.5 < x["tws"] < 35]
+        if len(dn) < 60 or len(up) < 60:
+            continue
+
+        def pct(rows, opts):
+            good = total = 0
+            for x in rows:
+                tws_b = int(math.floor(x["tws"]))
+                opt = opts.get(tws_b)
+                if opt is None or opt <= 0:
+                    continue
+                if abs(x["vmg"]) / opt >= 0.90:
+                    good += 1
+                total += 1
+            return (100.0 * good / total) if total else None
+
+        dn_pct = pct(dn, opt_dn)
+        up_pct = pct(up, opt_up)
+        sh = shifts_per_race.get(r["id"], {"good": 0, "bad": 0, "neutral": 0})
+        avg_tws_dn = statistics.mean([x["tws"] for x in dn])
+        avg_tws_up = statistics.mean([x["tws"] for x in up])
+        summary.append(
+            {
+                "date": r["date"],
+                "name": r["name"],
+                "id": r["id"],
+                "src": starts_info[r["id"]][1],
+                "tws_up": avg_tws_up,
+                "tws_dn": avg_tws_dn,
+                "dn_pct": dn_pct,
+                "up_pct": up_pct,
+                "good": sh["good"],
+                "bad": sh["bad"],
+                "neut": sh["neutral"],
+            }
+        )
+
+    summary.sort(key=lambda s: -((s["dn_pct"] or 0) + (s["up_pct"] or 0)) / 2)
+    print(
+        f"{'date':<11} {'race':<32} {'TWSu':>4} {'TWSd':>4} "
+        f"{'up%':>4} {'dn%':>4} {'shifts g/b/n':>13} {'start':>7}"
+    )
+    print("-" * 92)
+    for s in summary:
+        src_short = "vk" if s["src"] == "vakaros" else "+5m"
+        print(
+            f"{s['date']:<11} {s['name']:<32} "
+            f"{s['tws_up']:>4.1f} {s['tws_dn']:>4.1f} "
+            f"{s['up_pct']:>3.0f}% {s['dn_pct']:>3.0f}% "
+            f"  {s['good']:>2}/{s['bad']:>2}/{s['neut']:>2}      {src_short:>4}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/ocs_detect.py
+++ b/scripts/analysis/ocs_detect.py
@@ -1,0 +1,243 @@
+"""Detect OCS (over-the-line at the gun, returned to clear) races.
+
+Method per race:
+  1. Find the gun (vakaros race_start event) and the most recent start-line
+     endpoints (boat + pin) at or before the gun.
+  2. Establish the "pre-start side" of the line by averaging the boat's
+     side-of-line during the 60–10 sec window BEFORE the gun.
+  3. Determine the boat's side AT the gun (avg over ±2 sec).
+  4. If at-gun side != pre-start side → boat was over early. Then check the
+     post-gun window (gun → gun+300s) for a return to the pre-start side.
+  5. Classify:
+       - clean        → at-gun on pre-start side
+       - over_clear   → at-gun on race side AND returned to pre-start side
+       - over_no_clear→ at-gun on race side BUT no documented return (could
+                        be wrong, could be DSQ, could be race officials called
+                        them back later — flag for review)
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers — treat lat/lon as planar over short distances
+# ---------------------------------------------------------------------------
+
+
+def latlon_to_xy(lat, lon, ref_lat):
+    """Approx local meters from reference latitude (Mercator-ish)."""
+    R = 6371000.0
+    x = math.radians(lon) * R * math.cos(math.radians(ref_lat))
+    y = math.radians(lat) * R
+    return x, y
+
+
+def side_of_line(boat_xy, line_a_xy, line_b_xy):
+    """Cross product sign — +1, -1, or 0 (on the line)."""
+    abx = line_b_xy[0] - line_a_xy[0]
+    aby = line_b_xy[1] - line_a_xy[1]
+    apx = boat_xy[0] - line_a_xy[0]
+    apy = boat_xy[1] - line_a_xy[1]
+    cross = abx * apy - aby * apx
+    if cross > 0:
+        return 1
+    if cross < 0:
+        return -1
+    return 0
+
+
+def get_line_endpoints(conn, vk_session_id, gun_iso):
+    """Return (boat_lat, boat_lon, pin_lat, pin_lon) at or before gun_iso.
+
+    Picks the most recent ping for each end_kind. None if missing.
+    """
+    boat = conn.execute(
+        "SELECT latitude_deg, longitude_deg FROM vakaros_line_positions"
+        " WHERE session_id = ? AND line_type = 'boat' AND ts <= ?"
+        " ORDER BY ts DESC LIMIT 1",
+        (vk_session_id, gun_iso),
+    ).fetchone()
+    pin = conn.execute(
+        "SELECT latitude_deg, longitude_deg FROM vakaros_line_positions"
+        " WHERE session_id = ? AND line_type = 'pin' AND ts <= ?"
+        " ORDER BY ts DESC LIMIT 1",
+        (vk_session_id, gun_iso),
+    ).fetchone()
+    if boat is None or pin is None:
+        return None
+    return (boat["latitude_deg"], boat["longitude_deg"], pin["latitude_deg"], pin["longitude_deg"])
+
+
+def positions_in_range(conn, start_iso, end_iso):
+    """Yield (ts, lat, lon) per second within range."""
+    cur = conn.execute(
+        "SELECT substr(ts,1,19) AS k, AVG(latitude_deg) AS la,"
+        " AVG(longitude_deg) AS lo FROM positions"
+        " WHERE ts BETWEEN ? AND ? GROUP BY k ORDER BY k",
+        (start_iso, end_iso),
+    )
+    return [(r["k"], r["la"], r["lo"]) for r in cur]
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+
+    # All races (race + practice for context, but only RACE matters for OCS)
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, session_type, start_utc, end_utc, vakaros_session_id"
+            " FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND session_type='race' AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    print("=" * 90)
+    print("OCS DETECTION — pre-start side determined from boat track 60–10 sec before gun")
+    print("=" * 90)
+    print(
+        f"{'date':<11} {'race':<35} {'gun':<10} {'pre':>4} {'gun':>4} "
+        f"{'returned?':>10} {'verdict':<20}"
+    )
+    print("-" * 100)
+
+    classifications = {}
+
+    for r in races:
+        vk = r["vakaros_session_id"]
+        if vk is None:
+            continue
+
+        # Get gun
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events WHERE session_id=?"
+            " AND event_type='race_start' AND ts BETWEEN ? AND ?"
+            " ORDER BY ts DESC LIMIT 1",
+            (vk, r["start_utc"], r["end_utc"]),
+        ).fetchone()
+        if gun is None:
+            continue
+        gun_ts = gun["ts"]
+        gun_dt = datetime.fromisoformat(gun_ts)
+
+        # Line endpoints
+        line = get_line_endpoints(conn, vk, gun_ts)
+        if line is None:
+            continue
+        boat_lat, boat_lon, pin_lat, pin_lon = line
+        ref_lat = (boat_lat + pin_lat) / 2
+
+        # Convert line endpoints to xy
+        a_xy = latlon_to_xy(boat_lat, boat_lon, ref_lat)
+        b_xy = latlon_to_xy(pin_lat, pin_lon, ref_lat)
+
+        # Boat positions: 90 sec before gun → 300 sec after gun
+        win_start = (gun_dt - timedelta(seconds=90)).isoformat()
+        win_end = (gun_dt + timedelta(seconds=300)).isoformat()
+        positions = positions_in_range(conn, win_start, win_end)
+        if len(positions) < 30:
+            continue
+
+        # Side per second
+        sides = []
+        for ts, lat, lon in positions:
+            xy = latlon_to_xy(lat, lon, ref_lat)
+            sides.append((ts, side_of_line(xy, a_xy, b_xy)))
+
+        # Pre-start side: median side over t = gun-60 to gun-10
+        pre_window_start = gun_dt - timedelta(seconds=60)
+        pre_window_end = gun_dt - timedelta(seconds=10)
+        pre_sides = [
+            s
+            for ts, s in sides
+            if pre_window_start
+            <= datetime.fromisoformat(ts).replace(tzinfo=gun_dt.tzinfo)
+            <= pre_window_end
+            and s != 0
+        ]
+        if len(pre_sides) < 5:
+            continue
+        pre_side = 1 if sum(pre_sides) > 0 else -1
+
+        # At-gun side: median over gun ± 3 sec
+        atgun_window_start = gun_dt - timedelta(seconds=3)
+        atgun_window_end = gun_dt + timedelta(seconds=3)
+        atgun_sides = [
+            s
+            for ts, s in sides
+            if atgun_window_start
+            <= datetime.fromisoformat(ts).replace(tzinfo=gun_dt.tzinfo)
+            <= atgun_window_end
+            and s != 0
+        ]
+        if len(atgun_sides) < 2:
+            continue
+        atgun_side = 1 if sum(atgun_sides) > 0 else -1
+
+        # Post-gun: did the boat return to pre-start side any time in [gun+5, gun+300]?
+        returned = False
+        for ts, s in sides:
+            t = datetime.fromisoformat(ts).replace(tzinfo=gun_dt.tzinfo)
+            if t > gun_dt + timedelta(seconds=5) and t < gun_dt + timedelta(seconds=300):
+                if s == pre_side:
+                    returned = True
+                    break
+
+        # Classification
+        if pre_side == atgun_side:
+            verdict = "clean"
+        elif returned:
+            verdict = "OCS — RETURNED"
+        else:
+            verdict = "OCS? (no return)"
+
+        classifications[r["id"]] = {
+            "name": r["name"],
+            "date": r["date"],
+            "verdict": verdict,
+            "pre_side": pre_side,
+            "atgun_side": atgun_side,
+            "returned": returned,
+        }
+
+        gun_local = gun_ts[11:16]
+        print(
+            f"{r['date']:<11} {r['name'][:33]:<35} {gun_local:<10} "
+            f"{pre_side:>4} {atgun_side:>4} {('Y' if returned else '-'):>10} {verdict:<20}"
+        )
+
+    # Summary
+    print()
+    ocs_returned = [r for r in classifications.values() if r["verdict"] == "OCS — RETURNED"]
+    ocs_no_clear = [r for r in classifications.values() if r["verdict"] == "OCS? (no return)"]
+    clean = [r for r in classifications.values() if r["verdict"] == "clean"]
+    print(f"{'CLASSIFIED':>20}: {len(classifications)}")
+    print(f"{'CLEAN STARTS':>20}: {len(clean)}")
+    print(f"{'OCS — returned':>20}: {len(ocs_returned)}")
+    print(f"{'OCS? no return':>20}: {len(ocs_no_clear)}")
+
+    print()
+    print("OCS races (returned to pre-start side after gun):")
+    for r in ocs_returned:
+        print(f"  - {r['date']}  {r['name']}")
+    if ocs_no_clear:
+        print()
+        print("Possible OCS but no clear return — review manually:")
+        for r in ocs_no_clear:
+            print(f"  - {r['date']}  {r['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/polar_plot.py
+++ b/scripts/analysis/polar_plot.py
@@ -1,0 +1,263 @@
+"""Generate a clean polar diagram of mean BSP vs (TWS, TWA) for the report."""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+OUT = sys.argv[2] if len(sys.argv) > 2 else (os.environ.get("HELMLOG_OUT_DIR", ".") + "/polar.png")
+
+
+def fold(a):
+    a = abs(a) % 360
+    return 360 - a if a > 180 else a
+
+
+def load_aligned(conn, start, end):
+    sp = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(speed_kts) FROM speeds"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hd = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heading_deg) FROM headings"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    wb, wn = {}, {}
+    for r in conn.execute(
+        "SELECT substr(ts,1,19), reference, AVG(wind_speed_kts), AVG(wind_angle_deg)"
+        " FROM winds WHERE ts BETWEEN ? AND ? AND reference IN (0,4)"
+        " GROUP BY substr(ts,1,19), reference",
+        (start, end),
+    ):
+        (wb if r[1] == 0 else wn)[r[0]] = (r[2], r[3])
+    out = []
+    for k, bsp in sp.items():
+        if k in wb:
+            tws, raw = wb[k]
+            signed = ((raw + 180) % 360) - 180
+        elif k in wn and k in hd:
+            tws, twd_n = wn[k]
+            signed = ((twd_n - hd[k] + 180) % 360) - 180
+        else:
+            continue
+        twa = fold(signed)
+        out.append((tws, twa, bsp))
+    return out
+
+
+def get_effective_start(conn, race):
+    if race["vakaros_session_id"] is not None:
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events WHERE session_id=?"
+            " AND event_type='race_start' AND ts BETWEEN ? AND ? ORDER BY ts DESC LIMIT 1",
+            (race["vakaros_session_id"], race["start_utc"], race["end_utc"]),
+        ).fetchone()
+        if gun is not None:
+            return gun["ts"]
+    return (datetime.fromisoformat(race["start_utc"]) + timedelta(minutes=5)).isoformat()
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, start_utc, end_utc, vakaros_session_id FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND session_type='race' AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    samples = []
+    for r in races:
+        start = get_effective_start(conn, r)
+        for tws, twa, bsp in load_aligned(conn, start, r["end_utc"]):
+            if 1.5 < tws < 35 and bsp > 0.2 and 30 <= twa <= 180:
+                samples.append((tws, twa, bsp))
+
+    # Bin: 5° TWA × 1kt TWS, mean BSP per bin
+    cells = defaultdict(list)
+    for tws, twa, bsp in samples:
+        tb = int(math.floor(tws))
+        ab = int(math.floor(twa / 5) * 5)
+        cells[(tb, ab)].append(bsp)
+
+    # Build curves: for each TWS bin, the (twa, mean_bsp) for that wind speed
+    tws_bins_to_plot = [6, 8, 10, 12, 14, 16]
+    fig, ax = plt.subplots(figsize=(8.5, 8.5), subplot_kw={"projection": "polar"})
+
+    # Polar plot setup: 0° at top (head-to-wind), increasing clockwise
+    ax.set_theta_zero_location("N")
+    ax.set_theta_direction(-1)
+    # Show 0-180 only (one half of polar)
+    ax.set_thetamin(0)
+    ax.set_thetamax(180)
+
+    cmap = plt.colormaps["viridis"]
+    colors = [cmap(i / max(1, len(tws_bins_to_plot) - 1)) for i in range(len(tws_bins_to_plot))]
+
+    for tws_b, color in zip(tws_bins_to_plot, colors):
+        # Build separate upwind (TWA<90) and downwind (TWA>90) curves —
+        # we don't race in the 90° beam-reach zone, so a line crossing it
+        # would imply a polar shape we don't actually sail.
+        up_twas, up_bsps, dn_twas, dn_bsps = [], [], [], []
+        for ab in range(30, 181, 5):
+            v = cells.get((tws_b, ab), [])
+            if len(v) >= 30:
+                if ab < 90:
+                    up_twas.append(ab)
+                    up_bsps.append(statistics.mean(v))
+                elif ab >= 95:  # leave 90 as a gap
+                    dn_twas.append(ab)
+                    dn_bsps.append(statistics.mean(v))
+        label = f"{tws_b}–{tws_b + 1} kt TWS"
+        if len(up_twas) >= 3:
+            theta_up = [math.radians(t) for t in up_twas]
+            ax.plot(
+                theta_up, up_bsps, marker="o", markersize=4, linewidth=2, color=color, label=label
+            )
+            label = None  # avoid double legend entry
+        if len(dn_twas) >= 3:
+            theta_dn = [math.radians(t) for t in dn_twas]
+            ax.plot(
+                theta_dn, dn_bsps, marker="o", markersize=4, linewidth=2, color=color, label=label
+            )
+
+    # Style
+    ax.set_rmax(9)
+    ax.set_rticks([2, 4, 6, 8])
+    ax.set_rlabel_position(135)
+    ax.grid(True, alpha=0.4)
+    ax.set_title(
+        "Corvo 105 — Observed Polar (mean BSP per TWA bin)\n"
+        "Race-only data, post-gun, RTTS excluded · April 9 – May 12, 2026",
+        pad=20,
+        fontsize=11,
+    )
+    # Annotate axis
+    ax.text(math.radians(0), 9.3, "Head to wind", ha="center", fontsize=9, alpha=0.7)
+    ax.text(math.radians(180), 9.3, "Dead\ndownwind", ha="center", fontsize=9, alpha=0.7)
+    ax.text(math.radians(90), 9.3, "Beam reach", ha="center", fontsize=9, alpha=0.7)
+
+    ax.legend(loc="upper right", bbox_to_anchor=(1.18, 1.05), fontsize=9, framealpha=0.95)
+
+    fig.tight_layout()
+    fig.savefig(OUT, dpi=140, bbox_inches="tight")
+    print(f"Wrote {OUT}")
+
+    # ============================================================
+    # AWA polar — same data, but plotted vs apparent wind angle
+    # ============================================================
+    OUT_AWA = OUT.replace(".png", "_awa.png")
+    fig3, ax3 = plt.subplots(figsize=(8.5, 8.5), subplot_kw={"projection": "polar"})
+    ax3.set_theta_zero_location("N")
+    ax3.set_theta_direction(-1)
+    ax3.set_thetamin(0)
+    ax3.set_thetamax(180)
+    for tws_b, color in zip(tws_bins_to_plot, colors):
+        up_awas, up_bsps, dn_awas, dn_bsps = [], [], [], []
+        for ab in range(30, 181, 5):
+            v = cells.get((tws_b, ab), [])
+            if len(v) >= 30:
+                bsp_mean = statistics.mean(v)
+                # AWA from TWA + TWS + BSP
+                tws_mid = tws_b + 0.5
+                twa_rad = math.radians(ab + 2.5)
+                awa = math.degrees(
+                    math.atan2(
+                        tws_mid * math.sin(twa_rad),
+                        tws_mid * math.cos(twa_rad) + bsp_mean,
+                    )
+                )
+                awa_abs = abs(awa) if abs(awa) <= 180 else 360 - abs(awa)
+                if ab < 90:
+                    up_awas.append(awa_abs)
+                    up_bsps.append(bsp_mean)
+                elif ab >= 95:
+                    dn_awas.append(awa_abs)
+                    dn_bsps.append(bsp_mean)
+        label = f"{tws_b}–{tws_b + 1} kt TWS"
+        if len(up_awas) >= 3:
+            theta_up = [math.radians(a) for a in up_awas]
+            ax3.plot(
+                theta_up, up_bsps, marker="o", markersize=4, linewidth=2, color=color, label=label
+            )
+            label = None
+        if len(dn_awas) >= 3:
+            theta_dn = [math.radians(a) for a in dn_awas]
+            ax3.plot(
+                theta_dn, dn_bsps, marker="o", markersize=4, linewidth=2, color=color, label=label
+            )
+    ax3.set_rmax(9)
+    ax3.set_rticks([2, 4, 6, 8])
+    ax3.set_rlabel_position(135)
+    ax3.grid(True, alpha=0.4)
+    ax3.set_title(
+        "Corvo 105 — Observed Polar by APPARENT WIND ANGLE\n"
+        "(angular axis is what the AWA gauge reads, not TWA)\n"
+        "Race-only · post-gun · April 9 – May 12, 2026",
+        pad=20,
+        fontsize=11,
+    )
+    ax3.text(math.radians(0), 9.3, "Head to wind", ha="center", fontsize=9, alpha=0.7)
+    ax3.text(math.radians(180), 9.3, "Dead\ndownwind\n(AWA)", ha="center", fontsize=9, alpha=0.7)
+    ax3.legend(loc="upper right", bbox_to_anchor=(1.18, 1.05), fontsize=9, framealpha=0.95)
+    fig3.tight_layout()
+    fig3.savefig(OUT_AWA, dpi=140, bbox_inches="tight")
+    print(f"Wrote {OUT_AWA}")
+
+    # Also save a heatmap visualization
+    OUT2 = OUT.replace(".png", "_heatmap.png")
+    fig2, ax2 = plt.subplots(figsize=(11, 6))
+    twa_bins = list(range(35, 181, 5))
+    tws_bins = list(range(4, 21))
+    grid = np.full((len(tws_bins), len(twa_bins)), np.nan)
+    for i, tb in enumerate(tws_bins):
+        for j, ab in enumerate(twa_bins):
+            v = cells.get((tb, ab), [])
+            if len(v) >= 30:
+                grid[i, j] = statistics.mean(v)
+    im = ax2.imshow(
+        grid,
+        aspect="auto",
+        origin="lower",
+        cmap="viridis",
+        extent=[twa_bins[0], twa_bins[-1] + 5, tws_bins[0], tws_bins[-1] + 1],
+        vmin=2,
+        vmax=9,
+    )
+    cbar = fig2.colorbar(im, ax=ax2)
+    cbar.set_label("Mean BSP (kt)")
+    ax2.set_xlabel("TWA (°)")
+    ax2.set_ylabel("TWS (kt)")
+    ax2.set_title(
+        "Corvo 105 — Mean BSP heatmap by (TWS, TWA)\nRace-only · post-gun · cells with ≥30 sec only"
+    )
+    ax2.axvline(x=90, color="white", linestyle="--", alpha=0.5)
+    ax2.text(60, 19.5, "← upwind", color="white", fontsize=9, alpha=0.85)
+    ax2.text(120, 19.5, "downwind →", color="white", fontsize=9, alpha=0.85)
+    fig2.tight_layout()
+    fig2.savefig(OUT2, dpi=140, bbox_inches="tight")
+    print(f"Wrote {OUT2}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/start_quality.py
+++ b/scripts/analysis/start_quality.py
@@ -1,0 +1,695 @@
+"""Start quality matrix + trend chart.
+
+For each race with Vakaros line endpoints + boat track + gun event, compute:
+
+  - dist_at_gun_m   : signed perpendicular distance from line at the gun
+                      (negative = behind the line / pre-start side; 0 = on the
+                      line; positive = over the line at the gun)
+  - speed_at_gun_kt : boat speed (SOG, GPS-based, calibration-immune) at gun
+  - ttl_sec         : time from gun to first forward crossing of the line.
+                      0 = crossed exactly at gun. Positive = late. For OCS
+                      races where boat had to come back, this measures the
+                      RE-cross.
+  - score           : 0–100 composite (higher is better)
+
+Generates start_quality_trend.png — a chart showing each component over the
+season, plus a smoothed composite line.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+OUT = os.environ.get("HELMLOG_OUT_DIR", ".") + "/start_quality_trend.png"
+
+TARGET_SPEED_KT = 6.0  # J/105 upwind target start speed (rough)
+
+
+def latlon_to_xy(lat, lon, ref_lat):
+    R = 6371000.0
+    x = math.radians(lon) * R * math.cos(math.radians(ref_lat))
+    y = math.radians(lat) * R
+    return x, y
+
+
+def perp_distance_signed(boat_xy, line_a_xy, line_b_xy):
+    """Signed perpendicular distance from boat to the line (in meters).
+
+    Positive = on the side of the cross product +1.
+    """
+    abx = line_b_xy[0] - line_a_xy[0]
+    aby = line_b_xy[1] - line_a_xy[1]
+    apx = boat_xy[0] - line_a_xy[0]
+    apy = boat_xy[1] - line_a_xy[1]
+    cross = abx * apy - aby * apx
+    line_len = math.hypot(abx, aby)
+    if line_len < 1e-6:
+        return 0.0
+    return cross / line_len
+
+
+def line_bias(boat_a_xy, pin_b_xy, twd_deg):
+    """Compute line bias relative to the wind direction.
+
+    Returns dict with:
+      favored: 'boat', 'pin', or 'square' (within 2°)
+      bias_deg: angle the line is tilted off square (positive = boat favored,
+                negative = pin favored)
+      bias_m:   linear advantage in meters (how much closer to upwind the
+                favored end is)
+      line_len_m: total length of the line
+    """
+    abx = pin_b_xy[0] - boat_a_xy[0]
+    aby = pin_b_xy[1] - boat_a_xy[1]
+    line_len = math.hypot(abx, aby)
+    if line_len < 1e-6:
+        return {"favored": "square", "bias_deg": 0.0, "bias_m": 0.0, "line_len_m": 0.0}
+
+    # Line bearing from boat-end → pin-end (deg from N, increasing eastward)
+    line_bearing = (math.degrees(math.atan2(abx, aby)) + 360) % 360
+
+    # Wind FROM direction → upwind direction (where the boat wants to go)
+    upwind_bearing = twd_deg % 360
+
+    # Angle between line and the perpendicular to wind:
+    #   if line is perpendicular to wind, bias = 0 (square)
+    #   if line tilts so the boat-end is closer to upwind, bias > 0
+    # Compute the signed difference between line_bearing and (upwind_bearing + 90).
+    # The +90 makes the reference axis perpendicular to wind direction.
+    perpendicular_to_wind = (upwind_bearing + 90) % 360
+    diff = (line_bearing - perpendicular_to_wind + 540) % 360 - 180  # (-180, 180]
+
+    # The bias angle measures how much the line tilts off square.
+    # Convention: positive bias_deg = boat-end is more upwind = boat favored
+    # Negative = pin favored
+    # When line is perpendicular to wind (square), diff is ±0 or ±180.
+    # When line is parallel to wind, diff is ±90.
+    if abs(diff) > 90:
+        # Line vector is mostly opposite our reference direction; flip sign
+        bias_deg = (180 - abs(diff)) * (-1 if diff > 0 else 1)
+    else:
+        bias_deg = -diff  # positive = boat favored
+
+    # Linear advantage at favored end (meters along the line that the
+    # favored end is "ahead" in upwind terms)
+    bias_m = line_len * math.sin(math.radians(abs(bias_deg)))
+    if bias_deg < 0:
+        bias_m = -bias_m
+
+    if abs(bias_deg) < 2.0:
+        favored = "square"
+    elif bias_deg > 0:
+        favored = "boat"
+    else:
+        favored = "pin"
+
+    return {
+        "favored": favored,
+        "bias_deg": bias_deg,
+        "bias_m": bias_m,
+        "line_len_m": line_len,
+    }
+
+
+def boat_position_along_line(boat_xy, line_a_xy, line_b_xy):
+    """Return position along line as 0..1 (0 = boat-end, 1 = pin-end).
+
+    Negative = past boat-end; >1 = past pin-end.
+    """
+    abx = line_b_xy[0] - line_a_xy[0]
+    aby = line_b_xy[1] - line_a_xy[1]
+    apx = boat_xy[0] - line_a_xy[0]
+    apy = boat_xy[1] - line_a_xy[1]
+    line_len_sq = abx * abx + aby * aby
+    if line_len_sq < 1e-6:
+        return 0.0
+    return (apx * abx + apy * aby) / line_len_sq
+
+
+def get_line_endpoints(conn, vk_session_id, gun_iso):
+    boat = conn.execute(
+        "SELECT latitude_deg, longitude_deg FROM vakaros_line_positions"
+        " WHERE session_id = ? AND line_type = 'boat' AND ts <= ?"
+        " ORDER BY ts DESC LIMIT 1",
+        (vk_session_id, gun_iso),
+    ).fetchone()
+    pin = conn.execute(
+        "SELECT latitude_deg, longitude_deg FROM vakaros_line_positions"
+        " WHERE session_id = ? AND line_type = 'pin' AND ts <= ?"
+        " ORDER BY ts DESC LIMIT 1",
+        (vk_session_id, gun_iso),
+    ).fetchone()
+    if boat is None or pin is None:
+        return None
+    return (boat["latitude_deg"], boat["longitude_deg"], pin["latitude_deg"], pin["longitude_deg"])
+
+
+def main():
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    races = list(
+        conn.execute(
+            "SELECT id, name, date, start_utc, end_utc, vakaros_session_id FROM races"
+            " WHERE end_utc IS NOT NULL AND start_utc != end_utc"
+            "   AND session_type='race' AND name NOT LIKE '%RTTS%'"
+            " ORDER BY start_utc"
+        )
+    )
+
+    # OCS-tagged races. We pull from the entity_tags table when the tag is
+    # present in this DB, then union with a hard-coded fallback so the script
+    # is correct even when running against an older backup that doesn't have
+    # the tag yet (the tags were added on corvopi-live after the 5/12 backup).
+    ocs_ids = {
+        r["entity_id"]
+        for r in conn.execute(
+            "SELECT et.entity_id FROM entity_tags et JOIN tags t ON t.id=et.tag_id"
+            " WHERE t.name='ocs' AND et.entity_type='session'"
+        )
+    } | {35, 55}  # 4/14 BC1, 4/19 PSSR-2
+
+    # Load finishes (Corvo's place per logged-race-id, via local_session_id link)
+    finishes = {}
+    for r in conn.execute(
+        "SELECT r.local_session_id AS log_id, rr.place"
+        " FROM race_results rr"
+        " JOIN races r ON r.id = rr.race_id"
+        " WHERE rr.boat_id = 47 AND r.local_session_id IS NOT NULL"
+    ):
+        finishes[r["log_id"]] = r["place"]
+
+    rows = []
+    for r in races:
+        vk = r["vakaros_session_id"]
+        if vk is None:
+            continue
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events WHERE session_id=?"
+            " AND event_type='race_start' AND ts BETWEEN ? AND ?"
+            " ORDER BY ts DESC LIMIT 1",
+            (vk, r["start_utc"], r["end_utc"]),
+        ).fetchone()
+        if gun is None:
+            continue
+        gun_ts = gun["ts"]
+        gun_dt = datetime.fromisoformat(gun_ts)
+        line = get_line_endpoints(conn, vk, gun_ts)
+        if line is None:
+            continue
+        b_lat, b_lon, p_lat, p_lon = line
+        ref_lat = (b_lat + p_lat) / 2
+        a_xy = latlon_to_xy(b_lat, b_lon, ref_lat)
+        b_xy = latlon_to_xy(p_lat, p_lon, ref_lat)
+
+        # Boat positions: gun-240 (4 min before) to gun+300 (5 min after)
+        # — the wider window lets us track the pre-start setup
+        win_start = (gun_dt - timedelta(seconds=240)).isoformat()
+        win_end = (gun_dt + timedelta(seconds=300)).isoformat()
+        cur = conn.execute(
+            "SELECT substr(ts,1,19) AS k, AVG(latitude_deg) AS la,"
+            " AVG(longitude_deg) AS lo FROM positions"
+            " WHERE ts BETWEEN ? AND ? GROUP BY k ORDER BY k",
+            (win_start, win_end),
+        )
+        positions = list(cur)
+        if len(positions) < 30:
+            continue
+
+        # SOG at gun (avg ±5 sec)
+        sog_cur = conn.execute(
+            "SELECT AVG(sog_kts) FROM cogsog WHERE ts BETWEEN ? AND ?",
+            (
+                (gun_dt - timedelta(seconds=5)).isoformat(),
+                (gun_dt + timedelta(seconds=5)).isoformat(),
+            ),
+        )
+        sog_at_gun = sog_cur.fetchone()[0]
+
+        # Tack at gun: derived from signed TWA (boat-relative wind angle).
+        # Sign convention: positive = wind from starboard side = starboard tack.
+        tack_at_gun = None
+        twa_rows = list(
+            conn.execute(
+                "SELECT wind_angle_deg FROM winds WHERE reference=0 AND ts BETWEEN ? AND ?",
+                (
+                    (gun_dt - timedelta(seconds=10)).isoformat(),
+                    (gun_dt + timedelta(seconds=10)).isoformat(),
+                ),
+            )
+        )
+        if twa_rows:
+            # Each wind_angle_deg is the boat-referenced TWA (in [0, 360)
+            # where 0 = head to wind, 90 = wind from starboard, 180 = dead
+            # downwind, 270 = wind from port). Convert to signed (-180, 180]:
+            #   positive (0–180) = starboard, negative (-180–0) = port.
+            signed_twas = []
+            for tw in twa_rows:
+                signed = ((tw[0] + 180) % 360) - 180  # → (-180, 180]
+                signed_twas.append(signed)
+            avg_signed = statistics.mean(signed_twas)
+            tack_at_gun = "stbd" if avg_signed >= 0 else "port"
+
+        # TWD at gun (median over 60 sec before to 0 sec at gun). Try ref=4
+        # (north-referenced TWD) first, fall back to ref=0 (boat-relative TWA)
+        # + heading.
+        twd_at_gun = None
+        twd_window_start = (gun_dt - timedelta(seconds=60)).isoformat()
+        twd_window_end = gun_dt.isoformat()
+        twd_rows = list(
+            conn.execute(
+                "SELECT wind_angle_deg FROM winds WHERE reference=4 AND ts BETWEEN ? AND ?",
+                (twd_window_start, twd_window_end),
+            )
+        )
+        if twd_rows:
+            twd_at_gun = statistics.median([r[0] % 360 for r in twd_rows])
+        else:
+            # Fall back: ref=0 + heading per second
+            twds = []
+            for w in conn.execute(
+                "SELECT ts, wind_angle_deg FROM winds WHERE reference=0 AND ts BETWEEN ? AND ?",
+                (twd_window_start, twd_window_end),
+            ):
+                hdg_row = conn.execute(
+                    "SELECT heading_deg FROM headings WHERE ts >= ? AND ts < ? LIMIT 1",
+                    (w[0][:19], w[0][:19] + ":99"),
+                ).fetchone()
+                if hdg_row is None:
+                    continue
+                signed = ((w[1] + 180) % 360) - 180
+                twds.append((hdg_row[0] + signed) % 360)
+            if twds:
+                twd_at_gun = statistics.median(twds)
+
+        # Favored-end analysis
+        bias_info = None
+        boat_pos_along = None
+        if twd_at_gun is not None:
+            bias_info = line_bias(a_xy, b_xy, twd_at_gun)
+            # Where on the line did Corvo start? (use boat position at gun)
+            for p in positions:
+                t = datetime.fromisoformat(p["k"]).replace(tzinfo=gun_dt.tzinfo)
+                if abs((t - gun_dt).total_seconds()) <= 1:
+                    xy = latlon_to_xy(p["la"], p["lo"], ref_lat)
+                    boat_pos_along = boat_position_along_line(xy, a_xy, b_xy)
+                    break
+
+        # Compute pre-start side reference (median 60-10 sec before gun)
+        sides_pre = []
+        for p in positions:
+            t = datetime.fromisoformat(p["k"]).replace(tzinfo=gun_dt.tzinfo)
+            if gun_dt - timedelta(seconds=60) <= t <= gun_dt - timedelta(seconds=10):
+                xy = latlon_to_xy(p["la"], p["lo"], ref_lat)
+                d = perp_distance_signed(xy, a_xy, b_xy)
+                if abs(d) > 0.5:
+                    sides_pre.append(1 if d > 0 else -1)
+        if not sides_pre:
+            continue
+        pre_side = 1 if sum(sides_pre) > 0 else -1
+
+        # Distance at gun (signed in pre-start frame: negative = behind line, positive = over)
+        d_at_gun_signed = None
+        for p in positions:
+            t = datetime.fromisoformat(p["k"]).replace(tzinfo=gun_dt.tzinfo)
+            if abs((t - gun_dt).total_seconds()) <= 1:
+                xy = latlon_to_xy(p["la"], p["lo"], ref_lat)
+                d = perp_distance_signed(xy, a_xy, b_xy)
+                # Flip so that negative = pre-start side, positive = race side
+                d_at_gun_signed = d * pre_side * -1  # now: positive = OVER, negative = behind
+                break
+        if d_at_gun_signed is None:
+            continue
+
+        # Time-to-cross: first time after gun when boat is on race side AND stays
+        # there for ≥5 seconds (to ignore brief GPS noise). For OCS-returned
+        # races, we measure the RE-cross (after the boat goes back to clear).
+        is_ocs = r["id"] in ocs_ids
+        ttl_sec = None
+        race_side_streak = 0
+        seen_prestart_after_gun = False
+        for p in positions:
+            t = datetime.fromisoformat(p["k"]).replace(tzinfo=gun_dt.tzinfo)
+            if t < gun_dt:
+                continue
+            xy = latlon_to_xy(p["la"], p["lo"], ref_lat)
+            d = perp_distance_signed(xy, a_xy, b_xy) * pre_side * -1
+            if d > 0:
+                race_side_streak += 1
+                if race_side_streak >= 5 and ttl_sec is None:
+                    # First sustained race-side streak — back-fill to first sec
+                    candidate_ttl = (t - gun_dt).total_seconds() - 4
+                    if candidate_ttl < 0:
+                        candidate_ttl = 0
+                    # For OCS races, only accept this as TTL once we've seen the
+                    # boat on the pre-start side after the gun (the return).
+                    if (not is_ocs) or seen_prestart_after_gun:
+                        ttl_sec = candidate_ttl
+            else:
+                race_side_streak = 0
+                seen_prestart_after_gun = True
+        if ttl_sec is None:
+            ttl_sec = 999  # never crossed in window
+
+        # Composite score (0-100)
+        # Distance: 0 = perfect (right at line). Penalty for behind, cap at -50m.
+        # Over the line is bad too, cap at +5m for "barely on the line"
+        if d_at_gun_signed > 0:
+            d_score = max(0, 50 - 10 * d_at_gun_signed)  # 5m over → 0 pts
+        else:
+            d_score = max(0, 50 + 1.0 * d_at_gun_signed)  # 50m behind → 0 pts
+        # Speed: target 6 kt, penalty for slow
+        spd = sog_at_gun if sog_at_gun else 0
+        s_score = max(0, 30 - 4 * abs(spd - TARGET_SPEED_KT))
+        # Time to cross: 0 best, 30s ok, 60s+ bad
+        if ttl_sec >= 999:
+            t_score = 0
+        else:
+            t_score = max(0, 20 - 0.4 * ttl_sec)
+        score = d_score + s_score + t_score
+        # OCS penalty (already shows up in TTL but make it explicit)
+        if r["id"] in ocs_ids:
+            score *= 0.5
+
+        # Sanity filter: if distance at gun is > 100 m the line endpoints are
+        # almost certainly stale (line moved between races and we don't have
+        # the new pin coords). Skip rather than report a bogus score.
+        if abs(d_at_gun_signed) > 100:
+            print(
+                f"  -- skipping {r['name']}: |dist@gun|={abs(d_at_gun_signed):.0f}m → stale line data"
+            )
+            continue
+
+        # Determine where Corvo started on the line (boat-end / mid / pin-end)
+        if boat_pos_along is None:
+            corvo_end = "?"
+        elif boat_pos_along < 0.33:
+            corvo_end = "boat"
+        elif boat_pos_along > 0.67:
+            corvo_end = "pin"
+        else:
+            corvo_end = "mid"
+
+        # ---- Pre-start positioning trajectory ----
+        # Sample boat position-along-line at gun-180s, gun-120s, gun-60s, gun
+        # to see whether the team "drifted" to the boat-end (habit) or stayed
+        # near where they were positioned during the start sequence.
+        def pos_along_at(target_dt):
+            """Return position-along-line (0..1) at target_dt, or None."""
+            best = None
+            best_dt = None
+            for p in positions:
+                t = datetime.fromisoformat(p["k"]).replace(tzinfo=gun_dt.tzinfo)
+                dt_diff = abs((t - target_dt).total_seconds())
+                if dt_diff <= 5 and (best_dt is None or dt_diff < best_dt):
+                    xy = latlon_to_xy(p["la"], p["lo"], ref_lat)
+                    best = boat_position_along_line(xy, a_xy, b_xy)
+                    best_dt = dt_diff
+            return best
+
+        pos_at_3min = pos_along_at(gun_dt - timedelta(seconds=180))
+        pos_at_2min = pos_along_at(gun_dt - timedelta(seconds=120))
+        pos_at_1min = pos_along_at(gun_dt - timedelta(seconds=60))
+        pos_at_gun = boat_pos_along
+
+        # Classify the trajectory
+        # We mostly care about: did the team move TOWARD the boat-end (0.0)
+        # during the last 3 min? And was there a pre-start position?
+        traj_drift = None  # how much position changed from gun-3min to gun
+        if pos_at_3min is not None and pos_at_gun is not None:
+            traj_drift = pos_at_gun - pos_at_3min
+            # negative = drifted toward boat-end, positive = drifted toward pin
+
+        # Did Corvo start at the favored end?
+        if bias_info is None:
+            got_favored = None
+        elif bias_info["favored"] == "square":
+            got_favored = "—"  # no end favored, doesn't matter
+        elif bias_info["favored"] == corvo_end:
+            got_favored = "✓"
+        elif corvo_end == "mid":
+            # Mid-line on a biased line — half a boat length lost
+            got_favored = "~"
+        else:
+            got_favored = "✗"
+
+        rows.append(
+            {
+                "id": r["id"],
+                "date": r["date"],
+                "name": r["name"],
+                "gun_dt": gun_dt,
+                "d_at_gun_signed": d_at_gun_signed,
+                "sog_at_gun": spd,
+                "ttl_sec": ttl_sec,
+                "score": min(100, score),
+                "ocs": r["id"] in ocs_ids,
+                "place": finishes.get(r["id"]),
+                "twd_at_gun": twd_at_gun,
+                "favored_end": bias_info["favored"] if bias_info else "?",
+                "bias_deg": bias_info["bias_deg"] if bias_info else 0.0,
+                "bias_m": bias_info["bias_m"] if bias_info else 0.0,
+                "line_len_m": bias_info["line_len_m"] if bias_info else 0.0,
+                "corvo_end": corvo_end,
+                "got_favored": got_favored,
+                "pos_at_3min": pos_at_3min,
+                "pos_at_2min": pos_at_2min,
+                "pos_at_1min": pos_at_1min,
+                "pos_at_gun": pos_at_gun,
+                "traj_drift": traj_drift,
+                "tack_at_gun": tack_at_gun,
+            }
+        )
+
+    # ============================================================
+    # Print matrix
+    # ============================================================
+    print("=" * 140)
+    print("START QUALITY MATRIX — sorted chronologically")
+    print("=" * 140)
+    print(
+        f"{'date':<11} {'race':<30} {'dist@gun':>10} {'SOG':>5} "
+        f"{'TTL':>6} {'score':>6} {'fav':>5} {'bias°':>6} {'corvo':>6} "
+        f"{'got?':>5} {'tack':>5} {'place':>5} {'ocs':>4}"
+    )
+    print(f"{'':11} {'':30} {'(m)':>10} {'(kt)':>5} {'(s)':>6}")
+    print("-" * 140)
+    for row in sorted(rows, key=lambda x: x["gun_dt"]):
+        d_str = f"{row['d_at_gun_signed']:+.1f}"
+        if row["ttl_sec"] >= 999:
+            ttl_str = "—"
+        else:
+            ttl_str = f"{row['ttl_sec']:.0f}"
+        ocs_str = "OCS" if row["ocs"] else ""
+        place_str = str(row["place"]) if row["place"] else "—"
+        bias_str = f"{row['bias_deg']:+.0f}" if row["bias_deg"] else "0"
+        print(
+            f"{row['date']:<11} {row['name'][:28]:<30} {d_str:>10} "
+            f"{row['sog_at_gun']:>5.2f} {ttl_str:>6} "
+            f"{row['score']:>6.0f} {row['favored_end']:>5} {bias_str:>6} "
+            f"{row['corvo_end']:>6} {row['got_favored'] or '?':>5} "
+            f"{(row.get('tack_at_gun') or '?'):>5} "
+            f"{place_str:>5} {ocs_str:>4}"
+        )
+
+    # Tack vs corvo_end cross-tab
+    print()
+    print("--- Tack at gun vs end of line chosen ---")
+    cross = defaultdict(int)
+    for row in rows:
+        t = row.get("tack_at_gun") or "?"
+        c = row.get("corvo_end") or "?"
+        cross[(t, c)] += 1
+    print(f"{'tack':>8} {'boat':>6} {'mid':>6} {'pin':>6}")
+    for tack in ("stbd", "port"):
+        b = cross.get((tack, "boat"), 0)
+        m = cross.get((tack, "mid"), 0)
+        p = cross.get((tack, "pin"), 0)
+        print(f"{tack:>8} {b:>6} {m:>6} {p:>6}")
+
+    # ============================================================
+    # Plot trend
+    # ============================================================
+    rows.sort(key=lambda x: x["gun_dt"])
+    dates = [r["gun_dt"] for r in rows]
+    scores = [r["score"] for r in rows]
+    dists = [r["d_at_gun_signed"] for r in rows]
+    sogs = [r["sog_at_gun"] for r in rows]
+    ttls = [min(r["ttl_sec"], 60) for r in rows]
+    ocs_mask = [r["ocs"] for r in rows]
+
+    fig, axes = plt.subplots(4, 1, figsize=(11, 11), sharex=True)
+
+    # Score
+    ax = axes[0]
+    colors = ["red" if o else "tab:blue" for o in ocs_mask]
+    ax.scatter(dates, scores, c=colors, s=80, zorder=3)
+    ax.plot(dates, scores, color="tab:blue", alpha=0.4, zorder=2)
+    # Trend line (linear regression)
+    if len(dates) >= 3:
+        x_num = mdates.date2num(dates)
+        m, b = (
+            lambda x, y: (
+                (
+                    sum((xi - sum(x) / len(x)) * (yi - sum(y) / len(y)) for xi, yi in zip(x, y))
+                    / max(1e-6, sum((xi - sum(x) / len(x)) ** 2 for xi in x))
+                ),
+                sum(y) / len(y)
+                - (
+                    sum((xi - sum(x) / len(x)) * (yi - sum(y) / len(y)) for xi, yi in zip(x, y))
+                    / max(1e-6, sum((xi - sum(x) / len(x)) ** 2 for xi in x))
+                )
+                * (sum(x) / len(x)),
+            )
+        )(x_num, scores)
+        trend = [m * xi + b for xi in x_num]
+        ax.plot(
+            dates, trend, "g--", alpha=0.6, label=f"trend ({'improving' if m > 0 else 'declining'})"
+        )
+        ax.legend(loc="lower right", fontsize=9)
+    ax.set_ylabel("Composite\nstart score")
+    ax.set_ylim(0, 100)
+    ax.grid(True, alpha=0.3)
+    ax.set_title(
+        "Start quality over the season — Corvo 105\n"
+        "Red dots = OCS races (composite score halved as penalty)",
+        fontsize=11,
+    )
+
+    # Distance at gun
+    ax = axes[1]
+    ax.scatter(dates, dists, c=colors, s=80, zorder=3)
+    ax.plot(dates, dists, color="tab:orange", alpha=0.4, zorder=2)
+    ax.axhline(y=0, color="black", linestyle="--", alpha=0.4, label="on the line")
+    ax.fill_between(
+        dates,
+        [-100] * len(dates),
+        [0] * len(dates),
+        color="tab:blue",
+        alpha=0.05,
+        label="behind line",
+    )
+    ax.fill_between(
+        dates, [0] * len(dates), [100] * len(dates), color="tab:red", alpha=0.05, label="over line"
+    )
+    ax.set_ylabel("Distance from line\nat gun (m)")
+    ax.set_ylim(-50, 30)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="lower right", fontsize=8)
+
+    # Speed at gun
+    ax = axes[2]
+    ax.scatter(dates, sogs, c=colors, s=80, zorder=3)
+    ax.plot(dates, sogs, color="tab:green", alpha=0.4, zorder=2)
+    ax.axhline(
+        y=TARGET_SPEED_KT,
+        color="black",
+        linestyle="--",
+        alpha=0.4,
+        label=f"target {TARGET_SPEED_KT} kt",
+    )
+    ax.set_ylabel("SOG at gun (kt)")
+    ax.set_ylim(0, 9)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="lower right", fontsize=8)
+
+    # TTL
+    ax = axes[3]
+    ax.scatter(dates, ttls, c=colors, s=80, zorder=3)
+    ax.plot(dates, ttls, color="tab:purple", alpha=0.4, zorder=2)
+    ax.set_ylabel("Time to clear line\nafter gun (s, capped at 60)")
+    ax.set_ylim(0, 65)
+    ax.grid(True, alpha=0.3)
+
+    axes[-1].xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
+    fig.autofmt_xdate()
+    fig.tight_layout()
+    fig.savefig(OUT, dpi=140, bbox_inches="tight")
+    print(f"\nWrote {OUT}")
+
+    # ============================================================
+    # Pre-start positioning trajectory (habit vs opportunistic)
+    # ============================================================
+    print()
+    print("=" * 100)
+    print("PRE-START TRAJECTORY — boat position-along-line over time (0=boat-end, 1=pin-end)")
+    print("=" * 100)
+    print(
+        f"{'date':<11} {'race':<32} {'gun-3m':>7} {'gun-2m':>7} {'gun-1m':>7} {'gun':>7}"
+        f"  {'drift':>7} {'fav':>5} {'final':>6}"
+    )
+    print("-" * 95)
+    drifts = []
+    starts_at_3min = []
+    finals_at_gun = []
+    for row in sorted(rows, key=lambda x: x["gun_dt"]):
+
+        def fmt(p):
+            if p is None:
+                return "  —  "
+            return f"{p:+.2f}"
+
+        drift_str = ""
+        if row["traj_drift"] is not None:
+            d = row["traj_drift"]
+            if abs(d) < 0.10:
+                drift_str = "stable"
+            elif d < 0:
+                drift_str = "→boat"
+            else:
+                drift_str = "→pin"
+            drifts.append(d)
+        if row["pos_at_3min"] is not None:
+            starts_at_3min.append(row["pos_at_3min"])
+        if row["pos_at_gun"] is not None:
+            finals_at_gun.append(row["pos_at_gun"])
+        print(
+            f"{row['date']:<11} {row['name'][:30]:<32} "
+            f"{fmt(row['pos_at_3min']):>7} {fmt(row['pos_at_2min']):>7} "
+            f"{fmt(row['pos_at_1min']):>7} {fmt(row['pos_at_gun']):>7}  "
+            f"{drift_str:>7} {row['favored_end']:>5} {row['corvo_end']:>6}"
+        )
+
+    print()
+    print("-- Trajectory summary --")
+    if drifts:
+        print(
+            f"  Mean drift gun-3m → gun: {statistics.mean(drifts):+.2f}  "
+            f"(negative = drifted toward boat-end)"
+        )
+        toward_boat = sum(1 for d in drifts if d < -0.10)
+        toward_pin = sum(1 for d in drifts if d > 0.10)
+        stable = sum(1 for d in drifts if abs(d) <= 0.10)
+        print(f"  Drifted toward boat-end: {toward_boat}")
+        print(f"  Drifted toward pin-end:  {toward_pin}")
+        print(f"  Stayed stable:           {stable}")
+    if starts_at_3min:
+        boat_at_3min = sum(1 for p in starts_at_3min if p < 0.33)
+        pin_at_3min = sum(1 for p in starts_at_3min if p > 0.67)
+        mid_at_3min = len(starts_at_3min) - boat_at_3min - pin_at_3min
+        print(f"\n  At gun-3min: boat-end={boat_at_3min}, mid={mid_at_3min}, pin-end={pin_at_3min}")
+    if finals_at_gun:
+        boat_at_gun = sum(1 for p in finals_at_gun if p < 0.33)
+        pin_at_gun = sum(1 for p in finals_at_gun if p > 0.67)
+        mid_at_gun = len(finals_at_gun) - boat_at_gun - pin_at_gun
+        print(f"  At gun:      boat-end={boat_at_gun}, mid={mid_at_gun}, pin-end={pin_at_gun}")
+
+    print()
+    print("Verdict logic:")
+    print("  - If most races show 'stable' drift AND start_pos correlates with final_pos:")
+    print("      → opportunistic (final position reflects where the boat happened to be)")
+    print("  - If most races show 'drifted toward boat-end' AND finals cluster at boat-end")
+    print("    regardless of starting position: → habit / boat-end preference")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Tooling drop from a Spring 2026 end-of-season debrief for Corvo 105.
Brings the analysis scripts I wrote during the review into the repo so
they don't get lost, and adds two skills wired to them for ongoing use.

- **`scripts/analysis/`** — six standalone Python scripts (~2k LOC):
  - `full_analysis.py` — VMG / shift / current / scorecard
  - `polar_plot.py` — TWA + AWA polar diagrams + heatmap
  - `awa_table.py` — TWA → AWA conversion lookup
  - `current_and_shifts.py` — early current + shift work (kept for reference)
  - `ocs_detect.py` — OCS-returned race detection from line endpoints + boat track
  - `start_quality.py` — start matrix (dist@gun, SOG, TTL, score), favored-end
    analysis, pre-start trajectory, tack at gun, trend chart
  - All read DB via `HELMLOG_DB` env var (default `data/logger.db`); output
    PNGs honor `HELMLOG_OUT_DIR`
  - `pyproject.toml` adds a per-file-ignores entry so these one-shot scripts
    aren't held to the strict ANN/E7/SIM/etc. rules of the production code
- **`.claude/skills/debrief`** — `/debrief [race-id]` runs a focused
  per-race analysis, pulls + analyzes audio transcripts (kicks off
  transcription if missing), and creates a moment + comment on the
  session in the helmlog UI with the synthesized debrief
- **`.claude/skills/ocs-check`** — `/ocs-check` runs OCS detection
  against the live DB and applies the `ocs` tag to any newly-identified
  OCS-returned races (skips the high-FPR "no return" cases)

Both skills hit the live `weaties@corvopi-live` DB via SSH + sqlite3
for reads, and via SQL inserts for writes (avoids the auth flow needed
for the helmlog API). The transcript section uses the API since
that's the only way to wake up the worker process.

The actual debrief output (`CREW_DEBRIEF.md`, polar PNGs, DOCX) lives
outside the repo in `~/Backups/helmlog/_analysis/` since it's
boat-specific data. Only the reusable tooling is being committed here.

## Test plan

- [ ] `HELMLOG_DB=path/to/backup/logger.db uv run python scripts/analysis/full_analysis.py` produces a sensible scorecard
- [ ] `HELMLOG_OUT_DIR=/tmp uv run python scripts/analysis/polar_plot.py` writes polar.png + polar_awa.png + polar_heatmap.png
- [ ] `uv run python scripts/analysis/start_quality.py` shows the matrix + writes start_quality_trend.png
- [ ] `uv run python scripts/analysis/ocs_detect.py` flags 4/14 BC1 + 4/19 PSSR-2 as `OCS — RETURNED` (against the 5/12 backup)
- [ ] `uv run ruff check .` and `uv run ruff format --check .` both clean
- [ ] After merge: `/debrief` skill works end-to-end on a recent race (creates moment, attaches transcript notes if available)
- [ ] `/ocs-check` skill correctly identifies pre-tagged OCS races without re-tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)