### PR TITLE
fix(sessions): resolve imported races to live recording + lock-resilient maneuver detect

### DIFF
--- a/src/helmlog/analysis/maneuvers.py
+++ b/src/helmlog/analysis/maneuvers.py
@@ -961,6 +961,10 @@ async def enrich_session_maneuvers(
             maneuver_type=stored_type,
             twd=twd,
         )
+        # Capture the persisted head-to-wind before ``md`` overwrites it below,
+        # so the write-back can be skipped when it's already stored.
+        stored_htw = d.get("head_to_wind_ts")
+
         md = metrics.to_dict()
         # Don't let entry_ts/exit_ts clobber the stored ts/end_ts fields.
         md.pop("entry_ts", None)
@@ -972,11 +976,29 @@ async def enrich_session_maneuvers(
         # Persist head-to-wind onto the maneuvers row so downstream callers
         # (phase-split metrics #614, overlay chart #619) can query the
         # column directly without going through the enrichment cache.
-        if d.get("id") is not None:
-            await storage.set_maneuver_head_to_wind_ts(
-                int(d["id"]),
-                metrics.head_to_wind_ts.isoformat() if metrics.head_to_wind_ts else None,
-            )
+        #
+        # This is a GET path, so only write when the value isn't already
+        # persisted — a write on every page view contends with the live
+        # logger and, on a hot DB, fails with "database is locked" and 500s
+        # the maneuvers panel. ``write_maneuvers`` resets the column to NULL on
+        # every re-detect, so the first enrich after a detect still persists
+        # it; later views read the stored value and skip the write. A transient
+        # lock here is non-fatal: ``d`` already carries the computed value for
+        # this response, so we log and move on rather than fail the request.
+        computed_htw = metrics.head_to_wind_ts.isoformat() if metrics.head_to_wind_ts else None
+        if d.get("id") is not None and stored_htw is None and computed_htw is not None:
+            import sqlite3
+
+            from loguru import logger
+
+            try:
+                await storage.set_maneuver_head_to_wind_ts(int(d["id"]), computed_htw)
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "enrich: head_to_wind_ts persist skipped for maneuver {} (DB busy): {}",
+                    d["id"],
+                    exc,
+                )
 
         # Reclassify a wildly-large-turn gybe as a rounding. The detector
         # classifies by pre/post TWA mode, which misses "Mexican" roundings

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -87,6 +87,37 @@ def _canonical_session_url(race_id: int, slug: str | None) -> str:
     return f"/session/{race_id}/{slug}" if slug else f"/session/{race_id}"
 
 
+async def _imported_session_redirect(request: Request, race: Any) -> RedirectResponse | None:  # noqa: ANN401
+    """Redirect an imported results row to its linked live recording, or None.
+
+    Imported races (Clubspot et al., ``source != 'live'``) are scoreboard rows
+    pinned to a date with a placeholder ``start_utc == end_utc`` window and no
+    instrument data of their own — so their track, overlays, and maneuvers
+    panel all come up empty. When the import is matched to a recording it
+    carries ``local_session_id``, and the live session page already folds the
+    imported results back in (reverse ``local_session_id`` lookup), making it
+    the complete view. Redirect there instead of rendering the data-less
+    window. Unmatched imports (``local_session_id IS NULL``) render as-is.
+    """
+    storage = get_storage(request)
+    db = storage._read_conn()  # noqa: SLF001
+    cur = await db.execute("SELECT source, local_session_id FROM races WHERE id = ?", (race.id,))
+    row = await cur.fetchone()
+    if row is None:
+        return None
+    source = row["source"]
+    local_sid = row["local_session_id"]
+    if source in (None, "live") or local_sid is None or local_sid == race.id:
+        return None
+    live_race = await storage.get_race(local_sid)
+    if live_race is None:
+        return None
+    qs = f"?{request.url.query}" if request.url.query else ""
+    return RedirectResponse(
+        url=_canonical_session_url(live_race.id, live_race.slug) + qs, status_code=302
+    )
+
+
 async def _render_session_page(
     request: Request,
     race: Any,  # helmlog.races.Race  # noqa: ANN401
@@ -313,6 +344,9 @@ async def session_detail_page_canonical(request: Request, session_id: int, slug:
         return RedirectResponse(
             url=_canonical_session_url(race.id, race.slug) + qs, status_code=302
         )
+    imported_redirect = await _imported_session_redirect(request, race)
+    if imported_redirect is not None:
+        return imported_redirect
     return await _render_session_page(request, race)
 
 
@@ -379,6 +413,9 @@ async def session_detail_page(request: Request, session_ref: str) -> Response:
                     url=_canonical_session_url(race.id, slug) + qs, status_code=302
                 )
             # Last-resort fallback — render inline rather than redirect-loop.
+            imported_redirect = await _imported_session_redirect(request, race)
+            if imported_redirect is not None:
+                return imported_redirect
             return await _render_session_page(request, race)
         # Not a race — try the debrief (audio_sessions) id space so history
         # links to debrief sessions keep resolving.

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -2454,6 +2454,8 @@ async def api_detect_maneuvers(
 
     Returns immediately with the count of detected maneuvers.
     """
+    import sqlite3
+
     storage = get_storage(request)
     from helmlog.maneuver_detector import detect_maneuvers
 
@@ -2463,7 +2465,20 @@ async def api_detect_maneuvers(
     if await cur.fetchone() is None:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    maneuvers = await detect_maneuvers(storage, session_id)
+    try:
+        maneuvers = await detect_maneuvers(storage, session_id)
+    except sqlite3.OperationalError as exc:
+        # The detect write (write_maneuvers) can lose a race with the live
+        # logger or the startup maneuver-backfill task and fail with
+        # "database is locked". That's transient — surface a retryable 503
+        # instead of an opaque 500 so the UI can prompt the user to retry.
+        if "locked" not in str(exc).lower():
+            raise
+        return JSONResponse(
+            {"detail": "Database is busy; please retry maneuver detection.", "retryable": True},
+            status_code=503,
+            headers={"Retry-After": "3"},
+        )
     return JSONResponse(
         {
             "session_id": session_id,

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -1269,8 +1269,16 @@ class TestEnrichWriteBackGating:
             "INSERT INTO races"
             " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
             " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (session_id, "s", "e", 1, start.date().isoformat(), "race",
-             start.isoformat(), end.isoformat()),
+            (
+                session_id,
+                "s",
+                "e",
+                1,
+                start.date().isoformat(),
+                "race",
+                start.isoformat(),
+                end.isoformat(),
+            ),
         )
         for i in range(121):
             ts = (start + timedelta(seconds=i)).isoformat()
@@ -1278,24 +1286,39 @@ class TestEnrichWriteBackGating:
             bsp = 6.0 if i < 55 or i > 70 else 3.0
             await db.execute(
                 "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
-                (ts, 0x05, hdg))
+                (ts, 0x05, hdg),
+            )
             await db.execute(
-                "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
-                (ts, 0x05, bsp))
+                "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)", (ts, 0x05, bsp)
+            )
             await db.execute(
                 "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference)"
-                " VALUES (?, ?, ?, ?, 0)", (ts, 0x05, 12.5, 40.0))
+                " VALUES (?, ?, ?, ?, 0)",
+                (ts, 0x05, 12.5, 40.0),
+            )
             await db.execute(
                 "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
-                " VALUES (?, ?, ?, ?)", (ts, 0x05, 37.0 + i * 1e-5, -122.0))
+                " VALUES (?, ?, ?, ?)",
+                (ts, 0x05, 37.0 + i * 1e-5, -122.0),
+            )
         await db.execute(
             "INSERT INTO maneuvers"
             " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
             "  vmg_loss_kts, tws_bin, twa_bin, head_to_wind_ts, details)"
             " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (session_id, "tack", (start + timedelta(seconds=60)).isoformat(),
-             (start + timedelta(seconds=70)).isoformat(), 10.0, 3.0, None, 12, 40,
-             head_to_wind_ts, None),
+            (
+                session_id,
+                "tack",
+                (start + timedelta(seconds=60)).isoformat(),
+                (start + timedelta(seconds=70)).isoformat(),
+                10.0,
+                3.0,
+                None,
+                12,
+                40,
+                head_to_wind_ts,
+                None,
+            ),
         )
         await db.commit()
 
@@ -1305,9 +1328,7 @@ class TestEnrichWriteBackGating:
     ) -> None:
         """When the stored row already has head_to_wind_ts, enrich must not
         call the write-back."""
-        await self._seed_tack_session(
-            storage, 1, "2024-06-15T14:01:35+00:00"
-        )
+        await self._seed_tack_session(storage, 1, "2024-06-15T14:01:35+00:00")
 
         calls: list[int] = []
         orig = storage.set_maneuver_head_to_wind_ts

--- a/tests/test_analysis_maneuvers.py
+++ b/tests/test_analysis_maneuvers.py
@@ -1252,3 +1252,90 @@ class TestRankManeuvers:
         # so the spread-aware path should label everything 'consistent'.
         labels = {m["rank"] for m in items}
         assert labels == {"consistent"}
+
+
+class TestEnrichWriteBackGating:
+    """The maneuvers display path (a GET) must not write head_to_wind_ts back
+    to the DB when it is already persisted — that read-time write contends with
+    the live logger and 500s with 'database is locked' on hot sessions."""
+
+    async def _seed_tack_session(
+        self, storage: Storage, session_id: int, head_to_wind_ts: str | None
+    ) -> None:
+        db = storage._conn()
+        start = datetime(2024, 6, 15, 14, 0, 0, tzinfo=UTC)
+        end = start + timedelta(seconds=120)
+        await db.execute(
+            "INSERT INTO races"
+            " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (session_id, "s", "e", 1, start.date().isoformat(), "race",
+             start.isoformat(), end.isoformat()),
+        )
+        for i in range(121):
+            ts = (start + timedelta(seconds=i)).isoformat()
+            hdg = 10.0 if i < 60 else 280.0
+            bsp = 6.0 if i < 55 or i > 70 else 3.0
+            await db.execute(
+                "INSERT INTO headings (ts, source_addr, heading_deg) VALUES (?, ?, ?)",
+                (ts, 0x05, hdg))
+            await db.execute(
+                "INSERT INTO speeds (ts, source_addr, speed_kts) VALUES (?, ?, ?)",
+                (ts, 0x05, bsp))
+            await db.execute(
+                "INSERT INTO winds (ts, source_addr, wind_speed_kts, wind_angle_deg, reference)"
+                " VALUES (?, ?, ?, ?, 0)", (ts, 0x05, 12.5, 40.0))
+            await db.execute(
+                "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg)"
+                " VALUES (?, ?, ?, ?)", (ts, 0x05, 37.0 + i * 1e-5, -122.0))
+        await db.execute(
+            "INSERT INTO maneuvers"
+            " (session_id, type, ts, end_ts, duration_sec, loss_kts,"
+            "  vmg_loss_kts, tws_bin, twa_bin, head_to_wind_ts, details)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (session_id, "tack", (start + timedelta(seconds=60)).isoformat(),
+             (start + timedelta(seconds=70)).isoformat(), 10.0, 3.0, None, 12, 40,
+             head_to_wind_ts, None),
+        )
+        await db.commit()
+
+    @pytest.mark.asyncio
+    async def test_no_write_when_head_to_wind_already_set(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the stored row already has head_to_wind_ts, enrich must not
+        call the write-back."""
+        await self._seed_tack_session(
+            storage, 1, "2024-06-15T14:01:35+00:00"
+        )
+
+        calls: list[int] = []
+        orig = storage.set_maneuver_head_to_wind_ts
+
+        async def spy(mid: int, htw: str | None) -> None:
+            calls.append(mid)
+            await orig(mid, htw)
+
+        monkeypatch.setattr(storage, "set_maneuver_head_to_wind_ts", spy)
+        enriched, _ = await enrich_session_maneuvers(storage, 1)
+        assert len(enriched) == 1
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_writes_when_head_to_wind_is_null(
+        self, storage: Storage, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When head_to_wind_ts is NULL, enrich should still persist it once."""
+        await self._seed_tack_session(storage, 1, None)
+
+        calls: list[int] = []
+        orig = storage.set_maneuver_head_to_wind_ts
+
+        async def spy(mid: int, htw: str | None) -> None:
+            calls.append(mid)
+            await orig(mid, htw)
+
+        monkeypatch.setattr(storage, "set_maneuver_head_to_wind_ts", spy)
+        enriched, _ = await enrich_session_maneuvers(storage, 1)
+        assert len(enriched) == 1
+        assert len(calls) == 1

--- a/tests/test_detect_maneuvers_endpoint.py
+++ b/tests/test_detect_maneuvers_endpoint.py
@@ -1,0 +1,89 @@
+"""Tests for the POST /api/sessions/{id}/detect-maneuvers endpoint —
+specifically its resilience to a transient SQLite write lock.
+
+A re-detect writes through ``write_maneuvers`` and can lose a race with the
+live logger or the startup maneuver-backfill task, raising
+``sqlite3.OperationalError: database is locked``. The endpoint must surface a
+retryable 503 rather than an opaque 500 in that case.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _seed_race(storage: Storage, session_id: int) -> None:
+    db = storage._conn()
+    start = datetime(2026, 4, 20, 14, 0, 0, tzinfo=UTC)
+    end = start + timedelta(seconds=120)
+    await db.execute(
+        "INSERT INTO races"
+        " (id, name, event, race_num, date, session_type, start_utc, end_utc)"
+        " VALUES (?, ?, 'e', ?, ?, 'race', ?, ?)",
+        (session_id, "s", session_id, start.date().isoformat(), start.isoformat(), end.isoformat()),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_detect_maneuvers_lock_returns_503(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _seed_race(storage, 1)
+    from helmlog import maneuver_detector
+    from helmlog.web import create_app
+
+    async def boom(*_a: object, **_k: object) -> list:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(maneuver_detector, "detect_maneuvers", boom)
+
+    app = create_app(storage)
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/api/sessions/1/detect-maneuvers")
+    assert r.status_code == 503
+    assert r.headers.get("Retry-After") == "3"
+    assert r.json()["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_detect_maneuvers_non_lock_operationalerror_not_swallowed(
+    storage: Storage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-lock OperationalError (e.g. a real schema error) must NOT be
+    masked as a friendly 503 — it should propagate as a 500."""
+    await _seed_race(storage, 1)
+    from helmlog import maneuver_detector
+    from helmlog.web import create_app
+
+    async def boom(*_a: object, **_k: object) -> list:
+        raise sqlite3.OperationalError("no such column: bogus")
+
+    monkeypatch.setattr(maneuver_detector, "detect_maneuvers", boom)
+
+    app = create_app(storage)
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t", timeout=10) as c:
+        with pytest.raises(sqlite3.OperationalError):
+            await c.post("/api/sessions/1/detect-maneuvers")
+
+
+@pytest.mark.asyncio
+async def test_detect_maneuvers_unknown_session_404(storage: Storage) -> None:
+    from helmlog.web import create_app
+
+    app = create_app(storage)
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/api/sessions/999/detect-maneuvers")
+    assert r.status_code == 404

--- a/tests/test_imported_session_redirect.py
+++ b/tests/test_imported_session_redirect.py
@@ -1,0 +1,99 @@
+"""Tests for redirecting imported results sessions to their linked live
+recording (the imported→live navigation fix).
+
+Imported Clubspot/results rows (source != 'live') with a placeholder
+start_utc==end_utc window carry a local_session_id pointing at the live
+recording that actually holds the track + maneuvers. Visiting the imported
+race page should redirect to the live session's canonical URL, where the
+maneuvers exist and the imported results are folded back in.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _seed_live(storage: Storage, sid: int, slug: str) -> None:
+    db = storage._conn()
+    start = datetime(2026, 6, 4, 0, 13, 0, tzinfo=UTC)
+    end = start + timedelta(minutes=55)
+    await db.execute(
+        "INSERT INTO races (id, name, event, race_num, date, session_type,"
+        " start_utc, end_utc, slug, source)"
+        " VALUES (?, ?, 'e', ?, '2026-06-04', 'race', ?, ?, ?, 'live')",
+        (sid, f"Live {sid}", sid, start.isoformat(), end.isoformat(), slug),
+    )
+    await db.commit()
+
+
+async def _seed_imported(
+    storage: Storage, sid: int, slug: str, *, local_session_id: int | None
+) -> None:
+    db = storage._conn()
+    placeholder = "2026-06-04T00:00:00+00:00"
+    await db.execute(
+        "INSERT INTO races (id, name, event, race_num, date, session_type,"
+        " start_utc, end_utc, slug, source, source_id, local_session_id)"
+        " VALUES (?, ?, 'e', ?, '2026-06-04', 'race', ?, ?, ?, 'clubspot', ?, ?)",
+        (sid, f"Race {sid}", sid, placeholder, placeholder, slug, f"tok_{sid}", local_session_id),
+    )
+    await db.commit()
+
+
+def _client(storage: Storage) -> httpx.AsyncClient:
+    from helmlog.web import create_app
+
+    app = create_app(storage)
+    return httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t", follow_redirects=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_matched_import_redirects_to_live_session(storage: Storage) -> None:
+    await _seed_live(storage, 185, "live-185")
+    await _seed_imported(storage, 188, "race-19", local_session_id=185)
+
+    async with _client(storage) as c:
+        r = await c.get("/session/188/race-19")
+    assert r.status_code == 302
+    assert r.headers["location"] == "/session/185/live-185"
+
+
+@pytest.mark.asyncio
+async def test_redirect_preserves_query_string(storage: Storage) -> None:
+    await _seed_live(storage, 185, "live-185")
+    await _seed_imported(storage, 188, "race-19", local_session_id=185)
+
+    async with _client(storage) as c:
+        r = await c.get("/session/188/race-19", params={"moment": "5"})
+    assert r.status_code == 302
+    assert r.headers["location"] == "/session/185/live-185?moment=5"
+
+
+@pytest.mark.asyncio
+async def test_unmatched_import_renders_in_place(storage: Storage) -> None:
+    """An imported row with no local_session_id has nothing to redirect to —
+    it should still render its own (scoreboard) page, not 404 or 500."""
+    await _seed_imported(storage, 189, "race-20", local_session_id=None)
+
+    async with _client(storage) as c:
+        r = await c.get("/session/189/race-20")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_live_session_does_not_redirect(storage: Storage) -> None:
+    await _seed_live(storage, 185, "live-185")
+
+    async with _client(storage) as c:
+        r = await c.get("/session/185/live-185")
+    assert r.status_code == 200

--- a/tests/test_storage_wal.py
+++ b/tests/test_storage_wal.py
@@ -38,6 +38,36 @@ async def test_wal_mode_enabled(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_busy_timeout_set_on_write_connection(tmp_path: Path) -> None:
+    """A non-zero busy_timeout must be set so contending writes wait instead
+    of erroring instantly with 'database is locked'."""
+    db_path = str(tmp_path / "busy.db")
+    s = Storage(StorageConfig(db_path=db_path))
+    await s.connect()
+    try:
+        cur = await s._conn().execute("PRAGMA busy_timeout")
+        row = await cur.fetchone()
+        assert row[0] >= 5000
+    finally:
+        await s.close()
+
+
+@pytest.mark.asyncio
+async def test_busy_timeout_set_on_read_connection(tmp_path: Path) -> None:
+    """The read connection should also carry a busy_timeout."""
+    db_path = str(tmp_path / "busy_ro.db")
+    s = Storage(StorageConfig(db_path=db_path))
+    await s.connect()
+    try:
+        assert s._read_db is not None
+        cur = await s._read_db.execute("PRAGMA busy_timeout")
+        row = await cur.fetchone()
+        assert row[0] >= 5000
+    finally:
+        await s.close()
+
+
+@pytest.mark.asyncio
 async def test_read_connection_exists_for_file_db(tmp_path: Path) -> None:
     """File-backed storage should have a separate read connection."""
     db_path = str(tmp_path / "read.db")


### PR DESCRIPTION
## Summary
Fixes two bugs surfaced as "maneuvers missing from recent sessions + redetect 500s".

**1. Imported results rows now resolve to their live recording.** Clubspot imports (`source != 'live'`) are scoreboard rows with a placeholder `start_utc == end_utc` window and no instrument data, so their track/overlays/maneuvers render empty. When matched they carry `local_session_id`; the live session page already folds the imported results back in, so it's the complete view. The two `/session` detail render points now redirect a matched import to the live session's canonical URL. Unmatched imports, live sessions, and the home page are untouched; query string is preserved.

**2. `detect-maneuvers` is lock-resilient.** `write_maneuvers` can lose a race with the live logger / startup maneuver-backfill and raise `database is locked`; the endpoint surfaced that as an opaque 500. It now returns a retryable **503 + Retry-After** on lock and re-raises any other `OperationalError`. Separately, `enrich_session_maneuvers` no longer writes `head_to_wind_ts` on every GET — it persists only when not already stored and tolerates a transient lock instead of 500ing the panel. (`busy_timeout` is already 5000 ms by aiosqlite default — not the cause.)

## Test plan
- `tests/test_imported_session_redirect.py` — matched import → 302 to live URL; query string preserved; unmatched import renders 200; live session renders 200.
- `tests/test_detect_maneuvers_endpoint.py` — 503 + Retry-After on lock; non-lock `OperationalError` re-raised (not masked); unknown session 404.
- `tests/test_analysis_maneuvers.py::TestEnrichWriteBackGating` — no write when `head_to_wind_ts` already stored; writes once when NULL.
- `tests/test_storage_wal.py` — busy_timeout regression guards (>=5000 on both connections).
- 152 passed across affected suites; `ruff` + `mypy --strict` clean.

## Risk tier
Standard — touches `routes/pages.py`, `routes/sessions.py`, `analysis/maneuvers.py` (no `storage.py`/migrations/auth).

Fixes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)