### PR TITLE
feat(current): per-tack compass offset in compute_set_drift

### DIFF
--- a/src/helmlog/boat_settings.py
+++ b/src/helmlog/boat_settings.py
@@ -97,6 +97,20 @@ PARAMETERS: tuple[ParameterDef, ...] = (
         "number",
         "instrument_calibration",
     ),
+    ParameterDef(
+        "compass_offset_port",
+        "Compass offset (port tack)",
+        "°",
+        "number",
+        "instrument_calibration",
+    ),
+    ParameterDef(
+        "compass_offset_stbd",
+        "Compass offset (stbd tack)",
+        "°",
+        "number",
+        "instrument_calibration",
+    ),
     ParameterDef("mast_height", "Mast height", "m", "number", "instrument_calibration"),
 )
 

--- a/src/helmlog/cache.py
+++ b/src/helmlog/cache.py
@@ -49,6 +49,7 @@ def compute_race_data_hash(
     row_count: int,
     linked_imported_id: int | None = None,
     linked_imported_results: int = 0,
+    calibration_hash: str = "",
 ) -> str:
     """Stable 16-char hex digest of the race's cache-relevant inputs.
 
@@ -61,6 +62,12 @@ def compute_race_data_hash(
     imported-results link into the hash so ETag revalidation flips when
     a session's results are linked, unlinked, or rewritten — otherwise
     browsers that cached an empty-results response keep getting 304s.
+
+    ``calibration_hash`` (#711) folds in the boat-wide calibration
+    values that affect computed outputs (leeway, per-tack compass
+    offsets). When an admin updates a calibration constant the hash
+    flips and downstream caches (session replay, summary, …) miss on
+    the next read and recompute with the new values.
     """
     payload = {
         "race_id": race_id,
@@ -69,6 +76,7 @@ def compute_race_data_hash(
         "row_count": row_count,
         "linked_imported_id": linked_imported_id,
         "linked_imported_results": linked_imported_results,
+        "calibration_hash": calibration_hash,
     }
     raw = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
@@ -134,6 +142,14 @@ async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
 
     start_dt = datetime.fromisoformat(start_iso.replace("Z", "+00:00"))
     end_dt = datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else None
+    # Calibration inputs that flow through the compute path (#711). When an
+    # admin changes any of these, every per-race cache entry should miss on
+    # the next read and recompute with the new values.
+    calibration_hash = hashlib.sha256(
+        f"leeway={storage._leeway_k:.6f}|"
+        f"compass_port={storage._compass_offset_port:.6f}|"
+        f"compass_stbd={storage._compass_offset_stbd:.6f}".encode()
+    ).hexdigest()[:12]
     return compute_race_data_hash(
         race_id=race_id,
         start_utc=start_dt,
@@ -141,6 +157,7 @@ async def resolve_race_data_hash(storage: Storage, race_id: int) -> str | None:
         row_count=row_count,
         linked_imported_id=linked_imported_id,
         linked_imported_results=linked_imported_results,
+        calibration_hash=calibration_hash,
     )
 
 

--- a/src/helmlog/current.py
+++ b/src/helmlog/current.py
@@ -26,6 +26,8 @@ def compute_set_drift(
     hdg: float | None,
     heel_deg: float | None = None,
     leeway_k: float | None = None,
+    compass_offset_port: float = 0.0,
+    compass_offset_stbd: float = 0.0,
 ) -> tuple[float, float] | None:
     """Return (set_deg, drift_kts) or None if any required input is missing.
 
@@ -55,6 +57,20 @@ def compute_set_drift(
 
     ``leeway_k`` is boat-specific (typically 8–15 for a 30–40 ft
     sailboat). On HelmLog it lives in ``boat_settings.leeway_coefficient``.
+
+    Per-tack compass offset
+    -----------------------
+    Magnetic deviation curves are direction-dependent: a flat-deck
+    compass swing rarely matches deviation seen at race heel. The
+    residual is roughly tack-symmetric and not captured by a single
+    global ``heading_offset``. When non-zero, ``compass_offset_port``
+    is added to HDG while ``heel_deg > 0`` (port tack), and
+    ``compass_offset_stbd`` while ``heel_deg < 0`` (starboard tack).
+    Both default to 0.0 so behavior is unchanged for callers that
+    don't pass them. The offsets live in
+    ``boat_settings.compass_offset_port`` /
+    ``boat_settings.compass_offset_stbd`` and are typically derived
+    from a joint-fit against a session's maneuvers.
     """
     if sog is None or cog is None or stw is None or hdg is None:
         return None
@@ -62,6 +78,10 @@ def compute_set_drift(
     if heel_deg is not None and leeway_k is not None and leeway_k != 0.0:
         lee_deg = leeway_k * heel_deg / (max(abs(stw), 1.0) ** 2)
         hdg = (hdg + lee_deg) % 360.0
+
+    if heel_deg is not None and (compass_offset_port or compass_offset_stbd):
+        delta = compass_offset_port if heel_deg > 0 else compass_offset_stbd
+        hdg = (hdg + delta) % 360.0
 
     n_g, e_g = _polar_to_ne(sog, cog)
     n_w, e_w = _polar_to_ne(stw, hdg)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1510,6 +1510,8 @@ async def _compute_session_replay(storage: Storage, session_id: int) -> dict[str
             hdg=hdg_v,
             heel_deg=heel_v,
             leeway_k=storage._leeway_k,
+            compass_offset_port=storage._compass_offset_port,
+            compass_offset_stbd=storage._compass_offset_stbd,
         )
         set_v: float | None = sd[0] if sd is not None else None
         drift_v: float | None = sd[1] if sd is not None else None

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2213,6 +2213,12 @@ class Storage:
         # up admin changes. Default 10 is a reasonable starting point for a
         # 30–40 ft sailboat — admin can tune via /admin/boats.
         self._leeway_k: float = 10.0
+        # Per-tack compass offsets for the live current compute (#711). Loaded
+        # from boat_settings on connect; refresh_compass_offsets() picks up
+        # admin changes. Both default to 0.0 so non-tuned boats keep current
+        # behavior.
+        self._compass_offset_port: float = 0.0
+        self._compass_offset_stbd: float = 0.0
         self._last_rudder_write: float = 0.0
         self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
@@ -2294,7 +2300,16 @@ class Storage:
         stw = self._live["bsp_kts"]
         hdg = self._live["heading_deg"]
         heel = self._live.get("heel_deg")
-        result = compute_set_drift(sog, cog, stw, hdg, heel_deg=heel, leeway_k=self._leeway_k)
+        result = compute_set_drift(
+            sog,
+            cog,
+            stw,
+            hdg,
+            heel_deg=heel,
+            leeway_k=self._leeway_k,
+            compass_offset_port=self._compass_offset_port,
+            compass_offset_stbd=self._compass_offset_stbd,
+        )
         if result is None:
             return
         set_raw, drift_raw = result
@@ -2402,6 +2417,29 @@ class Storage:
                 break
         return self._leeway_k
 
+    async def refresh_compass_offsets(self) -> tuple[float, float]:
+        """Reload ``boat_settings.compass_offset_port`` /
+        ``compass_offset_stbd`` into the cached attributes (#711). Returns
+        ``(port, stbd)``. Called from ``connect()`` and on every settings
+        write that touches either parameter."""
+        try:
+            rows = await self.current_boat_settings(race_id=None)
+        except Exception:
+            return (self._compass_offset_port, self._compass_offset_stbd)
+        import contextlib
+
+        for row in rows:
+            param = row["parameter"]
+            if param not in ("compass_offset_port", "compass_offset_stbd"):
+                continue
+            with contextlib.suppress(TypeError, ValueError):
+                val = float(row["value"])
+                if param == "compass_offset_port":
+                    self._compass_offset_port = val
+                else:
+                    self._compass_offset_stbd = val
+        return (self._compass_offset_port, self._compass_offset_stbd)
+
     async def refresh_smoothing(self) -> dict[str, float]:
         """Reload per-channel time constants from ``app_settings`` and apply
         them to the live smoothers without losing accumulated state.
@@ -2462,6 +2500,7 @@ class Storage:
         self._active_race_id = current.id if current is not None else None
         await self.refresh_smoothing()
         await self.refresh_leeway_k()
+        await self.refresh_compass_offsets()
 
     async def close(self) -> None:
         """Flush any buffered writes and close the database connections."""
@@ -9677,6 +9716,8 @@ class Storage:
         # without a service restart (#730 follow-up).
         if any(e["parameter"] == "leeway_coefficient" for e in entries):
             await self.refresh_leeway_k()
+        if any(e["parameter"] in ("compass_offset_port", "compass_offset_stbd") for e in entries):
+            await self.refresh_compass_offsets()
         return ids
 
     async def list_boat_settings(self, race_id: int | None) -> list[dict[str, Any]]:

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2608,9 +2608,15 @@ class Storage:
         if current < 41:
             await self._migrate_v41_sail_changes()
 
-        # Post-DDL data migration for v55 (unified controls)
+        # Post-DDL data migration for v55 (unified controls).
         if current < 55:
             await self._migrate_v55_controls()
+
+        # PARAMETERS-as-source-of-truth sync (#711 follow-up). Always called;
+        # idempotent INSERT OR IGNORE means new ParameterDef additions to
+        # boat_settings.PARAMETERS auto-flow into the controls table on the
+        # next service start without needing a new migration each time.
+        await self._sync_controls_from_parameters()
 
         # Post-DDL data migration for v56 (seed categories)
         if current < 56:
@@ -2919,6 +2925,33 @@ class Storage:
             len(PARAMETERS) + len(aruco_rows),
             len(aruco_rows),
         )
+
+    async def _sync_controls_from_parameters(self) -> None:
+        """Ensure every ParameterDef in ``boat_settings.PARAMETERS`` is
+        present in the ``controls`` table (#711 follow-up).
+
+        Runs every connect. ``INSERT OR IGNORE`` against the UNIQUE(name)
+        constraint makes it idempotent — existing rows aren't touched
+        (admins may have customized label/sort_order), and new
+        PARAMETERS entries appear on /admin/controls without needing a
+        per-addition migration.
+        """
+        from helmlog.boat_settings import PARAMETERS
+
+        db = self._conn()
+        added = 0
+        for order, p in enumerate(PARAMETERS):
+            cur = await db.execute(
+                "INSERT OR IGNORE INTO controls"
+                " (name, label, unit, input_type, category, sort_order)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (p.name, p.label, p.unit, p.input_type, p.category, order),
+            )
+            if cur.rowcount > 0:
+                added += 1
+        if added:
+            await db.commit()
+            logger.info("Synced {} new ParameterDef(s) into controls table", added)
 
     async def _migrate_v56_categories(self) -> None:
         """Data migration for v56: seed control_categories from CATEGORY_ORDER."""

--- a/tests/test_current.py
+++ b/tests/test_current.py
@@ -177,3 +177,96 @@ class TestLeewayCorrection:
         set_v, drift_v = sd
         assert 0.0 <= set_v < 360.0
         assert math.isfinite(drift_v)
+
+
+class TestCompassOffsets:
+    """Per-tack compass offset correction (#711). Magnetic deviation is
+    direction-dependent; a flat-deck swing won't catch what the heeled
+    boat sees on each tack. Two scalar offsets close that gap."""
+
+    def test_zero_offsets_no_op(self) -> None:
+        """Default-zero kwargs preserve behavior for boats that haven't tuned."""
+        sd_zero = compute_set_drift(
+            sog=5.0,
+            cog=10.0,
+            stw=5.0,
+            hdg=0.0,
+            heel_deg=20.0,
+            compass_offset_port=0.0,
+            compass_offset_stbd=0.0,
+        )
+        sd_default = compute_set_drift(sog=5.0, cog=10.0, stw=5.0, hdg=0.0, heel_deg=20.0)
+        assert sd_zero == sd_default
+
+    def test_port_offset_applied_when_heel_positive(self) -> None:
+        """Heel > 0 selects the port-tack offset."""
+        # With heel=+20 and port offset of -9°, effective hdg shifts by -9.
+        # Compare against the same scenario with hdg shifted -9 manually,
+        # offsets zero.
+        sd_with = compute_set_drift(
+            sog=5.0,
+            cog=10.0,
+            stw=5.0,
+            hdg=100.0,
+            heel_deg=20.0,
+            compass_offset_port=-9.0,
+            compass_offset_stbd=5.0,
+        )
+        sd_manual = compute_set_drift(sog=5.0, cog=10.0, stw=5.0, hdg=91.0, heel_deg=20.0)
+        assert sd_with is not None and sd_manual is not None
+        assert sd_with[0] == pytest.approx(sd_manual[0], abs=1e-6)
+        assert sd_with[1] == pytest.approx(sd_manual[1], abs=1e-6)
+
+    def test_stbd_offset_applied_when_heel_negative(self) -> None:
+        """Heel < 0 selects the starboard-tack offset."""
+        sd_with = compute_set_drift(
+            sog=5.0,
+            cog=10.0,
+            stw=5.0,
+            hdg=100.0,
+            heel_deg=-20.0,
+            compass_offset_port=-9.0,
+            compass_offset_stbd=5.0,
+        )
+        sd_manual = compute_set_drift(sog=5.0, cog=10.0, stw=5.0, hdg=105.0, heel_deg=-20.0)
+        assert sd_with is not None and sd_manual is not None
+        assert sd_with[0] == pytest.approx(sd_manual[0], abs=1e-6)
+        assert sd_with[1] == pytest.approx(sd_manual[1], abs=1e-6)
+
+    def test_offsets_skipped_when_heel_missing(self) -> None:
+        """Without heel, neither offset can be selected — keeps the
+        function safe to call on samples where attitudes aren't logged."""
+        sd_with = compute_set_drift(
+            sog=5.0,
+            cog=10.0,
+            stw=5.0,
+            hdg=100.0,
+            heel_deg=None,
+            compass_offset_port=-9.0,
+            compass_offset_stbd=5.0,
+        )
+        sd_without = compute_set_drift(sog=5.0, cog=10.0, stw=5.0, hdg=100.0)
+        assert sd_with == sd_without
+
+    def test_offsets_compose_with_leeway(self) -> None:
+        """Both corrections shift the same hdg in sequence — verify the
+        composed effect matches an equivalent manual shift."""
+        K = 12.0
+        STW = 6.0
+        heel = 20.0
+        port_offset = -9.0
+        lee = K * heel / max(STW, 1.0) ** 2
+        eff_hdg = (100.0 + lee + port_offset) % 360.0
+        sd_with = compute_set_drift(
+            sog=5.0,
+            cog=10.0,
+            stw=STW,
+            hdg=100.0,
+            heel_deg=heel,
+            leeway_k=K,
+            compass_offset_port=port_offset,
+        )
+        sd_manual = compute_set_drift(sog=5.0, cog=10.0, stw=STW, hdg=eff_hdg)
+        assert sd_with is not None and sd_manual is not None
+        assert sd_with[0] == pytest.approx(sd_manual[0], abs=1e-6)
+        assert sd_with[1] == pytest.approx(sd_manual[1], abs=1e-6)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3005,7 +3005,7 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
     # Should be the last category
     assert cats[-1] == "instrument_calibration"
 
-    # All 15 calibration params present
+    # All 17 calibration params present
     cal_params = next(c for c in data["categories"] if c["category"] == "instrument_calibration")
     param_names = [p["name"] for p in cal_params["parameters"]]
     expected = [
@@ -3023,6 +3023,8 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
         "trim_offset",
         "leeway_coefficient",
         "rudder_angle_offset",
+        "compass_offset_port",
+        "compass_offset_stbd",
         "mast_height",
     ]
     assert param_names == expected

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3047,6 +3047,26 @@ async def test_instrument_calibration_labels_no_h5000_suffix(storage: Storage) -
 
 
 @pytest.mark.asyncio
+async def test_compass_offsets_seeded_into_controls_table(storage: Storage) -> None:
+    """#711 follow-up: migration v86 seeds the per-tack compass offsets
+    into the controls table so they appear on /admin/controls alongside
+    the rest of the instrument-calibration controls."""
+    cur = await storage._conn().execute(
+        "SELECT name, label, unit, category FROM controls"
+        " WHERE name IN ('compass_offset_port', 'compass_offset_stbd')"
+        " ORDER BY name"
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    assert len(rows) == 2, f"expected both compass-offset rows, got {rows}"
+    by_name = {r["name"]: r for r in rows}
+    assert by_name["compass_offset_port"]["label"] == "Compass offset (port tack)"
+    assert by_name["compass_offset_stbd"]["label"] == "Compass offset (stbd tack)"
+    for r in rows:
+        assert r["unit"] == "°"
+        assert r["category"] == "instrument_calibration"
+
+
+@pytest.mark.asyncio
 async def test_instrument_calibration_create_and_retrieve(storage: Storage) -> None:
     """POST/GET boat-settings works for calibration parameters."""
     app = create_app(storage)

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -62,6 +62,20 @@ def test_compute_race_data_hash_accepts_null_end_utc() -> None:
     assert compute_race_data_hash(race_id=42, start_utc=start, end_utc=None, row_count=0)
 
 
+def test_compute_race_data_hash_flips_on_calibration_change() -> None:
+    """#711: a change to the calibration hash must produce a fresh data
+    hash so per-race caches miss and recompute with the new offsets."""
+    start = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    end = datetime(2026, 4, 1, 13, 30, tzinfo=UTC)
+    base = compute_race_data_hash(
+        race_id=42, start_utc=start, end_utc=end, row_count=100, calibration_hash="cal-v1"
+    )
+    changed = compute_race_data_hash(
+        race_id=42, start_utc=start, end_utc=end, row_count=100, calibration_hash="cal-v2"
+    )
+    assert base != changed
+
+
 # ---------------------------------------------------------------------------
 # T1 process LRU with TTL
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds two optional kwargs to `compute_set_drift` — `compass_offset_port` (applied when `heel > 0`) and `compass_offset_stbd` (applied when `heel < 0`). Both default to 0.0, so callers and boats that haven't tuned see no behavior change.
- Two new `ParameterDef`s (`compass_offset_port` / `compass_offset_stbd`) in `boat_settings.instrument_calibration` so admins can set values per boat.
- `Storage` caches the offsets alongside `_leeway_k` (`refresh_compass_offsets()`), refreshed on connect and on every settings write touching either parameter — admin tuning takes effect on the live broadcast without a service restart.
- `routes/sessions.py` session-detail endpoint passes the cached values.

Magnetic deviation is direction-dependent: a flat-deck compass swing rarely matches deviation seen at race heel. The residual is roughly tack-symmetric and not captured by the single global `heading_offset`. Together with the existing leeway correction (#730), this closes the per-tack flip in derived current.

Closes #711.

## Validation steps for you

1. **Spot-check defaults preserved:** open an existing session detail page (any boat without these new settings filled in). Set/drift should look identical to before — confirm with a session you know well.
2. **Wire Corvo's joint-fit values** in admin → boat settings → instrument calibration:
   - `Leeway coefficient` = `8` (if not already set; the issue's joint-fit puts K=8)
   - `Compass offset (port tack)` = `-9`
   - `Compass offset (stbd tack)` = `+5`
3. **Recheck a maneuver where the old code visibly flipped current at the tack** (e.g. `results/2026-04-30/charts/maneuver_0437_rounding_2026-04-23.png` in the calibration repo, or any session with the 79% flip-rate symptom). Expected: median |Δset| at maneuver drops from ~55° to ~30°, drift flip rate drops from ~79% to ~57%.
4. **Live broadcast:** while the service is running, change `compass_offset_port` from 0 → -9 in admin. The live set/drift gauge should pick up the change without a restart (the same hot-reload path as leeway).
5. **Other boats:** confirm a boat without these settings configured still shows identical set/drift to pre-merge.

## Test plan
- [x] `uv run pytest tests/test_current.py tests/test_web.py` — all pass (16 in current.py, 192 in web.py)
- [x] `uv run ruff check` / `ruff format` clean on touched files
- [x] `uv run mypy src/helmlog/current.py src/helmlog/boat_settings.py` clean
- [ ] Manual: confirm admin UI shows the two new fields under instrument calibration
- [ ] Manual: enter Corvo values, verify maneuver flip rate drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)