### PR TITLE
Close races at last-data (not now) when power is killed mid-race

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ SK_PORT=3000
 # Falls back to reading ~/.signalk-admin-pass.txt if no env/file vars set
 # Rudder angle storage rate (Hz) — ESP32 publishes at 10 Hz; default stores at 2 Hz
 # RUDDER_STORAGE_HZ=2
+# Race close reconciliation (#785). If a race is ended more than this many
+# seconds after its last recorded data point, it is closed at the last data
+# point instead (power/instrument loss before the race was stopped).
+# RACE_CLOSE_GRACE_S=120
+# On boot, an open race whose last data is older than this (seconds) is treated
+# as stale (e.g. overnight power loss) and closed at its last data point; a
+# smaller gap is a quick reboot mid-race and recording resumes into it.
+# RACE_BOOT_RESUME_WINDOW_S=600
 # Audio recording (Gordik 2T1R or any USB Audio Class device)
 # AUDIO_DEVICE=Gordik
 AUDIO_DIR=data/audio

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -116,6 +116,23 @@ def _parse_utc(s: str | None) -> datetime | None:
     return dt.astimezone(UTC)
 
 
+def _reconcile_end_utc(proposed: datetime, last_data: datetime | None, grace_s: float) -> datetime:
+    """Resolve a race's end time, anchoring to the last real data point when a
+    data gap precedes the requested end — power/instrument loss before the race
+    was stopped (#785).
+
+    - No telemetry at all → keep ``proposed`` (nothing to anchor to).
+    - ``proposed`` more than ``grace_s`` after ``last_data`` → use ``last_data``
+      (the boat stopped reporting; everything after is empty wall-clock time).
+    - Otherwise (data still flowing within ``grace_s``) → keep ``proposed``.
+    """
+    if last_data is None:
+        return proposed
+    if (proposed - last_data).total_seconds() > grace_s:
+        return last_data
+    return proposed
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -128,6 +145,18 @@ class StorageConfig:
     db_path: str = field(default_factory=lambda: os.environ.get("DB_PATH", "data/logger.db"))
     rudder_storage_hz: float = field(
         default_factory=lambda: float(os.environ.get("RUDDER_STORAGE_HZ", "2"))
+    )
+    # Race-close reconciliation (#785). When the wall-clock end is more than
+    # ``close_grace_s`` after the last recorded data point, the race is closed
+    # at the last data point instead (power/instrument loss before stop).
+    close_grace_s: float = field(
+        default_factory=lambda: float(os.environ.get("RACE_CLOSE_GRACE_S", "120"))
+    )
+    # On boot, an open race whose last data is older than this is treated as
+    # stale (overnight power loss) and closed; a smaller gap is a quick reboot
+    # mid-race and recording resumes into the same race.
+    boot_resume_window_s: float = field(
+        default_factory=lambda: float(os.environ.get("RACE_BOOT_RESUME_WINDOW_S", "600"))
     )
 
 
@@ -2521,9 +2550,7 @@ class Storage:
             except Exception:
                 logger.warning("Failed to open read connection; falling back to single connection")
                 self._read_db = None
-        current = await self.get_current_race()
-        self._session_active = current is not None
-        self._active_race_id = current.id if current is not None else None
+        await self._reconcile_open_race_on_boot()
         await self.refresh_smoothing()
         await self.refresh_leeway_k()
         await self.refresh_compass_offsets()
@@ -3961,17 +3988,28 @@ class Storage:
 
         db = self._conn()
 
-        # Close any open race for this UTC date
+        # Close any open race for this UTC date. If its data stopped well before
+        # this new start (power loss before the prior race was ended), anchor its
+        # end to its last data point rather than spanning to the new gun (#785).
         open_cur = await db.execute(
             "SELECT id FROM races WHERE date = ? AND end_utc IS NULL",
             (date_str,),
         )
         open_row = await open_cur.fetchone()
+        auto_closed: tuple[int, datetime, float] | None = None
         if open_row is not None:
+            prior_last = await self.last_record_utc(open_row["id"])
+            prior_end = _reconcile_end_utc(start_utc, prior_last, self._config.close_grace_s)
             await db.execute(
                 "UPDATE races SET end_utc = ? WHERE id = ?",
-                (start_utc.isoformat(), open_row["id"]),
+                (prior_end.isoformat(), open_row["id"]),
             )
+            if prior_end != start_utc and prior_last is not None:
+                auto_closed = (
+                    open_row["id"],
+                    prior_end,
+                    (start_utc - prior_last).total_seconds() / 60,
+                )
 
         # Insert with NULL slug first; we compute and assign the final slug
         # after the insert so the empty-name fallback can use the row id.
@@ -3987,6 +4025,22 @@ class Storage:
         await db.execute("UPDATE races SET slug = ? WHERE id = ?", (slug, cur.lastrowid))
         await db.commit()
         await self._invalidate_race_cache(cur.lastrowid)
+        if auto_closed is not None:
+            prior_id, prior_end, gap_min = auto_closed
+            await self._invalidate_race_cache(prior_id)
+            logger.warning(
+                "Race {} auto-closed at last data {} on new race start ({:.0f} min gap)",
+                prior_id,
+                prior_end.isoformat(),
+                gap_min,
+            )
+            await self.log_action(
+                "race_auto_close",
+                detail=(
+                    f"Race {prior_id} closed at {prior_end.isoformat()} "
+                    f"(power loss suspected, {gap_min:.0f} min gap) on new race start"
+                ),
+            )
         logger.info("Race started: {} (id={}) type={}", name, cur.lastrowid, session_type)
         self._session_active = True
         self._active_race_id = cur.lastrowid
@@ -4002,8 +4056,28 @@ class Storage:
             slug=slug,
         )
 
-    async def end_race(self, race_id: int, end_utc: datetime) -> None:
-        """Set end_utc on the given race row."""
+    # Telemetry tables carrying a race_id; each is indexed by race_id so the
+    # per-race MAX(ts) below is an indexed lookup, not a scan (#785).
+    _TELEMETRY_TABLES = ("positions", "cogsog", "winds", "speeds", "headings", "depths")
+
+    async def last_record_utc(self, race_id: int) -> datetime | None:
+        """Latest telemetry timestamp recorded for a race, or None if it has no
+        data (#785). Used to anchor a race's end to when data actually stopped."""
+        union = " UNION ALL ".join(
+            f"SELECT MAX(ts) AS m FROM {t} WHERE race_id = ?" for t in self._TELEMETRY_TABLES
+        )
+        cur = await self._read_conn().execute(
+            f"SELECT MAX(m) FROM ({union})",  # noqa: S608 — table names from a fixed tuple
+            tuple([race_id] * len(self._TELEMETRY_TABLES)),
+        )
+        row = await cur.fetchone()
+        return _parse_utc(row[0]) if row and row[0] else None
+
+    async def _close_race(
+        self, race_id: int, end_utc: datetime, *, auto_close_reason: str | None
+    ) -> None:
+        """Write end_utc, invalidate cache, clear active state. When
+        ``auto_close_reason`` is set, also log + audit it for admin review (#785)."""
         db = self._conn()
         await db.execute(
             "UPDATE races SET end_utc = ? WHERE id = ?",
@@ -4014,7 +4088,67 @@ class Storage:
         self._session_active = False
         if self._active_race_id == race_id:
             self._active_race_id = None
-        logger.info("Race {} ended at {}", race_id, end_utc.isoformat())
+        if auto_close_reason is not None:
+            logger.warning(
+                "Race {} auto-closed at {} ({})", race_id, end_utc.isoformat(), auto_close_reason
+            )
+            await self.log_action(
+                "race_auto_close",
+                detail=f"Race {race_id} closed at {end_utc.isoformat()} ({auto_close_reason})",
+            )
+        else:
+            logger.info("Race {} ended at {}", race_id, end_utc.isoformat())
+
+    async def end_race(self, race_id: int, end_utc: datetime) -> None:
+        """Close a race. When a data gap precedes ``end_utc`` (power/instrument
+        loss before the race was stopped), anchor the end to the last real data
+        point instead of the requested time — #785."""
+        last = await self.last_record_utc(race_id)
+        resolved = _reconcile_end_utc(end_utc, last, self._config.close_grace_s)
+        reason: str | None = None
+        if resolved != end_utc and last is not None:
+            gap_min = (end_utc - last).total_seconds() / 60
+            reason = f"power loss suspected, {gap_min:.0f} min data gap"
+        await self._close_race(race_id, resolved, auto_close_reason=reason)
+
+    async def _reconcile_open_race_on_boot(self) -> None:
+        """Resolve an open race found at startup (#785, decision table B):
+
+        - no open race → idle.
+        - open, no data at all → delete it (started, power died before any record).
+        - open, last data older than ``boot_resume_window_s`` → stale (e.g.
+          overnight power loss): close at last data, do not resume into it.
+        - open, recent data → quick reboot mid-race: keep active, resume recording.
+        """
+        current = await self.get_current_race()
+        if current is None:
+            self._session_active = False
+            self._active_race_id = None
+            return
+        last = await self.last_record_utc(current.id)
+        if last is None:
+            await self.delete_race_session(current.id)
+            logger.warning("Boot: deleted open race {} with no recorded data", current.id)
+            await self.log_action(
+                "race_auto_close",
+                detail=f"Race {current.id} deleted on boot (open, no data recorded)",
+            )
+            self._session_active = False
+            self._active_race_id = None
+            return
+        gap_s = (datetime.now(UTC) - last).total_seconds()
+        if gap_s >= self._config.boot_resume_window_s:
+            await self._close_race(
+                current.id,
+                last,
+                auto_close_reason=f"stale open race on boot, {gap_s / 60:.0f} min since last data",
+            )
+        else:
+            self._session_active = True
+            self._active_race_id = current.id
+            logger.info(
+                "Boot: resuming active race {} ({:.0f}s since last data)", current.id, gap_s
+            )
 
     async def set_race_start_utc(self, race_id: int, start_utc: datetime) -> None:
         """Update the start_utc of a race (#644 — gun anchors session start).

--- a/tests/test_race_close_power_loss.py
+++ b/tests/test_race_close_power_loss.py
@@ -1,0 +1,242 @@
+"""Race close anchors to last real data when power dies before the race is
+ended (#785).
+
+Spec: issue #785 — close-at-last-data (decision table A), boot reconciliation
+(decision table B). Each test maps to a spec row, noted in the docstring.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.storage import Storage, StorageConfig, _reconcile_end_utc
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_GRACE = 120.0
+_BOOT_WINDOW = 600.0
+
+
+async def _insert_cogsog(storage: Storage, race_id: int, ts: datetime) -> None:
+    """Insert one telemetry row so a race has a known last-data timestamp."""
+    db = storage._conn()  # noqa: SLF001 — white-box telemetry seed
+    await db.execute(
+        "INSERT INTO cogsog (ts, source_addr, cog_deg, sog_kts, race_id) VALUES (?, ?, ?, ?, ?)",
+        (ts.isoformat(), 1, 0.0, 3.0, race_id),
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pure reconciliation helper
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_no_data_uses_proposed() -> None:
+    """No telemetry → nothing to anchor to, keep the proposed end (rows A3/A6/A9)."""
+    proposed = datetime(2026, 6, 9, 8, 0, tzinfo=UTC)
+    assert _reconcile_end_utc(proposed, None, _GRACE) == proposed
+
+
+def test_reconcile_gap_beyond_grace_uses_last_data() -> None:
+    """Proposed end far after last data → anchor to last data (rows A2/A5/A8)."""
+    last = datetime(2026, 6, 9, 2, 49, 37, tzinfo=UTC)
+    proposed = datetime(2026, 6, 9, 8, 0, tzinfo=UTC)  # ~5h later
+    assert _reconcile_end_utc(proposed, last, _GRACE) == last
+
+
+def test_reconcile_within_grace_uses_proposed() -> None:
+    """Data still flowing (gap <= grace) → keep the proposed end (rows A1/A4/A7)."""
+    last = datetime(2026, 6, 9, 8, 0, 0, tzinfo=UTC)
+    proposed = last + timedelta(seconds=60)  # within 120s grace
+    assert _reconcile_end_utc(proposed, last, _GRACE) == proposed
+
+
+def test_reconcile_boundary_equal_to_grace_uses_proposed() -> None:
+    """Exactly grace seconds is not a gap; only strictly greater anchors back."""
+    last = datetime(2026, 6, 9, 8, 0, 0, tzinfo=UTC)
+    proposed = last + timedelta(seconds=_GRACE)
+    assert _reconcile_end_utc(proposed, last, _GRACE) == proposed
+
+
+# ---------------------------------------------------------------------------
+# last_record_utc
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_record_utc_none_when_empty(storage: Storage) -> None:
+    race = await storage.start_race("CYC", datetime.now(UTC), "2026-06-09", 1, "R1")
+    assert await storage.last_record_utc(race.id) is None
+
+
+@pytest.mark.asyncio
+async def test_last_record_utc_returns_max_ts(storage: Storage) -> None:
+    race = await storage.start_race("CYC", datetime.now(UTC), "2026-06-09", 1, "R1")
+    t0 = datetime(2026, 6, 9, 2, 0, 0, tzinfo=UTC)
+    await _insert_cogsog(storage, race.id, t0)
+    await _insert_cogsog(storage, race.id, t0 + timedelta(minutes=49))
+    last = await storage.last_record_utc(race.id)
+    assert last == t0 + timedelta(minutes=49)
+
+
+# ---------------------------------------------------------------------------
+# end_race close-time (decision table A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_race_live_data_uses_now(storage: Storage) -> None:
+    """A1: ending on the water with data still arriving → end == now."""
+    now = datetime.now(UTC)
+    race = await storage.start_race("CYC", now - timedelta(hours=1), "2026-06-09", 1, "R1")
+    await _insert_cogsog(storage, race.id, now - timedelta(seconds=5))
+    await storage.end_race(race.id, now)
+    r = await storage.get_race(race.id)
+    assert r is not None and r.end_utc == now
+
+
+@pytest.mark.asyncio
+async def test_end_race_after_power_loss_uses_last_data(storage: Storage) -> None:
+    """A2: data stopped hours ago, closed later → end == last data, audited."""
+    now = datetime.now(UTC)
+    last = now - timedelta(hours=5)
+    race = await storage.start_race("CYC", now - timedelta(hours=8), "2026-06-09", 1, "R1")
+    await _insert_cogsog(storage, race.id, last)
+    await storage.end_race(race.id, now)
+    r = await storage.get_race(race.id)
+    assert r is not None and r.end_utc == last
+    audit = await storage.list_audit_log(limit=10)
+    assert any(e["action"] == "race_auto_close" for e in audit)
+
+
+@pytest.mark.asyncio
+async def test_end_race_empty_race_uses_now(storage: Storage) -> None:
+    """A3: empty race manual close → falls back to now, no audit entry."""
+    now = datetime.now(UTC)
+    race = await storage.start_race("CYC", now - timedelta(minutes=5), "2026-06-09", 1, "R1")
+    await storage.end_race(race.id, now)
+    r = await storage.get_race(race.id)
+    assert r is not None and r.end_utc == now
+    audit = await storage.list_audit_log(limit=10)
+    assert not any(e["action"] == "race_auto_close" for e in audit)
+
+
+# ---------------------------------------------------------------------------
+# start_race auto-close of a prior open race (decision table A, rows 7-9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_race_closes_prior_live_at_new_start(storage: Storage) -> None:
+    """A7: back-to-back races, prior live up to new gun → prior end == new start."""
+    base = datetime.now(UTC) - timedelta(hours=2)
+    r1 = await storage.start_race("CYC", base, "2026-06-09", 1, "R1")
+    await _insert_cogsog(storage, r1.id, base + timedelta(minutes=30))
+    new_start = base + timedelta(minutes=30, seconds=30)  # within grace of last data
+    await storage.start_race("CYC", new_start, "2026-06-09", 2, "R2")
+    r1_after = await storage.get_race(r1.id)
+    assert r1_after is not None and r1_after.end_utc == new_start
+
+
+@pytest.mark.asyncio
+async def test_start_race_closes_stale_prior_at_last_data(storage: Storage) -> None:
+    """A8: prior race's data stopped long before the new race → end == last data."""
+    base = datetime.now(UTC) - timedelta(hours=12)
+    r1 = await storage.start_race("CYC", base, "2026-06-09", 1, "R1")
+    last = base + timedelta(minutes=30)
+    await _insert_cogsog(storage, r1.id, last)
+    new_start = datetime.now(UTC)  # hours after last data
+    await storage.start_race("CYC", new_start, "2026-06-09", 2, "R2")
+    r1_after = await storage.get_race(r1.id)
+    assert r1_after is not None and r1_after.end_utc == last
+
+
+# ---------------------------------------------------------------------------
+# Boot reconciliation (decision table B) — needs a file-backed DB across
+# two Storage instances (a reboot).
+# ---------------------------------------------------------------------------
+
+
+async def _reopen(path: str) -> Storage:
+    s = Storage(
+        StorageConfig(db_path=path, close_grace_s=_GRACE, boot_resume_window_s=_BOOT_WINDOW)
+    )
+    await s.connect()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_boot_resumes_fresh_open_race(tmp_path: Path) -> None:
+    """B1: quick reboot, recent data (gap < window) → race stays active, resumes."""
+    db = str(tmp_path / "t.db")
+    s = await _reopen(db)
+    now = datetime.now(UTC)
+    race = await s.start_race("CYC", now - timedelta(minutes=20), "2026-06-09", 1, "R1")
+    await _insert_cogsog(s, race.id, now - timedelta(seconds=30))  # gap << 600s
+    await s.close()
+
+    s2 = await _reopen(db)
+    assert s2.session_active is True
+    assert s2._active_race_id == race.id  # noqa: SLF001
+    cur = await s2._conn().execute("SELECT end_utc FROM races WHERE id = ?", (race.id,))  # noqa: SLF001
+    assert (await cur.fetchone())["end_utc"] is None  # still open
+    await s2.close()
+
+
+@pytest.mark.asyncio
+async def test_boot_closes_stale_open_race_at_last_data(tmp_path: Path) -> None:
+    """B2: overnight power loss (gap >= window) → close at last data, not resumed."""
+    db = str(tmp_path / "t.db")
+    s = await _reopen(db)
+    now = datetime.now(UTC)
+    last = now - timedelta(hours=12)
+    race = await s.start_race("CYC", now - timedelta(hours=14), "2026-06-08", 1, "R1")
+    await _insert_cogsog(s, race.id, last)
+    await s.close()
+
+    s2 = await _reopen(db)
+    assert s2.session_active is False
+    assert s2._active_race_id is None  # noqa: SLF001
+    r = await s2.get_race(race.id)
+    assert r is not None and r.end_utc == last
+    audit = await s2.list_audit_log(limit=10)
+    assert any(e["action"] == "race_auto_close" for e in audit)
+    await s2.close()
+
+
+@pytest.mark.asyncio
+async def test_boot_deletes_empty_open_race(tmp_path: Path) -> None:
+    """B3: open race with no data at all on boot → deleted."""
+    db = str(tmp_path / "t.db")
+    s = await _reopen(db)
+    race = await s.start_race("CYC", datetime.now(UTC) - timedelta(hours=2), "2026-06-09", 1, "R1")
+    await s.close()
+
+    s2 = await _reopen(db)
+    assert s2.session_active is False
+    assert s2._active_race_id is None  # noqa: SLF001
+    assert await s2.get_race(race.id) is None  # row gone
+    await s2.close()
+
+
+@pytest.mark.asyncio
+async def test_boot_no_open_race_is_idle(tmp_path: Path) -> None:
+    """B4: a properly-closed race on boot → idle, untouched."""
+    db = str(tmp_path / "t.db")
+    s = await _reopen(db)
+    now = datetime.now(UTC)
+    race = await s.start_race("CYC", now - timedelta(hours=2), "2026-06-09", 1, "R1")
+    await _insert_cogsog(s, race.id, now - timedelta(hours=1))
+    await s.end_race(race.id, now - timedelta(minutes=58))
+    await s.close()
+
+    s2 = await _reopen(db)
+    assert s2.session_active is False
+    assert s2._active_race_id is None  # noqa: SLF001
+    assert await s2.get_race(race.id) is not None  # untouched
+    await s2.close()


### PR DESCRIPTION
## What & why

When power is killed (or instruments lose power) before a race is ended, the open race later gets its `end_utc` stamped with wall-clock **`now`**, producing a bogus multi-hour span.

**Real incident (2026-06-09):** race 191 "Ballad cup ii-1" had ~2h35m of real data, then power was cut; it stayed open overnight and was closed at 08:00 the next morning → a **~14.8h span with a ~12h empty tail**. On the next boot `warm_race_cache` ground a CPU core warming that oversized window, surfacing to the user as intermittent **nginx 504s**.

This anchors a race's end to the **last real data point** whenever a data gap precedes the close — no new persistent state, just an indexed `MAX(ts)`.

## Changes (`storage.py`)

- **`last_record_utc(race_id)`** — `MAX(ts)` across telemetry tables (`positions, cogsog, winds, speeds, headings, depths`); each subquery uses the table's `race_id` index, so no scan.
- **`_reconcile_end_utc(proposed, last_data, grace_s)`** — pure rule: no data → `proposed`; gap > grace → `last_data`; else `proposed`.
- **`end_race`** applies reconciliation (decision table A, rows 1–6).
- **`start_race`** prior-race auto-close applies reconciliation — closes a stale prior race at *its* last data, not the new gun (rows 7–9).
- **`_reconcile_open_race_on_boot`** (decision table B): quick reboot (gap < `RACE_BOOT_RESUME_WINDOW_S`, 600s) resumes the open race; stale gap closes at last data and does **not** resume into it; an open race with zero data is deleted.
- Auto-closes are logged (WARNING) and written to `audit_log` → visible on **`/admin/audit`** (the "admin list" surfacing; no migration, no new page).

Thresholds configurable: `RACE_CLOSE_GRACE_S=120`, `RACE_BOOT_RESUME_WINDOW_S=600` (documented in `.env.example`).

## Tests

`tests/test_race_close_power_loss.py` — 15 tests mapping to the spec decision tables: the pure helper (incl. boundary), `last_record_utc`, every `end_race` / `start_race` close path × gap/no-gap, and boot rows B1–B4 (file-backed DB across two `Storage` instances = a reboot).

## Verification

- `uv run pytest` — 2669 passed, 2 skipped (full suite, no regressions)
- `ruff check .` / `ruff format --check .` / `mypy src/` (strict) — all clean

## Risk tier

High — `storage.py` race-lifecycle logic. No schema migration, no auth/federation. Spec posted and decisions recorded on #785.

## Scope notes

- **L3 idle watchdog** (auto-close after N-min no-data when power *stayed* on) — deliberately out of scope; follow-up.
- Surfacing is via the existing audit log rather than a bespoke per-session banner — keeps this PR migration-free and reviewable.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)