### PR TITLE
feat(home): collapse race-end + debrief into one continuous session flow

### DIFF
--- a/src/helmlog/audio.py
+++ b/src/helmlog/audio.py
@@ -474,16 +474,14 @@ async def capture_start(
     if isinstance(recorder, AudioRecorderGroup):
         import asyncio as _asyncio
 
-        from helmlog.usb_audio import detect_all_capture_devices
+        from helmlog.usb_audio import DetectedDevice, detect_all_capture_devices
 
         # Chained race-end → debrief-start (#762) immediately re-acquires
         # the USB capture devices that capture_stop just released. On
         # Linux the kernel holds the handles for a fraction of a second,
         # so detect_all_capture_devices can briefly return [] right after
         # the stop. Retry a few times with short backoff before failing.
-        from helmlog.usb_audio import DetectedDevice as _DetectedDevice
-
-        devices: list[_DetectedDevice] = []
+        devices: list[DetectedDevice] = []
         for _attempt in range(6):
             devices = detect_all_capture_devices(min_channels=1)
             if devices:

--- a/src/helmlog/audio.py
+++ b/src/helmlog/audio.py
@@ -472,9 +472,25 @@ async def capture_start(
     current topology — debrief is not blocked by the change.
     """
     if isinstance(recorder, AudioRecorderGroup):
+        import asyncio as _asyncio
+
         from helmlog.usb_audio import detect_all_capture_devices
 
-        devices = detect_all_capture_devices(min_channels=1)
+        # Chained race-end → debrief-start (#762) immediately re-acquires
+        # the USB capture devices that capture_stop just released. On
+        # Linux the kernel holds the handles for a fraction of a second,
+        # so detect_all_capture_devices can briefly return [] right after
+        # the stop. Retry a few times with short backoff before failing.
+        from helmlog.usb_audio import DetectedDevice as _DetectedDevice
+
+        devices: list[_DetectedDevice] = []
+        for _attempt in range(6):
+            devices = detect_all_capture_devices(min_channels=1)
+            if devices:
+                break
+            await _asyncio.sleep(0.25)
+        else:
+            logger.warning("capture_start: no devices detected after 6 retries (1.5s)")
 
         if prev_capture_group_id is not None:
             await _warn_if_device_set_changed(

--- a/src/helmlog/static/home.js
+++ b/src/helmlog/static/home.js
@@ -148,7 +148,6 @@ function render(s) {
   const btnStartPractice = document.getElementById('btn-start-practice');
 
   const instCard = document.getElementById('instruments-card');
-  const btnDebriefLast = document.getElementById('btn-debrief-last');
   const todaySummary = document.getElementById('today-summary');
   const controlsDiv = document.getElementById('controls');
 
@@ -170,12 +169,11 @@ function render(s) {
     btnEnd.classList.remove('hidden');
     btnStartRace.classList.add('hidden');
     btnStartPractice.classList.add('hidden');
-    btnDebriefLast.classList.add('hidden');
     document.getElementById('cur-name').textContent = cur.name;
     document.getElementById('cur-meta').textContent =
       'Started ' + fmtTime(cur.start_utc);
     curRaceStartMs = new Date(cur.start_utc).getTime();
-    btnEnd.textContent = '■ END ' + cur.name;
+    btnEnd.textContent = '■ FINISH ' + cur.name;
     if(cur.id !== _crewLoadedForRaceId) {
       _crewLoadedForRaceId = cur.id;
       if (_crewMetaLoaded) loadCrewCurrentValues();
@@ -210,7 +208,6 @@ function render(s) {
     // Hide start buttons during debrief
     btnStartRace.classList.add('hidden');
     btnStartPractice.classList.add('hidden');
-    btnDebriefLast.classList.add('hidden');
   } else {
     debriefCard.classList.add('hidden');
     debriefStartMs = null;
@@ -243,16 +240,6 @@ function render(s) {
     schedPanel.classList.add('hidden');
     schedCountdown.classList.add('hidden');
     _stopScheduleCountdown();
-  }
-
-  // --- Debrief last race button: show when idle, has recorder, and finished races exist ---
-  const lastFinished = (s.today_races || []).filter(r => r.end_utc).slice(-1)[0];
-  if (isIdle && s.has_recorder && lastFinished) {
-    btnDebriefLast.classList.remove('hidden');
-    btnDebriefLast.textContent = '🎙 DEBRIEF ' + lastFinished.name;
-    btnDebriefLast.dataset.raceId = lastFinished.id;
-  } else {
-    btnDebriefLast.classList.add('hidden');
   }
 
   // --- Compact today's summary (idle only) ---
@@ -1041,12 +1028,12 @@ let _endConfirmTimer = null;
 let _endCountdownInterval = null;
 const END_CONFIRM_SECONDS = 4;
 
-function confirmEndRace() {
+function confirmFinishRace() {
   const btn = document.getElementById('btn-end');
   if (btn.dataset.confirming === 'true') {
-    // Second tap — actually end the race
+    // Second tap — finish the race and auto-start the debrief (#762)
     _clearEndConfirm(btn);
-    endRace();
+    finishRace();
     return;
   }
   // First tap — start countdown
@@ -1073,29 +1060,73 @@ function _clearEndConfirm(btn) {
   btn.dataset.confirming = '';
   btn.classList.remove('btn-end-confirm');
   if (state && state.current_race) {
-    btn.textContent = '\u25A0 END ' + state.current_race.name;
+    btn.textContent = '\u25A0 FINISH ' + state.current_race.name;
   }
 }
 
-async function endRace() {
+async function finishRace() {
+  // FINISH RACE: end the race recording, then silently start a debrief in
+  // the same session (#762). The /end endpoint runs the post-race side
+  // effects (camera stop, maneuver detect, polar warm, cache warm); the
+  // /debrief/start endpoint opens the new audio session against the same
+  // race row.
   if(!state || !state.current_race) return;
-  await fetch(`/api/races/${state.current_race.id}/end`, {method:'POST'});
+  const raceId = state.current_race.id;
+  await fetch(`/api/races/${raceId}/end`, {method:'POST'});
+  await fetch(`/api/races/${raceId}/debrief/start`, {method:'POST'});
   await loadState();
 }
 
-async function startDebrief(raceId) {
-  await fetch(`/api/races/${raceId}/debrief/start`, {method: 'POST'});
-  await loadState();
+let _completeConfirmTimer = null;
+let _completeCountdownInterval = null;
+
+function confirmCompleteSession() {
+  const btn = document.getElementById('btn-complete-session');
+  if (btn.dataset.confirming === 'true') {
+    _clearCompleteConfirm(btn);
+    completeSession();
+    return;
+  }
+  btn.dataset.confirming = 'true';
+  btn.classList.add('btn-end-confirm');
+  let remaining = END_CONFIRM_SECONDS;
+  btn.textContent = 'TAP TO CONFIRM (' + remaining + ')';
+  _completeCountdownInterval = setInterval(() => {
+    remaining--;
+    if (remaining <= 0) {
+      _clearCompleteConfirm(btn);
+      return;
+    }
+    btn.textContent = 'TAP TO CONFIRM (' + remaining + ')';
+  }, 1000);
+  _completeConfirmTimer = setTimeout(
+    () => _clearCompleteConfirm(btn), END_CONFIRM_SECONDS * 1000
+  );
 }
 
-async function startDebriefLast() {
-  const btn = document.getElementById('btn-debrief-last');
-  const raceId = btn && btn.dataset.raceId;
-  if (raceId) await startDebrief(parseInt(raceId, 10));
+function _clearCompleteConfirm(btn) {
+  clearTimeout(_completeConfirmTimer);
+  clearInterval(_completeCountdownInterval);
+  _completeConfirmTimer = null;
+  _completeCountdownInterval = null;
+  btn.dataset.confirming = '';
+  btn.classList.remove('btn-end-confirm');
+  btn.textContent = '\u25A0 COMPLETE SESSION';
 }
 
-async function stopDebrief() {
+async function completeSession() {
+  // Stop the debrief recording and end the session (#762). Equivalent to
+  // today's STOP DEBRIEF \u2014 the race itself ended at FINISH RACE.
   await fetch('/api/debrief/stop', {method: 'POST'});
+  await loadState();
+}
+
+async function startNextRace() {
+  // Stop the current debrief, then start the next race (#762). Debrief
+  // audio stays attached to the just-finished race; the new race opens
+  // a fresh audio session.
+  await fetch('/api/debrief/stop', {method: 'POST'});
+  await fetch('/api/races/start?session_type=race', {method: 'POST'});
   await loadState();
 }
 

--- a/src/helmlog/templates/home.html
+++ b/src/helmlog/templates/home.html
@@ -74,7 +74,10 @@
   <div class="race-name" id="debrief-name">&mdash;</div>
   <div class="label" style="margin-top:12px">Duration</div>
   <div class="duration" id="debrief-duration" style="color:var(--warning)">&mdash;</div>
-  <button class="btn btn-danger" style="margin-top:12px" onclick="stopDebrief()">STOP DEBRIEF</button>
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:12px">
+    <button class="btn btn-danger" id="btn-complete-session" onclick="confirmCompleteSession()">&#9632; COMPLETE SESSION</button>
+    <button class="btn btn-primary" id="btn-start-next-race" onclick="startNextRace()">&#9654; START NEXT RACE</button>
+  </div>
 </div>
 
 <div class="card" id="setup-card">
@@ -160,8 +163,7 @@
   <button class="btn btn-practice" id="btn-start-practice" onclick="startSession('practice')">&#9654; START PRACTICE</button>
   <button class="btn btn-schedule hidden" id="btn-schedule-toggle" onclick="toggleSchedulePanel()">&#9200; SET START TIME</button>
   <button class="btn btn-synthesize hidden" id="btn-synthesize" onclick="toggleSynthPanel()">&#9881; SYNTHESIZE RACE</button>
-  <button class="btn btn-debrief hidden" id="btn-debrief-last" onclick="startDebriefLast()">DEBRIEF LAST RACE</button>
-  <button class="btn btn-danger hidden" id="btn-end" onclick="confirmEndRace()">&#9632; END RACE</button>
+  <button class="btn btn-danger hidden" id="btn-end" onclick="confirmFinishRace()">&#9632; FINISH RACE</button>
 </div>
 
 <div id="schedule-panel" class="card hidden">

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -17,6 +17,7 @@ from helmlog.audio import (
     AudioRecorder,
     AudioRecorderGroup,
     _resolve_device,
+    capture_start,
 )
 from helmlog.usb_audio import DetectedDevice
 
@@ -554,3 +555,58 @@ def test_audio_recorder_group_start_cleans_up_on_sibling_failure(tmp_path: Path)
     assert mock_first_stream.stop.called
     assert mock_first_stream.close.called
     assert not group.is_recording
+
+
+def test_capture_start_retries_device_detection_after_stop(tmp_path: Path) -> None:
+    """#762: when /debrief/start fires right after /end's capture_stop,
+    the USB capture devices may briefly enumerate to [] before the
+    kernel releases them. capture_start retries detection a few times
+    before failing — covers the chained finish-race → debrief flow."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    config = AudioConfig(device=None, sample_rate=48000, channels=1, output_dir=str(tmp_path))
+
+    # First three detection calls return empty (devices still busy), then
+    # the fourth returns a single device.
+    fake_device = DetectedDevice(
+        vendor_id=0x1234,
+        product_id=0x5678,
+        serial="serialX",
+        usb_port_path="usb-0",
+        max_channels=2,
+        sounddevice_index=0,
+        name="usb-pcm-card",
+    )
+    detect_calls: list[list] = [[], [], [], [fake_device]]
+    real_detect = lambda *_a, **_kw: detect_calls.pop(0)  # noqa: E731
+
+    group = MagicMock(spec=AudioRecorderGroup)
+    group.start = AsyncMock(
+        return_value=[
+            # mimic AudioSession enough that write_audio_session is called once
+            MagicMock(file_path="x.wav", channel_count=2, ordinal=0)
+        ]
+    )
+
+    storage = MagicMock()
+    storage.write_audio_session = AsyncMock(return_value=42)
+
+    with patch("helmlog.usb_audio.detect_all_capture_devices", side_effect=real_detect):
+        primary = asyncio.run(
+            capture_start(
+                group,
+                config,
+                storage,
+                name="race-1-debrief",
+                race_id=1,
+                session_type="debrief",
+            )
+        )
+
+    assert primary == 42
+    # Detection retried until devices came back; recorder.start got the device.
+    assert group.start.await_count == 1
+    _args, kwargs = group.start.await_args
+    assert kwargs["devices"] == [fake_device]
+    assert len(detect_calls) == 0  # all four detection responses were consumed


### PR DESCRIPTION
## Summary

Race finish and debrief are conceptually one continuous flow, not two decisions. This PR makes the control page reflect that.

**Before:** `END RACE` (ends session) → manually tap `DEBRIEF LAST RACE` → `STOP DEBRIEF`. Easy to forget the middle step at a wet finish line.

**After:**
- `FINISH RACE` (replaces `END RACE`) — closes the race row + side-effects (camera stop, maneuver detect, polar warm, cache warm) AND silently opens a debrief in the same session. 4-sec hold-to-confirm preserved on the race-stop part.
- `COMPLETE SESSION` (debrief mode) — ends debrief + session in one click. 4-sec confirm so an accidental tap doesn't lose audio.
- `START NEXT RACE` (debrief mode) — stops debrief, opens race N+1. Debrief audio stays attached to the just-finished race (this is the explicit answer to the open question in the issue).
- `DEBRIEF LAST RACE` removed — redundant once `FINISH RACE` auto-starts the debrief.

Server endpoints are unchanged — the JS chains `/api/races/{id}/end` → `/api/races/{id}/debrief/start` so the existing post-race side effects all still run.

Closes #762.

## Validation steps for you

Boat needs to be running with a recorder + cameras for the full flow.

1. **Idle → race:** confirm controls show `START RACE 1` / `START PRACTICE`. Tap `START RACE 1`.
2. **In race:** confirm the live `FINISH RACE 1` button appears with the dynamic boat-name text. Confirm the 4-sec hold-to-confirm still works (first tap → countdown; tap again within 4s → race finishes).
3. **Post-FINISH:** verify the race ended (camera stopped, end_utc set in DB) AND a debrief is in progress (debrief-card visible, audio session running, mic indicator alive). One tap, both side effects.
4. **In debrief — COMPLETE SESSION path:** tap `COMPLETE SESSION` once → confirm prompt; tap again → debrief stops, session goes idle, controls show `START RACE 2`.
5. **In debrief — START NEXT RACE path:** start a new debrief (FINISH RACE), then tap `START NEXT RACE` → confirm debrief audio is saved against race N, and a fresh race N+1 starts with its own audio session.
6. **Edge: skip debrief.** If you don't want a debrief, currently the only way is `START NEXT RACE` to chain to the next race, or `COMPLETE SESSION` to end. There is no longer a way to silently end without recording even a few seconds of debrief audio — flag if that matters in practice.
7. **Mobile responsive:** debrief card on a narrow screen should show the two buttons side-by-side (`grid-template-columns:1fr 1fr`); on a phone in landscape they look reasonable.

## Test plan
- [x] `uv run pytest tests/test_web.py -k debrief` — 13 passed (existing endpoint tests still cover the underlying API)
- [x] `uv run ruff check src/helmlog/` clean
- [ ] Manual UI walkthrough on the Pi or `helmlog run` locally with a mock recorder
- [ ] Confirm camera stop + auto-detect maneuvers + polar warm still fire on FINISH RACE (these are post-race side effects in `api_end_race` — they run because the JS still calls `/end`)

## Open follow-ups (not in this PR)
- If you want a way to end the session without any debrief audio at all, add a third button (\"END SESSION (skip debrief)\") that calls `/end` only — easy to add post-merge if it bites in practice.
- The debrief audio quality / diarization improvements remain tracked in #648 per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)