### PR TITLE
docs: unify agent docs — canonical AGENTS.md imported by CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,122 +1,237 @@
 # AGENTS.md — HelmLog
 
-This file provides conventions for any AI coding agent working on HelmLog.
-Claude Code users: see `CLAUDE.md` for additional Claude-specific skills and workflows.
+Raspberry Pi sailing data logger: reads B&G instruments via Signal K
+(`sk_reader.py`), stores time-series data in SQLite, serves a FastAPI web UI
+for race marking, history, debrief audio, and CSV/GPX/JSON export.
 
----
+This file is the canonical project guide for **any** coding agent (Claude Code,
+Cursor, Codex, Copilot, …) and for humans — the single source of truth for
+conventions and workflow. Claude Code reads it via an `@AGENTS.md` import in
+`CLAUDE.md`, which adds only the Claude-Code-specific mechanics (the worktree
+tool, the skill catalog, file-based memory). References to `/name` below are
+Claude Code skill shortcuts; the behavior they wrap is described inline or in
+`docs/`, so any agent can follow the rule without them.
 
-## Project Overview
+## Top rules — read first
 
-A Raspberry Pi-based sailing data logger that reads from a B&G instrument system via Signal K,
-stores time-series data in SQLite, and provides a web interface for race marking, history,
-debrief audio, and performance exports.
+- **Always work in a git worktree.** Multiple agents run concurrently in this
+  repo. Two agents sharing a checkout collide on uncommitted changes and branch
+  switches, and a deploy can pick up a half-finished hotfix from the wrong
+  agent. Before any edit, check `git worktree list` and `ls .claude/worktrees/`;
+  enter an existing worktree if the branch matches the task, otherwise create a
+  new one (`git worktree add .claude/worktrees/<name> -b <branch>`). Read-only
+  work (questions, architecture/diagnosis/domain lookups) does not need a
+  worktree.
+- **Never push directly to `main`.** All changes go through merged PRs on a
+  feature branch. If a Pi hotfix is needed, branch + PR + merge — even then.
+- **Always include `Closes #N`** (or `Fixes #N` for bugs) in the PR body so
+  GitHub auto-closes the issue on merge and the tracker stays clean.
+- **Apply the `in-progress` label** when starting work on an issue:
+  `gh issue edit <N> --add-label "in-progress"` plus a comment naming the
+  branch and host.
+- **Commit and push every change immediately.** Uncommitted Pi edits are
+  lost on the next deploy.
 
-**Stack:** Python 3.12+, FastAPI, SQLite (aiosqlite), uv (dependency management), Ruff (lint/format), mypy (types), pytest (tests).
+### Judgment rules (not just process)
 
----
+- **Surface assumptions before building.** If the task is underspecified,
+  state the assumption you're proceeding on rather than silently guessing.
+- **Stop and ask when requirements conflict** — with an issue, with
+  `docs/data-licensing.md`, or with existing behavior. Don't pick a side
+  unasked.
+- **Push back when warranted.** A worse plan you were handed is still worse;
+  say so before implementing it.
+- **Prefer boring, obvious solutions.** This is a Pi logger where a reboot
+  must lose at most one record — reliability beats cleverness.
+- **Touch only what you're asked to touch.** No drive-by refactors of
+  adjacent code or unrelated TODOs; they widen the blast radius and the diff.
 
-## Essential Commands
+## Stack & tooling
+
+| Concern | Tool |
+|---|---|
+| Dependency management | `uv` (never `uv pip install` for project deps — use `uv add` / `uv sync`) |
+| Language | Python 3.12+ — modern syntax (`match`, `X | Y` unions, `tomllib`) |
+| Data source (primary) | Signal K WebSocket via `websockets` (`sk_reader.py`) |
+| NMEA 2000 / CAN (legacy) | `python-can` + `canboat` — `can_reader.py`, `DATA_SOURCE=can` |
+| Storage | SQLite via `aiosqlite` |
+| Web | `fastapi` + `uvicorn` + `jinja2`; `nginx` reverse proxy on :80 |
+| Audio | `sounddevice`, `soundfile`; transcription `faster-whisper` (+ optional `pyannote-audio`) |
+| Lint / format / types | `ruff` (line length 100), `mypy --strict` |
+| Testing | `pytest`, `pytest-asyncio`, `pytest-cov` |
+| Logging | `loguru` (never `print()` for operational output) |
+| External data | `httpx` — Open-Meteo weather, NOAA CO-OPS tides |
+| Monitoring | `psutil` → InfluxDB |
+
+## Project structure
+
+```
+src/helmlog/        # all Python; one module per concern. Key modules:
+  main.py           #   CLI entry point — wiring only, no business logic
+  sk_reader.py      #   Signal K WebSocket reader (primary data source)
+  can_reader.py     #   CAN bus reader (legacy, DATA_SOURCE=can)
+  storage.py        #   SQLite schema, migrations, read/write — single source of truth
+  web.py            #   FastAPI routes and API endpoints
+  auth.py           #   magic-link authentication
+  federation.py     #   boat identity (Ed25519), co-op membership
+  peer_api.py / peer_auth.py / peer_client.py  # inter-boat peer API + signing
+  export.py         #   CSV / GPX / JSON export
+  audio.py / transcribe.py   # USB audio recording + Whisper transcription
+  polar.py          #   polar performance baseline
+  templates/        #   Jinja2 (extends base.html)
+  static/           #   CSS + JS
+tests/              # pytest, runs anywhere; conftest.py provides in-memory Storage
+tests/integration/  # federation/co-op (Layer 1 in-process; Layer 2 Pi harness; Layer 3 Docker)
+docs/               # guides, policies, specs (data-licensing.md, testing-guide.md, …)
+docs/archive/       # dated point-in-time docs (incidents, audits, calibrations)
+scripts/            # deploy.sh, setup.sh, pi_harness.py, …
+```
+
+Use `ls`/`tree` for detail — don't ask the docs to enumerate every file.
+
+## Common commands
 
 ```bash
-uv sync                          # install dependencies (always run first)
-uv run pytest                    # run all tests
-uv run ruff check .              # lint
-uv run ruff format --check .     # format check
-uv run mypy src/                 # type check
-uv run pytest tests/integration/ -v  # federation integration tests
+uv sync                              # install deps from lockfile (run first)
+uv run pytest                        # all tests + coverage
+uv run pytest tests/integration/ -v  # federation tests
+uv run ruff check . && uv run ruff format --check . && uv run mypy src/
+
+helmlog run                          # start the logger
+helmlog status                       # DB row counts
+helmlog identity init|show           # Ed25519 boat identity
+helmlog co-op create|status|invite   # co-op membership
+helmlog --help                       # full subcommand list
 ```
 
-All four checks (tests, ruff check, ruff format, mypy) must pass before submitting a PR.
+All four checks (tests, ruff check, ruff format, mypy) must pass before a PR.
 
----
+## Architecture principles
 
-## Project Structure
+- **Signal K is the primary data source.** `sk_reader.py` is the default;
+  legacy direct-CAN (`can_reader.py`) only via `DATA_SOURCE=can`.
+- **Hardware isolation.** Hardware modules (`sk_reader.py`, `can_reader.py`,
+  `cameras.py`) are imported only by `main.py`. Everything else receives
+  decoded dataclasses, never raw frames or SK deltas — so it can be tested
+  without hardware.
+- **Decode early, store clean.** Raw bytes → frozen dataclass at the edge:
 
-```
-src/helmlog/           # all source code
-  main.py              # CLI entry point (wiring only, no business logic)
-  web.py               # FastAPI routes and API endpoints
-  storage.py           # SQLite schema, migrations, read/write
-  sk_reader.py         # Signal K WebSocket reader (primary data source)
-  can_reader.py        # CAN bus reader (legacy path)
-  auth.py              # Magic-link authentication
-  federation.py        # Boat identity (Ed25519), co-op membership
-  peer_api.py          # Inter-boat peer API endpoints
-  peer_auth.py         # Ed25519 request signing/verification
-  peer_client.py       # Async HTTP client for peer boats
-  export.py            # CSV / GPX / JSON export
-  audio.py             # USB audio recording
-  transcribe.py        # Whisper transcription + diarization
-  polar.py             # Polar performance baseline
-  templates/           # Jinja2 HTML templates
-  static/              # CSS and JS
+  ```python
+  @dataclass(frozen=True)
+  class HeadingRecord:
+      pgn: int
+      source_addr: int
+      timestamp: datetime
+      heading_deg: float  # converted from radians at decode time
+      deviation_deg: float | None
+      variation_deg: float | None
+  ```
 
-tests/                 # pytest suite (no hardware required)
-tests/integration/     # federation integration tests
-```
+- **SQLite is the single source of truth.** Every record gets a UTC timestamp
+  and is flushed promptly so a crash/reboot loses at most the last record.
+  Web/export/peer code reads from SQLite, never live data. New domains land
+  in `storage.py` alongside existing ones (per-domain repo extraction tracked
+  in #484).
+- **Timestamps are always UTC.** Convert to local only at display/export.
+- **External fetches are async.** Use `httpx` async for weather/tide.
+- **No business logic in `main.py`** — it only wires modules together.
 
----
+## Coding conventions
 
-## Coding Conventions
+Most style is enforced by `ruff` and `mypy --strict` — don't restate
+those rules here. The non-enforceable ones:
 
-- **Python 3.12+** — use modern syntax (`match`, `X | Y` unions, `tomllib`)
-- **Full type annotations** on all function signatures — mypy must pass
-- **Ruff** is the only linter/formatter — line length 100, `E501` suppressed only in `web.py`
-- **Loguru** for all logging — never use `print()`
-- **Dataclasses or TypedDict** for structured data — no raw dicts with unknown shapes
-- Modules stay under ~200 lines; split when they grow
-- Hardware-dependent code is isolated to its own module
+- **Modules are small and single-purpose.** Past ~200 lines, consider
+  splitting.
+- **Full type annotations** on all function signatures — mypy must pass.
+- **Hardware-dependent code stays in its hardware module** (see Architecture
+  principles).
+- **Use `loguru` and structured types** (dataclasses, `TypedDict`) — avoid
+  `print()` and raw dicts with unknown shapes.
 
----
+## Testing
 
-## Architecture Rules
+- **Follow TDD:** failing test → implement → green → lint.
+- **Tests run without hardware** — mock `audio.py`, `can_reader.py`,
+  `sk_reader.py`, `cameras.py`.
+- **Use the shared in-memory fixture** — no per-test schema setup:
 
-- **Signal K is the primary data source** — `sk_reader.py` connects to Signal K WebSocket
-- **Hardware isolation** — hardware modules are only imported by `main.py`; other modules receive decoded data structures
-- **Decode early, store clean** — raw data is decoded to named dataclasses immediately on arrival
-- **SQLite is the single source of truth** — all data goes to SQLite; exports read from SQLite
-- **Timestamps are always UTC** — convert to local time only at display/export boundaries
-- **No business logic in `main.py`** — it only wires modules together
+  ```python
+  @pytest_asyncio.fixture
+  async def storage() -> Storage:
+      s = Storage(StorageConfig(db_path=":memory:"))
+      await s.connect()
+      yield s
+      await s.close()
+  ```
 
----
+- **Web route tests** use `httpx.AsyncClient` with `ASGITransport`.
+- **Federation/co-op/peer-API changes require integration tests**
+  (`tests/integration/`) — don't skip them because unit tests pass.
 
-## Testing Requirements
+## Do / Don't
 
-- Follow TDD: write a failing test first, then implement
-- Tests run without hardware — mock `audio.py`, `can_reader.py`, `sk_reader.py`, `cameras.py`
-- Use the `storage` fixture from `conftest.py` for in-memory SQLite
-- Use `httpx.AsyncClient` with `ASGITransport` for web route tests
-- Federation/co-op/peer API changes require integration tests (`tests/integration/`)
+| Do | Don't |
+|---|---|
+| Enter a worktree before any file edit. | Edit files in the primary checkout `/Users/dweatbrook/src/helmlog`. |
+| Land changes via merged PRs on a feature branch. | Push directly to `main` — even for Pi hotfixes. |
+| Include `Closes #N` in every PR body that resolves an issue. | Open a PR without linking the issue; the tracker rots. |
+| Follow TDD: failing test → implement → green → lint. | Write code first and bolt tests on later. |
+| Flush each decoded record to SQLite as it arrives. | Hold data in memory across long runs — a reboot loses it all. |
+| Use `canboat` decoders; add new PGNs as dataclasses in `nmea2000.py`. | Hand-parse NMEA 2000 PGNs from raw bytes unless no library covers them. |
+| Read device paths from `.env` / config (`.env.example` is the reference). | Hardcode `/dev/can0` or similar paths. |
+| Keep `main.py` as wiring only — start the loop, no business logic. | Mix decode/storage/web logic into `main.py`. |
+| Add deps via `uv add <pkg>` then `uv sync`; verify the import. | Edit `pyproject.toml` by hand for deps, or use `uv pip install`. |
+| After a pull or branch switch, run `uv sync` (or `./scripts/deploy.sh` on the Pi). | Assume the venv is up to date — the Pi service runs `--no-sync`. |
+| Commit + push every change before stopping work. | Leave uncommitted edits on the Pi — the next deploy wipes them. |
+| Run `uv run pytest tests/integration/ -v` for federation/co-op/peer-API changes. | Skip integration tests for federation work because unit tests pass. |
+| Keep `.db` files and the `data/` directory out of git. | Commit `helmlog.db` or other local data. |
 
----
+## Risk tiers
 
-## Do NOT
-
-- Push directly to `main` — all changes go through PRs
-- Use `print()` — use loguru
-- Add raw dicts with string keys for structured data
-- Put business logic in `main.py`
-- Import hardware modules outside their isolated module
-- Use `uv pip install` — use `uv add` (to add deps) or `uv sync` (to install)
-- Commit `data/` directory or `.db` files
-- Hardcode device paths — use config/environment variables
-
----
-
-## Risk Tiers
-
-Changes to these modules require extra care:
+Changes to these modules are reviewed against a higher bar regardless of how
+small the diff looks. Full detail: [docs/risk-tiers.md](docs/risk-tiers.md).
 
 | Tier | Modules | Extra requirements |
 |---|---|---|
-| **Critical** | `auth.py`, `peer_auth.py`, `federation.py`, `storage.py` (migrations), `can_reader.py` | Integration tests + data-license review |
+| **Critical** | `auth.py`, `peer_auth.py`, `federation.py`, `storage.py` (migrations), `can_reader.py` | TDD + integration tests + data-licensing review (`docs/data-licensing.md`) + a structured spec before implementation |
 | **High** | `sk_reader.py`, `peer_api.py`, `peer_client.py`, `export.py`, `transcribe.py` | Integration tests where applicable |
 
----
+<important if="touching auth.py / peer_auth.py / federation.py / storage.py migrations / can_reader.py">
+**Critical-tier change.** Required: TDD + integration tests + a data-licensing
+review (`docs/data-licensing.md`) + a structured spec before implementation. See
+[docs/risk-tiers.md](docs/risk-tiers.md).
+</important>
 
-## Data Licensing
+<important if="working on the Pi (deployed device, not Mac dev)">
+- After `uv add <pkg>` or any dependency change, restart the service:
+  `sudo systemctl restart helmlog`. The service runs with `--no-sync` and
+  trusts the venv.
+- A hotfix on the Pi still goes through a feature branch + PR + merge.
+  Never commit to `main` from the device.
+- The Pi troubleshooting runbook (`/diagnose` in Claude Code) is the systematic
+  path — use it before ad-hoc poking.
+</important>
 
-HelmLog has a data licensing policy (`docs/data-licensing.md`). Code handling user data,
-PII (audio, photos, emails, biometrics), co-op data sharing, or exports must comply.
-Key rules: boat owns its data, PII has deletion rights, co-op data is view-only,
-no gambling or protest committee exports.
+## Where to look next
+
+- **User-facing feature index** (crew / viewer / admin breakdown):
+  [docs/features.md](docs/features.md)
+- **Risk tiers + spec formats:** [docs/risk-tiers.md](docs/risk-tiers.md)
+- **Data licensing policy** (PII, co-op embargoes, biometrics, gambling,
+  protest firewall): [docs/data-licensing.md](docs/data-licensing.md).
+  (Claude Code: `/data-license` reviews code against it.)
+- **Testing layers** (in-process, Pi harness, Docker) and Pi-harness SSH
+  setup: [docs/testing-guide.md](docs/testing-guide.md).
+  (Claude Code: `/integration-test` picks the right layer.)
+- **Promote gate (`main → stage`):** the `promote.yml` workflow requires a
+  new `##` heading in `RELEASES.md` for each promoted commit set (exempt
+  if all commits only touch `docs/ideation-log.md`). Draft the entry before
+  promoting (Claude Code: `/release-notes`). `stage → live` has no gate.
+- **Signal K paths, PGN byte layouts, and unit conversions:** `sk_reader.py`
+  and `nmea2000.py` are the source of truth. Tribal knowledge not visible in
+  those files (B&G quirks, J/105 polar targets, miscalibration symptoms) lives
+  in the `/domain` skill (Claude Code).
+- **Past decisions on this file** (e.g. why `/domain` isn't split, why
+  HelmLog now keeps a real `AGENTS.md`):
+  [docs/agent-context-decisions.md](docs/agent-context-decisions.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,195 +1,37 @@
 # CLAUDE.md — HelmLog
 
-Raspberry Pi sailing data logger: reads B&G instruments via Signal K
-(`sk_reader.py`), stores time-series data in SQLite, serves a FastAPI web UI
-for race marking, history, debrief audio, and CSV/GPX/JSON export.
+The canonical project guide for all agents (human or AI) lives in `AGENTS.md`.
+It is imported here so Claude Code loads it as project instructions:
 
-## Top rules — read first
+@AGENTS.md
 
-- **Always work in a git worktree.** Multiple Claude Code agents run
-  concurrently in this repo. Two agents sharing a checkout collide on
-  uncommitted changes and branch switches, and a deploy can pick up a
-  half-finished hotfix from the wrong agent. Before any edit, check
-  `git worktree list` and `ls .claude/worktrees/`; enter an existing one if
-  the branch matches the task, otherwise create a new one with `EnterWorktree`.
-  Read-only work (questions, `/architecture`, `/diagnose`, `/domain`) does
-  not need a worktree.
-- **Never push directly to `main`.** All changes go through merged PRs on a
-  feature branch. If a Pi hotfix is needed, branch + PR + merge — even then.
-- **Always include `Closes #N`** (or `Fixes #N` for bugs) in the PR body so
-  GitHub auto-closes the issue on merge and the tracker stays clean.
-- **Apply the `in-progress` label** when starting work on an issue:
-  `gh issue edit <N> --add-label "in-progress"` plus a comment naming the
-  branch and host.
-- **Commit and push every change immediately.** Uncommitted Pi edits are
-  lost on the next deploy.
+Everything in `AGENTS.md` applies. The rest of this file is **only** the
+Claude-Code-specific mechanics that implement or extend those rules — keep
+project conventions in `AGENTS.md`, not here.
 
-### Judgment rules (not just process)
+## Claude Code specifics
 
-- **Surface assumptions before building.** If the task is underspecified,
-  state the assumption you're proceeding on rather than silently guessing.
-- **Stop and ask when requirements conflict** — with an issue, with
-  `docs/data-licensing.md`, or with existing behavior. Don't pick a side
-  unasked.
-- **Push back when warranted.** A worse plan you were handed is still worse;
-  say so before implementing it.
-- **Prefer boring, obvious solutions.** This is a Pi logger where a reboot
-  must lose at most one record — reliability beats cleverness.
-- **Touch only what you're asked to touch.** No drive-by refactors of
-  adjacent code or unrelated TODOs; they widen the blast radius and the diff.
+- **Worktrees.** `AGENTS.md`'s "always work in a git worktree" rule is enforced
+  here via the **`EnterWorktree`** tool: before any edit, check
+  `git worktree list` and `ls .claude/worktrees/`, then enter an existing
+  worktree if the branch matches, otherwise `EnterWorktree` a new one. Read-only
+  work doesn't need one.
 
-## Stack & tooling
+- **Skills.** The harness lists available skills each session; invoke them with
+  the Skill tool (`/name`). The ones that back rules in `AGENTS.md`:
+  - `/architecture` — module map, data flow, complexity hotspots, "what changed".
+  - `/domain` — sailing instrument tribal knowledge (B&G quirks, J/105 polar
+    targets, miscalibration symptoms) not grep-recoverable from the code.
+  - `/data-license` — review changes against `docs/data-licensing.md`.
+  - `/spec` — structured spec (decision table / state diagram / EARS) for
+    Critical- and High-tier features.
+  - `/tdd` — HelmLog test patterns + the ruff/mypy pre-existing-error allowlist.
+  - `/integration-test` — pick the federation test layer (in-process / Pi / Docker).
+  - `/diagnose` — systematic Pi troubleshooting runbook.
+  - `/release-notes` — draft the `RELEASES.md` entry the promote gate requires.
+  - `/debrief`, `/ocs-check`, `/pr-checklist`, `/ideate` — race + workflow helpers.
 
-| Concern | Tool |
-|---|---|
-| Dependency management | `uv` (never `uv pip install` for project deps — use `uv add` / `uv sync`) |
-| Data source (primary) | Signal K WebSocket via `websockets` (`sk_reader.py`) |
-| NMEA 2000 / CAN (legacy) | `python-can` + `canboat` — `can_reader.py`, `DATA_SOURCE=can` |
-| Storage | SQLite via `aiosqlite` |
-| Web | `fastapi` + `uvicorn` + `jinja2`; `nginx` reverse proxy on :80 |
-| Audio | `sounddevice`, `soundfile`; transcription `faster-whisper` (+ optional `pyannote-audio`) |
-| Lint / format / types | `ruff` (line length 100), `mypy --strict` |
-| Testing | `pytest`, `pytest-asyncio`, `pytest-cov` |
-| Logging | `loguru` (never `print()` for operational output) |
-| External data | `httpx` — Open-Meteo weather, NOAA CO-OPS tides |
-| Monitoring | `psutil` → InfluxDB |
-
-## Project structure
-
-```
-src/helmlog/        # all Python; one module per concern (sk_reader, storage,
-                    # web, federation, peer_*, transcribe, audio, cameras, …)
-src/helmlog/templates/  # Jinja2 (extends base.html)
-src/helmlog/static/     # CSS + JS
-tests/              # pytest, runs anywhere; conftest.py provides in-memory Storage
-tests/integration/  # federation/co-op (Layer 1 in-process; Layer 2 Pi harness; Layer 3 Docker)
-docs/               # guides, policies, specs (data-licensing.md, testing-guide.md, …)
-docs/archive/       # dated point-in-time docs (incidents, audits, calibrations)
-scripts/            # deploy.sh, setup.sh, pi_harness.py, …
-```
-
-Use `ls`/`tree` for detail — don't ask the docs to enumerate every file.
-
-## Common commands
-
-```bash
-uv sync                              # install deps from lockfile
-uv run pytest                        # all tests + coverage
-uv run pytest tests/integration/ -v  # federation tests
-uv run ruff check . && uv run ruff format --check . && uv run mypy src/
-
-helmlog run                          # start the logger
-helmlog status                       # DB row counts
-helmlog identity init|show           # Ed25519 boat identity
-helmlog co-op create|status|invite   # co-op membership
-helmlog --help                       # full subcommand list
-```
-
-## Architecture principles
-
-- **Signal K is the primary data source.** `sk_reader.py` is the default;
-  legacy direct-CAN (`can_reader.py`) only via `DATA_SOURCE=can`.
-- **Hardware isolation.** Hardware modules (`sk_reader.py`, `can_reader.py`,
-  `cameras.py`) are imported only by `main.py`. Everything else receives
-  decoded dataclasses, never raw frames or SK deltas — so it can be tested
-  without hardware.
-- **Decode early, store clean.** Raw bytes → frozen dataclass at the edge:
-
-  ```python
-  @dataclass(frozen=True)
-  class HeadingRecord:
-      pgn: int
-      source_addr: int
-      timestamp: datetime
-      heading_deg: float  # converted from radians at decode time
-      deviation_deg: float | None
-      variation_deg: float | None
-  ```
-
-- **SQLite is the single source of truth.** Every record gets a UTC timestamp
-  and is flushed promptly so a crash/reboot loses at most the last record.
-  Web/export/peer code reads from SQLite, never live data. New domains land
-  in `storage.py` alongside existing ones (per-domain repo extraction tracked
-  in #484).
-- **Tests use the shared in-memory fixture** — no per-test schema setup:
-
-  ```python
-  @pytest_asyncio.fixture
-  async def storage() -> Storage:
-      s = Storage(StorageConfig(db_path=":memory:"))
-      await s.connect()
-      yield s
-      await s.close()
-  ```
-
-- **Timestamps are always UTC.** Convert to local only at display/export.
-- **External fetches are async.** Use `httpx` async for weather/tide.
-
-## Coding conventions
-
-Most style is enforced by `ruff` and `mypy --strict` — don't restate
-those rules here. The non-enforceable ones:
-
-- **Modules are small and single-purpose.** Past ~200 lines, consider
-  splitting.
-- **Hardware-dependent code stays in its hardware module** (see Architecture
-  principles).
-- **Use `loguru` and structured types** (dataclasses, `TypedDict`) — avoid
-  `print()` and raw dicts with unknown shapes.
-
-## Do / Don't
-
-| Do | Don't |
-|---|---|
-| Enter a worktree before any file edit (`EnterWorktree`). | Edit files in the primary checkout `/Users/dweatbrook/src/helmlog`. |
-| Land changes via merged PRs on a feature branch. | Push directly to `main` — even for Pi hotfixes. |
-| Include `Closes #N` in every PR body that resolves an issue. | Open a PR without linking the issue; the tracker rots. |
-| Follow TDD: failing test → implement → green → lint (see `/tdd`). | Write code first and bolt tests on later. |
-| Flush each decoded record to SQLite as it arrives. | Hold data in memory across long runs — a reboot loses it all. |
-| Use `canboat` decoders; add new PGNs as dataclasses in `nmea2000.py`. | Hand-parse NMEA 2000 PGNs from raw bytes unless no library covers them. |
-| Read device paths from `.env` / config (`.env.example` is the reference). | Hardcode `/dev/can0` or similar paths. |
-| Keep `main.py` as wiring only — start the loop, no business logic. | Mix decode/storage/web logic into `main.py`. |
-| Add deps via `uv add <pkg>` then `uv sync`; verify the import. | Edit `pyproject.toml` by hand for deps, or use `uv pip install`. |
-| After a pull or branch switch, run `uv sync` (or `./scripts/deploy.sh` on the Pi). | Assume the venv is up to date — the Pi service runs `--no-sync`. |
-| Commit + push every change before stopping work. | Leave uncommitted edits on the Pi — the next deploy wipes them. |
-| Run `uv run pytest tests/integration/ -v` for federation/co-op/peer-API changes. | Skip integration tests for federation work because unit tests pass. |
-
-<important if="touching auth.py / peer_auth.py / federation.py / storage.py migrations / can_reader.py">
-**Critical-tier change.** Required: TDD + integration tests + `/data-license`
-review + a structured spec (`/spec`) before implementation. See
-[docs/risk-tiers.md](docs/risk-tiers.md). PRs touching these files will be
-reviewed against this bar regardless of how small they look.
-</important>
-
-<important if="working on the Pi (deployed device, not Mac dev)">
-- After `uv add <pkg>` or any dependency change, restart the service:
-  `sudo systemctl restart helmlog`. The service runs with `--no-sync` and
-  trusts the venv.
-- A hotfix on the Pi still goes through a feature branch + PR + merge.
-  Never commit to `main` from the device.
-- `/diagnose` is the systematic Pi troubleshooting runbook. Use it before
-  ad-hoc poking.
-</important>
-
-## Where to look next
-
-- **User-facing feature index** (crew / viewer / admin breakdown):
-  [docs/features.md](docs/features.md)
-- **Risk tiers + spec formats:** [docs/risk-tiers.md](docs/risk-tiers.md)
-- **Data licensing policy** (PII, co-op embargoes, biometrics, gambling,
-  protest firewall): [docs/data-licensing.md](docs/data-licensing.md). Run
-  `/data-license` to review code against it.
-- **Testing layers** (in-process, Pi harness, Docker) and Pi-harness SSH
-  setup: [docs/testing-guide.md](docs/testing-guide.md). Run
-  `/integration-test` to pick the right layer.
-- **Promote gate (`main → stage`):** the `promote.yml` workflow requires a
-  new `##` heading in `RELEASES.md` for each promoted commit set (exempt
-  if all commits only touch `docs/ideation-log.md`). Run `/release-notes`
-  before promoting. `stage → live` has no gate.
-- **Skill catalog and domain reference:** the harness lists available
-  skills each session. For Signal K paths, PGN byte layouts, and unit
-  conversions, `sk_reader.py` and `nmea2000.py` are the source of truth;
-  `/domain` only encodes tribal knowledge that is not directly visible in
-  those files (B&G quirks, J/105 polar targets, miscalibration symptoms).
-- **Past decisions on this file** (e.g. why `/domain` isn't split, why no
-  `AGENTS.md` symlink): [docs/agent-context-decisions.md](docs/agent-context-decisions.md).
+- **Memory.** File-based memory persists across sessions under
+  `~/.claude/projects/-Users-dweatbrook-src-helmlog/memory/`, indexed by
+  `MEMORY.md`. Save durable facts there (user prefs, project state, references);
+  don't restate what the repo or `AGENTS.md` already records.

--- a/docs/agent-context-decisions.md
+++ b/docs/agent-context-decisions.md
@@ -20,16 +20,33 @@ typical instrument work, defeating the goal. Revisit if the file grows
 past ~500 lines or if a slice (likely `domain-racing`) becomes
 self-contained.
 
-## Decision: skip `CLAUDE.md` → `AGENTS.md` symlink
+## Decision: `AGENTS.md` is canonical; `CLAUDE.md` imports it
+
+**Supersedes** the earlier "skip `AGENTS.md`" call below (kept for the record).
+
+**Chose:** keep a single, real `AGENTS.md` as the tool-agnostic source of truth
+and reduce `CLAUDE.md` to an `@AGENTS.md` import plus a short Claude-Code-only
+tail (the `EnterWorktree` tool, the skill catalog, file-based memory).
+
+**Why:** a parallel `CLAUDE.md` and `AGENTS.md` had already drifted — the
+`AGENTS.md` was a thinner, partially stale copy of `CLAUDE.md`'s rules. One
+canonical file removes the drift, and `AGENTS.md` is the cross-agent standard
+(Cursor, Copilot, Codex, Windsurf, Zed all read it), so any agent now works from
+the same conventions. A `@AGENTS.md` import (not a symlink) keeps Claude Code's
+extra mechanics layered on top without duplicating the substance. Done as part
+of bringing the sibling `shiftsimulator` repo to the same convention.
+
+### Earlier decision (superseded): skip `CLAUDE.md` → `AGENTS.md` symlink
 
 **Considered:** symlinking `AGENTS.md → CLAUDE.md` for portability across
 Cursor, Copilot, Codex, Factory, Windsurf, Zed (60k+ repos use the standard).
 
-**Chose:** skip for now.
+**Chose at the time:** skip for now.
 
-**Why:** HelmLog is single-tool (Claude Code) and there's no concrete plan
-to use another agent. The symlink is cheap to add later and adds clutter to
-the repo root today. Revisit if a contributor uses a different agent.
+**Why (at the time):** HelmLog was single-tool (Claude Code) with no concrete
+plan to use another agent; the symlink was cheap to add later and added clutter
+to the repo root. (Reversed above once a real `AGENTS.md` existed and had
+drifted from `CLAUDE.md`.)
 
 ## Decision: third-person skill descriptions — audit pass clean
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -541,4 +541,4 @@ read the policy or run `/data-license` against the change.
 | Fleet champion pitching adoption | [`guide-champions.md`](guide-champions.md) |
 | Boat owner setting up federation | [`guide-federation.md`](guide-federation.md) |
 | Operator setting up a new Pi | [`bootstrap-new-pi.md`](bootstrap-new-pi.md) |
-| Developer | [`../CONTRIBUTING.md`](../CONTRIBUTING.md), [`../CLAUDE.md`](../CLAUDE.md) |
+| Developer | [`../AGENTS.md`](../AGENTS.md) (canonical conventions), [`../CONTRIBUTING.md`](../CONTRIBUTING.md) |


### PR DESCRIPTION
## What

HelmLog carried both a `CLAUDE.md` and a separate, thinner `AGENTS.md` that had drifted. This reconciles them into **one best-of-class `AGENTS.md`** (the tool-agnostic source of truth) and reduces `CLAUDE.md` to an `@AGENTS.md` import plus a Claude-Code-only tail.

## Why

So *any* agent (Cursor, Codex, Copilot, Claude Code) works from the same conventions, with no drift between two parallel files. Reverses the earlier "skip AGENTS.md" decision now that a real (drifted) AGENTS.md already existed.

## Changes

- **`AGENTS.md`** — merge CLAUDE.md's depth with the bits unique to the old AGENTS.md: explicit module annotations, the Critical/High risk-tier table, concrete testing specifics (mock list, `ASGITransport`). Worktree/skill mechanics phrased generically; slash-commands framed as Claude Code shortcuts.
- **`CLAUDE.md`** — now `@AGENTS.md` + a "Claude Code specifics" section (EnterWorktree, skill catalog, file memory).
- **`docs/agent-context-decisions.md`** — supersede the stale "skip AGENTS.md" decision, keeping the original for the record.
- **`docs/features.md`** — point developers at `AGENTS.md` as canonical.

## Notes

No code or behavior change. Done alongside bringing the sibling `shiftsimulator` repo to the same convention.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)