### PR TITLE
feat(nmea2000): decode Triton² SET-timer discriminator [gated]

### DIFF
--- a/docs/specs/bg-timer-port-plan.md
+++ b/docs/specs/bg-timer-port-plan.md
@@ -66,6 +66,15 @@ Outcomes:
 
 ## Phase 1 — Decoder + read path (port, behind validation)
 
+> **On-water result (2026-06-10, race night):** Triton² **does** emit both PGNs.
+> **130850** (start/stop/reset/nearest-minute) decodes unchanged — fully working.
+> **130845** uses a Triton²-specific SET discriminator `07 c0 00 01` (vs Simrad
+> `07 42 00 01`); the decoder now ignores the byte[7] variant. The duration byte
+> position is still unconfirmed — pinned by a dockside capture
+> (`docs/specs/triton2-timer-capture.md`). Decoder change in progress as a gated
+> stacked PR; the 0x80/0x23 state-broadcast decode is deferred until the same
+> capture disambiguates it.
+
 - Port `FastPacketBuffer`, `SimradTimerRecord`, the 130845/130850 decoders, and
   the PGN constants into `src/helmlog/nmea2000.py` (adapting the layout if the
   Phase 0 capture differed). Bring the fork's `tests/test_nmea2000.py`

--- a/docs/specs/triton2-timer-capture.md
+++ b/docs/specs/triton2-timer-capture.md
@@ -1,0 +1,80 @@
+# Triton² timer-PGN capture — findings + dockside procedure
+
+On-water validation of the B&G timer feature (#789) on Corvo / Triton². The
+`/admin/pgn-audit` sniffer ran during a race night (2026-06-10, 23:27–02:27 UTC)
+and captured 138 timer-PGN observations. This doc records what we learned and
+the controlled dockside capture needed to finish the SET-duration decode.
+
+## What the race night showed
+
+### PGN 130850 (Start/Stop/Reset/Nearest-Minute) — fully decoded ✅
+
+Byte layout is identical to the Simrad reference (`41 9F FF FF 01 17 <cmd> 00`,
+cmd `3D`/`3E`/`3F`/`40`). All 16 frames decoded; source address `0x07`. The
+night's control sequence (≈4 race starts):
+
+```
+23:27 start/stop (practice) · 23:29 start · 00:39 start ·
+01:23 start + nearest_minute(sync) · 02:23 start
+```
+
+This path needs **no decoder changes**.
+
+### PGN 130845 (Set duration) — different Triton² layout ⚠️
+
+122 frames, 0 decoded against the Simrad layout. Distinct payloads captured
+(SA = source address):
+
+| SA | raw payload | n | reading |
+|----|-------------|---|---------|
+| 07 | `41 9f ff ff ff ff 07 c0 00 01 00 ff ff ff` | 1 | **SET command** (disc `07 c0 00 01`) |
+| 07 | `41 9f ff ff ff ff 07 c0 00 01 01 ff ff ff` | 1 | **SET command** |
+| 07 | `41 9f 23 ff ff ff 06 00 00 00 ff ff ff ff` | 48 | state/heartbeat (byte[6]=0x06) |
+| 07 | `41 9f 80 ff ff ff 00 00 00 00 ff ff ff ff` | 12 | state (byte[6]=0x00) |
+| 07 | `41 9f 80 ff ff ff 31 00 00 00 ff ff ff ff` | 12 | state (byte[6]=0x31=49) |
+| 07 | `41 9f 80 ff ff ff 39 00 00 00 ff ff ff ff` | 12 | state (byte[6]=0x39=57) |
+| 128 | `41 9f ff ff ff ff 00 00 00 02 23 06 00 00` | 12 | display echo |
+| 128 | `41 9f ff ff ff ff 31 00 00 02 00 00 00 00` | 12 | display echo |
+| 128 | `41 9f ff ff ff ff 39 00 00 02 8c fa 00 00` | 12 | display echo |
+
+**Findings:**
+1. The SET command uses discriminator **`07 c0 00 01`** vs the Simrad
+   **`07 42 00 01`** — only byte[7] differs (vendor variant). The decoder now
+   keys on byte[6]==0x07 + byte[8:10]==00 01 and ignores byte[7], so both
+   decode.
+2. Most 130845 traffic is **live state/countdown broadcasts** (byte[6] != 0x07),
+   correctly ignored — same as the Simrad running-state broadcast.
+3. **Open:** the duration *value* position is unconfirmed. The two captured SET
+   frames carried byte[10] = 0x00 / 0x01, which don't match plausible start
+   lengths, and there were only 2 across ~4 starts (so they read more like
+   occasional manual adjustments than per-start sets). The decoder reads
+   byte[10] as minutes for now, **gated** on the capture below.
+
+## Dockside controlled capture (≈5 min, no sailing)
+
+Goal: set a sequence of **known** durations on the Triton² and capture the
+130845 frames so we can pin the duration byte.
+
+1. **Confirm the sniffer is live:** open `/admin/pgn-audit` (admin) — the page
+   should not show the "OFF" banner. (Or on the Pi: `sudo journalctl -u helmlog
+   --since "5 min ago" | grep "PGN audit"` shows `listening read-only on can0`.)
+2. **Note the wall-clock start** (so frames can be correlated by time).
+3. On the Triton², change the **start-timer value** to each of these in order,
+   pausing ~5 s between each so frames land distinctly:
+   **5:00 → 3:00 → 2:00 → 6:00 → 1:00 → 4:00**.
+   Write down the order + rough times. (Use the same control you'd use to set a
+   start — whatever changes the countdown's configured length.)
+4. If the value is set via a dedicated "set" action vs. up/down nudges, do both
+   ways once each — they may emit different frames.
+5. Optionally press Start then Stop once, to re-confirm 130850 still flows.
+6. **Report back** — ping me, or send the output of:
+   ```bash
+   sqlite3 ~/helmlog/data/logger.db \
+     "SELECT observed_at, source_addr, raw_hex FROM pgn_audit
+       WHERE pgn=130845 AND observed_at > '<your start time ISO>'
+       ORDER BY observed_at;"
+   ```
+
+I'll diff the captured payloads against the known 5/3/2/6/1/4 sequence, identify
+which byte (or 16-bit field) tracks the duration and its unit, then finalize the
+decoder and lift the gate on this PR.

--- a/src/helmlog/nmea2000.py
+++ b/src/helmlog/nmea2000.py
@@ -214,14 +214,17 @@ class SimradTimerRecord:
         [6]    3D=start / 3E=stop / 3F=nearest-minute / 40=reset
 
     Set Timer  (PGN 130845, 14 bytes after reassembly):
-        [0-1]  41 9F        Simrad manufacturer ID
+        [0-1]  41 9F        manufacturer ID
         [2-5]  FF FF FF FF  reserved
-        [6-9]  07 42 00 01  SET command discriminator
-        [10]   minutes
+        [6]    07           SET command marker
+        [7]    42 / C0      vendor variant (42 = Simrad bench, C0 = Triton2)
+        [8-9]  00 01        SET discriminator tail
+        [10]   minutes      (Simrad-confirmed; Triton2 position pending — #789)
         [11-13] 00 00 00    trailing (0xFF = NMEA N/A sentinel)
 
-    Running-state broadcasts (also PGN 130845) carry discriminator 02 00 00 01
-    at [6:10] and decode to None (ignored).
+    Running-state / countdown broadcasts (also PGN 130845) carry byte[6] != 0x07
+    (e.g. 0x02 running-state, or the 0x80/0x23 Triton2 state frames) and decode
+    to None (ignored).
     """
 
     pgn: int
@@ -546,11 +549,33 @@ _SIMRAD_ACTIONS: Final[dict[int, str]] = {
     0x3F: "nearest_minute",
     0x40: "reset",
 }
-_SIMRAD_SET_DISCRIMINATOR: Final[bytes] = bytes([0x07, 0x42, 0x00, 0x01])
+# SET command discriminator. The fork's Simrad bench sent 07 42 00 01; the
+# Corvo Triton2 on-water capture (#789) sent 07 c0 00 01 — byte[7] is a vendor/
+# model variant. We key on byte[6]==0x07 and byte[8:10]==00 01, treating byte[7]
+# as a don't-care, which still excludes the running-state broadcast (byte[6]==
+# 0x02) and the 0x80/0x23 countdown frames (byte[6] not 0x07). See
+# docs/specs/triton2-timer-capture.md for the raw payloads.
+_SIMRAD_SET_B6: Final[int] = 0x07
+_SIMRAD_SET_B8: Final[int] = 0x00
+_SIMRAD_SET_B9: Final[int] = 0x01
 
 
 def _is_simrad(p: bytes) -> bool:
     return len(p) >= 2 and p[0:2] == _SIMRAD_MFR
+
+
+def _is_set_command(data: bytes) -> bool:
+    """True if the reassembled 130845 payload is a SET-duration command.
+
+    Matches both the Simrad (07 42 00 01) and Triton2 (07 c0 00 01) layouts by
+    ignoring the byte[7] vendor variant.
+    """
+    return (
+        len(data) >= 11
+        and data[6] == _SIMRAD_SET_B6
+        and data[8] == _SIMRAD_SET_B8
+        and data[9] == _SIMRAD_SET_B9
+    )
 
 
 def _decode_130850(data: bytes, source: int, ts: datetime) -> SimradTimerRecord | None:
@@ -570,13 +595,19 @@ def _decode_130850(data: bytes, source: int, ts: datetime) -> SimradTimerRecord 
 
 
 def _decode_130845(data: bytes, source: int, ts: datetime) -> SimradTimerRecord | None:
-    """PGN 130845 — Simrad Set Timer (14 bytes).
+    """PGN 130845 — Simrad/B&G Set Timer (14 bytes).
 
-    Running-state broadcasts (discriminator 02 00 00 01) decode to None.
+    Only the SET-duration command decodes; running-state / countdown broadcasts
+    on this PGN (byte[6] != 0x07) decode to None.
+
+    NOTE (#789): the duration is read from byte[10] as on the Simrad bench. The
+    Triton2 SET *discriminator* is confirmed from the on-water capture, but the
+    duration *byte position* is NOT yet confirmed for Triton2 (the two captured
+    SET frames carried 0x00/0x01, which don't map to plausible start lengths).
+    A controlled dockside capture (docs/specs/triton2-timer-capture.md) pins it
+    before this is trusted for headless race creation — hence the gated PR.
     """
-    if not _is_simrad(data) or len(data) < 11:
-        return None
-    if data[6:10] != _SIMRAD_SET_DISCRIMINATOR:
+    if not _is_simrad(data) or not _is_set_command(data):
         return None
     return SimradTimerRecord(
         pgn=PGN_SIMRAD_SET_TIMER,

--- a/src/helmlog/static/race_start_widget.js
+++ b/src/helmlog/static/race_start_widget.js
@@ -19,16 +19,19 @@
     if (panel) return panel;
     panel = document.createElement("div");
     panel.id = "race-start-widget";
+    // Follow the active theme — use the same surface/border/text tokens as the
+    // page cards. (Previously hardcoded a dark fallback via the nonexistent
+    // --bg-elev var, so the strip stayed black in light themes.)
     panel.style.cssText = [
       "display:none",
       "padding:.5rem 1rem",
-      "background:var(--bg-elev,#1a1d23)",
-      "border:1px solid var(--border,#333)",
+      "background:var(--bg-secondary)",
+      "border:1px solid var(--border)",
       "border-radius:.5rem",
       "margin:.5rem auto",
       "max-width:960px",
       "font-family:inherit",
-      "color:var(--text-primary,#fff)",
+      "color:var(--text-primary)",
     ].join(";");
     panel.innerHTML = `
       <div style="display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap;

--- a/tests/test_nmea2000.py
+++ b/tests/test_nmea2000.py
@@ -371,15 +371,44 @@ class TestDecode130850:
         assert decode(PGN_SIMRAD_START_STOP, first_frame, 9, _UNIX_TS) is None
 
 
+def _hexbytes(s: str) -> bytes:
+    """Build a payload from a space-separated hex string (real capture rows)."""
+    return bytes(int(b, 16) for b in s.split())
+
+
 class TestDecode130845:
-    def test_set_minutes(self) -> None:
+    def test_set_minutes_simrad(self) -> None:
+        # Simrad bench discriminator 07 42 00 01.
         r = decode(PGN_SIMRAD_SET_TIMER, _set_timer_payload(5), 9, _UNIX_TS)
         assert isinstance(r, SimradTimerRecord)
         assert (r.action, r.minutes) == ("set", 5)
 
+    def test_set_command_triton2_discriminator(self) -> None:
+        # Real Corvo Triton2 on-water SET frames (#789) — discriminator 07 c0 00
+        # 01 (byte[7]=0xC0). Must now decode as a SET; byte[10] read as minutes
+        # (position pending dockside confirmation, see decoder note).
+        for raw, expect_min in (
+            ("41 9f ff ff ff ff 07 c0 00 01 00 ff ff ff", 0),
+            ("41 9f ff ff ff ff 07 c0 00 01 01 ff ff ff", 1),
+        ):
+            r = decode(PGN_SIMRAD_SET_TIMER, _hexbytes(raw), 7, _UNIX_TS)
+            assert isinstance(r, SimradTimerRecord)
+            assert (r.action, r.minutes) == ("set", expect_min)
+
     def test_running_state_broadcast_ignored(self) -> None:
         payload = _MFR + bytes([0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x00, 0x00, 0x01, 5, 0, 0, 0])
         assert decode(PGN_SIMRAD_SET_TIMER, payload, 9, _UNIX_TS) is None
+
+    def test_triton2_countdown_frames_do_not_decode(self) -> None:
+        # Real Triton2 state/countdown 130845 frames (byte[6] != 0x07) must stay
+        # undecoded — they are not SET commands. Captured #789.
+        for raw in (
+            "41 9f 80 ff ff ff 31 00 00 00 ff ff ff ff",  # SA7 0x80 state
+            "41 9f 80 ff ff ff 39 00 00 00 ff ff ff ff",
+            "41 9f 23 ff ff ff 06 00 00 00 ff ff ff ff",  # SA7 0x23 heartbeat
+            "41 9f ff ff ff ff 00 00 00 02 23 06 00 00",  # SA128 echo (byte[6]=0x00)
+        ):
+            assert decode(PGN_SIMRAD_SET_TIMER, _hexbytes(raw), 7, _UNIX_TS) is None
 
 
 class TestFastPacketBuffer:


### PR DESCRIPTION
Phase 1 of the B&G timer port (#789), driven by the on-water validation result.
**Draft / gated** — see the gate below.

## Stacking
Based on `feat/bg-timer-pgn-validation` (#790, the audit feature, not yet merged)
since it depends on the ported decoder. Retarget to `main` once #790 merges.

## What the race night (2026-06-10) showed
- **130850 (start/stop/reset/nearest-minute):** identical to Simrad layout —
  decoded all 16 frames. No changes needed.
- **130845 (SET duration):** Triton² uses discriminator **`07 c0 00 01`** vs the
  Simrad **`07 42 00 01`** — only byte[7] (a vendor variant) differs. Most 130845
  traffic is live state/countdown broadcasts (byte[6] != 0x07), correctly ignored.

## Change
`_decode_130845` now keys on `byte[6]==0x07 && byte[8:10]==00 01`, ignoring
byte[7], so both Simrad and Triton² SET commands decode. Tests use the **real
captured Triton² bytes** — SET frames decode, state frames stay undecoded.

## 🚧 Gate (why this is a draft)
The duration **byte position** for Triton² is unconfirmed: the two captured SET
frames carried `byte[10]=0x00/0x01`, which don't map to plausible start lengths,
and there were only 2 across ~4 starts. byte[10] is read as minutes for now. A
**dockside controlled capture** (`docs/specs/triton2-timer-capture.md`) sets known
durations and pins the byte before this merges.

Deferred (not guessing): the `0x80`/`0x23` state/countdown decode — the passive
data is ambiguous (values 0/49/57 cycle together). The same dockside capture
disambiguates it; separate follow-up.

## Verification
- Full lint trio clean: `ruff check . && ruff format --check . && mypy src/`.
- Decoder + audit + CLI tests: 78 passed.

Refs #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)