### PR TITLE
feat(sessions): GPS-discipline recording timestamps + clock provenance (#794)

### DIFF
--- a/src/helmlog/clock_sync.py
+++ b/src/helmlog/clock_sync.py
@@ -1,0 +1,180 @@
+"""GPS clock discipline for the recording path (#794).
+
+The Signal K server runs on the Pi (``SK_HOST=localhost``), so delta
+timestamps carry the Pi's *system* clock. When the Pi boots before NTP/GPS
+sync, that clock can be wrong and stamp an entire recording at the wrong
+absolute time — the race-201 incident, where the whole session was 1h slow.
+
+The GPS broadcasts authoritative UTC on the NMEA 2000 bus (PGN 126992 System
+Time / 129033 Time & Date), surfaced by Signal K as ``navigation.datetime``.
+This module measures the offset between the host clock and that GPS time and
+disciplines record timestamps to it.
+
+Pure and hardware-free: feed it ``(host_ts, gps_ts)`` samples plus the host
+timestamp of each record, and it returns disciplined timestamps and a
+per-session clock flag. The ``SKReader`` edge wires it to the live stream.
+
+Design (per the approved spec):
+- The offset is the **median** of the last ``window`` ``gps - host`` samples.
+  A rolling median is the outlier guard the spec calls for: a single bad GPS
+  sample cannot move the output, while a *sustained* step (a real NTP
+  correction mid-session) is adopted after a few samples.
+- Recording is **never blocked** on clock state — losing the race is worse
+  than logging it with a flag. When GPS time is unavailable we fall back to
+  host time and flag the session ``unverified``.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+# Defaults (spec Q2). Max tolerated host<->GPS divergence, and how long
+# without a GPS sample before the reference is considered lost.
+SKEW_OK_S: float = 30.0
+REF_TIMEOUT_S: float = 120.0
+_WINDOW: int = 5
+
+
+class ClockFlag(StrEnum):
+    """Per-session time-base provenance, persisted on the race row."""
+
+    SYNCED = "synced"  # host within SKEW_OK of GPS; timestamps trusted as-is
+    CORRECTED = "corrected"  # host diverged; timestamps GPS-disciplined
+    UNVERIFIED = "unverified"  # no GPS time ever seen; host time, best effort
+    REF_LOST = "ref_lost"  # had GPS, now stale; coasting on last offset
+
+
+@dataclass
+class ClockDiscipliner:
+    """Tracks the host<->GPS offset and disciplines record timestamps."""
+
+    skew_ok_s: float = SKEW_OK_S
+    ref_timeout_s: float = REF_TIMEOUT_S
+    window: int = _WINDOW
+
+    _samples: list[float] = field(default_factory=list)  # recent (gps - host) seconds
+    _offset_s: float = 0.0  # smoothed offset, gps - host
+    _have_ref: bool = False
+    _last_gps_host: datetime | None = None  # host ts of the last GPS sample
+    _flag: ClockFlag = ClockFlag.UNVERIFIED
+
+    def observe(self, host_ts: datetime, gps_ts: datetime) -> None:
+        """Record a GPS-time observation paired with the host time of the same delta."""
+        self._samples.append((gps_ts - host_ts).total_seconds())
+        if len(self._samples) > self.window:
+            self._samples.pop(0)
+        self._offset_s = statistics.median(self._samples)
+        self._have_ref = True
+        self._last_gps_host = host_ts
+        self._recompute_flag(host_ts)
+
+    def apply(self, host_ts: datetime) -> datetime:
+        """Return the timestamp a record stamped at ``host_ts`` should carry."""
+        self._recompute_flag(host_ts)  # record arrival may reveal a stale ref
+        if self._flag in (ClockFlag.CORRECTED, ClockFlag.REF_LOST):
+            return host_ts + timedelta(seconds=self._offset_s)
+        return host_ts
+
+    def _recompute_flag(self, now_host: datetime) -> None:
+        if not self._have_ref:
+            self._flag = ClockFlag.UNVERIFIED
+            return
+        if (
+            self._last_gps_host is not None
+            and (now_host - self._last_gps_host).total_seconds() > self.ref_timeout_s
+        ):
+            self._flag = ClockFlag.REF_LOST
+            return
+        self._flag = (
+            ClockFlag.SYNCED if abs(self._offset_s) <= self.skew_ok_s else ClockFlag.CORRECTED
+        )
+
+    @property
+    def flag(self) -> ClockFlag:
+        return self._flag
+
+    @property
+    def offset_s(self) -> float:
+        """Smoothed ``gps - host`` offset in seconds (0.0 until a GPS ref exists)."""
+        return self._offset_s
+
+
+# Threshold above which a recording's clock is considered skewed relative to a
+# GPS-sourced external track (Vakaros). 60s comfortably clears GPS/host jitter
+# while catching the whole-recording offsets this feature exists to find (#794).
+IMPORT_SKEW_OK_S: float = 60.0
+
+# A track point: (timestamp, latitude_deg, longitude_deg).
+TrackPoint = tuple[datetime, float, float]
+
+
+def _equirect_m2(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Squared planar distance (m^2) between two nearby lat/lon points.
+
+    Equirectangular approximation — exact enough for the few-km scales and
+    sub-degree separations of a single race course, and cheap (no trig per
+    pair beyond one cosine)."""
+    import math
+
+    mean_lat = math.radians((lat1 + lat2) * 0.5)
+    dx = math.radians(lon2 - lon1) * math.cos(mean_lat) * 6_371_000.0
+    dy = math.radians(lat2 - lat1) * 6_371_000.0
+    return dx * dx + dy * dy
+
+
+def estimate_track_offset_s(
+    track: list[TrackPoint],
+    reference: list[TrackPoint],
+    *,
+    max_offset_s: float = 7200.0,
+    step_s: float = 10.0,
+) -> float | None:
+    """Best-fit time offset aligning ``track`` onto ``reference`` GPS tracks.
+
+    Both are the *same boat* logged by two devices; if their clocks agree, the
+    same wall-clock instant is the same position. We scan candidate offsets and
+    return the ``offset`` (seconds, ``reference_clock - track_clock``) that
+    minimises the median squared distance between each ``track`` point at time
+    ``t`` and the ``reference`` point nearest in time to ``t + offset``.
+
+    Iterate the *contiguous* track and look up the *covering* one: at the
+    Vakaros→live cross-check pass ``track=race`` (one race) and
+    ``reference=vakaros`` (the whole race day), so non-overlapping reference
+    points never poison the median. Returns ``None`` when either side is too
+    sparse to decide. Used to catch a recording whose clock was wrong (#794).
+    """
+    if len(track) < 5 or len(reference) < 5:
+        return None
+
+    import bisect
+    import statistics
+
+    ref_sorted = sorted(reference, key=lambda p: p[0])
+    ref_epoch = [p[0].timestamp() for p in ref_sorted]
+
+    def nearest_ref(t: float) -> TrackPoint:
+        i = bisect.bisect_left(ref_epoch, t)
+        if i == 0:
+            return ref_sorted[0]
+        if i >= len(ref_sorted):
+            return ref_sorted[-1]
+        before, after = ref_sorted[i - 1], ref_sorted[i]
+        return before if (t - ref_epoch[i - 1]) <= (ref_epoch[i] - t) else after
+
+    best_offset: float | None = None
+    best_cost = float("inf")
+    n_steps = int(max_offset_s / step_s)
+    for k in range(-n_steps, n_steps + 1):
+        offset = k * step_s
+        dists = [
+            _equirect_m2(lat, lon, *nearest_ref(ts.timestamp() + offset)[1:])
+            for ts, lat, lon in track
+        ]
+        cost = statistics.median(dists)
+        if cost < best_cost:
+            best_cost = cost
+            best_offset = offset
+    return best_offset

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -491,9 +491,7 @@ async def _run() -> None:
                         if reader.clock_flag is not last_clock_flag:
                             race_id = storage.active_race_id
                             if race_id is not None:
-                                await storage.set_race_clock_flag(
-                                    race_id, reader.clock_flag.value
-                                )
+                                await storage.set_race_clock_flag(race_id, reader.clock_flag.value)
                             last_clock_flag = reader.clock_flag
             else:
                 from helmlog.can_reader import CANReader, CANReaderConfig, extract_pgn

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -481,10 +481,20 @@ async def _run() -> None:
                     sk_config.port,
                     storage_config.db_path,
                 )
-                async for record in SKReader(sk_config):
+                reader = SKReader(sk_config)
+                last_clock_flag = reader.clock_flag
+                async for record in reader:
                     storage.update_live(record)
                     if storage.session_active:
                         await storage.write(record)
+                        # Persist GPS-clock provenance when it changes (#794).
+                        if reader.clock_flag is not last_clock_flag:
+                            race_id = storage.active_race_id
+                            if race_id is not None:
+                                await storage.set_race_clock_flag(
+                                    race_id, reader.clock_flag.value
+                                )
+                            last_clock_flag = reader.clock_flag
             else:
                 from helmlog.can_reader import CANReader, CANReaderConfig, extract_pgn
                 from helmlog.nmea2000 import decode

--- a/src/helmlog/races.py
+++ b/src/helmlog/races.py
@@ -36,6 +36,9 @@ class Race:
     session_type: str = "race"  # "race" | "practice"
     slug: str = ""  # human-readable URL slug (#449); backfilled from name
     renamed_at: datetime | None = None  # UTC ts of most recent rename (#449)
+    # GPS-clock provenance of the live recording (#794): "synced" | "corrected"
+    # | "unverified" | "ref_lost". None = legacy/imported (not time-base tracked).
+    clock_flag: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/helmlog/routes/pages.py
+++ b/src/helmlog/routes/pages.py
@@ -161,6 +161,7 @@ async def _render_session_page(
             session_slug=race.slug,
             session_url=_canonical_session_url(race.id, race.slug),
             renamed_from=renamed_banner,
+            clock_flag=race.clock_flag,
             grafana_port=request.app.state.race_config.grafana_port,
             grafana_uid=request.app.state.race_config.grafana_uid,
             user_role=user_role,

--- a/src/helmlog/sk_reader.py
+++ b/src/helmlog/sk_reader.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from websockets.asyncio.client import connect as _ws_connect
 
+from helmlog.clock_sync import ClockDiscipliner, ClockFlag
 from helmlog.nmea2000 import (
     PGN_ATTITUDE,
     PGN_COG_SOG_RAPID,
@@ -185,8 +186,38 @@ _PAIR: dict[str, Callable[[dict[str, float], datetime], PGNRecord | None]] = {
 # ---------------------------------------------------------------------------
 
 
+# Signal K path carrying GPS-authoritative UTC (PGN 126992 / 129033). Its
+# *value* comes from the GPS; the update's *timestamp* is the host (SK server)
+# clock — comparing the two yields the host<->GPS offset (#794).
+_GPS_TIME_PATH = "navigation.datetime"
+
+
+def _parse_update_ts(update: dict[str, Any]) -> datetime:
+    """Host timestamp of a Signal K update, falling back to wall-clock now."""
+    ts_str: str = update.get("timestamp", "")
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return datetime.now(UTC)
+
+
+def _parse_gps_dt(value: object) -> datetime | None:
+    """Parse a ``navigation.datetime`` value (ISO 8601 GPS time) to aware UTC."""
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
 def process_delta(
-    raw: str, buf: dict[str, float], *, self_context: str | None = None
+    raw: str,
+    buf: dict[str, float],
+    *,
+    self_context: str | None = None,
+    clock: ClockDiscipliner | None = None,
 ) -> list[PGNRecord]:
     """Parse a Signal K delta message; return any records it produces.
 
@@ -197,6 +228,10 @@ def process_delta(
     *self_context* is the resolved self-vessel context from the SK API
     (e.g. ``"vessels.urn:mrn:signalk:uuid:..."``) so UUID-style contexts are
     accepted when they match.
+
+    *clock*, when supplied, GPS-disciplines every emitted record timestamp:
+    ``navigation.datetime`` values feed :meth:`ClockDiscipliner.observe` and
+    record timestamps are routed through :meth:`ClockDiscipliner.apply` (#794).
     """
     try:
         delta: Any = json.loads(raw)
@@ -217,12 +252,21 @@ def process_delta(
         logger.warning("SK: rejecting non-self delta (context={!r})", context)
         return []
 
+    # Pre-scan for GPS time so this delta's records are disciplined with the
+    # offset it carries (a delta may hold navigation.datetime alongside a fix).
+    if clock is not None:
+        for update in delta.get("updates", []):
+            host_ts = _parse_update_ts(update)
+            for entry in update.get("values", []):
+                if entry.get("path") == _GPS_TIME_PATH:
+                    gps_ts = _parse_gps_dt(entry.get("value"))
+                    if gps_ts is not None:
+                        clock.observe(host_ts, gps_ts)
+
     for update in delta.get("updates", []):
-        ts_str: str = update.get("timestamp", "")
-        try:
-            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            ts = datetime.now(UTC)
+        ts = _parse_update_ts(update)
+        if clock is not None:
+            ts = clock.apply(ts)
 
         # Per-update Signal K source label (e.g. "n2k.0.130577.0"). Hashed
         # to an int so position rows from different physical GPS antennas
@@ -247,6 +291,10 @@ def process_delta(
             # Block AIS-related paths (#208)
             if "ais" in path.lower() or path.startswith("vessels.urn:"):
                 logger.warning("SK: rejecting AIS/other-vessel path {!r}", path)
+                continue
+
+            # GPS time: consumed by the clock pre-scan above, not a record.
+            if path == _GPS_TIME_PATH:
                 continue
 
             if path == "navigation.position":
@@ -334,6 +382,18 @@ class SKReader:
         self._buf: dict[str, float] = {}
         self._self_context: str | None = None
         self._token: str | None = None
+        self._clock = ClockDiscipliner()
+        self._clock_flag = ClockFlag.UNVERIFIED
+
+    @property
+    def clock_flag(self) -> ClockFlag:
+        """Current GPS-clock provenance for the session being recorded (#794)."""
+        return self._clock_flag
+
+    @property
+    def clock_offset_s(self) -> float:
+        """Smoothed host<->GPS offset in seconds (0.0 until a GPS ref exists)."""
+        return self._clock.offset_s
 
     def __aiter__(self) -> AsyncIterator[PGNRecord]:
         return self._stream()
@@ -431,9 +491,20 @@ class SKReader:
                     logger.info("SK: connected")
                     async for raw in ws:
                         for record in process_delta(
-                            str(raw), self._buf, self_context=self._self_context
+                            str(raw),
+                            self._buf,
+                            self_context=self._self_context,
+                            clock=self._clock,
                         ):
                             yield record
+                        if self._clock.flag is not self._clock_flag:
+                            logger.warning(
+                                "SK: clock provenance {} -> {} (offset {:+.1f}s)",
+                                self._clock_flag.value,
+                                self._clock.flag.value,
+                                self._clock.offset_s,
+                            )
+                            self._clock_flag = self._clock.flag
             except asyncio.CancelledError:
                 logger.info("SK: cancelled — stopping")
                 raise

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -232,7 +232,7 @@ _LIVE_KEYS = (
 # Schema version & migrations
 # ---------------------------------------------------------------------------
 
-_CURRENT_VERSION: int = 86
+_CURRENT_VERSION: int = 87
 
 _MIGRATIONS: dict[int, str] = {
     1: """
@@ -2162,6 +2162,16 @@ _MIGRATIONS: dict[int, str] = {
         ALTER TABLE races ADD COLUMN gear_preset TEXT;
         ALTER TABLE users ADD COLUMN gear_default_lbs REAL;
     """,
+    87: """
+        -- GPS-clock provenance per live recording (#794). The Signal K server
+        -- runs on the Pi, so delta timestamps inherit the host clock, and an
+        -- unsynced boot can stamp a whole recording at the wrong UTC. The
+        -- logger now disciplines record timestamps to GPS time and records the
+        -- outcome here as synced, corrected, unverified, or ref_lost.
+        -- NULL = legacy/imported race (time base not tracked) so no banner.
+        -- (Migration comments must avoid semicolons -- the splitter cuts on them.)
+        ALTER TABLE races ADD COLUMN clock_flag TEXT;
+    """,
 }
 
 # Retention window for retired slugs (#449). Requests for a retired slug 301
@@ -2314,6 +2324,11 @@ class Storage:
     def session_active(self) -> bool:
         """True when a race or practice session is currently in progress."""
         return self._session_active
+
+    @property
+    def active_race_id(self) -> int | None:
+        """Id of the race currently being recorded, or None when idle (#794)."""
+        return self._active_race_id
 
     # ------------------------------------------------------------------
     # In-memory live instrument cache (always updated, no DB I/O)
@@ -4167,6 +4182,21 @@ class Storage:
         await self._invalidate_race_cache(race_id)
         logger.info("Race {} start_utc anchored to gun at {}", race_id, start_utc.isoformat())
 
+    async def set_race_clock_flag(self, race_id: int, clock_flag: str) -> None:
+        """Persist the GPS-clock provenance of a live recording (#794).
+
+        Called by the logger as the recording's clock state evolves
+        (``unverified`` → ``synced``/``corrected``/``ref_lost``). Idempotent:
+        the logger only calls this when the flag changes.
+        """
+        db = self._conn()
+        await db.execute(
+            "UPDATE races SET clock_flag = ? WHERE id = ?",
+            (clock_flag, race_id),
+        )
+        await db.commit()
+        await self._invalidate_race_cache(race_id)
+
     async def rename_race(
         self,
         race_id: int,
@@ -4528,10 +4558,12 @@ class Storage:
             session_type=row["session_type"],
             slug=row["slug"] or "",
             renamed_at=(datetime.fromisoformat(row["renamed_at"]) if row["renamed_at"] else None),
+            clock_flag=row["clock_flag"],
         )
 
     _RACE_COLS = (
-        "id, name, event, race_num, date, start_utc, end_utc, session_type, slug, renamed_at"
+        "id, name, event, race_num, date, start_utc, end_utc, session_type, slug, renamed_at,"
+        " clock_flag"
     )
 
     async def get_race(self, race_id: int) -> Race | None:
@@ -11974,6 +12006,81 @@ class Storage:
             s["matched_races"] = matches_by_session.get(int(s["id"]), [])
         return sessions
 
+    async def _sample_track(
+        self, table: str, id_col: str, id_val: int, *, target: int = 200
+    ) -> list[tuple[datetime, float, float]]:
+        """Time-ordered, evenly-downsampled ``(ts, lat, lon)`` track (~target points).
+
+        Used by the Vakaros import-skew cross-check (#794). ``table`` is one of
+        the position tables — ``positions`` (live) and ``vakaros_positions``
+        share the ts / latitude_deg / longitude_deg columns. ``table``/``id_col``
+        are internal constants, never user input.
+        """
+        db = self._read_conn()
+        cur = await db.execute(
+            f"SELECT COUNT(*) AS n FROM {table} WHERE {id_col} = ?",  # noqa: S608
+            (id_val,),
+        )
+        row = await cur.fetchone()
+        n = int(row["n"]) if row else 0
+        if n == 0:
+            return []
+        stride = max(1, n // target)
+        cur = await db.execute(
+            f"SELECT ts, latitude_deg, longitude_deg FROM "  # noqa: S608
+            f"(SELECT ts, latitude_deg, longitude_deg, "
+            f"ROW_NUMBER() OVER (ORDER BY ts) AS rn FROM {table} WHERE {id_col} = ?) "
+            f"WHERE rn % ? = 0",
+            (id_val, stride),
+        )
+        out: list[tuple[datetime, float, float]] = []
+        for r in await cur.fetchall():
+            ts = _parse_utc(r["ts"])
+            if ts is not None:
+                out.append((ts, r["latitude_deg"], r["longitude_deg"]))
+        return out
+
+    async def _flag_import_clock_skew(self, session_id: int, race_ids: list[int]) -> None:
+        """Cross-check linked recordings against the GPS-sourced Vakaros track (#794).
+
+        A Vakaros session carries GPS-authoritative time. If a freshly-linked
+        live recording's track is time-shifted relative to it, the recording's
+        clock was wrong (the race-201 incident). Logs a WARNING and, for
+        recordings whose time base was never GPS-tracked (``clock_flag IS
+        NULL``), sets ``unverified`` so the session page warns. Recordings that
+        already carry a real GPS-discipline flag are left as-is (that flag is
+        authoritative) but still logged.
+        """
+        if not race_ids:
+            return
+        from helmlog.clock_sync import IMPORT_SKEW_OK_S, estimate_track_offset_s
+
+        vak_track = await self._sample_track("vakaros_positions", "session_id", session_id)
+        if len(vak_track) < 5:
+            return
+        db = self._conn()
+        changed = False
+        for rid in race_ids:
+            race_track = await self._sample_track("positions", "race_id", rid)
+            offset = estimate_track_offset_s(race_track, vak_track)
+            if offset is None or abs(offset) <= IMPORT_SKEW_OK_S:
+                continue
+            logger.warning(
+                "Race {} clock skew vs Vakaros session {}: {:+.0f}s track offset "
+                "— recording clock likely wrong (#794)",
+                rid,
+                session_id,
+                offset,
+            )
+            cur = await db.execute("SELECT clock_flag FROM races WHERE id = ?", (rid,))
+            row = await cur.fetchone()
+            if row is not None and row["clock_flag"] is None:
+                await db.execute("UPDATE races SET clock_flag = 'unverified' WHERE id = ?", (rid,))
+                await self._invalidate_race_cache(rid)
+                changed = True
+        if changed:
+            await db.commit()
+
     async def match_vakaros_session(self, session_id: int) -> list[int]:
         """Link a Vakaros session to *all* overlapping races.
 
@@ -12044,6 +12151,7 @@ class Storage:
             linked.append(int(cand["id"]))
 
         await db.commit()
+        await self._flag_import_clock_skew(session_id, linked)
         return linked
 
     async def rematch_all_vakaros_sessions(self) -> dict[int, list[int]]:

--- a/src/helmlog/templates/session.html
+++ b/src/helmlog/templates/session.html
@@ -154,6 +154,17 @@ body.live-race #session-tags-row{display:none!important}
 </div>
 {% endif %}
 
+{# Clock provenance (#794): warn when the recording's time base is suspect. #}
+{% if (clock_flag or '') in ('unverified', 'ref_lost') %}
+<div class="stale-banner" style="margin-bottom:8px">
+  <span>⚠ Recording clock {{ 'had no GPS time reference' if clock_flag == 'unverified' else 'lost its GPS time reference mid-session' }} — timestamps come from the device clock and may not match true UTC. Cross-check against external sources (results, video, Vakaros) before trusting absolute times.</span>
+</div>
+{% elif (clock_flag or '') == 'corrected' %}
+<div class="card" style="background:var(--bg-secondary);border:1px dashed var(--warning);font-size:.78rem;color:var(--text-secondary);margin-bottom:8px">
+  ⏱ This recording's device clock was off; timestamps were automatically corrected to GPS time.
+</div>
+{% endif %}
+
 <div class="card">
   <div id="session-header" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
     <div style="flex:1;min-width:0">

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -1,0 +1,147 @@
+"""Tests for clock_sync.ClockDiscipliner — GPS clock discipline (#794).
+
+Each test maps to a row of the spec decision table or a transition in the
+clock-sync state diagram on issue #794.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from helmlog.clock_sync import (
+    ClockDiscipliner,
+    ClockFlag,
+    estimate_track_offset_s,
+)
+
+BASE = datetime(2026, 6, 16, 1, 0, 0, tzinfo=UTC)
+
+
+def _host(sec: float) -> datetime:
+    return BASE + timedelta(seconds=sec)
+
+
+# --- decision table -------------------------------------------------------
+
+
+def test_no_gps_ever_is_unverified_and_passthrough() -> None:
+    c = ClockDiscipliner()
+    assert c.flag is ClockFlag.UNVERIFIED
+    ts = _host(10)
+    assert c.apply(ts) == ts  # host time used unchanged, never dropped
+
+
+def test_small_skew_is_synced_and_passthrough() -> None:
+    c = ClockDiscipliner()
+    # GPS only 5s ahead of host — within SKEW_OK.
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=5))
+    assert c.flag is ClockFlag.SYNCED
+    ts = _host(10)
+    assert c.apply(ts) == ts
+
+
+def test_large_skew_is_corrected_and_disciplined() -> None:
+    c = ClockDiscipliner()
+    # Host clock is 1h slow: GPS = host + 3600s (the race-201 incident).
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=3600))
+    assert c.flag is ClockFlag.CORRECTED
+    # A record stamped at host time is bumped to true (GPS) time.
+    assert c.apply(_host(10)) == _host(10) + timedelta(seconds=3600)
+
+
+def test_ref_lost_after_timeout_keeps_last_offset() -> None:
+    c = ClockDiscipliner()
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=3600))
+    assert c.flag is ClockFlag.CORRECTED
+    # No GPS for > REF_TIMEOUT: still disciplined with the last-known offset.
+    late = _host(5 + 200)
+    assert c.apply(late) == late + timedelta(seconds=3600)
+    assert c.flag is ClockFlag.REF_LOST
+
+
+# --- state transitions ----------------------------------------------------
+
+
+def test_single_outlier_does_not_move_synced_offset() -> None:
+    c = ClockDiscipliner()
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=2))
+    assert c.flag is ClockFlag.SYNCED
+    # One garbage GPS sample (parse glitch) 1h off — median ignores it.
+    c.observe(_host(5), _host(5) + timedelta(seconds=3600))
+    assert c.flag is ClockFlag.SYNCED
+    assert abs(c.offset_s - 2.0) < 1.0
+
+
+def test_sustained_step_is_adopted() -> None:
+    c = ClockDiscipliner()
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=2))
+    assert c.flag is ClockFlag.SYNCED
+    # A real, sustained clock step (e.g. NTP correction) of +3600s.
+    for s in range(5, 12):
+        c.observe(_host(s), _host(s) + timedelta(seconds=3600))
+    assert c.flag is ClockFlag.CORRECTED
+
+
+def test_ref_lost_recovers_on_resume() -> None:
+    c = ClockDiscipliner()
+    for s in range(5):
+        c.observe(_host(s), _host(s) + timedelta(seconds=3600))
+    # Force ref_lost via a stale apply.
+    c.apply(_host(300))
+    assert c.flag is ClockFlag.REF_LOST
+    # GPS resumes, now in sync (host clock fixed): back to SYNCED.
+    for s in range(300, 306):
+        c.observe(_host(s), _host(s) + timedelta(seconds=1))
+    assert c.flag is ClockFlag.SYNCED
+
+
+# --- import-skew cross-check (track time-offset) --------------------------
+
+
+def _line_track(start: datetime, n: int, step_s: float = 1.0) -> list:
+    # Boat moving steadily NE so every second is a distinct position.
+    return [
+        (start + timedelta(seconds=i * step_s), 47.60 + i * 1e-4, -122.40 + i * 1e-4)
+        for i in range(n)
+    ]
+
+
+def test_track_offset_recovers_known_one_hour_shift() -> None:
+    live = _line_track(BASE, 200)
+    # External (Vakaros) device clock is 1h ahead — the race-201 condition.
+    external = [(ts + timedelta(seconds=3600), lat, lon) for (ts, lat, lon) in live[::5]]
+    off = estimate_track_offset_s(live, external)
+    assert off is not None
+    assert abs(off - 3600) <= 10
+
+
+def test_track_offset_zero_when_aligned() -> None:
+    live = _line_track(BASE, 200)
+    external = [(ts, lat, lon) for (ts, lat, lon) in live[::5]]
+    off = estimate_track_offset_s(live, external)
+    assert off is not None
+    assert abs(off) <= 10
+
+
+def test_track_offset_none_when_too_few_points() -> None:
+    live = _line_track(BASE, 3)
+    external = _line_track(BASE, 3)
+    assert estimate_track_offset_s(live, external) is None
+
+
+def test_track_offset_race_subset_of_full_day_reference() -> None:
+    # GPS-correct Vakaros reference spanning the whole race day.
+    full_day = _line_track(BASE, 3600)
+    # One race is a 600s slice, but its recording clock is 1h SLOW: its
+    # timestamps read 3600s earlier than the true (reference) time. Only the
+    # race slice overlaps — the rest of the day must not poison the estimate.
+    race = [(ts - timedelta(seconds=3600), lat, lon) for (ts, lat, lon) in full_day[1500:2100:5]]
+    off = estimate_track_offset_s(race, full_day)
+    assert off is not None
+    # reference_clock - track_clock = +3600 (recording is 1h behind true time).
+    assert abs(off - 3600) <= 10

--- a/tests/test_sk_reader.py
+++ b/tests/test_sk_reader.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import json
 import math
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -794,3 +794,73 @@ class TestAuthPlumbing:
         assert len(captured_uris) >= 1
         assert "token=" not in captured_uris[0]
         assert captured_uris[0].endswith("subscribe=all")
+
+
+# ---------------------------------------------------------------------------
+# TestClockDiscipline — GPS-disciplined record timestamps (#794)
+# ---------------------------------------------------------------------------
+
+
+class TestClockDiscipline:
+    """process_delta routes record timestamps through a ClockDiscipliner."""
+
+    @staticmethod
+    def _gps_pos_delta(host_ts: str, gps_dt: str, pos: dict[str, float]) -> str:
+        # One delta carrying GPS time and a position fix at the same host time.
+        return json.dumps(
+            {
+                "context": "vessels.self",
+                "updates": [
+                    {
+                        "timestamp": host_ts,
+                        "values": [
+                            {"path": "navigation.datetime", "value": gps_dt},
+                            {"path": "navigation.position", "value": pos},
+                        ],
+                    }
+                ],
+            }
+        )
+
+    def test_no_clock_uses_host_timestamp(self) -> None:
+        # Without a discipliner, behaviour is unchanged: host timestamp wins.
+        recs = process_delta(_delta("navigation.headingTrue", math.pi), {})
+        assert recs[0].timestamp == _TS_DT
+
+    def test_host_clock_slow_records_disciplined_to_gps(self) -> None:
+        # Host clock 1h slow vs GPS (the race-201 condition).
+        from helmlog.clock_sync import ClockFlag
+        from helmlog.sk_reader import ClockDiscipliner
+
+        clock = ClockDiscipliner()
+        pos = {"latitude": 47.68, "longitude": -122.41}
+        rec = None
+        for i in range(6):
+            host = datetime(2026, 6, 16, 0, 27, i, tzinfo=UTC)
+            gps = host + timedelta(seconds=3600)
+            out = process_delta(
+                self._gps_pos_delta(host.isoformat(), gps.isoformat(), pos),
+                {},
+                clock=clock,
+            )
+            rec = next(r for r in out if isinstance(r, PositionRecord))
+        assert clock.flag is ClockFlag.CORRECTED
+        # Position is stamped at true (GPS) time, ~1h ahead of the host clock.
+        assert rec is not None
+        assert rec.timestamp.hour == 1  # 00:27 host -> 01:27 GPS-disciplined
+
+    def test_synced_clock_leaves_timestamp_untouched(self) -> None:
+        from helmlog.clock_sync import ClockFlag
+        from helmlog.sk_reader import ClockDiscipliner
+
+        clock = ClockDiscipliner()
+        pos = {"latitude": 47.68, "longitude": -122.41}
+        for i in range(6):
+            host = datetime(2026, 6, 16, 1, 30, i, tzinfo=UTC)
+            gps = host + timedelta(seconds=1)  # within SKEW_OK
+            process_delta(
+                self._gps_pos_delta(host.isoformat(), gps.isoformat(), pos),
+                {},
+                clock=clock,
+            )
+        assert clock.flag is ClockFlag.SYNCED

--- a/tests/test_storage_clock_flag.py
+++ b/tests/test_storage_clock_flag.py
@@ -1,0 +1,134 @@
+"""Storage persistence of GPS-clock provenance on races (#794)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+BASE = datetime(2026, 6, 16, 1, 0, 0, tzinfo=UTC)
+
+
+def _pos(k: int) -> tuple[float, float]:
+    # Distinct lat/lon per course index so a time shift is spatially visible.
+    return (47.60 + k * 1e-4, -122.40 + k * 1e-4)
+
+
+async def _seed_race_and_vakaros(storage: Storage, *, race_clock_skew_s: int) -> tuple[int, int]:
+    """Seed a 900s live race + a same-course Vakaros session (GPS-correct).
+
+    The race recording's clock is offset from true time by ``race_clock_skew_s``
+    (negative = slow, the race-201 condition). Windows are long relative to the
+    skew so the time-overlap matcher still links them. Returns (race_id, sid).
+    """
+    db = storage._conn()  # noqa: SLF001
+    race = await storage.start_race(
+        event="Test",
+        start_utc=BASE + timedelta(seconds=race_clock_skew_s),
+        date_str="2026-06-16",
+        race_num=1,
+        name=f"20260616-skew{race_clock_skew_s}-1",
+    )
+    await db.execute(
+        "UPDATE races SET end_utc = ? WHERE id = ?",
+        ((BASE + timedelta(seconds=900 + race_clock_skew_s)).isoformat(), race.id),
+    )
+    pos_rows = [
+        (
+            (BASE + timedelta(seconds=k + race_clock_skew_s)).isoformat(),
+            0,
+            *_pos(k),
+            race.id,
+        )
+        for k in range(0, 900, 2)
+    ]
+    await db.executemany(
+        "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+        " VALUES (?, ?, ?, ?, ?)",
+        pos_rows,
+    )
+    cur = await db.execute(
+        "INSERT INTO vakaros_sessions (source_hash, source_file, start_utc, end_utc,"
+        " ingested_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            f"h{race_clock_skew_s}".ljust(64, "0"),
+            "skew.vkx",
+            BASE.isoformat(),
+            (BASE + timedelta(seconds=900)).isoformat(),
+            BASE.isoformat(),
+        ),
+    )
+    sid = int(cur.lastrowid)  # type: ignore[arg-type]
+    vak_rows = [
+        (sid, (BASE + timedelta(seconds=k)).isoformat(), *_pos(k), 3.0, 45.0)
+        for k in range(0, 900, 2)
+    ]
+    await db.executemany(
+        "INSERT INTO vakaros_positions (session_id, ts, latitude_deg, longitude_deg,"
+        " sog_mps, cog_deg) VALUES (?, ?, ?, ?, ?, ?)",
+        vak_rows,
+    )
+    await db.commit()
+    return race.id, sid
+
+
+@pytest.mark.asyncio
+async def test_import_skew_flags_recording_unverified(storage: Storage) -> None:
+    # Recording clock 5 min slow vs the GPS-correct Vakaros track.
+    race_id, sid = await _seed_race_and_vakaros(storage, race_clock_skew_s=-300)
+    linked = await storage.match_vakaros_session(sid)
+    assert race_id in linked
+    refreshed = await storage.get_race(race_id)
+    assert refreshed is not None
+    assert refreshed.clock_flag == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_aligned_tracks_leave_clock_flag_untouched(storage: Storage) -> None:
+    race_id, sid = await _seed_race_and_vakaros(storage, race_clock_skew_s=0)
+    linked = await storage.match_vakaros_session(sid)
+    assert race_id in linked
+    refreshed = await storage.get_race(race_id)
+    assert refreshed is not None
+    assert refreshed.clock_flag is None
+
+
+@pytest.mark.asyncio
+async def test_clock_flag_defaults_to_none(storage: Storage) -> None:
+    race = await storage.start_race(
+        event="Test",
+        start_utc=datetime(2026, 6, 16, 1, 27, tzinfo=UTC),
+        date_str="2026-06-16",
+        race_num=1,
+        name="20260616-Test-1",
+    )
+    # A freshly started race has no clock provenance recorded yet (NULL),
+    # so the UI shows no banner until the logger reports a flag.
+    fetched = await storage.get_race(race.id)
+    assert fetched is not None
+    assert fetched.clock_flag is None
+
+
+@pytest.mark.asyncio
+async def test_set_and_read_clock_flag(storage: Storage) -> None:
+    race = await storage.start_race(
+        event="Test",
+        start_utc=datetime(2026, 6, 16, 1, 27, tzinfo=UTC),
+        date_str="2026-06-16",
+        race_num=1,
+        name="20260616-Test-1",
+    )
+    await storage.set_race_clock_flag(race.id, "corrected")
+    fetched = await storage.get_race(race.id)
+    assert fetched is not None
+    assert fetched.clock_flag == "corrected"
+
+    # Idempotent overwrite as the session's state evolves.
+    await storage.set_race_clock_flag(race.id, "ref_lost")
+    fetched = await storage.get_race(race.id)
+    assert fetched is not None
+    assert fetched.clock_flag == "ref_lost"


### PR DESCRIPTION
## What

GPS-discipline the recording path so an unsynced Pi clock can no longer stamp a whole recording at the wrong UTC, and surface clock provenance per recording.

**Root cause it prevents** (the race-201 incident): the Signal K server runs on the Pi (`SK_HOST=localhost`), so SK delta timestamps carry the Pi's *system* clock. When the Pi boots before NTP/GPS sync, the entire recording is uniformly time-shifted. Race 201 was logged **1 h slow**; the GPS-correct Vakaros file, official STYC results, and onboard video all agreed on the true start (18:45), while the live track read 17:44. The one-off +1 h data fix for race 201 was applied separately.

## How

- **`clock_sync.py` (new)** — `ClockDiscipliner` derives the host↔GPS offset from `navigation.datetime` (PGN 126992 / 129033), **median-smoothed** over a rolling window (this *is* the spec's outlier guard: one bad sample can't move the output; a sustained NTP step is adopted after a few). States: `synced` / `corrected` / `unverified` / `ref_lost`. Recording is **never blocked** — falls back to host time and flags `unverified` when GPS time is unavailable. Also `estimate_track_offset_s()` for the cross-check.
- **`sk_reader.py`** — pre-scans each delta for GPS time, routes every emitted record timestamp through the discipliner, exposes `clock_flag` / `clock_offset_s`, logs provenance transitions.
- **`storage.py`** — migration **v87** adds `races.clock_flag` (NULL = legacy/imported, no banner); `set_race_clock_flag()` + `active_race_id`; `match_vakaros_session` now cross-checks the linked live track against the GPS-correct Vakaros track and flags `unverified` on a **>60 s** track offset (catches a skewed recording at ingest instead of months later).
- **`main.py`** — persists clock-flag transitions onto the active race during recording.
- **`session.html`** — warning banner for `unverified` / `ref_lost`, info note for `corrected`.

## Spec coverage (approved on #794)

Implements option 1 (GPS-sourced time — root fix), option 2 (flag + banner), and option 3 (import-skew detection). Per the approved answers: never block recording (Q1), `SKEW_OK=30 s` / `REF_TIMEOUT=120 s` / median offset (Q2), `host + smoothed_offset` disciplining (Q3).

## Tests

- `test_clock_sync.py` — each decision-table row + state transition + the track-offset estimator (incl. the race-is-a-slice-of-the-full-day case).
- `test_sk_reader.py::TestClockDiscipline` — disciplined timestamps end-to-end through `process_delta`.
- `test_storage_clock_flag.py` — persistence + import-skew flagging (skewed → `unverified`, aligned → untouched).

`ruff` + `ruff format` + `mypy --strict` clean; 210 passed across the touched areas. No PII / sharing / export / federation touched — no data-licensing implications.

## Deploy note

The Pi DB is currently at schema **v86**. On deploy, `migrate()` applies v87 (adds `clock_flag`) cleanly. Restart the service after deploy so the disciplined recording path takes effect.

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
