### PR TITLE
feat(crew): per-race body+gear weight with verified-vs-assumed flag

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,44 @@
 # Release Notes
 
+## Per-Race Crew, Body Weight, and Gear Weight (2026-05-13)
+
+Crew weight is now a first-class part of every race rather than a
+boat-wide default that never moves. Setting the crew for a race flips
+the lineup from "assumed default" to "verified", a new gear preset
+(dry/wet/foulies) fills in clothing weight for the session, and the
+analysis API now reports verified-vs-assumed and total crew weight so
+debrief findings can finally tell apart "we sailed underweight" from
+"we sailed badly."
+
+- **Verified-vs-assumed flag on every race** — new `races.crew_assumed`
+  column defaults to 1 (the boat default is unverified for this race)
+  and flips to 0 the moment a crew or admin saves a per-race crew via
+  `POST /api/races/{race_id}/crew`. Existing historical races stay
+  flagged as `assumed` until a backfill confirms them.
+- **Gear preset per race** — `races.gear_preset` records one of
+  `dry`/`wet`/`foulies` (free-form NULL allowed). Confirming a crew
+  with a preset fills in any per-entry `gear_weight` that wasn't set
+  explicitly, so totals stay consistent without the user having to
+  re-enter clothing weight for every position.
+- **Per-user gear default** — new `users.gear_default_lbs` so a sailor
+  who always shows up in heavy foulies (or never does) doesn't get
+  surprised by the preset on every race. The analysis API falls
+  through to this when a per-race row omits gear weight.
+- **Admin backfill endpoint** —
+  `POST /api/admin/crew-backfill` accepts a list of
+  `{race_id, crew, gear_preset}` and applies them in one batch, with
+  one audit-trail row per race for protest readiness (data-licensing
+  §11).
+- **Anonymisation now clears weight data** —
+  `anonymize_sailor` and the user soft-delete path both NULL out
+  `users.weight_lbs`, `users.gear_default_lbs`, and any per-race body
+  and gear weights referencing the user (data-licensing §1).
+- **Analysis API surfaces it all** —
+  `/api/sessions/{id}/summary` now includes a `crew` block with the
+  resolved lineup, the assumed flag, the gear preset, and totals for
+  body, gear, and crew weight. `/api/races/{id}/crew` returns the
+  same fields alongside the existing crew list. Closes #761.
+
 ## Moments Unified, Sharper Debriefs, Safer Backups (2026-04-24)
 
 Bookmarks, comment threads, and notes are now one thing — "Moments" —

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -455,6 +455,17 @@ class PasswordChange(BaseModel):
 
 class WeightUpdate(BaseModel):
     weight_lbs: float | None = None
+    gear_default_lbs: float | None = None
+
+
+class BulkCrewBackfillEntry(BaseModel):
+    race_id: int
+    crew: list[CrewEntry]
+    gear_preset: str | None = None
+
+
+class BulkCrewBackfill(BaseModel):
+    updates: list[BulkCrewBackfillEntry]
 
 
 class PositionEntry(BaseModel):

--- a/src/helmlog/routes/admin.py
+++ b/src/helmlog/routes/admin.py
@@ -252,6 +252,11 @@ async def admin_update_user(
         w = body["weight_lbs"]
         weight_val = float(w) if w is not None and w != "" else None
         await storage.update_user_weight(user_id, weight_val)
+    # Per-user gear default (#761).
+    if "gear_default_lbs" in body:
+        g = body["gear_default_lbs"]
+        gear_val = float(g) if g is not None and g != "" else None
+        await storage.update_user_gear_default(user_id, gear_val)
     changes = []
     if name is not None:
         changes.append(f"name={name!r}")
@@ -263,6 +268,8 @@ async def admin_update_user(
         changes.append(f"is_developer={body['is_developer']!r}")
     if "weight_lbs" in body:
         changes.append(f"weight_lbs={body['weight_lbs']!r}")
+    if "gear_default_lbs" in body:
+        changes.append(f"gear_default_lbs={body['gear_default_lbs']!r}")
     await audit(request, "user.update", detail=f"user={user_id} {' '.join(changes)}", user=_user)
 
 

--- a/src/helmlog/routes/crew.py
+++ b/src/helmlog/routes/crew.py
@@ -11,6 +11,7 @@ from helmlog.auth import require_auth
 from helmlog.routes._helpers import (
     BoatCreate,
     BoatUpdate,
+    BulkCrewBackfill,
     CrewEntry,
     PositionEntry,
     RaceResultEntry,
@@ -26,8 +27,16 @@ async def api_set_crew(
     request: Request,
     race_id: int,
     body: list[CrewEntry],
+    gear_preset: str | None = None,
     _user: dict[str, Any] = Depends(require_auth("crew")),  # noqa: B008
 ) -> None:
+    """Write a verified per-race crew lineup (#761).
+
+    Calling this endpoint is treated as confirmation: ``races.crew_assumed``
+    flips to 0 and ``races.gear_preset`` is recorded. Pass ``?gear_preset=
+    dry|wet|foulies`` to fill in missing per-entry gear_weight values from
+    the preset.
+    """
     storage = get_storage(request)
     cur = await storage._conn().execute("SELECT id FROM races WHERE id = ?", (race_id,))
     if await cur.fetchone() is None:
@@ -54,10 +63,13 @@ async def api_set_crew(
         for e in body
     ]
     try:
-        await storage.set_crew_defaults(race_id, crew)
+        await storage.confirm_race_crew(race_id, crew, gear_preset=gear_preset)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    await audit(request, "crew.set", detail=str(race_id), user=_user)
+    detail = f"race={race_id} verified n={len(crew)}"
+    if gear_preset is not None:
+        detail += f" gear={gear_preset}"
+    await audit(request, "crew.set", detail=detail, user=_user)
 
 
 @router.get("/api/races/{race_id}/crew")
@@ -72,7 +84,77 @@ async def api_get_crew(
         raise HTTPException(status_code=404, detail="Race not found")
 
     crew = await storage.resolve_crew(race_id)
-    return JSONResponse({"crew": crew})
+    summary = await storage.get_race_crew_summary(race_id)
+    return JSONResponse(
+        {
+            "crew": crew,
+            "crew_assumed": summary["crew_assumed"],
+            "gear_preset": summary["gear_preset"],
+            "total_body_weight_lb": summary["total_body_weight_lb"],
+            "total_gear_weight_lb": summary["total_gear_weight_lb"],
+            "total_crew_weight_lb": summary["total_crew_weight_lb"],
+        }
+    )
+
+
+@router.post("/api/admin/crew-backfill", status_code=200)
+async def api_crew_backfill(
+    request: Request,
+    body: BulkCrewBackfill,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Bulk-edit per-race crew + gear for historical races (#761 PR-C).
+
+    Emits one ``crew.set`` audit_log row per race (data-licensing §11
+    protest readiness — the trail must show who set crew weight per race,
+    not a single batch row).
+    """
+    storage = get_storage(request)
+    positions = await storage.get_crew_positions()
+    valid_ids = {p["id"] for p in positions}
+
+    updates: list[dict[str, Any]] = []
+    for entry in body.updates:
+        cur = await storage._conn().execute("SELECT id FROM races WHERE id = ?", (entry.race_id,))
+        if await cur.fetchone() is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Race {entry.race_id} not found",
+            )
+        invalid = [c.position_id for c in entry.crew if c.position_id not in valid_ids]
+        if invalid:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown position_id(s) in race {entry.race_id}: {invalid}",
+            )
+        updates.append(
+            {
+                "race_id": entry.race_id,
+                "gear_preset": entry.gear_preset,
+                "crew": [
+                    {
+                        "position_id": c.position_id,
+                        "user_id": c.user_id,
+                        "attributed": c.attributed,
+                        "body_weight": c.body_weight,
+                        "gear_weight": c.gear_weight,
+                    }
+                    for c in entry.crew
+                ],
+            }
+        )
+
+    try:
+        applied = await storage.bulk_confirm_race_crew(updates)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    for u in updates:
+        detail = f"race={u['race_id']} verified n={len(u['crew'])} backfill"
+        if u.get("gear_preset"):
+            detail += f" gear={u['gear_preset']}"
+        await audit(request, "crew.set", detail=detail, user=_user)
+    return JSONResponse({"applied": applied})
 
 
 @router.post("/api/crew/defaults", status_code=204)

--- a/src/helmlog/routes/me.py
+++ b/src/helmlog/routes/me.py
@@ -59,7 +59,15 @@ async def api_update_my_weight(
                 status_code=403,
                 detail="Biometric consent required before storing weight data",
             )
-    await storage.update_user_weight(_user["id"], weight)
+    # Only touch fields the caller explicitly sent — avoids clearing one
+    # value when the other is being updated.
+    fields_set = body.model_fields_set
+    if "weight_lbs" in fields_set:
+        await storage.update_user_weight(_user["id"], weight)
+    # Gear weight is a clothing/equipment preference, not biometric — no
+    # consent gate.
+    if "gear_default_lbs" in fields_set:
+        await storage.update_user_gear_default(_user["id"], body.gear_default_lbs)
 
 
 @router.patch("/api/me/password", status_code=204)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import os
@@ -608,11 +609,26 @@ async def _compute_session_summary(storage: Storage, session_id: int) -> dict[st
     if own_result and not any(str(row.get("sail_number") or "") == str(own_sail) for row in top3):
         results.append(own_result)
 
+    # Crew + gear summary (#761) — let analysis consumers and the session
+    # detail badge distinguish 'verified' from 'assumed default' lineups.
+    crew_summary: dict[str, Any] = {
+        "crew_assumed": True,
+        "gear_preset": None,
+        "lineup": [],
+        "total_body_weight_lb": None,
+        "total_gear_weight_lb": None,
+        "total_crew_weight_lb": None,
+    }
+    # Race row may not be present for non-race session types (debriefs).
+    with contextlib.suppress(ValueError):
+        crew_summary = await storage.get_race_crew_summary(session_id)
+
     return {
         "track": track,
         "events": events,
         "wind": wind,
         "results": results,
+        "crew": crew_summary,
     }
 
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -203,7 +203,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 85
+_CURRENT_VERSION: int = 86
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -2119,6 +2119,19 @@ _MIGRATIONS: dict[int, str] = {
             at           TEXT
         );
         INSERT OR IGNORE INTO llm_consent (id, acknowledged) VALUES (1, 0);
+    """,
+    86: """
+        -- Per-race crew capture (#761).
+        -- races.crew_assumed: 1 = lineup is the boat default (unverified for
+        -- this race), 0 = a user explicitly confirmed the lineup. Default 1
+        -- so every historical race shows up as 'assumed' until backfilled.
+        -- races.gear_preset: one preset per race ("dry"/"wet"/"foulies"),
+        -- applied to entries without an explicit gear_weight at confirm time.
+        -- users.gear_default_lbs: per-user fallback when a race entry doesn't
+        -- override gear_weight (e.g. somebody always sails dry).
+        ALTER TABLE races ADD COLUMN crew_assumed INTEGER NOT NULL DEFAULT 1;
+        ALTER TABLE races ADD COLUMN gear_preset TEXT;
+        ALTER TABLE users ADD COLUMN gear_default_lbs REAL;
     """,
 }
 
@@ -5121,6 +5134,171 @@ class Storage:
         await db.execute("UPDATE users SET weight_lbs = ? WHERE id = ?", (weight_lbs, user_id))
         await db.commit()
 
+    async def update_user_gear_default(self, user_id: int, gear_default_lbs: float | None) -> None:
+        """Update a user's default per-race gear weight (#761)."""
+        db = self._conn()
+        await db.execute(
+            "UPDATE users SET gear_default_lbs = ? WHERE id = ?",
+            (gear_default_lbs, user_id),
+        )
+        await db.commit()
+
+    # ------------------------------------------------------------------
+    # Per-race crew confirmation (#761)
+    # ------------------------------------------------------------------
+
+    # Gear preset → per-person lbs. From the /spec; folded here rather than
+    # config because the values are a starting point — admin override per
+    # user lives on users.gear_default_lbs.
+    GEAR_PRESET_LBS: dict[str, float] = {
+        "dry": 0.0,
+        "wet": 8.0,
+        "foulies": 18.0,
+    }
+
+    async def confirm_race_crew(
+        self,
+        race_id: int,
+        crew: list[dict[str, Any]],
+        *,
+        gear_preset: str | None = None,
+    ) -> None:
+        """Write a verified per-race crew lineup.
+
+        Stores rows in crew_defaults (race_id=race_id) via the existing
+        set_crew_defaults plumbing, flips races.crew_assumed to 0, and
+        records the gear preset on the race. When *gear_preset* is set and
+        an entry omits gear_weight, the preset's per-person lbs is filled
+        in so the totals on the analysis API are consistent.
+
+        Raises ValueError on an unknown gear_preset or the duplicate-user-id
+        check that set_crew_defaults already performs.
+        """
+        if gear_preset is not None and gear_preset not in self.GEAR_PRESET_LBS:
+            valid = ", ".join(sorted(self.GEAR_PRESET_LBS))
+            raise ValueError(f"gear_preset must be one of: {valid}")
+
+        if gear_preset is not None:
+            preset_lbs = self.GEAR_PRESET_LBS[gear_preset]
+            for entry in crew:
+                if entry.get("gear_weight") is None:
+                    entry["gear_weight"] = preset_lbs
+
+        await self.set_crew_defaults(race_id, crew)
+        db = self._conn()
+        await db.execute(
+            "UPDATE races SET crew_assumed = 0, gear_preset = ? WHERE id = ?",
+            (gear_preset, race_id),
+        )
+        await db.commit()
+        await self._invalidate_race_cache(race_id)
+        logger.debug(
+            "Race {} crew confirmed: {} entries, gear_preset={}",
+            race_id,
+            len(crew),
+            gear_preset,
+        )
+
+    async def get_race_crew_summary(self, race_id: int) -> dict[str, Any]:
+        """Return resolved lineup + assumption flag + weight totals.
+
+        Per-entry weights win; if absent, fall through to users.weight_lbs
+        and users.gear_default_lbs. None totals when no weight is known.
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            "SELECT crew_assumed, gear_preset FROM races WHERE id = ?",
+            (race_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise ValueError(f"Race {race_id} not found")
+
+        resolved = await self.resolve_crew(race_id)
+
+        total_body: float = 0.0
+        total_gear: float = 0.0
+        body_count = 0
+        gear_count = 0
+        lineup: list[dict[str, Any]] = []
+        for entry in resolved:
+            body_w = entry.get("body_weight")
+            gear_w = entry.get("gear_weight")
+            user_weight_lbs: float | None = None
+            user_gear_lbs: float | None = None
+            if entry.get("user_id") is not None and (body_w is None or gear_w is None):
+                ucur = await db.execute(
+                    "SELECT weight_lbs, gear_default_lbs FROM users WHERE id = ?",
+                    (entry["user_id"],),
+                )
+                urow = await ucur.fetchone()
+                if urow is not None:
+                    user_weight_lbs = urow["weight_lbs"]
+                    user_gear_lbs = urow["gear_default_lbs"]
+            if body_w is None:
+                body_w = user_weight_lbs
+            if gear_w is None:
+                gear_w = user_gear_lbs
+            if body_w is not None:
+                total_body += body_w
+                body_count += 1
+            if gear_w is not None:
+                total_gear += gear_w
+                gear_count += 1
+            lineup.append(
+                {
+                    "position": entry["position"],
+                    "user_id": entry.get("user_id"),
+                    "user_name": entry.get("user_name"),
+                    "attributed": entry.get("attributed"),
+                    "body_weight_lb": body_w,
+                    "gear_weight_lb": gear_w,
+                    "source": entry.get("source"),
+                }
+            )
+
+        body_total = total_body if body_count else None
+        gear_total = total_gear if gear_count else None
+        crew_total: float | None
+        if body_total is not None and gear_total is not None:
+            crew_total = body_total + gear_total
+        elif body_total is not None:
+            crew_total = body_total
+        elif gear_total is not None:
+            crew_total = gear_total
+        else:
+            crew_total = None
+
+        return {
+            "crew_assumed": bool(row["crew_assumed"]),
+            "gear_preset": row["gear_preset"],
+            "lineup": lineup,
+            "total_body_weight_lb": body_total,
+            "total_gear_weight_lb": gear_total,
+            "total_crew_weight_lb": crew_total,
+        }
+
+    async def bulk_confirm_race_crew(
+        self,
+        updates: list[dict[str, Any]],
+    ) -> list[int]:
+        """Apply confirm_race_crew to a batch of races.
+
+        *updates* entries: ``{race_id, crew, gear_preset?}``. Returns the
+        list of race_ids that were updated (in input order). Caller is
+        responsible for emitting one audit_events row per race_id so the
+        protest-readiness trail is per-race.
+        """
+        applied: list[int] = []
+        for u in updates:
+            await self.confirm_race_crew(
+                u["race_id"],
+                u["crew"],
+                gear_preset=u.get("gear_preset"),
+            )
+            applied.append(u["race_id"])
+        return applied
+
     # ------------------------------------------------------------------
     # Boat registry
     # ------------------------------------------------------------------
@@ -6620,7 +6798,7 @@ class Storage:
 
     _USER_COLS = (
         "id, email, name, role, created_at, last_seen,"
-        " avatar_path, is_developer, is_active, weight_lbs, color_scheme"
+        " avatar_path, is_developer, is_active, weight_lbs, gear_default_lbs, color_scheme"
     )
 
     async def get_user_by_id(self, user_id: int) -> dict[str, Any] | None:
@@ -6675,7 +6853,7 @@ class Storage:
     async def list_users(self) -> list[dict[str, Any]]:
         cur = await self._read_conn().execute(
             "SELECT id, email, name, role, created_at, last_seen, is_developer,"
-            " weight_lbs"
+            " weight_lbs, gear_default_lbs"
             " FROM users WHERE email NOT LIKE 'deleted_%@redacted'"
             " ORDER BY created_at"
         )
@@ -9041,13 +9219,20 @@ class Storage:
         db = self._conn()
         anon_email = f"deleted_{user_id}@redacted"
         await db.execute(
-            "UPDATE users SET email = ?, name = NULL, avatar_path = NULL WHERE id = ?",
+            "UPDATE users SET email = ?, name = NULL, avatar_path = NULL,"
+            " weight_lbs = NULL, gear_default_lbs = NULL WHERE id = ?",
             (anon_email, user_id),
         )
         await db.execute("DELETE FROM auth_sessions WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM user_credentials WHERE user_id = ?", (user_id,))
         await db.execute(
             "UPDATE invitations SET invited_by = NULL WHERE invited_by = ?", (user_id,)
+        )
+        # data-licensing §1: per-race weight overrides referencing this user
+        # must not survive deletion.
+        await db.execute(
+            "UPDATE crew_defaults SET body_weight = NULL, gear_weight = NULL WHERE user_id = ?",
+            (user_id,),
         )
         await db.commit()
         logger.info("User {} anonymized and sessions deleted", user_id)
@@ -9170,15 +9355,24 @@ class Storage:
         return rows
 
     async def anonymize_sailor(self, user_id: int, replacement: str = "Anonymous") -> int:
-        """Anonymize a crew member by updating their user name. Returns rows updated."""
+        """Anonymize a crew member by updating their user name. Returns rows updated.
+
+        Also clears health-adjacent weight data: users.weight_lbs,
+        users.gear_default_lbs, and any per-race body/gear weight overrides
+        in crew_defaults that reference this user (data-licensing §1).
+        """
         db = self._conn()
         cur = await db.execute(
-            "UPDATE users SET name = ? WHERE id = ?",
+            "UPDATE users SET name = ?, weight_lbs = NULL, gear_default_lbs = NULL WHERE id = ?",
             (replacement, user_id),
         )
         count = cur.rowcount or 0
+        await db.execute(
+            "UPDATE crew_defaults SET body_weight = NULL, gear_weight = NULL WHERE user_id = ?",
+            (user_id,),
+        )
         await db.commit()
-        logger.info("User {} anonymized to {!r}", user_id, replacement)
+        logger.info("User {} anonymized to {!r}; weights cleared", user_id, replacement)
         return count
 
     # ------------------------------------------------------------------

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -962,6 +962,197 @@ class TestCrewStorage:
         assert consents[0]["granted"] == 0
         assert consents[0]["revoked_at"] is not None
 
+    # ------------------------------------------------------------------
+    # #761 per-race crew confirmation
+    # ------------------------------------------------------------------
+
+    async def test_race_starts_with_crew_assumed(self, storage: Storage) -> None:
+        """New races start with crew_assumed=1 — the boat default is unverified."""
+        race_id = await self._make_race(storage)
+        summary = await storage.get_race_crew_summary(race_id)
+        assert summary["crew_assumed"] is True
+        assert summary["gear_preset"] is None
+
+    async def test_confirm_race_crew_flips_assumed(self, storage: Storage) -> None:
+        """Calling confirm_race_crew flips the flag to 0 and records the preset."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+        await storage.confirm_race_crew(
+            race_id,
+            [{"position_id": helm_id, "user_id": alice_id, "body_weight": 155.0}],
+            gear_preset="wet",
+        )
+        summary = await storage.get_race_crew_summary(race_id)
+        assert summary["crew_assumed"] is False
+        assert summary["gear_preset"] == "wet"
+
+    async def test_gear_preset_fills_missing_gear_weight(self, storage: Storage) -> None:
+        """Entries without explicit gear_weight inherit the preset's lb/person."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        main_id = await self._pos_id(storage, "main")
+        alice_id = await storage.create_placeholder_user("Alice")
+        bob_id = await storage.create_placeholder_user("Bob")
+        await storage.confirm_race_crew(
+            race_id,
+            [
+                # Alice has explicit gear — preset must NOT overwrite it.
+                {
+                    "position_id": helm_id,
+                    "user_id": alice_id,
+                    "body_weight": 155.0,
+                    "gear_weight": 5.0,
+                },
+                # Bob has no gear — preset fills "wet" = 8 lb.
+                {
+                    "position_id": main_id,
+                    "user_id": bob_id,
+                    "body_weight": 180.0,
+                },
+            ],
+            gear_preset="wet",
+        )
+        summary = await storage.get_race_crew_summary(race_id)
+        gear_by_pos = {entry["position"]: entry["gear_weight_lb"] for entry in summary["lineup"]}
+        assert gear_by_pos["helm"] == 5.0
+        assert gear_by_pos["main"] == 8.0
+
+    async def test_invalid_gear_preset_rejected(self, storage: Storage) -> None:
+        """Unknown gear_preset raises ValueError so the route can 422."""
+        race_id = await self._make_race(storage)
+        with pytest.raises(ValueError, match="gear_preset must be one of"):
+            await storage.confirm_race_crew(race_id, [], gear_preset="lederhosen")
+
+    async def test_summary_totals_use_user_fallbacks(self, storage: Storage) -> None:
+        """When a per-race row omits weights, fall through to users.weight_lbs
+        and users.gear_default_lbs (R8 — users.weight_lbs is source of truth)."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+        await storage.update_user_weight(alice_id, 145.0)
+        await storage.update_user_gear_default(alice_id, 12.0)
+        await storage.confirm_race_crew(
+            race_id,
+            [{"position_id": helm_id, "user_id": alice_id}],
+        )
+        summary = await storage.get_race_crew_summary(race_id)
+        assert summary["total_body_weight_lb"] == 145.0
+        assert summary["total_gear_weight_lb"] == 12.0
+        assert summary["total_crew_weight_lb"] == 157.0
+
+    async def test_summary_totals_prefer_explicit_over_user(self, storage: Storage) -> None:
+        """Per-race weight wins over users.weight_lbs."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+        await storage.update_user_weight(alice_id, 145.0)  # User default
+        await storage.confirm_race_crew(
+            race_id,
+            [
+                # Different weight this race (Alice borrowed weights from a friend?
+                # The point is the per-race row overrides the user default.)
+                {"position_id": helm_id, "user_id": alice_id, "body_weight": 160.0},
+            ],
+        )
+        summary = await storage.get_race_crew_summary(race_id)
+        assert summary["total_body_weight_lb"] == 160.0
+
+    async def test_bulk_confirm_race_crew(self, storage: Storage) -> None:
+        """bulk_confirm_race_crew applies updates to multiple races (PR-C)."""
+        race1 = await self._make_race(storage)
+        # Need a second race — start_race uses UNIQUE on (name, date, race_num)
+        # so bump race_num.
+        from datetime import datetime as _dt
+
+        race2_obj = await storage.start_race(
+            "Regatta",
+            _dt(2025, 9, 1, 15, 0, 0, tzinfo=UTC),
+            _CREW_DATE,
+            2,
+            "20250901-Regatta-2",
+        )
+        race2 = race2_obj.id
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+
+        applied = await storage.bulk_confirm_race_crew(
+            [
+                {
+                    "race_id": race1,
+                    "crew": [{"position_id": helm_id, "user_id": alice_id}],
+                    "gear_preset": "dry",
+                },
+                {
+                    "race_id": race2,
+                    "crew": [{"position_id": helm_id, "user_id": alice_id}],
+                },
+            ]
+        )
+        assert applied == [race1, race2]
+        s1 = await storage.get_race_crew_summary(race1)
+        s2 = await storage.get_race_crew_summary(race2)
+        assert s1["crew_assumed"] is False
+        assert s1["gear_preset"] == "dry"
+        assert s2["crew_assumed"] is False
+        assert s2["gear_preset"] is None
+
+    async def test_anonymize_sailor_clears_weights(self, storage: Storage) -> None:
+        """anonymize_sailor wipes weight_lbs, gear_default_lbs, and per-race
+        weight overrides (data-licensing §1)."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+        await storage.update_user_weight(alice_id, 175.0)
+        await storage.update_user_gear_default(alice_id, 18.0)
+        await storage.confirm_race_crew(
+            race_id,
+            [
+                {
+                    "position_id": helm_id,
+                    "user_id": alice_id,
+                    "body_weight": 160.0,
+                    "gear_weight": 12.0,
+                }
+            ],
+        )
+        await storage.anonymize_sailor(alice_id)
+        user = await storage.get_user_by_id(alice_id)
+        assert user is not None
+        assert user["weight_lbs"] is None
+        assert user["gear_default_lbs"] is None
+        entries = await storage.get_crew_defaults(race_id)
+        assert entries[0]["body_weight"] is None
+        assert entries[0]["gear_weight"] is None
+
+    async def test_delete_user_clears_weights(self, storage: Storage) -> None:
+        """delete_user (soft-delete) wipes weight columns and per-race overrides
+        (data-licensing §1)."""
+        race_id = await self._make_race(storage)
+        helm_id = await self._pos_id(storage, "helm")
+        alice_id = await storage.create_placeholder_user("Alice")
+        await storage.update_user_weight(alice_id, 175.0)
+        await storage.update_user_gear_default(alice_id, 18.0)
+        await storage.confirm_race_crew(
+            race_id,
+            [
+                {
+                    "position_id": helm_id,
+                    "user_id": alice_id,
+                    "body_weight": 160.0,
+                    "gear_weight": 12.0,
+                }
+            ],
+        )
+        await storage.delete_user(alice_id)
+        user = await storage.get_user_by_id(alice_id)
+        assert user is not None
+        assert user["weight_lbs"] is None
+        assert user["gear_default_lbs"] is None
+        entries = await storage.get_crew_defaults(race_id)
+        assert entries[0]["body_weight"] is None
+        assert entries[0]["gear_weight"] is None
+
 
 # ---------------------------------------------------------------------------
 # Boat registry tests

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1245,6 +1245,121 @@ async def test_post_crew_non_attributed(storage: Storage) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #761 — per-race crew, gear preset, bulk backfill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_crew_flips_assumed_and_surfaces_summary(storage: Storage) -> None:
+    """POST /api/races/{id}/crew flips crew_assumed; GET returns it + totals."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+
+        # Before any crew is set: assumed=True.
+        before = (await client.get(f"/api/races/{race_id}/crew")).json()
+        assert before["crew_assumed"] is True
+        assert before["gear_preset"] is None
+
+        pos_ids = await _get_pos_ids(client)
+        mark_id = await _make_crew_user(client, "Mark")
+        resp = await client.post(
+            f"/api/races/{race_id}/crew",
+            params={"gear_preset": "wet"},
+            json=[
+                {
+                    "position_id": pos_ids["helm"],
+                    "user_id": mark_id,
+                    "body_weight": 180.0,
+                }
+            ],
+        )
+        assert resp.status_code == 204
+
+        after = (await client.get(f"/api/races/{race_id}/crew")).json()
+        assert after["crew_assumed"] is False
+        assert after["gear_preset"] == "wet"
+        # 180 lb body + 8 lb wet preset
+        assert after["total_body_weight_lb"] == 180.0
+        assert after["total_gear_weight_lb"] == 8.0
+        assert after["total_crew_weight_lb"] == 188.0
+
+
+@pytest.mark.asyncio
+async def test_post_crew_bad_gear_preset_422(storage: Storage) -> None:
+    """An unknown gear_preset value returns 422."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        race_id = (await client.post("/api/races/start")).json()["id"]
+        pos_ids = await _get_pos_ids(client)
+        resp = await client.post(
+            f"/api/races/{race_id}/crew",
+            params={"gear_preset": "lederhosen"},
+            json=[{"position_id": pos_ids["helm"]}],
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_crew_backfill_emits_per_race_audit(storage: Storage) -> None:
+    """Bulk backfill applies updates and writes one audit row per race
+    (data-licensing §11 protest readiness)."""
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        await _set_event(client)
+        r1 = (await client.post("/api/races/start")).json()["id"]
+        await client.post(f"/api/races/{r1}/end")
+        r2 = (await client.post("/api/races/start")).json()["id"]
+        await client.post(f"/api/races/{r2}/end")
+        pos_ids = await _get_pos_ids(client)
+        alice_id = await _make_crew_user(client, "Alice")
+
+        # Audit baseline.
+        db = storage._conn()
+        cur = await db.execute("SELECT COUNT(*) AS n FROM audit_log WHERE action = 'crew.set'")
+        before_n = (await cur.fetchone())["n"]
+
+        resp = await client.post(
+            "/api/admin/crew-backfill",
+            json={
+                "updates": [
+                    {
+                        "race_id": r1,
+                        "crew": [{"position_id": pos_ids["helm"], "user_id": alice_id}],
+                        "gear_preset": "dry",
+                    },
+                    {
+                        "race_id": r2,
+                        "crew": [{"position_id": pos_ids["helm"], "user_id": alice_id}],
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["applied"] == [r1, r2]
+
+        # Both races verified.
+        s1 = (await client.get(f"/api/races/{r1}/crew")).json()
+        s2 = (await client.get(f"/api/races/{r2}/crew")).json()
+        assert s1["crew_assumed"] is False
+        assert s1["gear_preset"] == "dry"
+        assert s2["crew_assumed"] is False
+
+        # One audit_events row per race, not a single batch row.
+        cur = await db.execute("SELECT COUNT(*) AS n FROM audit_log WHERE action = 'crew.set'")
+        after_n = (await cur.fetchone())["n"]
+        assert after_n - before_n == 2
+
+
+# ---------------------------------------------------------------------------
 # Issue #30: debrief auto-stop + crew carry-forward
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Per-race crew is now first-class. `POST /api/races/{id}/crew` flips `races.crew_assumed` from 1 (boat default, unverified) to 0 (verified for this race), records a gear preset, and the analysis API surfaces verified-vs-assumed plus body, gear, and total crew weight. The PSSR-4/19-style "we sailed underweight" story finally shows up in the data.
- `?gear_preset=dry|wet|foulies` query param on the crew endpoint fills in any per-entry `gear_weight` that wasn't set explicitly (8 lb for wet, 18 lb for full foulies, from the /spec). `users.gear_default_lbs` is a per-user fallback so somebody who always sails in heavy foulies doesn't get surprised every race.
- `POST /api/admin/crew-backfill` accepts `{updates: [{race_id, crew, gear_preset}]}` to retroactively confirm historical races. Emits one `crew.set` row in `audit_log` per race — not a single batch row — for protest readiness (data-licensing §11).
- `anonymize_sailor` and `delete_user` now NULL out `users.weight_lbs`, `users.gear_default_lbs`, and any per-race body/gear weight overrides for that user (data-licensing §1). Body weight is health-adjacent personal data and must not survive deletion.

## Design choice — reuse `crew_defaults` instead of resurrecting `race_crew`

The /spec on the issue called for a new `race_crew` table, but `crew_defaults` already supports per-race rows (`race_id IS NOT NULL` is allowed and `resolve_crew()` already merges race-level over boat-level — `crew_defaults.race_id` was just unused in practice). The issue's own acceptance criteria says "persisted as `crew_defaults` rows with `race_id` set," so this PR follows the AC. No new table, no risky migration recreating an FK-heavy table — just `races.crew_assumed`, `races.gear_preset`, and `users.gear_default_lbs` added as columns in migration v86.

## What's deliberately not in this PR

A dedicated pre-race wizard step on `/race-start`. The /spec called for one, but the existing `/race-start` page is a button-driven FSM, not a wizard, and the issue's AC explicitly permits post-race correction. The existing per-race crew editor in `session.js` already writes through the new endpoint, so verifying a race's crew works today via the session detail page. A `/race-start` prompt can land as follow-up if it turns out crews really do forget.

## Test plan

- [x] `uv run pytest tests/` — 2591 passed, 2 skipped
- [x] `uv run pytest tests/integration/` — 38 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/` — clean
- [x] /data-license review — anonymize + soft-delete weight clearing, per-race audit_log rows, no federation/co-op exposure of crew weight
- [ ] Manual: confirm a race's crew via the existing session detail editor and verify the "verified" badge flips on `GET /api/races/{id}/crew`

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)