### PR TITLE
fix(cameras): fail fast on stop when camera is unreachable

### DIFF
--- a/src/helmlog/cameras.py
+++ b/src/helmlog/cameras.py
@@ -43,6 +43,13 @@ def _default_timeout() -> float:
     return float(os.environ.get("CAMERA_START_TIMEOUT", "10"))
 
 
+def _default_stop_timeout() -> float:
+    # Short by design: at end-race we expect the camera to be reachable. If it's
+    # not (Pi off the camera's hotspot, camera off, dead battery), waiting the
+    # full start timeout × multiple endpoints can wedge end-race for minutes (#773).
+    return float(os.environ.get("CAMERA_STOP_TIMEOUT", "2"))
+
+
 _OSC_PATH = "/osc/commands/execute"
 _OSC_HEADERS = {"X-XSRF-Protected": "1"}
 
@@ -161,7 +168,7 @@ async def stop_camera(camera: Camera, timeout: float | None = None) -> CameraSta
     ``startCapture`` first "claims" the session for OSC, after which
     ``stopCapture`` succeeds.
     """
-    timeout = timeout if timeout is not None else _default_timeout()
+    timeout = timeout if timeout is not None else _default_stop_timeout()
     try:
         async with httpx.AsyncClient() as client:
             resp = await client.post(

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -174,6 +174,50 @@ async def test_stop_camera_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_camera_default_timeout_is_short(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop should fail fast — an offline camera must not wedge end-race (#773)."""
+    monkeypatch.delenv("CAMERA_STOP_TIMEOUT", raising=False)
+    cam = Camera(name="stern", ip="192.168.42.1")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = '{"state": "done"}'
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await stop_camera(cam)  # no explicit timeout — use default
+
+    assert mock_client.post.await_count >= 1
+    sent = mock_client.post.await_args.kwargs["timeout"]
+    assert sent <= 3.0, f"stop default {sent}s too long; must fail fast when offline"
+
+
+@pytest.mark.asyncio
+async def test_stop_camera_default_timeout_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CAMERA_STOP_TIMEOUT overrides the fail-fast default for ops who want longer."""
+    monkeypatch.setenv("CAMERA_STOP_TIMEOUT", "4.5")
+    cam = Camera(name="stern", ip="192.168.42.1")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = '{"state": "done"}'
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await stop_camera(cam)
+
+    assert mock_client.post.await_args.kwargs["timeout"] == 4.5
+
+
+@pytest.mark.asyncio
 async def test_get_status_recording() -> None:
     cam = Camera(name="test", ip="192.168.8.50")
     mock_resp = MagicMock()


### PR DESCRIPTION
## Summary
- Split camera timeout defaults: `start_camera` keeps 10s (user is watching), `stop_camera` now defaults to 2s.
- New env var `CAMERA_STOP_TIMEOUT` overrides the stop default.
- End-race already fires `stop_camera` as a background task, so the wedge wasn't in the HTTP path — but the pile-up of multi-minute background work still degraded the UI on the next refresh / websocket reconnect. Fail-fast caps worst-case to ~2 s × n_cameras × n_endpoints.

## Why
Real incident with race 187 (2026-06-04): Pi brought home with the boat's Insta360 X4 (at `192.168.42.1`, only reachable on its own WiFi hotspot) powered off. End-race button: race ended in DB on click #1, but camera stop calls timed out one after another for ~2:46. User clicked again thinking the UI was frozen. Diagnostic log:

```
06:09:21  Race 187 ended (click #1, succeeded in DB)
06:09:26  Race 187 ended (click #2 — UI looked frozen)
06:09:31  Camera Stern stopCapture failed (ConnectTimeout)
06:09:37  Camera Stern stopCapture failed (ConnectTimeout)
06:12:07  Camera Stern failed to stop (×2)
```

## Test plan
- [x] New `test_stop_camera_default_timeout_is_short` — asserts the timeout passed to httpx is ≤ 3 s when no explicit value is given.
- [x] New `test_stop_camera_default_timeout_env_override` — confirms `CAMERA_STOP_TIMEOUT=4.5` is respected.
- [x] Existing 24 camera tests still pass.
- [x] `ruff check` + `ruff format --check` clean repo-wide.
- [x] `mypy --strict` clean on touched files (`cameras.py`, `routes/races.py`). Pre-existing `usb_audio.py` errors on `main` are unrelated.
- [ ] CI to run the full suite (Pi local run hung at 15 min on the unrelated heavy tests; deferred to CI).
- [ ] Manual verification on next race: bring Pi off camera network, click End Race, confirm response is snappy and orphan tasks complete quickly in the background.

## Out of scope
- Orphan audio sessions on reboot (separate issue — `ss.audio_session_id` is lost on Pi power cycle).
- Pre-flight TCP connectivity check (mentioned in #773 as optional; deferred unless we see this recur).

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)