### PR TITLE
feat(screenshots): shot-scraper harness for headless web UI captures

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,109 @@
+name: Screenshots
+
+# Capture the web UI against a synthetic, PII-free demo DB and publish the PNGs
+# to the orphan `screenshots` branch — one commit per build, so the visual
+# history is git-diffable (and release notes can diff a build against the last
+# stage tag to show what changed). Never runs on the Pi; dev/CI only.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write # push to the screenshots branch
+
+concurrency:
+  group: screenshots-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libportaudio2 libsndfile1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      # shot-scraper's Playwright browser is the expensive download — cache it.
+      # Bust the key when the shot-scraper version changes (it pins a browser).
+      - name: Cache Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-shotscraper
+
+      - name: Install shot-scraper browser
+        run: uvx shot-scraper install
+
+      - name: Seed synthetic demo DB
+        run: uv run python scripts/screenshots/seed_demo.py --db /tmp/demo.db --sessions 4
+
+      - name: Capture screenshots
+        run: SHOTS_DB=/tmp/demo.db uvx shot-scraper multi scripts/screenshots/shots.yml
+        # PNGs land in the working directory by the output: names in shots.yml.
+
+      - name: Publish to screenshots branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          shots=(*.png)
+          if [ ${#shots[@]} -eq 0 ]; then
+            echo "::error::no screenshots were produced"
+            exit 1
+          fi
+
+          mkdir -p /tmp/shots
+          mv "${shots[@]}" /tmp/shots/
+
+          url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Fetch the existing screenshots branch, or start a fresh orphan.
+          if git clone --branch screenshots --depth 1 "$url" /tmp/sb 2>/dev/null; then
+            cd /tmp/sb
+          else
+            git clone --depth 1 "$url" /tmp/sb
+            cd /tmp/sb
+            git checkout --orphan screenshots
+            git rm -rfq . || true
+          fi
+
+          rm -f ./*.png
+          cp /tmp/shots/*.png .
+
+          # A browsable index so the branch renders on GitHub and diffs read well.
+          {
+            echo "# Web UI screenshots"
+            echo
+            echo "Auto-generated from a synthetic, PII-free demo DB by"
+            echo "\`.github/workflows/screenshots.yml\`. Do not edit by hand."
+            echo
+            echo "- Build: \`${GITHUB_SHA}\`"
+            echo "- Ref: \`${GITHUB_REF_NAME}\`"
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+            for f in $(ls *.png | sort); do
+              echo "## ${f%.png}"
+              echo
+              echo "![${f%.png}](./${f})"
+              echo
+            done
+          } > README.md
+
+          git add -A
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "screenshots: ${GITHUB_SHA::12} (${GITHUB_REF_NAME})" \
+            || { echo "No visual changes since last build."; exit 0; }
+          git push "$url" HEAD:screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ htmlcov/
 *.swp
 *.swo
 
+# Generated web-UI screenshots (shot-scraper). Regenerable, and may contain
+# real crew names / audio transcripts when shot against a populated DB — PII,
+# so never commit. See scripts/screenshots/README.md.
+docs/screenshots/
+
 # macOS
 .DS_Store
 **/.DS_Store

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -1,0 +1,62 @@
+# Web UI screenshots (shot-scraper)
+
+Headless, reproducible screenshots of the HelmLog web UI using
+[shot-scraper](https://shot-scraper.datasette.io/). Dev/CI only — never install
+on the Pi (it pulls Playwright + a browser).
+
+## Usage
+
+```bash
+uv sync                                # the venv must exist (serve.py uses .venv/bin/python)
+uvx shot-scraper install               # one-time: download the Playwright browser
+
+# Empty auto-created DB (structure only, no data):
+uvx shot-scraper multi scripts/screenshots/shots.yml
+
+# Against a real logger.db (populated pages):
+SHOTS_DB=/path/to/logger.db uvx shot-scraper multi scripts/screenshots/shots.yml
+```
+
+PNGs land in the current directory by the `output:` names in `shots.yml`. Move
+them to `docs/screenshots/` (gitignored) if you want to keep them locally.
+
+## How it works
+
+`shots.yml`'s first entry is a `server:` block that runs `serve.py`, which:
+
+- builds a `Storage`, connects, and serves `create_app(storage)` on `WEB_PORT`
+  (default 3010) — mirroring `main._web_loop`, but without any hardware readers;
+- sets `AUTH_DISABLED=true` so every page is reachable with no magic-link login;
+- **snapshots the DB read-only** via SQLite's backup API into a temp file, so a
+  run never mutates the live logger DB.
+
+A `/healthz` gate then waits for boot (schema migrations on an empty DB take a
+few seconds) before the shots run.
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `SHOTS_DB` | `data/logger.db` | DB to snapshot and serve. Point at a real DB for populated shots. |
+| `WEB_PORT` | `3010` | Port `serve.py` binds (must match the URLs in `shots.yml`). |
+| `SHOTS_SKIP_MIGRATE` | unset | Serve the snapshot **as-is**, skipping migrations. Only needed for very old snapshots that predate a breaking migration; some pages may 500. A current Pi DB is already at head, so migrate is a no-op there. |
+
+## ⚠️ Output is not committed
+
+Screenshots shot against a populated DB contain **real crew names and audio
+transcripts** — PII under `docs/data-licensing.md`. `docs/screenshots/` is
+gitignored; regenerate locally rather than committing images.
+
+## Gotchas baked into serve.py
+
+- **WAL-mode copy** — the live DB runs in WAL; a plain file copy misses data in
+  the `-wal` file. `serve.py` uses the backup API for a consistent snapshot.
+- **Stale sidecars** — the temp path is fixed, so leftover `-wal`/`-shm` from a
+  prior run pair with a fresh main file and yield `malformed database schema`.
+  `serve.py` clears the sidecars before each copy.
+- **Server cleanup** — shot-scraper kills only the direct child of a `server:`
+  command, so `shots.yml` `exec`s the venv python directly (not via `uv run`),
+  otherwise the python grandchild orphans and squats the port.
+- **Client-side charts** — map/canvas pages fetch JSON after load with no ready
+  flag, so shots use a fixed `wait:`. For sharper CI shots against a known DB,
+  swap in a selector wait (e.g. `.leaflet-tile-loaded`).

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -10,15 +10,36 @@ on the Pi (it pulls Playwright + a browser).
 uv sync                                # the venv must exist (serve.py uses .venv/bin/python)
 uvx shot-scraper install               # one-time: download the Playwright browser
 
-# Empty auto-created DB (structure only, no data):
+# Populated pages from synthetic, PII-free data (recommended — same as CI):
+uv run python scripts/screenshots/seed_demo.py --db /tmp/demo.db --sessions 4
+SHOTS_DB=/tmp/demo.db uvx shot-scraper multi scripts/screenshots/shots.yml
+
+# Structure only, no data (empty auto-created DB):
 uvx shot-scraper multi scripts/screenshots/shots.yml
 
-# Against a real logger.db (populated pages):
+# Against a real logger.db (contains PII — local eyeballing only, never commit):
 SHOTS_DB=/path/to/logger.db uvx shot-scraper multi scripts/screenshots/shots.yml
 ```
 
 PNGs land in the current directory by the `output:` names in `shots.yml`. Move
 them to `docs/screenshots/` (gitignored) if you want to keep them locally.
+
+## Synthetic demo data (`seed_demo.py`)
+
+`seed_demo.py` builds a disposable DB populated entirely with **synthesised**
+data using HelmLog's own simulator (the same pipeline as the "Synthesize Race"
+web action) — track, gauges, wind, maneuvers, polar baseline, sails, and a few
+moments — so pages render realistically with **zero PII**. This is what CI
+shoots. No real crew names or audio transcripts are ever produced.
+
+## CI (`.github/workflows/screenshots.yml`)
+
+On push to `main`, CI seeds a synthetic DB, captures the pages, and commits the
+PNGs to the orphan **`screenshots`** branch — one commit per build. That gives a
+git-diffable visual history: `git diff` between two builds (or against the last
+`stage/*` tag) shows exactly which pages changed, which is how release notes can
+point at where a feature landed. The `screenshots` branch renders as a gallery
+(`README.md` with all shots) on GitHub.
 
 ## How it works
 

--- a/scripts/screenshots/seed_demo.py
+++ b/scripts/screenshots/seed_demo.py
@@ -1,0 +1,211 @@
+"""Seed a synthetic, PII-free demo DB for screenshots.
+
+CI has no real ``logger.db`` (and must not — screenshots of real data leak crew
+names and audio transcripts). This builds a disposable DB populated entirely
+with *synthesised* data using HelmLog's own simulator, so the web UI pages —
+track map, gauges, wind field, polar scatter, maneuvers table, history — render
+with realistic content and zero PII.
+
+It reuses the exact building blocks behind the "Synthesize Race" web action
+(`routes/sessions.py::api_synthesize_session`): `simulate` → `import_race` →
+`import_synthesized_data` → boat settings → `detect_maneuvers`, then builds the
+polar baseline (needs >= 3 sessions) and adds a few sails, crew slots, and
+moments. Secondary panels are best-effort so a signature drift degrades the
+screenshot rather than failing the seed.
+
+Usage:
+    uv run python scripts/screenshots/seed_demo.py --db /tmp/demo.db [--sessions 4]
+
+Then point the harness at it:
+    SHOTS_DB=/tmp/demo.db uvx shot-scraper multi scripts/screenshots/shots.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+from datetime import UTC, datetime, timedelta
+
+from loguru import logger
+
+
+async def _seed_sails(storage: object) -> None:
+    """Create a small sail inventory and set boat-level defaults."""
+    ids: dict[str, int] = {}
+    for sail_type, name in (("main", "2024 main"), ("jib", "2024 jib"), ("spinnaker", "2024 A2")):
+        with contextlib.suppress(ValueError):  # ValueError → already exists (re-seed)
+            ids[sail_type] = await storage.add_sail(sail_type, name)  # type: ignore[attr-defined]
+    if len(ids) == 3:
+        await storage.set_sail_defaults(  # type: ignore[attr-defined]
+            main_id=ids["main"], jib_id=ids["jib"], spinnaker_id=ids["spinnaker"]
+        )
+
+
+async def _seed_crew(storage: object) -> None:
+    """Populate boat-level crew slots by position (no user names → no PII)."""
+    db = storage._read_conn()  # noqa: SLF001
+    cur = await db.execute("SELECT id FROM crew_positions ORDER BY id LIMIT 5")
+    position_ids = [row["id"] for row in await cur.fetchall()]
+    weights = [82, 75, 90, 78, 85]
+    crew = [
+        {"position_id": pid, "body_weight": w, "attributed": True}
+        for pid, w in zip(position_ids, weights, strict=False)
+    ]
+    if crew:
+        await storage.set_crew_defaults(None, crew)  # type: ignore[attr-defined]
+
+
+async def _synthesize_session(storage: object, *, day_offset: int, seed: int) -> int:
+    """Simulate one windward/leeward race and import it. Returns race_id."""
+    from helmlog.maneuver_detector import detect_maneuvers
+    from helmlog.races import build_race_name
+    from helmlog.synthesize import (
+        CollisionAvoidanceConfig,
+        HeaderResponseConfig,
+        SynthConfig,
+        generate_boat_settings,
+        simulate,
+    )
+
+    start_lat, start_lon = 47.63, -122.40
+    wind_dir = 200.0 + seed * 7.0
+    day = (datetime.now(UTC) - timedelta(days=day_offset)).replace(
+        hour=18, minute=25, second=0, microsecond=0
+    )
+    date_str = day.date().isoformat()
+
+    from helmlog.courses import build_wl_course
+
+    legs = build_wl_course(start_lat, start_lon, wind_dir, leg_nm=1.0, laps=2)
+    config = SynthConfig(
+        start_lat=start_lat,
+        start_lon=start_lon,
+        base_twd=wind_dir,
+        tws_low=8.0,
+        tws_high=14.0,
+        shift_interval=(600.0, 1200.0),
+        shift_magnitude=(5.0, 14.0),
+        legs=legs,
+        seed=seed,
+        start_time=day,
+        wind_seed=seed,
+        header_response=HeaderResponseConfig(),
+        collision_avoidance=CollisionAvoidanceConfig(min_separation_m=30.0),
+    )
+    rows = await asyncio.to_thread(simulate, config, None)
+    if not rows:
+        raise RuntimeError("simulate produced no rows")
+
+    race_num = await storage.count_sessions_for_date(date_str, "synthesized") + 1  # type: ignore[attr-defined]
+    event = "Demo Regatta"
+    name = build_race_name(event, day.date(), race_num, "synthesized")
+    race_id = await storage.import_race(  # type: ignore[attr-defined]
+        name=name,
+        event=event,
+        race_num=race_num,
+        date_str=date_str,
+        start_utc=rows[0].ts,
+        end_utc=rows[-1].ts,
+        session_type="synthesized",
+        source="synthesized",
+        source_id=f"demo-{seed}",
+    )
+    await storage.import_synthesized_data(rows, race_id=race_id)  # type: ignore[attr-defined]
+
+    # Boat settings (rig/trim params shown on the session page)
+    try:
+        settings = generate_boat_settings(rows, config)
+        for scope, race_arg in ((True, None), (False, race_id)):
+            batch = [
+                {"ts": s.ts, "parameter": s.parameter, "value": s.value}
+                for s in settings
+                if s.race_id_is_null is scope
+            ]
+            if batch:
+                await storage.create_boat_settings(race_arg, batch, source="synthesized")  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("demo-seed: boat settings skipped ({})", exc)
+
+    # Apply default sails to this race
+    try:
+        defaults = await storage.get_sail_defaults()  # type: ignore[attr-defined]
+        if any(defaults[t] for t in ("main", "jib", "spinnaker")):
+            await storage.insert_sail_change(  # type: ignore[attr-defined]
+                race_id,
+                rows[0].ts.isoformat(),
+                main_id=defaults["main"]["id"] if defaults["main"] else None,
+                jib_id=defaults["jib"]["id"] if defaults["jib"] else None,
+                spinnaker_id=defaults["spinnaker"]["id"] if defaults["spinnaker"] else None,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("demo-seed: sail change skipped ({})", exc)
+
+    # Maneuvers (tacks/gybes table)
+    maneuvers = await detect_maneuvers(storage, race_id)  # type: ignore[arg-type]
+    logger.info("demo-seed: race {} ({}) — {} maneuvers", race_id, name, len(maneuvers))
+    return race_id
+
+
+async def _seed_moments(storage: object, race_id: int) -> None:
+    """Add a few generic moments to the latest session (no real names)."""
+    db = storage._read_conn()  # noqa: SLF001
+    cur = await db.execute("SELECT start_utc FROM races WHERE id = ?", (race_id,))
+    row = await cur.fetchone()
+    if row is None:
+        return
+    start = datetime.fromisoformat(str(row["start_utc"]))
+    notes = [
+        (2, "Good start at the boat end, clear lane off the line."),
+        (11, "Header on the left — tacked to consolidate."),
+        (19, "Nice leeward mark rounding, held the inside lane."),
+    ]
+    for minutes, subject in notes:
+        try:
+            await storage.create_moment(  # type: ignore[attr-defined]
+                session_id=race_id,
+                anchor_kind="timestamp",
+                anchor_t_start=(start + timedelta(minutes=minutes)).isoformat(),
+                subject=subject,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("demo-seed: moment skipped ({})", exc)
+
+
+async def main(db_path: str, num_sessions: int) -> None:
+    from helmlog.storage import Storage, StorageConfig
+
+    storage = Storage(StorageConfig(db_path=db_path))
+    await storage.connect()
+    try:
+        await _seed_sails(storage)
+        await _seed_crew(storage)
+
+        race_ids: list[int] = []
+        for i in range(num_sessions):
+            rid = await _synthesize_session(storage, day_offset=num_sessions - i, seed=42 + i)
+            race_ids.append(rid)
+
+        # Polar baseline needs >= 3 sessions of racing data
+        try:
+            from helmlog.polar import build_polar_baseline
+
+            points = await build_polar_baseline(storage, min_sessions=2)
+            logger.info("demo-seed: polar baseline built from {} points", points)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("demo-seed: polar baseline skipped ({})", exc)
+
+        if race_ids:
+            await _seed_moments(storage, race_ids[-1])
+
+        logger.info("demo-seed: done — {} sessions ({})", len(race_ids), race_ids)
+    finally:
+        await storage.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Seed a synthetic demo DB for screenshots")
+    parser.add_argument("--db", required=True, help="Path to the DB file to create/populate")
+    parser.add_argument("--sessions", type=int, default=4, help="Number of synthetic races")
+    args = parser.parse_args()
+    asyncio.run(main(args.db, args.sessions))

--- a/scripts/screenshots/serve.py
+++ b/scripts/screenshots/serve.py
@@ -1,0 +1,109 @@
+"""Boot the HelmLog web UI headlessly for shot-scraper (prototype).
+
+The FastAPI app is factory-built (`create_app(storage)`) and normally only
+runs inside `helmlog run`, which also starts CAN/Signal K/audio hardware. For
+screenshots we want the web layer *without* the hardware, so this launcher
+mirrors `main._web_loop`: build a Storage, connect it, `create_app`, serve.
+
+- Auth is bypassed with AUTH_DISABLED=true (every request is treated as admin),
+  so shot-scraper reaches every page without a magic-link session.
+- The DB is *copied to a temp file* first, so screenshotting never mutates the
+  real logger DB. Point SHOTS_DB at a real/sample DB for populated screenshots;
+  with no DB present the schema auto-creates and pages render (mostly) empty.
+
+Run standalone to eyeball it:
+
+    AUTH_DISABLED=true SHOTS_DB=data/logger.db uv run python scripts/screenshots/serve.py
+
+shot-scraper drives it via the `server:` block in shots.yml — you don't call
+this directly for a screenshot run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import uvicorn
+from loguru import logger
+
+
+def _prepare_db() -> str:
+    """Return a temp DB path: a WAL-consistent copy of SHOTS_DB/DB_PATH if it
+    exists, else a fresh file the schema will auto-create into. Never serve the
+    live DB.
+
+    Two footguns handled here:
+    - The live DB runs in WAL mode, so a plain file copy misses data still in
+      the ``-wal`` file. We use SQLite's backup API for a consistent snapshot.
+    - The temp path is fixed, so a stale ``-wal``/``-shm`` from a prior run pairs
+      with a fresh main file and yields "malformed database schema". Clear the
+      sidecars first.
+    """
+    src = os.environ.get("SHOTS_DB") or os.environ.get("DB_PATH", "data/logger.db")
+    tmp = Path(tempfile.gettempdir()) / "helmlog-shots.db"
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(tmp) + suffix).unlink(missing_ok=True)
+
+    if Path(src).exists():
+        src_conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+        dst_conn = sqlite3.connect(str(tmp))
+        try:
+            src_conn.backup(dst_conn)  # WAL-consistent single-file snapshot
+        finally:
+            dst_conn.close()
+            src_conn.close()
+        logger.info("shots: serving a snapshot of {} ({} bytes)", src, tmp.stat().st_size)
+    else:
+        logger.warning("shots: {} not found — serving an empty auto-created DB", src)
+    return str(tmp)
+
+
+async def main() -> None:
+    os.environ.setdefault("AUTH_DISABLED", "true")
+
+    from helmlog.storage import Storage, StorageConfig
+    from helmlog.web import create_app
+
+    storage = Storage(StorageConfig(db_path=_prepare_db()))
+
+    # A live Pi DB is always at the current schema, so connect()'s migrate step
+    # is a no-op there. Old *snapshots* (e.g. a months-old logger.db) are behind
+    # and running the migration/schema-repair chain against them can fail on
+    # non-idempotent DDL. SHOTS_SKIP_MIGRATE serves the snapshot as-is so you can
+    # still screenshot it — pages that need newer columns may 500, most won't.
+    if os.environ.get("SHOTS_SKIP_MIGRATE"):
+
+        async def _no_migrate() -> None:
+            logger.warning("shots: SHOTS_SKIP_MIGRATE set — serving DB as-is, migrations skipped")
+
+        storage.migrate = _no_migrate  # type: ignore[method-assign]
+
+    await storage.connect()
+
+    # Log the latest session URL so you know what to point a /session shot at.
+    try:
+        db = storage._read_conn()  # noqa: SLF001 — prototype convenience
+        cur = await db.execute("SELECT id, slug FROM races ORDER BY id DESC LIMIT 1")
+        row = await cur.fetchone()
+        if row is not None:
+            slug = row["slug"]
+            path = f"/session/{row['id']}/{slug}" if slug else f"/session/{row['id']}"
+            logger.info("shots: latest session page → {}", path)
+        else:
+            logger.info("shots: no races in DB — /session/N shots will 404")
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        logger.warning("shots: could not resolve latest session ({})", exc)
+
+    port = int(os.environ.get("WEB_PORT", "3002"))
+    app = create_app(storage)
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning"))
+    logger.info("shots: HelmLog web UI on http://127.0.0.1:{}  (AUTH_DISABLED)", port)
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/screenshots/shots.yml
+++ b/scripts/screenshots/shots.yml
@@ -82,11 +82,11 @@
   wait: 800
 
 # --- Individual session detail (richest page: track map, polar heatmap, moments)
-# Needs a real session id — serve.py logs the latest one on boot ("latest
-# session page → /session/N/..."). Edit the id below, or shoot just the polar
-# heatmap panel with the selector crop.
+# Session id 1 always exists after seed_demo.py. Against a real DB, edit the id
+# (serve.py logs the latest one on boot: "latest session page → /session/N/...")
+# or shoot just the polar heatmap panel with the selector crop.
 - output: session.png
-  url: http://localhost:3010/session/35
+  url: http://localhost:3010/session/1
   wait: 3000
   # Crop to just the polar heatmap panel instead of the whole page:
   # selector: "#polar-heatmap-view"

--- a/scripts/screenshots/shots.yml
+++ b/scripts/screenshots/shots.yml
@@ -1,0 +1,92 @@
+# shot-scraper multi-config for the HelmLog web UI (prototype).
+#
+#   uvx shot-scraper multi scripts/screenshots/shots.yml --output-dir docs/screenshots
+#   # or, if installed:  shot-scraper multi scripts/screenshots/shots.yml
+#
+# The first entry boots the app via serve.py (AUTH_DISABLED bypasses login and
+# the DB is copied to a temp file, so this never touches the live logger DB).
+# Point SHOTS_DB at a real/sample DB to get populated screenshots. All shots
+# then hit http://localhost:3010.
+#
+# Timing: map/canvas pages fetch their data as JSON after load and expose no
+# explicit "ready" flag, so we pause with `wait:`. For sharper CI shots against
+# a known-populated DB, swap in a selector-based wait, e.g.
+#   wait_for: document.querySelector('#track-map .leaflet-tile-loaded') !== null
+
+# `exec` + the venv python directly (not `uv run`) so the process shot-scraper
+# kills on cleanup IS the server — otherwise the python grandchild orphans and
+# leaks onto :3010. Run `uv sync` once first so the venv exists.
+# SHOTS_DB is inherited from the environment (defaults to data/logger.db inside
+# serve.py); export it before running to screenshot a populated DB:
+#   SHOTS_DB=/path/to/logger.db uvx shot-scraper multi scripts/screenshots/shots.yml
+- server: exec env AUTH_DISABLED=true WEB_PORT=3010 .venv/bin/python scripts/screenshots/serve.py
+
+# shot-scraper only sleeps 1s after starting a server, but our boot runs schema
+# migrations first (~3s on an empty DB). Block on /healthz until the app answers.
+- sh: 'for i in $(seq 1 60); do curl -sf http://localhost:3010/healthz >/dev/null 2>&1 && exit 0; sleep 0.5; done; echo "helmlog web never came up on :3010" >&2; exit 1'
+
+# --- Landing / dashboard (Leaflet map + canvas sparklines) --------------------
+- output: home.png
+  url: http://localhost:3010/
+  wait: 2500
+
+# Mobile viewport — the UI is mobile-optimised for on-boat crew use.
+- output: home-mobile.png
+  url: http://localhost:3010/
+  width: 390
+  height: 844
+  wait: 2500
+
+# --- Core pages (server-rendered; tables may hydrate via fetch) ---------------
+- output: history.png
+  url: http://localhost:3010/history
+  wait: 800
+
+- output: control.png
+  url: http://localhost:3010/control
+  wait: 800
+
+- output: analysis.png
+  url: http://localhost:3010/analysis
+  wait: 800
+
+- output: sails.png
+  url: http://localhost:3010/sails
+  wait: 800
+
+- output: attention.png
+  url: http://localhost:3010/attention
+  wait: 800
+
+# --- Maneuver analysis (canvas overlay chart) ---------------------------------
+- output: maneuvers.png
+  url: http://localhost:3010/maneuvers
+  wait: 1500
+
+- output: maneuvers-overlay.png
+  url: http://localhost:3010/maneuvers/overlay
+  wait: 2500
+
+- output: compare.png
+  url: http://localhost:3010/compare
+  wait: 1500
+
+# --- Race start line / timer --------------------------------------------------
+- output: race-start.png
+  url: http://localhost:3010/race-start
+  wait: 1500
+
+# --- Admin (example) ----------------------------------------------------------
+- output: admin-settings.png
+  url: http://localhost:3010/admin/settings
+  wait: 800
+
+# --- Individual session detail (richest page: track map, polar heatmap, moments)
+# Needs a real session id — serve.py logs the latest one on boot ("latest
+# session page → /session/N/..."). Edit the id below, or shoot just the polar
+# heatmap panel with the selector crop.
+- output: session.png
+  url: http://localhost:3010/session/35
+  wait: 3000
+  # Crop to just the polar heatmap panel instead of the whole page:
+  # selector: "#polar-heatmap-view"


### PR DESCRIPTION
## What

A [shot-scraper](https://shot-scraper.datasette.io/) harness for reproducible,
headless screenshots of the web UI, **plus a synthetic seeder and a CI workflow
that publishes a git-diffable visual history**. Under `scripts/screenshots/` and
`.github/workflows/`:

- **`serve.py`** — boots the FastAPI app the way `main._web_loop` does (build
  `Storage`, connect, `create_app`, serve on `WEB_PORT`) with no hardware.
  `AUTH_DISABLED=true` so every page is reachable; snapshots the DB **read-only
  via SQLite's backup API** — never touches a live DB.
- **`shots.yml`** — a `shot-scraper multi` config: a `server:` block starts
  `serve.py`, a `/healthz` gate waits for boot, then 13 shots (home + mobile,
  history, control, analysis, sails, attention, maneuvers, overlay, compare,
  race-start, admin, session).
- **`seed_demo.py`** — builds a **PII-free** demo DB using HelmLog's own race
  simulator (the "Synthesize Race" pipeline): track, gauges, wind, maneuvers,
  polar baseline, sails, moments. No real crew names or audio transcripts.
- **`.github/workflows/screenshots.yml`** — on push to `main`: seed the demo DB,
  capture the pages, and commit the PNGs to the orphan **`screenshots`** branch,
  one commit per build.
- **`README.md`** — usage, env vars, gotchas.

## Why

`docs/features.md` and `RELEASES.md` are prose-only and we have no
visual-regression signal on `web.py` / templates / `static/`. This makes UI
captures reproducible and gives a per-build visual history: diffing the
`screenshots` branch between two builds (or against the last `stage/*` tag)
shows exactly which pages changed — which is how release notes can point at
where a feature landed.

## Verification

- Seeder produces 4 races, 54 maneuvers, 126 polar bins, sails, moments — no
  errors, all synthetic.
- Ran the **exact CI command sequence** locally (`seed_demo.py` → `SHOTS_DB=…
  shot-scraper multi shots.yml`): all 13 pages render, `session.png` ~670 KB
  (fully populated — track, gauges, moments, polar scatter, maneuvers, sails),
  exit 0, no leaked processes.
- Also verified against an empty auto-created DB and a real `logger.db`.
- `ruff check` / `ruff format --check` pass; `mypy src/` unaffected (scripts
  live under `scripts/`); `screenshots.yml` is valid YAML.

## Notes

- **Dev/CI only** — pulls Playwright + a browser; never installed on the Pi.
- **`docs/screenshots/` is gitignored** — output shot against a *real* DB
  contains crew names + audio transcripts (PII, `docs/data-licensing.md`). CI
  only ever shoots the synthetic DB, so the `screenshots` branch is PII-free.
- Footguns handled in `serve.py`: WAL-mode DBs need the backup API (a plain copy
  misses the `-wal`), and the fixed temp path needs its `-wal`/`-shm` sidecars
  cleared between runs, else SQLite reports a malformed schema.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
