### PR TITLE
fix(cameras): restore hardware isolation via injected CameraController

### DIFF
--- a/src/helmlog/camera_control.py
+++ b/src/helmlog/camera_control.py
@@ -1,0 +1,117 @@
+"""Camera abstraction shared by the web tier and the hardware module (#780).
+
+Hardware isolation: web routes must never import ``helmlog.cameras`` (the OSC
+HTTP/hardware module).  Instead they reach camera operations through the
+:class:`CameraController` injected on ``app.state.cameras``.  ``main.py`` — the
+only module allowed to touch hardware — constructs the concrete
+``HardwareCameraController`` (defined in ``cameras.py``) and passes it into
+``create_app``.  Tests and headless runs fall back to :class:`NullCameraController`.
+
+This module holds only the pure pieces (dataclasses, the controller protocol,
+and the no-op default), so importing it carries no hardware dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+@dataclass(frozen=True)
+class Camera:
+    """A configured camera with a human-readable name and network address."""
+
+    name: str
+    ip: str
+    model: str = "insta360-x4"
+    wifi_ssid: str | None = None
+    wifi_password: str | None = None
+
+
+@dataclass
+class CameraStatus:
+    """Result of a camera operation."""
+
+    name: str
+    ip: str
+    recording: bool
+    error: str | None = None
+    latency_ms: int | None = None
+
+
+@runtime_checkable
+class CameraController(Protocol):
+    """Operations the web tier needs, with no hardware import on the caller side."""
+
+    async def load(self, storage: Storage) -> list[Camera]: ...
+
+    async def statuses(self, cams: list[Camera]) -> list[CameraStatus]: ...
+
+    async def start(self, cam: Camera) -> CameraStatus: ...
+
+    async def stop(self, cam: Camera) -> CameraStatus: ...
+
+    async def start_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]: ...
+
+    async def stop_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]: ...
+
+
+async def load_cameras_from_storage(storage: Storage) -> list[Camera]:
+    """Build :class:`Camera` config objects from the ``cameras`` table rows.
+
+    Pure data assembly — shared by every controller so the web tier never has
+    to construct cameras itself.
+    """
+    rows = await storage.list_cameras()
+    return [
+        Camera(
+            name=r["name"],
+            ip=r["ip"],
+            model=r["model"],
+            wifi_ssid=r.get("wifi_ssid"),
+            wifi_password=r.get("wifi_password"),
+        )
+        for r in rows
+    ]
+
+
+class NullCameraController:
+    """Default controller when no camera hardware is wired (tests, headless).
+
+    Lists configured cameras (pure DB read) but performs no network I/O — every
+    camera is reported idle and start/stop are no-ops.
+    """
+
+    async def load(self, storage: Storage) -> list[Camera]:
+        return await load_cameras_from_storage(storage)
+
+    async def statuses(self, cams: list[Camera]) -> list[CameraStatus]:
+        return [CameraStatus(name=c.name, ip=c.ip, recording=False) for c in cams]
+
+    async def start(self, cam: Camera) -> CameraStatus:
+        return CameraStatus(
+            name=cam.name,
+            ip=cam.ip,
+            recording=False,
+            error="no camera controller configured",
+        )
+
+    async def stop(self, cam: Camera) -> CameraStatus:
+        return CameraStatus(name=cam.name, ip=cam.ip, recording=False)
+
+    async def start_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]:
+        return []
+
+    async def stop_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]:
+        return []

--- a/src/helmlog/cameras.py
+++ b/src/helmlog/cameras.py
@@ -23,19 +23,36 @@ from __future__ import annotations
 import asyncio
 import os
 import time
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import httpx
 from loguru import logger
 
+# Camera / CameraStatus live in the pure ``camera_control`` module so the web
+# tier can reference them without importing this hardware module.  Re-exported
+# here for backward compatibility (existing callers import them from
+# ``helmlog.cameras``).
+from helmlog.camera_control import (
+    Camera,
+    CameraStatus,
+    load_cameras_from_storage,
+)
+
 if TYPE_CHECKING:
     from helmlog.storage import Storage
 
-# ---------------------------------------------------------------------------
-# Dataclasses
-# ---------------------------------------------------------------------------
+__all__ = [
+    "Camera",
+    "CameraStatus",
+    "HardwareCameraController",
+    "get_status",
+    "parse_cameras_config",
+    "start_all",
+    "start_camera",
+    "stop_all",
+    "stop_camera",
+]
 
 
 def _default_timeout() -> float:
@@ -52,28 +69,6 @@ def _default_stop_timeout() -> float:
 
 _OSC_PATH = "/osc/commands/execute"
 _OSC_HEADERS = {"X-XSRF-Protected": "1"}
-
-
-@dataclass(frozen=True)
-class Camera:
-    """A configured camera with a human-readable name and network address."""
-
-    name: str
-    ip: str
-    model: str = "insta360-x4"
-    wifi_ssid: str | None = None
-    wifi_password: str | None = None
-
-
-@dataclass
-class CameraStatus:
-    """Result of a camera operation."""
-
-    name: str
-    ip: str
-    recording: bool
-    error: str | None = None
-    latency_ms: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -306,3 +301,48 @@ async def stop_all(
         )
 
     return statuses
+
+
+# ---------------------------------------------------------------------------
+# Controller — the hardware-backed adapter injected on app.state.cameras (#780)
+# ---------------------------------------------------------------------------
+
+
+class HardwareCameraController:
+    """Concrete :class:`~helmlog.camera_control.CameraController` over real OSC
+    cameras.  Constructed by ``main.py`` and injected so web routes never import
+    this hardware module.
+    """
+
+    async def load(self, storage: Storage) -> list[Camera]:
+        return await load_cameras_from_storage(storage)
+
+    async def statuses(self, cams: list[Camera]) -> list[CameraStatus]:
+        results = await asyncio.gather(
+            *(get_status(cam) for cam in cams), return_exceptions=True
+        )
+        out: list[CameraStatus] = []
+        for cam, st in zip(cams, results, strict=True):
+            if isinstance(st, BaseException):
+                out.append(
+                    CameraStatus(name=cam.name, ip=cam.ip, recording=False, error=str(st))
+                )
+            else:
+                out.append(st)
+        return out
+
+    async def start(self, cam: Camera) -> CameraStatus:
+        return await start_camera(cam)
+
+    async def stop(self, cam: Camera) -> CameraStatus:
+        return await stop_camera(cam)
+
+    async def start_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]:
+        return await start_all(cams, session_id, storage)
+
+    async def stop_all(
+        self, cams: list[Camera], session_id: int, storage: Storage
+    ) -> list[CameraStatus]:
+        return await stop_all(cams, session_id, storage)

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -134,6 +134,7 @@ async def _web_loop(
     import uvicorn
 
     from helmlog.audio import AudioConfig, AudioRecorder, AudioRecorderGroup
+    from helmlog.cameras import HardwareCameraController
     from helmlog.races import RaceConfig
     from helmlog.storage import Storage
     from helmlog.web import create_app
@@ -148,7 +149,12 @@ async def _web_loop(
         cfg = RaceConfig()
         server = uvicorn.Server(
             uvicorn.Config(
-                create_app(storage, _recorder, _audio_config),
+                create_app(
+                    storage,
+                    _recorder,
+                    _audio_config,
+                    camera_controller=HardwareCameraController(),
+                ),
                 host=cfg.web_host,
                 port=cfg.web_port,
                 log_level="warning",

--- a/src/helmlog/routes/_helpers.py
+++ b/src/helmlog/routes/_helpers.py
@@ -231,21 +231,13 @@ async def audit(
 
 
 async def load_cameras(request: Request) -> list[Any]:
-    """Load cameras from the database and return Camera objects."""
-    from helmlog.cameras import Camera
+    """Load configured cameras via the injected camera controller (#780).
 
-    storage = get_storage(request)
-    rows = await storage.list_cameras()
-    return [
-        Camera(
-            name=r["name"],
-            ip=r["ip"],
-            model=r["model"],
-            wifi_ssid=r.get("wifi_ssid"),
-            wifi_password=r.get("wifi_password"),
-        )
-        for r in rows
-    ]
+    Routes go through ``request.app.state.cameras`` rather than importing the
+    hardware module directly, preserving hardware isolation.
+    """
+    cams: list[Any] = await request.app.state.cameras.load(get_storage(request))
+    return cams
 
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/routes/cameras.py
+++ b/src/helmlog/routes/cameras.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -25,40 +24,22 @@ async def api_list_cameras(
     if not cams:
         return JSONResponse([])
 
-    import helmlog.cameras as cameras_mod
-
-    statuses = await asyncio.gather(
-        *(cameras_mod.get_status(cam) for cam in cams),
-        return_exceptions=True,
-    )
+    statuses = await request.app.state.cameras.statuses(cams)
     result: list[dict[str, Any]] = []
     for cam, st in zip(cams, statuses, strict=True):
         # Mask WiFi passwords in API responses (#210)
         masked_pw = "••••••••" if cam.wifi_password else None
-        if isinstance(st, BaseException):
-            result.append(
-                {
-                    "name": cam.name,
-                    "ip": cam.ip,
-                    "model": cam.model,
-                    "wifi_ssid": cam.wifi_ssid,
-                    "wifi_password": masked_pw,
-                    "recording": False,
-                    "error": str(st),
-                }
-            )
-        else:
-            result.append(
-                {
-                    "name": st.name,
-                    "ip": st.ip,
-                    "model": cam.model,
-                    "wifi_ssid": cam.wifi_ssid,
-                    "wifi_password": masked_pw,
-                    "recording": st.recording,
-                    "error": st.error,
-                }
-            )
+        result.append(
+            {
+                "name": st.name,
+                "ip": st.ip,
+                "model": cam.model,
+                "wifi_ssid": cam.wifi_ssid,
+                "wifi_password": masked_pw,
+                "recording": st.recording,
+                "error": st.error,
+            }
+        )
     return JSONResponse(result)
 
 
@@ -70,13 +51,11 @@ async def api_start_camera(
 ) -> JSONResponse:
     """Manually start recording on a single camera."""
     get_storage(request)
-    import helmlog.cameras as cameras_mod
-
     cams = await load_cameras(request)
     cam = next((c for c in cams if c.name == camera_name), None)
     if cam is None:
         raise HTTPException(404, detail=f"Camera {camera_name!r} not found")
-    status = await cameras_mod.start_camera(cam)
+    status = await request.app.state.cameras.start(cam)
     return JSONResponse(
         {
             "name": status.name,
@@ -95,13 +74,11 @@ async def api_stop_camera(
 ) -> JSONResponse:
     """Manually stop recording on a single camera."""
     get_storage(request)
-    import helmlog.cameras as cameras_mod
-
     cams = await load_cameras(request)
     cam = next((c for c in cams if c.name == camera_name), None)
     if cam is None:
         raise HTTPException(404, detail=f"Camera {camera_name!r} not found")
-    status = await cameras_mod.stop_camera(cam)
+    status = await request.app.state.cameras.stop(cam)
     return JSONResponse(
         {
             "name": status.name,
@@ -233,16 +210,8 @@ async def api_camera_status_crew(
     cams = await load_cameras(request)
     if not cams:
         return JSONResponse({"recording": False, "cameras": []})
-    import helmlog.cameras as cameras_mod
-
-    statuses = await asyncio.gather(
-        *(cameras_mod.get_status(cam) for cam in cams),
-        return_exceptions=True,
-    )
-    recording_cams: list[str] = []
-    for cam, st in zip(cams, statuses, strict=True):
-        if not isinstance(st, BaseException) and st.recording:
-            recording_cams.append(cam.name)
+    statuses = await request.app.state.cameras.statuses(cams)
+    recording_cams: list[str] = [st.name for st in statuses if st.recording]
     return JSONResponse(
         {
             "recording": bool(recording_cams),

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -467,10 +467,8 @@ async def api_start_race(
         cams = await load_cameras(request)
         if not cams:
             return
-        import helmlog.cameras as cameras_mod
-
         try:
-            statuses = await cameras_mod.start_all(cams, rid, storage)
+            statuses = await request.app.state.cameras.start_all(cams, rid, storage)
             for s in statuses:
                 if s.error:
                     logger.warning("Camera {} failed to start: {}", s.name, s.error)
@@ -521,10 +519,8 @@ async def api_end_race(
         cams = await load_cameras(request)
         if not cams:
             return
-        import helmlog.cameras as cameras_mod
-
         try:
-            statuses = await cameras_mod.stop_all(cams, rid, storage)
+            statuses = await request.app.state.cameras.stop_all(cams, rid, storage)
             for s in statuses:
                 if s.error:
                     logger.warning("Camera {} failed to stop: {}", s.name, s.error)

--- a/src/helmlog/web.py
+++ b/src/helmlog/web.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from fastapi.responses import Response
 
     from helmlog.audio import AudioConfig, AudioRecorder, AudioRecorderGroup
+    from helmlog.camera_control import CameraController
     from helmlog.storage import Storage
 
 # Re-export _get_git_info for backward compatibility (used by tests)
@@ -44,12 +45,19 @@ def create_app(
     storage: Storage,
     recorder: AudioRecorder | AudioRecorderGroup | None = None,
     audio_config: AudioConfig | None = None,
+    camera_controller: CameraController | None = None,
 ) -> FastAPI:
     """Create and return the FastAPI application bound to the given Storage.
 
     If *recorder* and *audio_config* are provided, recording starts when a race
     starts and stops when the race ends.  Cameras are managed in the database
     and loaded dynamically for each operation.
+
+    *camera_controller* is the :class:`~helmlog.camera_control.CameraController`
+    that web routes use to drive cameras without importing the hardware module
+    (#780).  ``main.py`` passes the hardware-backed controller; tests and
+    headless runs fall back to a no-op
+    :class:`~helmlog.camera_control.NullCameraController`.
     """
     from slowapi import _rate_limit_exceeded_handler
     from slowapi.errors import RateLimitExceeded
@@ -83,6 +91,11 @@ def create_app(
     app.state.storage = storage
     app.state.recorder = recorder
     app.state.audio_config = audio_config
+    if camera_controller is None:
+        from helmlog.camera_control import NullCameraController
+
+        camera_controller = NullCameraController()
+    app.state.cameras = camera_controller
     app.state.session_state = AppSessionState()
     app.state.startup_sha = STARTUP_SHA
     app.state.ws_clients = set()  # WebSocket client connections

--- a/tests/test_camera_isolation.py
+++ b/tests/test_camera_isolation.py
@@ -1,0 +1,160 @@
+"""Hardware-isolation guard + DI behaviour for the camera subsystem (#780).
+
+The architecture rule (CLAUDE.md / AGENTS.md): hardware modules
+(``sk_reader.py``, ``can_reader.py``, ``cameras.py``) are imported only by
+``main.py``.  Web routes must reach camera operations through the
+``CameraController`` injected on ``app.state.cameras`` — never by importing
+``helmlog.cameras`` directly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+import helmlog.routes._helpers as helpers_mod
+import helmlog.routes.cameras as cameras_route_mod
+import helmlog.routes.races as races_route_mod
+from helmlog.camera_control import NullCameraController
+from helmlog.cameras import Camera, CameraStatus
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from fastapi import FastAPI
+
+    from helmlog.camera_control import CameraController
+    from helmlog.storage import Storage
+
+_GUARDED_MODULES = [helpers_mod, cameras_route_mod, races_route_mod]
+
+
+def _imports_helmlog_cameras(source: str) -> bool:
+    """True if the module source imports ``helmlog.cameras`` in any form."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name == "helmlog.cameras" or a.name == "cameras" for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module in {"helmlog.cameras", "cameras"}:
+                return True
+            # `from helmlog import cameras`
+            if node.module == "helmlog" and any(a.name == "cameras" for a in node.names):
+                return True
+    return False
+
+
+@pytest.mark.parametrize("mod", _GUARDED_MODULES, ids=lambda m: m.__name__)
+def test_route_modules_do_not_import_camera_hardware(mod: ModuleType) -> None:
+    """Route modules must not import the hardware camera module."""
+    source = Path(mod.__file__).read_text()
+    assert not _imports_helmlog_cameras(source), (
+        f"{mod.__name__} imports helmlog.cameras directly — route the call "
+        f"through request.app.state.cameras instead (#780)."
+    )
+
+
+class _FakeController:
+    """Records calls and returns canned results, no hardware."""
+
+    def __init__(self, cams: list[Camera]) -> None:
+        self._cams = cams
+        self.calls: list[tuple[str, str]] = []
+
+    async def load(self, storage: Storage) -> list[Camera]:
+        return self._cams
+
+    async def statuses(self, cams: list[Camera]) -> list[CameraStatus]:
+        self.calls.append(("statuses", ""))
+        return [CameraStatus(name=c.name, ip=c.ip, recording=True) for c in cams]
+
+    async def start(self, cam: Camera) -> CameraStatus:
+        self.calls.append(("start", cam.name))
+        return CameraStatus(name=cam.name, ip=cam.ip, recording=True)
+
+    async def stop(self, cam: Camera) -> CameraStatus:
+        self.calls.append(("stop", cam.name))
+        return CameraStatus(name=cam.name, ip=cam.ip, recording=False)
+
+
+def _app_with_controller(storage: Storage, ctl: CameraController) -> FastAPI:
+    app = create_app(storage)
+    app.state.cameras = ctl
+    return app
+
+
+@pytest.mark.asyncio
+async def test_start_route_delegates_to_controller(storage: Storage) -> None:
+    ctl = _FakeController([Camera(name="bow", ip="10.0.0.1")])
+    app = _app_with_controller(storage, ctl)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cameras/bow/start")
+    assert resp.status_code == 200
+    assert resp.json()["recording"] is True
+    assert ("start", "bow") in ctl.calls
+
+
+@pytest.mark.asyncio
+async def test_stop_route_delegates_to_controller(storage: Storage) -> None:
+    ctl = _FakeController([Camera(name="bow", ip="10.0.0.1")])
+    app = _app_with_controller(storage, ctl)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cameras/bow/stop")
+    assert resp.status_code == 200
+    assert resp.json()["recording"] is False
+    assert ("stop", "bow") in ctl.calls
+
+
+@pytest.mark.asyncio
+async def test_start_unknown_camera_404(storage: Storage) -> None:
+    ctl = _FakeController([Camera(name="bow", ip="10.0.0.1")])
+    app = _app_with_controller(storage, ctl)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/cameras/stern/start")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_route_uses_controller_statuses(storage: Storage) -> None:
+    ctl = _FakeController([Camera(name="bow", ip="10.0.0.1")])
+    app = _app_with_controller(storage, ctl)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/cameras")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["name"] == "bow"
+    assert body[0]["recording"] is True
+    assert ("statuses", "") in ctl.calls
+
+
+@pytest.mark.asyncio
+async def test_default_app_uses_null_controller(storage: Storage) -> None:
+    """create_app with no controller binds a hardware-free default."""
+    app = create_app(storage)
+    assert isinstance(app.state.cameras, NullCameraController)
+
+
+@pytest.mark.asyncio
+async def test_null_controller_reports_no_recording(storage: Storage) -> None:
+    """NullCameraController loads configured cameras but reports them idle."""
+    await storage.add_camera("bow", "10.0.0.1", "insta360-x4", None, None)
+    ctl = NullCameraController()
+    cams = await ctl.load(storage)
+    assert [c.name for c in cams] == ["bow"]
+    statuses = await ctl.statuses(cams)
+    assert all(not s.recording for s in statuses)


### PR DESCRIPTION
## Summary

Web route modules imported `helmlog.cameras` directly and drove camera hardware I/O from the web tier, violating the architecture rule that hardware modules (`sk_reader.py`, `can_reader.py`, `cameras.py`) are imported only by `main.py`.

This introduces a `CameraController` abstraction injected on `app.state.cameras`, following the existing `storage`/`recorder`/`audio_config` DI pattern in `create_app`.

### Verified leak surface (corrected)
- `routes/_helpers.py` — `from helmlog.cameras import Camera`
- `routes/cameras.py` — `import helmlog.cameras` (4×): `get_status`, `start_camera`, `stop_camera`
- `routes/races.py` — `import helmlog.cameras`: `start_all`, `stop_all`

> Note: an earlier audit named `routes/admin.py`, but it only renders a template and never imports `helmlog.cameras` — no change needed there.

## Changes
- **`camera_control.py` (new, pure):** `Camera`/`CameraStatus` dataclasses, the `CameraController` protocol, `load_cameras_from_storage`, and a no-op `NullCameraController` default. Importing it carries no hardware dependency.
- **`cameras.py`:** re-exports the dataclasses (backward compat for existing importers) and adds `HardwareCameraController`, the OSC-backed adapter.
- **`main.py`:** constructs `HardwareCameraController()` (composition root, allowed to touch hardware) and passes it into `create_app(..., camera_controller=...)`.
- **`web.py`:** new `camera_controller` param bound to `app.state.cameras`; falls back to `NullCameraController` for the test/headless path (no hardware import in `web.py`).
- **routes:** `_helpers`, `cameras`, `races` now call `request.app.state.cameras.*`. No route imports `helmlog.cameras`.

## Tests
- **AST guard test** asserting `routes/_helpers.py`, `routes/cameras.py`, `routes/races.py` never import the hardware module again (regression fence).
- **New behavioural coverage** for the start/stop/status routes via an injected fake controller — these routes previously had no route-level tests.
- Full suite green: **2663 passed, 2 skipped**. `ruff` + `mypy --strict` clean.

## Out of scope
`storage.py` also imports `parse_cameras_config` (a pure parser) from `helmlog.cameras` via a lazy import — a minor instance of the same leak, not in the web tier. Left for a follow-up.

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)