### PR TITLE
fix(replay): hide boat marker outside the GPS track's time span

### DIFF
--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -1324,6 +1324,16 @@ function _moveCursorToUtc(utc) {
   const {latLngs, timestamps} = _trackData;
   if (!latLngs.length) return;
   const tMs = utc.getTime();
+  // Outside the GPS track's time span there is no real boat position to show.
+  // The replay scrubber extends ~20 min into the prestart (#712) so video /
+  // audio / gauges can be scrubbed before the gun, but the GPS track almost
+  // always begins at the gun (instruments come online just before racing).
+  // Clamping to an endpoint would falsely park the boat on the green "Start"
+  // dot for that whole pre-gun window — so hide the cursor instead.
+  if (tMs < timestamps[0].getTime() || tMs > timestamps[timestamps.length - 1].getTime()) {
+    if (_map && _map.hasLayer(_trackData.cursor)) _map.removeLayer(_trackData.cursor);
+    return;
+  }
   // Bracket the timestamps
   let hi = _trackLowerBound(tMs);
   if (hi <= 0) { hi = 1; }


### PR DESCRIPTION
## Problem
On the session map the boat marker parks on the green **Start** dot for many minutes at the beginning of a session before it starts moving (reported on `/session/212`).

## Root cause
PR #712 extended the replay scrubber ~20 min into the prestart (`prestart_start_utc` = gun − `_PRESTART_WINDOW_S`) so video/audio/gauges can be scrubbed before the gun. But the GPS track almost always begins **at the gun** — the instruments come online just before racing (verified against the live DB: every race back to late May has its first fix at the gun). Across that void, `_moveCursorToUtc` clamped the cursor to `latLngs[0]` because `_trackLowerBound` returns 0 and `frac` floors at 0 for `tMs < timestamps[0]`.

Confirmed on live race 212: replay window starts `01:10:31` (gun − 20 min), first GPS point is `01:30:31` (the gun) → exactly the 20-min stuck window. Data, renderer, and cache are all correct — purely a frontend cursor issue.

## Fix
In `_moveCursorToUtc`, hide the boat marker when the replay time is outside the track's `[timestamps[0], timestamps[last]]` span instead of clamping to an endpoint. The marker re-adds itself via `.addTo(_map)` once replay re-enters the track span, so #712's prestart video/audio/gauge scrubbing is unaffected.

## Testing
No JS test harness exists in this repo (Python-only CI). Validated the boundary logic with a standalone mirror (hides before first ts / after last ts, shows within) and `node --check` on `session.js`. Manual verification on the live page recommended after deploy.

Fixes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)