### PR TITLE
nginx: proxy /sim/ to shiftsimulator (coexist on corvopi-live)

### DIFF
--- a/scripts/nginx/helmlog.conf
+++ b/scripts/nginx/helmlog.conf
@@ -15,6 +15,12 @@ upstream signalk {
     server 127.0.0.1:3000;
 }
 
+# shiftsimulator — sailing-tactics simulator, runs as its own systemd service.
+# See https://github.com/weaties/shiftsimulator (deployed service-only).
+upstream shiftsim {
+    server 127.0.0.1:8765;
+}
+
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
@@ -94,5 +100,16 @@ server {
 
         # Rewrite redirects from SK (e.g. / → /admin/) to include /sk/ prefix
         proxy_redirect / /sk/;
+    }
+
+    # shiftsimulator — /sim/  (prefix stripped; the app is subpath-safe and
+    # serves the viewer at its own root, redirecting / → web/).
+    location = /sim { return 301 /sim/; }
+    location /sim/ {
+        proxy_pass http://shiftsim/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
## Summary

- Add a `shiftsim` upstream (`127.0.0.1:8765`) and a `/sim/` location to `scripts/nginx/helmlog.conf`, mirroring `/grafana/` and `/signalk/`.
- Lets [shiftsimulator](https://github.com/weaties/shiftsimulator) coexist on corvopi-live's single-port nginx. shiftsim runs as its own systemd service (service-only; does not touch nginx). Prefix is stripped; the app is subpath-safe.
- Additive proxy route only — no helmlog service or data affected.

Crew URL: `http://corvopi-live/sim/`

## Test plan

- [ ] `sudo nginx -t` on corvopi-live after deploy (config validates)
- [x] Brace-balanced; mirrors existing location blocks

## Related issues

Closes #801