### PR TITLE
docs(skills): anti-rationalization tables + judgment rules

### DIFF
--- a/.claude/skills/data-license/SKILL.md
+++ b/.claude/skills/data-license/SKILL.md
@@ -75,6 +75,19 @@ These are the policies a general PII review will NOT catch:
 - [ ] Soft delete (suppression) supported during 30-day grace period.
 - [ ] Hard delete is irreversible after grace period.
 
+## Don't rationalize skipping the review
+
+These policies are invisible to a generalist PII pass — which is exactly
+why "it looked fine" is not a clearance. Common excuses and rebuttals:
+
+| Rationalization | Rebuttal |
+|---|---|
+| "General PII looks clean, so we're compliant." | The general pass cannot see embargoes, the protest firewall, the 4-boat benchmark floor, or biometric consent separation. Walk Section 2 explicitly. |
+| "There's already an embargo check, so it's covered." | Presence ≠ correctness. Verify the comparison operator matches `embargo_until`'s meaning — a flipped check leaks early. |
+| "Boat owner consented, so biometric data is fine." | Biometrics need per-person consent separate from instrument sharing. Owner consent is not sufficient. |
+| "Coach just needs access for the season." | No permanent or blanket grants — time-limited, per-session authorization only. |
+| "It's only an export format tweak." | Export is where the protest firewall and AIS-exclusion rules bite. Re-check both before clearing. |
+
 ## 3. Report findings
 
 For each issue: state the policy section, quote the relevant policy

--- a/.claude/skills/pr-checklist/SKILL.md
+++ b/.claude/skills/pr-checklist/SKILL.md
@@ -82,6 +82,19 @@ tier — Critical/High hotspots are more urgent than Standard. Also flag
 files that grew by more than 50 lines in this PR even if they were
 already over 200.
 
+## Don't rationalize skipping a check
+
+The tier matrix is resolved by file, not by how the diff feels. Common
+excuses and their rebuttals:
+
+| Rationalization | Rebuttal |
+|---|---|
+| "The `storage.py` change is tiny, skip the spec." | Tier is set by file + migration content, not diff size. If migrations changed, it's Critical and needs an approved `/spec` before merge. |
+| "Unit tests pass — integration tests are overkill." | For federation/peer/auth/PII changes, integration tests are Required regardless of unit coverage. Run them. |
+| "This Pi hotfix is urgent, just commit to main." | Never. Branch + PR + merge — even for hotfixes (CLAUDE.md). Urgency is not an exception. |
+| "Module isn't in the tier table, so it's low-risk." | Unclassified `.py` defaults to **Standard**, not Low — and you must flag it for classification. |
+| "Docs are out of scope for this PR." | If you added a module / env var / CLI command / migration / dep, the documentation-update map below is part of the PR. |
+
 ## Final steps
 
 - PR body must include `Closes #N` (or `Fixes #N` for bugs).

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -48,6 +48,19 @@ with patch("helmlog.cameras.httpx.AsyncClient") as mock_client:
 Hardware modules to mock: `audio.py`, `can_reader.py`, `sk_reader.py`,
 `cameras.py`.
 
+## Don't rationalize skipping the cycle
+
+The cycle only helps if you don't talk yourself out of it. Common excuses
+and their rebuttals:
+
+| Rationalization | Rebuttal |
+|---|---|
+| "This change is too small to need a test." | Size predicts neither breakage nor regression. A failing test first is what proves the change does what you think — write it. |
+| "I'll write the test after I see it work." | Test-after rationalizes whatever the code already does, bugs included. Red-Green-Refactor is mandated in CLAUDE.md for a reason. |
+| "It's just a renderer/route tweak — I'll eyeball it." | Web routes are the easiest place to ship a silent 500. Use the `AsyncClient`/`ASGITransport` pattern above. |
+| "Tests pass, so it's correct." | Passing tests are evidence, not proof. Confirm the test exercises the new behavior and would actually fail without your change. |
+| "ruff/mypy is noisy here, I'll skip the lint gate." | Only the pre-existing-error allowlist below is exempt. Everything else is green-before-PR. |
+
 ## Pre-existing errors to ignore
 
 Do not fix these unless explicitly asked — they are tracked separately:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,20 @@ for race marking, history, debrief audio, and CSV/GPX/JSON export.
 - **Commit and push every change immediately.** Uncommitted Pi edits are
   lost on the next deploy.
 
+### Judgment rules (not just process)
+
+- **Surface assumptions before building.** If the task is underspecified,
+  state the assumption you're proceeding on rather than silently guessing.
+- **Stop and ask when requirements conflict** — with an issue, with
+  `docs/data-licensing.md`, or with existing behavior. Don't pick a side
+  unasked.
+- **Push back when warranted.** A worse plan you were handed is still worse;
+  say so before implementing it.
+- **Prefer boring, obvious solutions.** This is a Pi logger where a reboot
+  must lose at most one record — reliability beats cleverness.
+- **Touch only what you're asked to touch.** No drive-by refactors of
+  adjacent code or unrelated TODOs; they widen the blast radius and the diff.
+
 ## Stack & tooling
 
 | Concern | Tool |


### PR DESCRIPTION
## Summary

Adopts two transferable ideas from Addy Osmani's ["Agent Skills"](https://www.oreilly.com/radar/agent-skills/) that weren't already covered by our suite:

- **Anti-rationalization tables** in `tdd`, `pr-checklist`, and `data-license` — each pairs the specific excuse an agent uses to skip a verification step with a written rebuttal, placed at the point of temptation. Targets known HelmLog failure modes: skipping the spec on a "small" `storage.py` change, skipping integration tests when unit tests pass, committing a Pi hotfix straight to `main`, clearing a data-license review on a generalist PII pass.
- **Judgment rules** subsection in CLAUDE.md Top rules — surface assumptions, ask on conflict, push back when warranted, prefer boring solutions (framed around the Pi reliability constraint), scope discipline. Complements the existing process rules.

Deliberately **skipped** the article's generic 20-skill SDLC pack and `using-agent-skills` router — already covered by our domain-tailored skills and TRIGGER/DO-NOT-TRIGGER gating, which the article would consider a stronger form of progressive disclosure.

## Test plan

Docs/skill-definition changes only — no Python touched, no runtime behavior affected (Low tier). Verified the four files render as well-formed Markdown tables and the additions match each skill's existing voice and structure.

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)