### PR TITLE
fix(sessions): discipline race + audio boundaries to GPS clock (#797)

### DIFF
--- a/docs/operators-guide.md
+++ b/docs/operators-guide.md
@@ -210,6 +210,16 @@ Each session card has buttons for:
 **"The START RACE button is missing or greyed out"**
 → A race or debrief is already active. Tap the **■ END** button to close it first.
 
+**"A past race shows a clock warning, or its times look off by ~an hour"**
+→ The Pi has no battery clock, so if it booted with no internet *and* before GPS
+  lock, it can start on a wrong time. The logger GPS-corrects the recorded track
+  automatically, and a banner flags any race whose window doesn't match its own
+  data. To prevent it, a boot service (`helmlog-gpsclock`) steps the system clock
+  to GPS time before recording starts — give the Pi a minute with a GPS fix after
+  power-on before starting a race. The navigator can confirm with
+  `systemctl status helmlog-gpsclock` (it runs once at boot). A flagged past race
+  needs a manual time fix — note the race and tell the data admin.
+
 **Emergency note**
 The logger is read-only on the instruments — it cannot affect boat systems.
 If anything breaks in the app, simply close the browser. The boat is fine.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -718,6 +718,32 @@ fi
 #    UV_CACHE_DIR: helmlog has no home dir, so point uv cache to /var/cache.
 # ---------------------------------------------------------------------------
 
+step "Installing helmlog GPS clock-sync one-shot (#799)..."
+# Best-effort: step the system clock to GPS time once at boot, before recording
+# starts, so a Pi that booted before NTP/GPS sync (no RTC, no dock internet)
+# doesn't stamp race boundaries on a wrong host clock. Runs as root so it can set
+# the clock; never blocks boot (TimeoutStartSec, no Requires=). The in-app
+# discipliner + boundary guard remain the safety net if this no-ops.
+sudo tee /etc/systemd/system/helmlog-gpsclock.service > /dev/null << EOF
+[Unit]
+Description=HelmLog GPS system-clock discipline (one-shot at boot)
+After=signalk.service
+Wants=signalk.service
+Before=helmlog.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=${PROJECT_DIR}
+EnvironmentFile=${ENV_FILE}
+Environment=UV_CACHE_DIR=/var/cache/helmlog
+Environment=HOME=/var/cache/helmlog
+ExecStart=${UV_BIN} run --no-sync --project ${PROJECT_DIR} helmlog gps-clock-sync --timeout 30
+TimeoutStartSec=45
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 step "Installing helmlog service..."
 sudo tee /etc/systemd/system/helmlog.service > /dev/null << EOF
 [Unit]
@@ -742,6 +768,7 @@ UMask=0002
 WantedBy=multi-user.target
 EOF
 sudo systemctl daemon-reload
+sudo systemctl enable helmlog-gpsclock.service
 sudo systemctl enable helmlog.service
 
 if sudo systemctl is-active --quiet signalk.service 2>/dev/null; then

--- a/src/helmlog/clock_sync.py
+++ b/src/helmlog/clock_sync.py
@@ -30,6 +30,10 @@ import statistics
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
 # Defaults (spec Q2). Max tolerated host<->GPS divergence, and how long
 # without a GPS sample before the reference is considered lost.
@@ -178,3 +182,75 @@ def estimate_track_offset_s(
             best_cost = cost
             best_offset = offset
     return best_offset
+
+
+# ---------------------------------------------------------------------------
+# OS-level GPS clock discipline at boot (#799)
+# ---------------------------------------------------------------------------
+#
+# The in-recording-path discipline above corrects *record* timestamps, but a
+# race marked before GPS sync still gets a host-time boundary (the pre-sync
+# residual #797 leaves). The complete fix is to step the *system* clock to GPS
+# time once, at boot, before the recording service starts — so even raw host
+# stamps are right. This orchestration is kept hardware-free: ``main.py`` injects
+# the SK-offset reader, the system-clock setter, and the sync check.
+
+# Don't step the system clock for sub-threshold jitter — only a real boot skew.
+STEP_THRESHOLD_S: float = 10.0
+
+
+def should_step_clock(
+    *, offset_s: float, clock_synchronized: bool, threshold_s: float = STEP_THRESHOLD_S
+) -> bool:
+    """Decide whether to step the system clock to GPS time at boot.
+
+    Step only when the system clock is **not** already synchronized — never
+    fight an authoritative NTP/timesyncd source — and the host↔GPS offset
+    clears ``threshold_s`` so jitter can't trigger a needless step.
+    """
+    if clock_synchronized:
+        return False
+    return abs(offset_s) >= threshold_s
+
+
+@dataclass(frozen=True)
+class BootClockSyncResult:
+    """Outcome of a boot-time GPS clock-sync attempt (for logging/tests)."""
+
+    action: str  # "stepped" | "skipped-synchronized" | "skipped-small" | "no-gps"
+    offset_s: float | None = None
+    target_utc: datetime | None = None
+
+
+async def gps_boot_clock_sync(
+    *,
+    measure_offset: Callable[[], Awaitable[float | None]],
+    is_synchronized: Callable[[], bool],
+    set_clock: Callable[[datetime], None],
+    now: Callable[[], datetime],
+    threshold_s: float = STEP_THRESHOLD_S,
+) -> BootClockSyncResult:
+    """Best-effort: step the system clock to GPS time at boot if it's adrift.
+
+    All side-effecting parts are injected so this stays hardware-free and fully
+    testable: ``measure_offset`` reads the host↔GPS offset from Signal K
+    (``None`` if no GPS reference appears in time), ``is_synchronized`` reports
+    whether the OS clock is already disciplined, ``set_clock`` applies the step,
+    and ``now`` supplies the host time being corrected.
+
+    Never raises and never blocks indefinitely (the injected ``measure_offset``
+    owns the timeout): the in-app discipliner + boundary guard remain the safety
+    net, so a no-op here only forfeits the *system*-clock correction.
+    """
+    offset = await measure_offset()
+    if offset is None:
+        return BootClockSyncResult(action="no-gps")
+    synchronized = is_synchronized()
+    if not should_step_clock(
+        offset_s=offset, clock_synchronized=synchronized, threshold_s=threshold_s
+    ):
+        action = "skipped-synchronized" if synchronized else "skipped-small"
+        return BootClockSyncResult(action=action, offset_s=offset)
+    target = now() + timedelta(seconds=offset)
+    set_clock(target)
+    return BootClockSyncResult(action="stepped", offset_s=offset, target_utc=target)

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -575,6 +575,77 @@ async def _export(start_iso: str, end_iso: str, out: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _measure_gps_offset(timeout_s: float) -> float | None:
+    """Read the host↔GPS offset from Signal K, or None if no GPS time appears
+    within ``timeout_s``. Reuses the live ``SKReader`` discipliner so the offset
+    carries the same median-smoothing as the recording path (#799)."""
+    from helmlog.clock_sync import ClockFlag
+    from helmlog.sk_reader import SKReader, SKReaderConfig
+
+    reader = SKReader(SKReaderConfig())
+    try:
+        async with asyncio.timeout(timeout_s):
+            async for _record in reader:
+                # Any non-unverified flag means a GPS reference has been seen and
+                # offset_s is meaningful (synced ⇒ ~0, corrected ⇒ the boot skew).
+                if reader.clock_flag is not ClockFlag.UNVERIFIED:
+                    return reader.clock_offset_s
+    except TimeoutError:
+        logger.warning("gps-clock-sync: no GPS time from Signal K within {:.0f}s", timeout_s)
+    return None
+
+
+def _clock_is_synchronized() -> bool:
+    """True when the OS already considers its clock disciplined (NTP/timesyncd).
+    On any error, return False — better to attempt a GPS step than to assume a
+    possibly-wrong clock is good (the step is still gated on the offset)."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["timedatectl", "show", "-p", "NTPSynchronized", "--value"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        return out.stdout.strip() == "yes"
+    except Exception as exc:  # noqa: BLE001 — best-effort probe, never fatal
+        logger.warning("gps-clock-sync: could not read clock-sync state: {}", exc)
+        return False
+
+
+def _set_system_clock(target: datetime) -> None:
+    """Step the system clock to ``target`` (UTC). No-op unless running as root."""
+    import subprocess
+
+    if os.geteuid() != 0:
+        logger.warning("gps-clock-sync: not root (euid={}), cannot step clock", os.geteuid())
+        return
+    ts = target.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    # `date -u -s` sets the clock unconditionally; `timedatectl set-time` refuses
+    # while timesyncd is active, which is exactly the no-internet dock case.
+    subprocess.run(["date", "-u", "-s", ts], check=True, timeout=5)
+    logger.warning("gps-clock-sync: stepped system clock to {} UTC", ts)
+
+
+async def _gps_clock_sync(timeout_s: float) -> None:
+    """CLI: best-effort one-shot GPS system-clock discipline at boot (#799)."""
+    from helmlog.clock_sync import gps_boot_clock_sync
+
+    result = await gps_boot_clock_sync(
+        measure_offset=lambda: _measure_gps_offset(timeout_s),
+        is_synchronized=_clock_is_synchronized,
+        set_clock=_set_system_clock,
+        now=lambda: datetime.now(UTC),
+    )
+    logger.info(
+        "gps-clock-sync: {} (offset={})",
+        result.action,
+        f"{result.offset_s:+.1f}s" if result.offset_s is not None else "n/a",
+    )
+
+
 async def _status() -> None:
     """Print row counts and last-seen timestamps for each data table."""
     from helmlog.storage import Storage, StorageConfig
@@ -1627,6 +1698,17 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("status", help="Show DB row counts and last-seen timestamps")
 
+    gcs = sub.add_parser(
+        "gps-clock-sync",
+        help="One-shot: step the system clock to GPS time at boot (best-effort, #799)",
+    )
+    gcs.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for GPS time from Signal K before giving up (default 30)",
+    )
+
     lv = sub.add_parser(
         "link-video",
         help="Link a YouTube video to logged data via a time sync point",
@@ -1795,6 +1877,8 @@ def main() -> None:
                 asyncio.run(_export(args.start, args.end, args.out))
             case "status":
                 asyncio.run(_status())
+            case "gps-clock-sync":
+                asyncio.run(_gps_clock_sync(args.timeout))
             case "link-video":
                 sync_utc_iso = args.start if args.start else args.sync_utc
                 sync_offset = 0.0 if args.start else args.sync_offset

--- a/src/helmlog/main.py
+++ b/src/helmlog/main.py
@@ -485,14 +485,19 @@ async def _run() -> None:
                 last_clock_flag = reader.clock_flag
                 async for record in reader:
                     storage.update_live(record)
+                    # Mirror the GPS-clock state onto storage on every change so
+                    # web routes (race/audio boundaries) stamp on the same time
+                    # base as the telemetry — even between races (#794 follow-up).
+                    if reader.clock_flag is not last_clock_flag:
+                        storage.update_clock(reader.clock_offset_s, reader.clock_flag)
+                        # Persist provenance onto the active race when recording.
+                        if storage.session_active and storage.active_race_id is not None:
+                            await storage.set_race_clock_flag(
+                                storage.active_race_id, reader.clock_flag.value
+                            )
+                        last_clock_flag = reader.clock_flag
                     if storage.session_active:
                         await storage.write(record)
-                        # Persist GPS-clock provenance when it changes (#794).
-                        if reader.clock_flag is not last_clock_flag:
-                            race_id = storage.active_race_id
-                            if race_id is not None:
-                                await storage.set_race_clock_flag(race_id, reader.clock_flag.value)
-                            last_clock_flag = reader.clock_flag
             else:
                 from helmlog.can_reader import CANReader, CANReaderConfig, extract_pgn
                 from helmlog.nmea2000 import decode

--- a/src/helmlog/routes/races.py
+++ b/src/helmlog/routes/races.py
@@ -170,7 +170,7 @@ async def _do_scheduled_start(
     ss = app.state.session_state
     from helmlog.races import build_race_name, local_today
 
-    now = datetime.now(UTC)
+    now = storage.disciplined_now()  # GPS-disciplined clock, not host (#794)
     today = local_today()
     date_str = today.isoformat()
     race_num = await storage.count_sessions_for_date(date_str, session_type) + 1
@@ -413,7 +413,9 @@ async def api_start_race(
     race_num = await storage.count_sessions_for_date(date_str, session_type) + 1
     name = build_race_name(event, today, race_num, session_type)
 
-    now = datetime.now(UTC)
+    # Stamp the race window on the GPS-disciplined clock, not raw host time, so
+    # an unsynced-boot Pi can't skew the window away from its telemetry (#794).
+    now = storage.disciplined_now()
     race = await storage.start_race(event, now, date_str, race_num, name, session_type)
 
     # Boat-level crew defaults auto-apply via resolve_crew() —
@@ -513,7 +515,7 @@ async def api_end_race(
 ) -> None:
     storage = get_storage(request)
     ss = request.app.state.session_state
-    now = datetime.now(UTC)
+    now = storage.disciplined_now()  # GPS-disciplined clock, not host (#794)
     await storage.end_race(race_id, now)
     await audit(request, "race.end", detail=str(race_id), user=_user)
 
@@ -614,7 +616,7 @@ async def api_start_debrief(
 
     # Defensive: if the race is still in progress, auto-end it first
     if row["end_utc"] is None:
-        now_end = datetime.now(UTC)
+        now_end = storage.disciplined_now()  # GPS-disciplined clock, not host (#794)
         await storage.end_race(race_id, now_end)
         if ss.audio_session_id is not None:
             await capture_stop(
@@ -634,7 +636,7 @@ async def api_start_debrief(
         ss.debrief_audio_session_id = None
 
     debrief_name = f"{row['name']}-debrief"
-    now = datetime.now(UTC)
+    now = storage.disciplined_now()  # GPS-disciplined clock, not host (#794)
     # Hand capture_start the race's sibling group so it can warn when the USB
     # device set has changed between race-end and debrief-start (#648 C5).
     prev_audio = await storage.get_race_primary_audio_session(race_id)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -12,7 +12,7 @@ import json
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from helmlog.vakaros import VakarosSession
 
 from helmlog.anchors import AnchorError
+from helmlog.clock_sync import IMPORT_SKEW_OK_S, ClockFlag
 from helmlog.nmea2000 import (
     AttitudeRecord,
     COGSOGRecord,
@@ -2233,6 +2234,13 @@ class Storage:
         # Active race id, if any. Maintained by start_race / end_race. Used
         # to tag WS position broadcasts so clients can filter by race.
         self._active_race_id: int | None = None
+        # Live GPS-clock discipline, mirrored from the SK reader by the
+        # recording loop (#794 follow-up). Web routes stamp recording-correlated
+        # timestamps (race/audio boundaries) through ``disciplined_now`` so an
+        # unsynced-boot Pi clock can't skew the race window away from the
+        # GPS-disciplined telemetry — the race-203 split.
+        self._clock_offset_s: float = 0.0
+        self._clock_apply: bool = False
         self._live: dict[str, float | None] = dict.fromkeys(_LIVE_KEYS)
         self._live_tw_ref: int | None = None
         self._live_tw_angle_raw: float | None = None
@@ -2329,6 +2337,45 @@ class Storage:
     def active_race_id(self) -> int | None:
         """Id of the race currently being recorded, or None when idle (#794)."""
         return self._active_race_id
+
+    # ------------------------------------------------------------------
+    # GPS-clock discipline for web-route timestamps (#794 follow-up)
+    # ------------------------------------------------------------------
+
+    def update_clock(self, offset_s: float, flag: ClockFlag) -> None:
+        """Mirror the live SK reader's GPS-clock offset onto the storage
+        singleton so web routes can stamp recording-correlated timestamps on the
+        same time base as the telemetry stream.
+
+        The offset is *applied* only when the reader is actively disciplining
+        (``corrected``/``ref_lost``) — exactly ``ClockDiscipliner.apply``'s rule.
+        When the host is trusted (``synced``) or no GPS reference exists yet
+        (``unverified``), routes fall back to raw host time. Called by the
+        recording loop whenever the reader's clock state changes.
+        """
+        self._clock_offset_s = offset_s
+        self._clock_apply = flag in (ClockFlag.CORRECTED, ClockFlag.REF_LOST)
+
+    def discipline_ts(self, host_ts: datetime) -> datetime:
+        """Return the GPS-disciplined equivalent of a host timestamp.
+
+        Mirrors :meth:`helmlog.clock_sync.ClockDiscipliner.apply` so a record
+        stamped by a web route lands on the same time base as the live
+        telemetry stream.
+        """
+        if self._clock_apply:
+            return host_ts + timedelta(seconds=self._clock_offset_s)
+        return host_ts
+
+    def disciplined_now(self) -> datetime:
+        """``datetime.now(UTC)`` disciplined to GPS time (#794 follow-up).
+
+        Web routes use this in place of ``datetime.now(UTC)`` when stamping
+        recording-correlated boundaries (race start/end, audio sessions) so an
+        unsynced-boot Pi clock can't skew the race window away from its own
+        GPS-disciplined telemetry.
+        """
+        return self.discipline_ts(datetime.now(UTC))
 
     # ------------------------------------------------------------------
     # In-memory live instrument cache (always updated, no DB I/O)
@@ -3786,8 +3833,10 @@ class Storage:
             (
                 session.file_path,
                 session.device_name,
-                session.start_utc.isoformat(),
-                session.end_utc.isoformat() if session.end_utc else None,
+                # Discipline the recorder's host-clock stamp to GPS time so audio
+                # boundaries stay consistent with the telemetry stream (#794).
+                self.discipline_ts(session.start_utc).isoformat(),
+                self.discipline_ts(session.end_utc).isoformat() if session.end_utc else None,
                 session.sample_rate,
                 session.channels,
                 race_id,
@@ -3855,11 +3904,14 @@ class Storage:
         )
 
     async def update_audio_session_end(self, session_id: int, end_utc: datetime) -> None:
-        """Set the end_utc for an existing audio session row."""
+        """Set the end_utc for an existing audio session row.
+
+        ``end_utc`` is disciplined to GPS time so it stays on the same time base
+        as the session's ``start_utc`` and the telemetry stream (#794)."""
         db = self._conn()
         await db.execute(
             "UPDATE audio_sessions SET end_utc = ? WHERE id = ?",
-            (end_utc.isoformat(), session_id),
+            (self.discipline_ts(end_utc).isoformat(), session_id),
         )
         await db.commit()
         logger.debug("Audio session {} end_utc updated", session_id)
@@ -4088,6 +4140,78 @@ class Storage:
         row = await cur.fetchone()
         return _parse_utc(row[0]) if row and row[0] else None
 
+    async def _record_span_utc(self, race_id: int) -> tuple[datetime, datetime] | None:
+        """(earliest, latest) telemetry timestamp for a race, or None when it has
+        no data. The span the race's boundaries should bracket (#794 follow-up)."""
+        lo_union = " UNION ALL ".join(
+            f"SELECT MIN(ts) AS m FROM {t} WHERE race_id = ?" for t in self._TELEMETRY_TABLES
+        )
+        hi_union = " UNION ALL ".join(
+            f"SELECT MAX(ts) AS m FROM {t} WHERE race_id = ?" for t in self._TELEMETRY_TABLES
+        )
+        params = tuple([race_id] * len(self._TELEMETRY_TABLES))
+        cur = await self._read_conn().execute(
+            f"SELECT MIN(m), MAX(m) FROM ("  # noqa: S608 — table names from a fixed tuple
+            f"SELECT m FROM ({lo_union}) UNION ALL SELECT m FROM ({hi_union}))",
+            params + params,
+        )
+        row = await cur.fetchone()
+        if not row or row[0] is None or row[1] is None:
+            return None
+        first, last = _parse_utc(row[0]), _parse_utc(row[1])
+        if first is None or last is None:
+            return None
+        return first, last
+
+    async def _flag_boundary_clock_skew(self, race_id: int, end_utc: datetime) -> None:
+        """Flag a race whose start/end boundaries disagree with its own telemetry.
+
+        PR #795 disciplines the recording stream to GPS time but a race marked or
+        ended on an unsynced host clock still gets host-time boundaries (the
+        race-203 split: a window 2630s behind its own GPS-correct data). The
+        Vakaros track cross-check (:meth:`_flag_import_clock_skew`) can't catch
+        this — it validates the track, which is already correct — so we compare
+        the boundaries against the recorded data directly.
+
+        The boundaries must bracket the telemetry: data stamped *after* the
+        recorded end, or *well after* the recorded start, means the boundary
+        clock was wrong. When the skew clears ``IMPORT_SKEW_OK_S`` we log it and
+        set ``unverified`` so the session page warns — the same surfacing the
+        track cross-check uses. No telemetry → nothing to compare, leave as-is.
+        """
+        span = await self._record_span_utc(race_id)
+        if span is None:
+            return
+        first, last = span
+        db = self._conn()
+        cur = await db.execute("SELECT start_utc FROM races WHERE id = ?", (race_id,))
+        row = await cur.fetchone()
+        if row is None:
+            return
+        start_utc = _parse_utc(row["start_utc"])
+        if start_utc is None:
+            return
+        # Positive = boundary stamped behind the data it brackets (the skew).
+        # End-after-data and start-before-data are the normal, ignored cases.
+        skew_s = max(
+            (first - start_utc).total_seconds(),
+            (last - end_utc).total_seconds(),
+        )
+        if skew_s <= IMPORT_SKEW_OK_S:
+            return
+        logger.warning(
+            "Race {} clock skew: boundaries {:+.0f}s behind their own telemetry "
+            "— race window host-stamped while the recording was GPS-disciplined (#794)",
+            race_id,
+            skew_s,
+        )
+        await db.execute(
+            "UPDATE races SET clock_flag = ? WHERE id = ?",
+            (ClockFlag.UNVERIFIED.value, race_id),
+        )
+        await db.commit()
+        await self._invalidate_race_cache(race_id)
+
     async def _close_race(
         self, race_id: int, end_utc: datetime, *, auto_close_reason: str | None
     ) -> None:
@@ -4100,6 +4224,7 @@ class Storage:
         )
         await db.commit()
         await self._invalidate_race_cache(race_id)
+        await self._flag_boundary_clock_skew(race_id, end_utc)
         self._session_active = False
         if self._active_race_id == race_id:
             self._active_race_id = None

--- a/tests/test_clock_discipline_boundaries.py
+++ b/tests/test_clock_discipline_boundaries.py
@@ -1,0 +1,153 @@
+"""Disciplined-clock stamping of race/audio boundaries + a boundary-vs-data
+consistency guard (#794 follow-up).
+
+PR #795 routed the *recording stream* through the GPS discipliner but left the
+*web-route* timestamps (race start/end, audio sessions) on the raw host clock.
+On an unsynced-boot Pi that splits a recording: the telemetry is GPS-correct
+while the race window is host-skewed (the race-203 incident — boundaries 2630s
+behind their own data). These tests pin:
+
+1. ``Storage.disciplined_now`` / ``discipline_ts`` apply the live GPS offset.
+2. ``_close_race`` flags a race whose boundaries disagree with its own
+   (disciplined) telemetry — the failure the Vakaros track cross-check misses,
+   because it validates the track, not the boundaries.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from helmlog.clock_sync import ClockFlag
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+pytestmark = pytest.mark.asyncio
+
+BASE = datetime(2026, 6, 18, 1, 0, 0, tzinfo=UTC)
+SKEW_S = 2630.0  # the race-203 offset: host clock 43m50s slow
+
+
+async def _seed_positions(storage: Storage, race_id: int, start: datetime, span_s: int) -> None:
+    db = storage._conn()  # noqa: SLF001
+    rows = [
+        ((start + timedelta(seconds=k)).isoformat(), 0, 47.60 + k * 1e-5, -122.40, race_id)
+        for k in range(0, span_s, 10)
+    ]
+    await db.executemany(
+        "INSERT INTO positions (ts, source_addr, latitude_deg, longitude_deg, race_id)"
+        " VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+
+class TestDisciplinedNow:
+    async def test_passthrough_before_any_gps_ref(self, storage: Storage) -> None:
+        before = datetime.now(UTC)
+        d = storage.disciplined_now()
+        after = datetime.now(UTC)
+        assert before <= d <= after  # default: no offset known yet -> host time
+
+    async def test_applies_offset_when_corrected(self, storage: Storage) -> None:
+        storage.update_clock(SKEW_S, ClockFlag.CORRECTED)
+        gap = (storage.disciplined_now() - datetime.now(UTC)).total_seconds()
+        assert abs(gap - SKEW_S) < 2.0
+
+    async def test_applies_offset_when_ref_lost(self, storage: Storage) -> None:
+        storage.update_clock(SKEW_S, ClockFlag.REF_LOST)
+        gap = (storage.disciplined_now() - datetime.now(UTC)).total_seconds()
+        assert abs(gap - SKEW_S) < 2.0
+
+    async def test_no_offset_when_synced(self, storage: Storage) -> None:
+        # SYNCED means host is within skew tolerance — trust it as-is.
+        storage.update_clock(5.0, ClockFlag.SYNCED)
+        gap = (storage.disciplined_now() - datetime.now(UTC)).total_seconds()
+        assert abs(gap) < 2.0
+
+    async def test_no_offset_when_unverified(self, storage: Storage) -> None:
+        storage.update_clock(0.0, ClockFlag.UNVERIFIED)
+        gap = (storage.disciplined_now() - datetime.now(UTC)).total_seconds()
+        assert abs(gap) < 2.0
+
+    async def test_discipline_ts_shifts_given_timestamp(self, storage: Storage) -> None:
+        storage.update_clock(SKEW_S, ClockFlag.CORRECTED)
+        assert storage.discipline_ts(BASE) == BASE + timedelta(seconds=SKEW_S)
+
+
+class TestBoundaryGuard:
+    async def test_flags_unverified_when_data_extends_past_end(self, storage: Storage) -> None:
+        # Race marked + ended on a host clock that is SKEW_S slow, while the
+        # telemetry is GPS-disciplined (correct). End_utc lands ~SKEW_S before
+        # the last recorded fix — physically impossible with a sane clock.
+        race = await storage.start_race("Test", BASE, "2026-06-18", 1, "20260618-skew-1")
+        await storage.set_race_clock_flag(race.id, ClockFlag.CORRECTED.value)
+        # Disciplined data runs from BASE for 90 min.
+        await _seed_positions(storage, race.id, BASE, span_s=5400)
+        # The host-skewed "end" button fires SKEW_S after start in host time.
+        await storage.end_race(race.id, BASE + timedelta(seconds=100))
+        race2 = await storage.get_race(race.id)
+        assert race2 is not None
+        assert race2.clock_flag == ClockFlag.UNVERIFIED.value
+
+    async def test_keeps_flag_when_boundaries_consistent(self, storage: Storage) -> None:
+        race = await storage.start_race("Test", BASE, "2026-06-18", 2, "20260618-ok-2")
+        await storage.set_race_clock_flag(race.id, ClockFlag.CORRECTED.value)
+        await _seed_positions(storage, race.id, BASE, span_s=900)
+        # End after the last fix — the normal case.
+        await storage.end_race(race.id, BASE + timedelta(seconds=950))
+        race2 = await storage.get_race(race.id)
+        assert race2 is not None
+        assert race2.clock_flag == ClockFlag.CORRECTED.value
+
+    async def test_no_flag_when_race_has_no_telemetry(self, storage: Storage) -> None:
+        # Nothing to compare against — leave the flag untouched, never false-positive.
+        race = await storage.start_race("Test", BASE, "2026-06-18", 3, "20260618-empty-3")
+        await storage.set_race_clock_flag(race.id, ClockFlag.CORRECTED.value)
+        await storage.end_race(race.id, BASE + timedelta(seconds=950))
+        race2 = await storage.get_race(race.id)
+        assert race2 is not None
+        assert race2.clock_flag == ClockFlag.CORRECTED.value
+
+
+class TestAudioBoundaryDiscipline:
+    async def test_audio_start_end_disciplined_on_persist(self, storage: Storage) -> None:
+        from helmlog.audio import AudioSession
+
+        storage.update_clock(SKEW_S, ClockFlag.CORRECTED)
+        host_start = BASE
+        host_end = BASE + timedelta(seconds=600)
+        session = AudioSession(
+            file_path="/tmp/a.wav",
+            device_name="dev",
+            start_utc=host_start,
+            end_utc=None,
+            sample_rate=48000,
+            channels=1,
+        )
+        sid = await storage.write_audio_session(session, race_id=None, session_type="race")
+        await storage.update_audio_session_end(sid, host_end)
+        row = await storage.get_audio_session_row(sid)
+        assert row is not None
+        assert datetime.fromisoformat(row["start_utc"]) == host_start + timedelta(seconds=SKEW_S)
+        assert datetime.fromisoformat(row["end_utc"]) == host_end + timedelta(seconds=SKEW_S)
+
+    async def test_audio_untouched_when_not_disciplining(self, storage: Storage) -> None:
+        from helmlog.audio import AudioSession
+
+        storage.update_clock(0.0, ClockFlag.UNVERIFIED)  # default: host time, no shift
+        session = AudioSession(
+            file_path="/tmp/b.wav",
+            device_name="dev",
+            start_utc=BASE,
+            end_utc=None,
+            sample_rate=48000,
+            channels=1,
+        )
+        sid = await storage.write_audio_session(session, race_id=None, session_type="race")
+        row = await storage.get_audio_session_row(sid)
+        assert row is not None
+        assert datetime.fromisoformat(row["start_utc"]) == BASE

--- a/tests/test_gps_boot_clock_sync.py
+++ b/tests/test_gps_boot_clock_sync.py
@@ -1,0 +1,102 @@
+"""Best-effort GPS system-clock discipline at boot (#799).
+
+The orchestrator is hardware-free — the SK-offset reader, the OS-clock setter,
+and the sync probe are all injected — so these tests drive every branch of the
+decision with fakes and never touch the real clock.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+
+from helmlog.clock_sync import (
+    STEP_THRESHOLD_S,
+    gps_boot_clock_sync,
+    should_step_clock,
+)
+
+_Fakes = tuple[
+    Callable[[], Awaitable[float | None]],
+    Callable[[], bool],
+    Callable[[datetime], None],
+    list[datetime],
+]
+
+NOW = datetime(2026, 6, 18, 1, 0, 0, tzinfo=UTC)
+BOOT_SKEW_S = 2630.0
+
+
+class TestShouldStepClock:
+    def test_never_steps_when_already_synchronized(self) -> None:
+        # An authoritative NTP/timesyncd clock wins — don't fight it.
+        assert should_step_clock(offset_s=BOOT_SKEW_S, clock_synchronized=True) is False
+
+    def test_steps_when_unsynced_and_offset_large(self) -> None:
+        assert should_step_clock(offset_s=BOOT_SKEW_S, clock_synchronized=False) is True
+        assert should_step_clock(offset_s=-BOOT_SKEW_S, clock_synchronized=False) is True
+
+    def test_skips_sub_threshold_jitter(self) -> None:
+        assert should_step_clock(offset_s=STEP_THRESHOLD_S - 0.1, clock_synchronized=False) is False
+
+
+def _fakes(*, offset: float | None, synced: bool) -> _Fakes:
+    calls: list[datetime] = []
+
+    async def measure_offset() -> float | None:
+        return offset
+
+    def is_synchronized() -> bool:
+        return synced
+
+    def set_clock(target: datetime) -> None:
+        calls.append(target)
+
+    return measure_offset, is_synchronized, set_clock, calls
+
+
+class TestGpsBootClockSync:
+    async def test_steps_clock_when_unsynced_and_adrift(self) -> None:
+        measure, synced, setter, calls = _fakes(offset=BOOT_SKEW_S, synced=False)
+        result = await gps_boot_clock_sync(
+            measure_offset=measure,
+            is_synchronized=synced,
+            set_clock=setter,
+            now=lambda: NOW,
+        )
+        assert result.action == "stepped"
+        assert result.offset_s == BOOT_SKEW_S
+        assert calls == [NOW + timedelta(seconds=BOOT_SKEW_S)]
+
+    async def test_no_step_when_no_gps_time(self) -> None:
+        measure, synced, setter, calls = _fakes(offset=None, synced=False)
+        result = await gps_boot_clock_sync(
+            measure_offset=measure,
+            is_synchronized=synced,
+            set_clock=setter,
+            now=lambda: NOW,
+        )
+        assert result.action == "no-gps"
+        assert calls == []
+
+    async def test_no_step_when_already_synchronized(self) -> None:
+        measure, synced, setter, calls = _fakes(offset=BOOT_SKEW_S, synced=True)
+        result = await gps_boot_clock_sync(
+            measure_offset=measure,
+            is_synchronized=synced,
+            set_clock=setter,
+            now=lambda: NOW,
+        )
+        assert result.action == "skipped-synchronized"
+        assert calls == []
+
+    async def test_no_step_when_offset_small(self) -> None:
+        measure, synced, setter, calls = _fakes(offset=2.0, synced=False)
+        result = await gps_boot_clock_sync(
+            measure_offset=measure,
+            is_synchronized=synced,
+            set_clock=setter,
+            now=lambda: NOW,
+        )
+        assert result.action == "skipped-small"
+        assert calls == []


### PR DESCRIPTION
## What
Race/audio boundary timestamps (`races.start_utc`/`end_utc`, audio sessions) were stamped on the **raw host clock** while PR #795 (#794) only disciplined the **recording stream**. On an unsynced-boot Pi this splits a recording: the telemetry is GPS-correct but the race window is host-skewed. **Race 203** (`20260618-cyc-solstice-1`) landed **2630s (43m50s) behind its own data**.

## Root cause
The `ClockDiscipliner` lives on the SK reader inside the recording loop and was never reachable from the web-route handlers, so every `datetime.now(UTC)` that stamps a race/audio boundary stayed on host time. The Vakaros track cross-check (`_flag_import_clock_skew`) can't catch this — it validates the *track* (already GPS-correct), not the *boundary* columns.

## How
- **`storage.py`** — mirror the reader's GPS offset+flag onto the `Storage` singleton (`update_clock`); add `disciplined_now()` / `discipline_ts()` (same apply-rule as `ClockDiscipliner.apply`: shift only when `corrected`/`ref_lost`).
- **`main.py`** — recording loop calls `update_clock` on every clock-state change, including between races, so routes always have the current offset.
- **`routes/races.py`** — race start/end (`api_start_race`, scheduled-start fire, `api_end_race`, debrief auto-end) stamp via `disciplined_now()`. Scheduling comparisons (poll/validate/countdown) deliberately stay on host time.
- **`storage.py` (audio)** — audio `start_utc`/`end_utc` disciplined at the persistence boundary (`write_audio_session` / `update_audio_session_end`). Default is a no-op until the reader reports `corrected`, so existing behavior is unchanged and the hardware audio module stays untouched.
- **Consistency guard** — `_close_race` flags `unverified` (+ WARNING) when a race's boundaries diverge from its own telemetry span by more than `IMPORT_SKEW_OK_S`. This is the safety net for the failure the track cross-check structurally can't see.

## Data repair (already applied to live)
Race 203's live-DB boundaries + 4 audio sessions + the start sail-change row shifted **+2630s** in one transaction; caches for the race cleared. Full 5 GB backup taken first (`logger.pre-race203-shift.db`, `integrity_check ok`). Post-repair boundary-vs-data gap: **0.0s / 0.4s** (was 2630s).

## Scope note
`disciplined_now()` prevents the bug for races marked **after** GPS sync (the common case) and fixes the **end** boundary even in the 203 scenario (the clock is synced by race-end). A race **marked before** GPS lock still gets a host-time *start* — that residual case is caught by the consistency guard → `unverified` banner → manual repair. OS-level GPS/NTP discipline at boot (out of scope here) would close the residual.

## Tests
- `tests/test_clock_discipline_boundaries.py` — `disciplined_now`/`discipline_ts` apply-rules across all four `ClockFlag` states; the boundary guard (flags on data-past-end, leaves consistent/empty races alone); audio start/end disciplined at persist + no-op when not disciplining.
- Regression: `audio/races/storage/clock/session` subset **759 passed, 2 skipped**; federation integration **38 passed**; `ruff` + `mypy --strict` clean.

## Compliance
`/data-license`: compliant — local timestamp re-basing only; no co-op sharing, embargo, benchmark, biometric, or export surface touched.

Fixes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: OS-level GPS clock discipline at boot (Closes #799)
The in-app fix above prevents the bug for races marked **after** GPS sync and fixes the **end** boundary even in the 203 case, but a race **marked before** GPS lock still gets a host-time *start*. This second commit closes that residual by making the **system clock** itself correct before recording starts:

- **`clock_sync.py`** — hardware-free `gps_boot_clock_sync()` orchestrator + pure `should_step_clock()` (step only when the OS clock is **not** already synchronized — never fight NTP — and the host↔GPS offset clears a threshold).
- **`main.py`** — reads the offset via a bounded `SKReader` run (reuses the live discipliner's median smoothing), probes `NTPSynchronized` via `timedatectl`, steps via `date -u -s` (no-op unless root). New `helmlog gps-clock-sync` command.
- **`setup.sh`** — installs + enables `helmlog-gpsclock.service`: a root one-shot ordered `After=signalk` / `Before=helmlog`, bounded by `TimeoutStartSec`, **no `Requires=`** so it never blocks boot. Activation is a deliberate `setup.sh` run, so a normal green deploy can't surprise-add a clock-stepping boot service.
- **docs** — operator troubleshooting note.

Best-effort and **layered**: if GPS is absent or the step can't run, it's a no-op and the in-app discipliner + boundary guard remain the safety net.

**Tests:** `tests/test_gps_boot_clock_sync.py` — `should_step_clock` decision table + every orchestrator branch (steps / no-gps / already-synced / sub-threshold) with injected fakes (never touches the real clock). All clock suites: **82 passed**; ruff + mypy clean; `bash -n setup.sh` clean.

Closes #799
