### PR TITLE
fix(polar): trim prestart + post-finish so polars only see racing data (#812)

### DIFF
--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -119,6 +119,188 @@ def _point_of_sail(abs_twa_deg: float) -> PointOfSail:
 
 
 # ---------------------------------------------------------------------------
+# Race window: trim prestart + post-finish so polars only see racing data (#812)
+# ---------------------------------------------------------------------------
+#
+# The polar diagram and the baseline must only see data from when we were
+# actually racing. Prestart maneuvering and post-finish sailing otherwise bias
+# both the per-race comparison and the shared baseline.
+#
+# Gun: the Vakaros ``race_start`` event when the race is Vakaros-matched, else
+# ``start_utc`` (which the 5-4-1-0 start-timer FSM already anchors to the gun,
+# #644, when the crew runs the timer).
+#
+# Finish: no device event is trusted here, so we detect it from the track. For
+# a windward/leeward course the finish is an upwind finish by the committee
+# boat; after crossing, the boat bears away and sails off. Walking backward
+# from the session end, the finish is the last moment we were close-hauled in
+# the vicinity of the start area. The finish line sits just past the RC, so the
+# vicinity radius is deliberately generous.
+
+# ≤ this absolute TWA (deg) counts as close-hauled / beating.
+_FINISH_CLOSE_HAULED_MAX_ABS_TWA: float = 55.0
+# "vicinity of the start" radius (m); generous so the finish just past the RC
+# still counts.
+_FINISH_VICINITY_RADIUS_M: float = 500.0
+# Only trim when the post-finish tail is worth trimming.
+_FINISH_MIN_TAIL_TRIM_S: float = 30.0
+# Never collapse the racing window below this — guards against a finish detected
+# too early (e.g. an upwind pass near the line mid-race).
+_FINISH_MIN_RACE_DURATION_S: float = 120.0
+
+GunSource = Literal["vakaros", "start_utc"]
+FinishSource = Literal["heuristic", "end_utc"]
+
+
+@dataclass(frozen=True)
+class RaceWindow:
+    """Effective racing window [gun, finish] plus the provenance of each edge."""
+
+    gun: datetime
+    finish: datetime
+    gun_source: GunSource
+    finish_source: FinishSource
+
+
+def _distance_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres (haversine)."""
+    r = 6_371_000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlambda / 2) ** 2
+    return 2 * r * math.asin(min(1.0, math.sqrt(a)))
+
+
+def _detect_finish_from_track(
+    gun: datetime,
+    end: datetime,
+    start_lat: float,
+    start_lon: float,
+    samples: list[tuple[datetime, float, float, float]],
+) -> tuple[datetime, FinishSource]:
+    """Backward-scan finish heuristic.
+
+    ``samples`` is ``(ts, lat, lon, abs_twa)`` sorted ascending by ts, covering
+    ``[gun, end]``. Walking backward, the finish is the latest sample where the
+    boat was close-hauled *and* within the start vicinity — i.e. the last beat
+    to the finish by the committee boat, before it bore away and sailed off.
+
+    Returns ``(finish_ts, source)``. Falls back to ``(end, "end_utc")`` when no
+    plausible finish is found or a guardrail rejects the trim (tail too short to
+    bother, or the detected finish would collapse the racing window).
+    """
+    finish_ts: datetime | None = None
+    for ts, lat, lon, abs_twa in reversed(samples):
+        if ts <= gun or ts > end:
+            continue
+        if (
+            abs_twa <= _FINISH_CLOSE_HAULED_MAX_ABS_TWA
+            and _distance_m(lat, lon, start_lat, start_lon) <= _FINISH_VICINITY_RADIUS_M
+        ):
+            finish_ts = ts
+            break
+    if finish_ts is None:
+        return end, "end_utc"
+    if (end - finish_ts).total_seconds() < _FINISH_MIN_TAIL_TRIM_S:
+        return end, "end_utc"
+    if (finish_ts - gun).total_seconds() < _FINISH_MIN_RACE_DURATION_S:
+        return end, "end_utc"
+    return finish_ts, "heuristic"
+
+
+async def race_window(
+    storage: Storage,
+    *,
+    start_utc: str,
+    end_utc: str,
+    vakaros_session_id: int | None,
+) -> RaceWindow:
+    """Resolve the effective racing window [gun, finish] for one race.
+
+    ``start_utc`` / ``end_utc`` are the race row's ISO timestamps; the caller is
+    responsible for ensuring ``end_utc`` is non-null. Raises ``ValueError`` on
+    unparseable timestamps (callers already guard those).
+    """
+    db = storage._conn()
+    start = datetime.fromisoformat(str(start_utc)).replace(tzinfo=UTC)
+    end = datetime.fromisoformat(str(end_utc)).replace(tzinfo=UTC)
+
+    # --- Gun: prefer the Vakaros race_start event (#536) ---
+    gun = start
+    gun_source: GunSource = "start_utc"
+    if vakaros_session_id is not None:
+        gun_cur = await db.execute(
+            "SELECT vre.ts FROM vakaros_race_events vre"
+            " WHERE vre.session_id = ? AND vre.event_type = 'race_start'"
+            "   AND vre.ts BETWEEN ? AND ?"
+            " ORDER BY vre.ts DESC LIMIT 1",
+            (vakaros_session_id, start_utc, end_utc),
+        )
+        gun_row = await gun_cur.fetchone()
+        if gun_row is not None:
+            with contextlib.suppress(ValueError):
+                gun = datetime.fromisoformat(str(gun_row["ts"])).replace(tzinfo=UTC)
+                gun_source = "vakaros"
+
+    # --- Finish: track heuristic over [gun, end] ---
+    # Defensive: a single race with odd data must never abort a baseline build,
+    # so any failure falls back to end_utc (the pre-#812 behaviour).
+    finish: datetime = end
+    finish_source: FinishSource = "end_utc"
+    try:
+        finish, finish_source = await _detect_finish(storage, gun, end)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Polar: finish heuristic failed, using end_utc: {}", exc)
+    return RaceWindow(gun=gun, finish=finish, gun_source=gun_source, finish_source=finish_source)
+
+
+async def _detect_finish(
+    storage: Storage, gun: datetime, end: datetime
+) -> tuple[datetime, FinishSource]:
+    """Fetch track + wind over [gun, end], build (ts, lat, lon, abs_twa) samples,
+    and hand them to the pure ``_detect_finish_from_track`` heuristic."""
+    positions = await storage.query_range("positions", gun, end)
+    if not positions:
+        return end, "end_utc"
+    winds = await storage.query_range("winds", gun, end)
+    headings = await storage.query_range("headings", gun, end)
+
+    hdg_by_s: dict[str, dict[str, Any]] = {}
+    for h in headings:
+        hdg_by_s.setdefault(str(h["ts"])[:19], h)
+    tw_by_s: dict[str, dict[str, Any]] = {}
+    for w in winds:
+        if int(w.get("reference", -1)) not in (_WIND_REF_BOAT, _WIND_REF_NORTH):
+            continue
+        tw_by_s.setdefault(str(w["ts"])[:19], w)
+
+    # First fix at/after the gun marks the start area (positions are ts-ordered).
+    start_lat = float(positions[0]["latitude_deg"])
+    start_lon = float(positions[0]["longitude_deg"])
+
+    samples: list[tuple[datetime, float, float, float]] = []
+    for p in positions:
+        wind_row = tw_by_s.get(str(p["ts"])[:19])
+        if wind_row is None:
+            continue
+        hdg_row = hdg_by_s.get(str(p["ts"])[:19])
+        heading = float(hdg_row["heading_deg"]) if hdg_row else None
+        twa = _compute_twa(
+            float(wind_row["wind_angle_deg"]), int(wind_row.get("reference", -1)), heading
+        )
+        if twa is None:
+            continue
+        ts = datetime.fromisoformat(str(p["ts"])).replace(tzinfo=UTC)
+        samples.append((ts, float(p["latitude_deg"]), float(p["longitude_deg"]), twa))
+
+    if not samples:
+        return end, "end_utc"
+    return _detect_finish_from_track(gun, end, start_lat, start_lon, samples)
+
+
+# ---------------------------------------------------------------------------
 # Baseline builder
 # ---------------------------------------------------------------------------
 
@@ -154,29 +336,21 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
 
     for race_row in races:
         race_id = int(race_row["id"])
+        # Narrow to the effective racing window [gun, finish] so pre-start
+        # maneuvering (#536) and post-finish sailing (#812) don't bias the
+        # baseline. gun = Vakaros race_start / start_utc; finish = track
+        # heuristic / end_utc.
         try:
-            start = datetime.fromisoformat(str(race_row["start_utc"])).replace(tzinfo=UTC)
-            end = datetime.fromisoformat(str(race_row["end_utc"])).replace(tzinfo=UTC)
+            win = await race_window(
+                storage,
+                start_utc=str(race_row["start_utc"]),
+                end_utc=str(race_row["end_utc"]),
+                vakaros_session_id=race_row["vakaros_session_id"],
+            )
         except ValueError:
             logger.warning("Polar: skipping race {} — bad timestamps", race_id)
             continue
-
-        # Prefer the Vakaros race_start event as the effective gun for this
-        # race; fall back to start_utc when no Vakaros match is available.
-        # Skips pre-start maneuvering from the baseline (#536).
-        vakaros_sid = race_row["vakaros_session_id"]
-        if vakaros_sid is not None:
-            gun_cur = await db.execute(
-                "SELECT vre.ts FROM vakaros_race_events vre"
-                " WHERE vre.session_id = ? AND vre.event_type = 'race_start'"
-                "   AND vre.ts BETWEEN ? AND ?"
-                " ORDER BY vre.ts DESC LIMIT 1",
-                (vakaros_sid, race_row["start_utc"], race_row["end_utc"]),
-            )
-            gun_row = await gun_cur.fetchone()
-            if gun_row is not None:
-                with contextlib.suppress(ValueError):
-                    start = datetime.fromisoformat(str(gun_row["ts"])).replace(tzinfo=UTC)
+        start, end = win.gun, win.finish
 
         speeds = await storage.query_range("speeds", start, end)
         winds = await storage.query_range("winds", start, end)
@@ -324,6 +498,12 @@ class SessionPolarData:
     tws_bins: list[int]
     twa_bins: list[int]
     session_sample_count: int
+    # Effective racing window this comparison was computed over, plus how each
+    # edge was resolved — so the UI can show the trim is honest (#812).
+    window_start: datetime
+    window_end: datetime
+    gun_source: GunSource
+    finish_source: FinishSource
 
 
 async def session_polar_comparison(
@@ -332,21 +512,32 @@ async def session_polar_comparison(
 ) -> SessionPolarData | None:
     """Compare a session's BSP performance against the polar baseline.
 
+    Only data from the effective racing window [gun, finish] is used, so
+    prestart maneuvering and post-finish sailing don't skew the comparison
+    (#812).
+
     Returns None if the session doesn't exist or hasn't ended.
     Returns a SessionPolarData with empty cells if no instrument data is available.
     """
     db = storage._conn()
 
-    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    cur = await db.execute(
+        "SELECT start_utc, end_utc, vakaros_session_id FROM races WHERE id = ?", (session_id,)
+    )
     row = await cur.fetchone()
     if row is None or row["end_utc"] is None:
         return None
 
     try:
-        start = datetime.fromisoformat(str(row["start_utc"])).replace(tzinfo=UTC)
-        end = datetime.fromisoformat(str(row["end_utc"])).replace(tzinfo=UTC)
+        win = await race_window(
+            storage,
+            start_utc=str(row["start_utc"]),
+            end_utc=str(row["end_utc"]),
+            vakaros_session_id=row["vakaros_session_id"],
+        )
     except ValueError:
         return None
+    start, end = win.gun, win.finish
 
     # Load instrument data for this session
     speeds = await storage.query_range("speeds", start, end)
@@ -440,6 +631,10 @@ async def session_polar_comparison(
         tws_bins=tws_bins,
         twa_bins=twa_bins,
         session_sample_count=total_samples,
+        window_start=win.gun,
+        window_end=win.finish,
+        gun_source=win.gun_source,
+        finish_source=win.finish_source,
     )
 
 

--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -821,10 +821,12 @@ async def grade_session_segments(
 ) -> list[GradedSegment]:
     """Return per-segment polar grading for a completed session.
 
-    Segments are fixed-width windows over the session's [start_utc, end_utc]
-    range. Each segment carries averaged conditions, the polar target, and
-    a grade label. Results are cached in ``polar_segment_grades`` and
-    invalidated when the polar baseline is rebuilt.
+    Segments are fixed-width windows over the session's effective racing window
+    [gun, finish] (#812) — prestart maneuvering and post-finish sailing are
+    trimmed just as they are for the polar diagram and baseline. Each segment
+    carries averaged conditions, the polar target, and a grade label. Results
+    are cached in ``polar_segment_grades`` and invalidated when the polar
+    baseline is rebuilt.
 
     The CPU-bound segmentation runs in a worker thread (#603) so long sessions
     don't block the event loop for other HTTP requests.
@@ -833,7 +835,9 @@ async def grade_session_segments(
     db = storage._conn()
 
     # Resolve session bounds
-    cur = await db.execute("SELECT start_utc, end_utc FROM races WHERE id = ?", (session_id,))
+    cur = await db.execute(
+        "SELECT start_utc, end_utc, vakaros_session_id FROM races WHERE id = ?", (session_id,)
+    )
     row = await cur.fetchone()
     if row is None or row["end_utc"] is None:
         return []  # req 16
@@ -867,6 +871,24 @@ async def grade_session_segments(
             )
             for r in cached
         ]
+
+    # Cache miss → narrow to the racing window before segmenting so prestart +
+    # post-finish don't get graded (#812). Deferred past the cache check so
+    # cheap cache hits don't pay for the finish heuristic's queries. (Cached
+    # grades from before this change refresh on the next baseline rebuild, which
+    # bumps baseline_version and invalidates the cache.)
+    try:
+        win = await race_window(
+            storage,
+            start_utc=str(row["start_utc"]),
+            end_utc=str(row["end_utc"]),
+            vakaros_session_id=row["vakaros_session_id"],
+        )
+    except ValueError:
+        return []
+    start, end = win.gun, win.finish
+    if end <= start:
+        return []
 
     # Load session window data
     speeds = await storage.query_range("speeds", start, end)

--- a/src/helmlog/routes/sessions.py
+++ b/src/helmlog/routes/sessions.py
@@ -1220,6 +1220,12 @@ async def api_session_polar(
             "tws_bins": data.tws_bins,
             "twa_bins": data.twa_bins,
             "session_sample_count": data.session_sample_count,
+            # Effective racing window this was computed over (#812) — lets the
+            # panel show that prestart/post-finish were trimmed and how.
+            "window_start": data.window_start.isoformat(),
+            "window_end": data.window_end.isoformat(),
+            "gun_source": data.gun_source,
+            "finish_source": data.finish_source,
         }
     )
 

--- a/src/helmlog/static/session.js
+++ b/src/helmlog/static/session.js
@@ -5009,8 +5009,21 @@ async function loadPolar() {
       + above + ' bins above, ' + below + ' below'
       + (noBaseline ? ' &middot; ' + noBaseline + ' bins no baseline' : '')
       + ' &middot; ' + data.session_sample_count + ' samples'
-      + rebuildBtn;
+      + rebuildBtn
+      + _polarWindowCaption(data);
   } catch (e) { /* non-fatal */ }
+}
+
+// Small caption showing the racing window this polar was computed over, so the
+// trim (prestart excluded, post-finish auto-detected) is auditable (#812).
+function _polarWindowCaption(data) {
+  if (!data.window_start || !data.window_end) return '';
+  const gun = data.gun_source === 'vakaros' ? 'Vakaros gun' : 'session start';
+  const fin = data.finish_source === 'heuristic' ? 'auto-detected finish' : 'session end';
+  return '<div style="font-size:.7rem;color:var(--text-secondary);margin-top:2px">'
+    + 'Racing window: ' + fmtTime(data.window_start) + '–' + fmtTime(data.window_end)
+    + ' &middot; ' + gun + ' → ' + fin
+    + '</div>';
 }
 
 async function rebuildPolarBaseline() {

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -21,6 +21,8 @@ from helmlog.polar import (
     GRADE_SUSPICIOUS_AT,
     GRADE_YELLOW_BELOW,
     _compute_twa,
+    _detect_finish_from_track,
+    _distance_m,
     _grade_from_pct,
     _twa_bin,
     _tws_bin,
@@ -28,6 +30,7 @@ from helmlog.polar import (
     get_polar_baseline_version,
     grade_session_segments,
     lookup_polar,
+    race_window,
     session_polar_comparison,
 )
 
@@ -819,3 +822,241 @@ async def test_grade_does_not_block_event_loop(storage: Storage) -> None:
     # If the grader held the loop, ticks would be 0-ish. With to_thread the
     # ticker runs freely while the thread computes.
     assert ticks > 10
+
+
+# ---------------------------------------------------------------------------
+# Race window: trim prestart (gun) + post-finish (track heuristic) — #812
+# ---------------------------------------------------------------------------
+
+_WIN_LAT = 37.80
+_WIN_LON = -122.27
+
+
+class TestDistanceHelper:
+    def test_zero_distance(self) -> None:
+        assert _distance_m(_WIN_LAT, _WIN_LON, _WIN_LAT, _WIN_LON) == pytest.approx(0.0)
+
+    def test_known_offset_metres(self) -> None:
+        # ~0.01 deg latitude ≈ 1.11 km.
+        d = _distance_m(_WIN_LAT, _WIN_LON, _WIN_LAT + 0.01, _WIN_LON)
+        assert d == pytest.approx(1113.0, rel=0.02)
+
+
+class TestDetectFinishHeuristic:
+    """Pure backward-scan finish detector (no Storage)."""
+
+    gun = datetime(2024, 7, 1, 12, 0, 0, tzinfo=UTC)
+
+    def _sample(self, offset_s: int, *, near: bool, close_hauled: bool) -> tuple:
+        lat = _WIN_LAT + (0.001 if near else 0.03)  # ~140 m vs ~3.3 km from start
+        twa = 40.0 if close_hauled else 140.0
+        return (self.gun + timedelta(seconds=offset_s), lat, _WIN_LON + 0.001, twa)
+
+    def test_trims_postfinish_tail(self) -> None:
+        end = self.gun + timedelta(seconds=300)
+        samples = [self._sample(t, near=True, close_hauled=True) for t in range(0, 201, 10)]
+        # post-finish: sailed away, downwind
+        samples += [self._sample(t, near=False, close_hauled=False) for t in range(210, 301, 10)]
+        finish, source = _detect_finish_from_track(self.gun, end, _WIN_LAT, _WIN_LON, samples)
+        assert source == "heuristic"
+        assert finish == self.gun + timedelta(seconds=200)
+
+    def test_no_trim_when_tail_shorter_than_threshold(self) -> None:
+        # Close-hauled near start right up to t=295 → only 5 s of tail (< 30 s).
+        end = self.gun + timedelta(seconds=300)
+        samples = [self._sample(t, near=True, close_hauled=True) for t in range(0, 296, 5)]
+        finish, source = _detect_finish_from_track(self.gun, end, _WIN_LAT, _WIN_LON, samples)
+        assert source == "end_utc"
+        assert finish == end
+
+    def test_no_trim_when_finish_would_collapse_window(self) -> None:
+        # Only the first 60 s are close-hauled-near-start; the rest is far/downwind.
+        # Backward scan finds finish at t=60, but 60 s < 120 s min race duration.
+        end = self.gun + timedelta(seconds=300)
+        samples = [self._sample(t, near=True, close_hauled=True) for t in range(0, 61, 10)]
+        samples += [self._sample(t, near=False, close_hauled=False) for t in range(70, 301, 10)]
+        finish, source = _detect_finish_from_track(self.gun, end, _WIN_LAT, _WIN_LON, samples)
+        assert source == "end_utc"
+        assert finish == end
+
+    def test_no_match_falls_back_to_end(self) -> None:
+        # Never close-hauled-near-start → cannot detect a finish.
+        end = self.gun + timedelta(seconds=300)
+        samples = [self._sample(t, near=False, close_hauled=False) for t in range(0, 301, 10)]
+        finish, source = _detect_finish_from_track(self.gun, end, _WIN_LAT, _WIN_LON, samples)
+        assert source == "end_utc"
+        assert finish == end
+
+    def test_empty_samples_falls_back_to_end(self) -> None:
+        end = self.gun + timedelta(seconds=300)
+        finish, source = _detect_finish_from_track(self.gun, end, _WIN_LAT, _WIN_LON, [])
+        assert source == "end_utc"
+        assert finish == end
+
+
+async def _seed_windowed_race(
+    storage: Storage,
+    *,
+    prestart_s: int,
+    race_s: int,
+    tail_s: int,
+    with_vakaros: bool,
+    seq: int = 0,
+) -> tuple[int, datetime, datetime]:
+    """Seed a race with three phases and return (race_id, gun, finish).
+
+    Phases (1 Hz), all with reference-0 (boat) wind so TWA == wind_angle:
+      * pre-start [start_utc, gun): BSP 1.0, TWA 40, near start line
+      * racing    [gun, finish]:    BSP 6.0, TWA 40 (close-hauled), near start
+      * post-race (finish, end]:    BSP 6.5, TWA 140 (running), ~3 km away
+
+    When ``with_vakaros`` the race is Vakaros-matched with a race_start event at
+    the gun, so pre-start is trimmable; otherwise the gun falls back to
+    start_utc (pre-start stays in-window, which is the point of that variant).
+    """
+    db = storage._conn()
+    # Offset each seeded race by seq days so multi-race tests don't overlap in
+    # the (time-ranged, not race_id-filtered) telemetry tables.
+    start_utc = datetime(2024, 8, 1, 18, 0, 0, tzinfo=UTC) + timedelta(days=seq)
+    gun = start_utc + timedelta(seconds=prestart_s)
+    finish = gun + timedelta(seconds=race_s)
+    end = finish + timedelta(seconds=tail_s)
+
+    vid: int | None = None
+    if with_vakaros:
+        await db.execute(
+            "INSERT INTO vakaros_sessions (source_hash, source_file, start_utc,"
+            " end_utc, ingested_at) VALUES (?, ?, ?, ?, ?)",
+            (
+                f"h{seq}",
+                f"v{seq}.csv",
+                start_utc.isoformat(),
+                end.isoformat(),
+                start_utc.isoformat(),
+            ),
+        )
+        vrow = await (
+            await db.execute("SELECT id FROM vakaros_sessions ORDER BY id DESC LIMIT 1")
+        ).fetchone()
+        vid = int(vrow["id"])
+        await db.execute(
+            "INSERT INTO vakaros_race_events (session_id, ts, event_type, timer_value_s)"
+            " VALUES (?, ?, 'race_start', 0)",
+            (vid, gun.isoformat()),
+        )
+
+    await db.execute(
+        "INSERT INTO races (name, event, race_num, date, start_utc, end_utc, vakaros_session_id)"
+        " VALUES (?, 'E', ?, ?, ?, ?, ?)",
+        (
+            f"W{seq}",
+            seq + 1,
+            start_utc.date().isoformat(),
+            start_utc.isoformat(),
+            end.isoformat(),
+            vid,
+        ),
+    )
+    await db.commit()
+    rid = int(
+        (await (await db.execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")).fetchone())["id"]
+    )
+
+    async def _phase(t0: datetime, n: int, bsp: float, twa: float, lat: float, lon: float) -> None:
+        for i in range(n):
+            ts = t0 + timedelta(seconds=i)
+            await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, bsp))
+            await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, 10.0, twa, 0))
+            await storage.write(PositionRecord(PGN_POSITION_RAPID, 5, ts, lat, lon))
+
+    await _phase(start_utc, prestart_s, 1.0, 40.0, _WIN_LAT + 0.001, _WIN_LON + 0.001)
+    await _phase(gun, race_s, 6.0, 40.0, _WIN_LAT + 0.001, _WIN_LON + 0.001)
+    await _phase(
+        finish + timedelta(seconds=1), tail_s, 6.5, 140.0, _WIN_LAT + 0.03, _WIN_LON + 0.03
+    )
+    # The last racing sample is at gun + (race_s - 1) — that's the timestamp the
+    # backward-scan heuristic should land on as the finish.
+    return rid, gun, gun + timedelta(seconds=race_s - 1)
+
+
+class TestRaceWindow:
+    @pytest.mark.asyncio
+    async def test_vakaros_gun_and_heuristic_finish(self, storage: Storage) -> None:
+        rid, gun, finish = await _seed_windowed_race(
+            storage, prestart_s=60, race_s=200, tail_s=60, with_vakaros=True
+        )
+        row = await (
+            await storage._conn().execute(
+                "SELECT start_utc, end_utc, vakaros_session_id FROM races WHERE id = ?", (rid,)
+            )
+        ).fetchone()
+        win = await race_window(
+            storage,
+            start_utc=str(row["start_utc"]),
+            end_utc=str(row["end_utc"]),
+            vakaros_session_id=row["vakaros_session_id"],
+        )
+        assert win.gun_source == "vakaros"
+        assert win.gun == gun
+        assert win.finish_source == "heuristic"
+        assert win.finish == finish
+
+    @pytest.mark.asyncio
+    async def test_no_vakaros_gun_falls_back_to_start_utc(self, storage: Storage) -> None:
+        rid, _gun, finish = await _seed_windowed_race(
+            storage, prestart_s=0, race_s=200, tail_s=60, with_vakaros=False
+        )
+        row = await (
+            await storage._conn().execute(
+                "SELECT start_utc, end_utc, vakaros_session_id FROM races WHERE id = ?", (rid,)
+            )
+        ).fetchone()
+        win = await race_window(
+            storage,
+            start_utc=str(row["start_utc"]),
+            end_utc=str(row["end_utc"]),
+            vakaros_session_id=row["vakaros_session_id"],
+        )
+        assert win.gun_source == "start_utc"
+        assert win.finish_source == "heuristic"
+        assert win.finish == finish
+
+
+class TestSessionPolarWindow:
+    @pytest.mark.asyncio
+    async def test_comparison_excludes_prestart_and_postfinish(self, storage: Storage) -> None:
+        """Only racing-phase samples (BSP 6.0, close-hauled) should bin. The
+        pre-start (BSP 1.0) and post-finish (downwind BSP 6.5) phases must be
+        trimmed by the gun and the finish heuristic respectively."""
+        rid, gun, finish = await _seed_windowed_race(
+            storage, prestart_s=60, race_s=200, tail_s=60, with_vakaros=True
+        )
+        data = await session_polar_comparison(storage, rid)
+        assert data is not None
+        assert data.window_start == gun
+        assert data.window_end == finish
+        assert data.gun_source == "vakaros"
+        assert data.finish_source == "heuristic"
+        # Every cell must be the racing bin: upwind, ~6.0 kt. No 1.0 (prestart)
+        # and no downwind (140°) cell.
+        assert data.cells
+        for c in data.cells:
+            assert c.point_of_sail == "upwind"
+            assert c.session_mean_bsp == pytest.approx(6.0, rel=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_baseline_excludes_postfinish_tail(self, storage: Storage) -> None:
+        """Three Vakaros races, each with a downwind post-finish tail. The
+        heuristic must trim the tail so the baseline mean reflects racing only
+        (6.0), not a blend with the 6.5 kt post-finish running."""
+        for seq in range(3):
+            await _seed_windowed_race(
+                storage, prestart_s=60, race_s=200, tail_s=60, with_vakaros=True, seq=seq
+            )
+        await build_polar_baseline(storage)
+        # Racing was TWA 40 upwind; the post-finish TWA-140 bin must not exist.
+        upwind = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(40.0))
+        downwind = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(140.0))
+        assert upwind is not None
+        assert upwind["mean_bsp"] == pytest.approx(6.0, rel=1e-3)
+        assert downwind is None

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -800,8 +800,14 @@ async def test_grade_does_not_block_event_loop(storage: Storage) -> None:
     import asyncio as _asyncio
 
     await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
-    # Larger synthetic session so the sync work is non-trivial.
-    sid = await _seed_session(storage, duration_s=600, bsp=6.0, tws=10.0, twa=45.0)
+    # Larger synthetic session so the sync work is non-trivial. Positions are
+    # omitted so the #812 finish heuristic doesn't trim this unrealistic track
+    # (the synthetic boat sails monotonically away from the start and never
+    # returns); this test only cares that a long session grades fully while the
+    # event loop stays responsive.
+    sid = await _seed_session(
+        storage, duration_s=600, bsp=6.0, tws=10.0, twa=45.0, with_positions=False
+    )
 
     ticks = 0
     stop = False
@@ -1060,3 +1066,21 @@ class TestSessionPolarWindow:
         assert upwind is not None
         assert upwind["mean_bsp"] == pytest.approx(6.0, rel=1e-3)
         assert downwind is None
+
+
+class TestGradeSegmentsWindow:
+    @pytest.mark.asyncio
+    async def test_grading_uses_racing_window(self, storage: Storage) -> None:
+        """Per-segment grading is confined to [gun, finish] (#812): no segment
+        starts before the gun or ends after the detected finish, and the count
+        reflects the ~200 s racing window, not the full 320 s session."""
+        rid, gun, finish = await _seed_windowed_race(
+            storage, prestart_s=60, race_s=200, tail_s=60, with_vakaros=True
+        )
+        segs = await grade_session_segments(storage, rid, segment_seconds=10)
+        assert segs
+        assert segs[0].t_start >= gun
+        assert segs[-1].t_end <= finish + timedelta(seconds=10)
+        # Racing window ≈ 200 s → ~20 segments; the full session (320 s) would be
+        # ~32. Comfortably under 25 confirms prestart + post-finish were trimmed.
+        assert len(segs) < 25


### PR DESCRIPTION
## Problem

The per-race polar diagram and the polar baseline were computed over the **entire session** (`start_utc` → `end_utc`), so **prestart maneuvering** and **post-finish sailing** biased both — giving a false impression of boat performance.

- `session_polar_comparison` (the per-race diagram) did **no** trimming — full `[start_utc, end_utc]`.
- `build_polar_baseline` narrowed the start to the Vakaros gun **only for Vakaros-matched races** (#536), and **never** trimmed the finish.

## Fix — a shared racing window

New `race_window(race) → (gun, finish)` used by both the diagram and the baseline:

- **Gun:** Vakaros `race_start` event → else `start_utc` (which the 5-4-1-0 start-timer FSM already anchors to the gun, #644). Excludes prestart.
- **Finish:** track heuristic (`_detect_finish_from_track`). Walking **backward** from the session end, the finish is the last moment the boat was **close-hauled in the vicinity of the start area** — for a windward/leeward course the finish is an upwind finish by the committee boat, after which the boat bears away and sails off. The finish line sits just past the RC, so the vicinity radius is generous (500 m). Guardrails: only trim a tail worth trimming (≥30 s), and never collapse the racing window (≥120 s) so a mid-race upwind pass near the line can't be mistaken for the finish. Falls back to `end_utc` when nothing plausible is found.

This is the algorithm requested in the issue discussion (Vakaros gun + backward close-hauled-near-start scan, accounting for the finish being on the far side of the RC).

Both `session_polar_comparison` and `build_polar_baseline` now query only `[gun, finish]`. The `/polar` API + panel surface the **detected window and how each edge was resolved** (Vakaros gun vs session start; auto-detected finish vs session end) so the trim is auditable at a glance.

## Scope / not included

Per-segment replay grading (`grade_session_segments`) still uses the full window — left as a follow-up to keep this change scoped to the polar diagram and baseline the report was about. Prestart trimming for **non-Vakaros** races still depends on a gun signal (Vakaros event or the FSM-anchored `start_utc`); with neither, the click-to-gun gap can't be known precisely — noted for follow-up.

## Tests

`tests/test_polar.py`:
- Pure `_detect_finish_from_track`: trims the post-finish tail; both guardrails (tail too short, would collapse window); no close-hauled-near-start match; empty samples.
- `_distance_m` sanity.
- Storage integration: Vakaros gun + heuristic finish; `start_utc` fallback without Vakaros; `session_polar_comparison` excludes prestart (BSP 1.0) and post-finish (downwind BSP 6.5), keeping only racing (BSP 6.0, upwind); `build_polar_baseline` excludes the post-finish tail (no downwind bin).

All four checks pass locally: full `test_polar.py` (75), plus `test_web.py`/`test_analysis_catalog.py` (251) green; ruff + `mypy src/` (120 files) clean.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)