### PR TITLE
feat(polar): heel-dependent STW correction for off-center paddlewheel (#810)

### DIFF
--- a/scripts/analysis/calibrate_speed_heel.py
+++ b/scripts/analysis/calibrate_speed_heel.py
@@ -20,22 +20,25 @@ that current from the GPS ground vector gives GPS-through-water, and the ratio
 
 is regressed on signed heel to recover ``a`` (intercept) and ``b`` (slope).
 
-The fit is reported on a train/holdout split so the numbers aren't just an
-in-sample echo, along with R² and a sign check: ``b`` is expected POSITIVE
-(port tack heels to starboard, lifting the port-offset wheel so it over-reads
-most). A non-positive ``b`` or a low R² means the linear model doesn't hold —
-prefer a heel→factor lookup table in that case.
+The heel-linear fit is reported on a train/holdout split with R² and a sign
+check. In practice the live data shows the tack bias *reverses sign* with wind
+speed, so the heel slope fits poorly (low R²); the script therefore also emits
+a **TWS × tack table** (per-(TWS bin, tack) mean ``k``) plus a suggested
+**breeze gate** — the model the data actually supports.
 
 Usage
 -----
     uv run python scripts/analysis/calibrate_speed_heel.py [path/to/logger.db]
 
-Writes nothing; prints the fit. Persist the chosen coefficients via the admin
-boat-settings UI (``speed_cal_base`` / ``speed_cal_heel_slope``).
+Writes nothing; prints the fit. Persist the results:
+  * ``speed_cal_table`` (JSON) → app_settings,
+  * ``speed_cal_gate_min_tws`` → boat-settings,
+  * optionally ``speed_cal_base`` / ``speed_cal_heel_slope`` → boat-settings.
 """
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import sqlite3
@@ -103,6 +106,16 @@ def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> li
             (start, end),
         )
     }
+    # Corvo logs true wind as reference=0 (wind_angle_deg IS signed TWA); TWS
+    # feeds the per-bin table fit.
+    wb = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(wind_speed_kts) FROM winds"
+            " WHERE ts BETWEEN ? AND ? AND reference=0 GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
     out = []
     for k, bsp in sp.items():
         cog, sog = cg.get(k, (None, None))
@@ -114,6 +127,7 @@ def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> li
                 "cog": cog,
                 "hdg": hd.get(k),
                 "heel": hl.get(k),
+                "tws": wb.get(k),
             }
         )
     out.sort(key=lambda r: r["k"])
@@ -187,8 +201,12 @@ def race_current(rows: list[dict], legs: list[tuple[int, int]]) -> tuple[float, 
     return (sum(xs) / len(xs), sum(ys) / len(ys))
 
 
-def collect_samples(conn: sqlite3.Connection, race: sqlite3.Row) -> list[tuple[float, float]]:
-    """Return (heel_signed, k_observed) pairs for one race's steady legs."""
+def collect_samples(
+    conn: sqlite3.Connection, race: sqlite3.Row
+) -> list[tuple[float, float, float]]:
+    """Return (heel_signed, k_observed, tws) triples for one race's steady legs.
+
+    ``tws`` is ``nan`` when no true-wind sample aligns to that second."""
     start = get_effective_start(conn, race)
     rows = load_aligned_with_heel(conn, start, str(race["end_utc"]))
     legs = list(detect_steady_legs(rows))
@@ -210,8 +228,43 @@ def collect_samples(conn: sqlite3.Connection, race: sqlite3.Row) -> list[tuple[f
             if gps_stw < MIN_GPS_STW:
                 continue
             k_obs = x["bsp"] / gps_stw
-            samples.append((x["heel"], k_obs))
+            tws = x["tws"] if x["tws"] is not None else float("nan")
+            samples.append((x["heel"], k_obs, tws))
     return samples
+
+
+# TWS bins for the emitted table (kt); tws_max exclusive.
+TABLE_TWS_BINS = [(0, 6), (6, 9), (9, 12), (12, 15), (15, 30)]
+# Minimum per-(bin, tack) samples before a bin is trusted / emitted.
+MIN_BIN_SAMPLES = 100
+
+
+def fit_table(
+    samples: list[tuple[float, float, float]],
+) -> tuple[list[dict[str, float]], float | None]:
+    """Fit per-(TWS bin, tack) mean k and return (table_rows, suggested_gate).
+
+    Tack is taken from heel sign (matching runtime ``resolve_stw``): heel > 0 =
+    port. A bin is emitted only when both tacks clear ``MIN_BIN_SAMPLES``. The
+    suggested gate is the lower edge of the lowest bin where port over-reads
+    starboard (``port_k > stbd_k``) — i.e. where the breeze regime begins and
+    the correction stops flipping sign.
+    """
+    rows: list[dict[str, float]] = []
+    gate: float | None = None
+    for lo, hi in TABLE_TWS_BINS:
+        port = [k for h, k, t in samples if t == t and lo <= t < hi and h > 0]
+        stbd = [k for h, k, t in samples if t == t and lo <= t < hi and h < 0]
+        if len(port) < MIN_BIN_SAMPLES or len(stbd) < MIN_BIN_SAMPLES:
+            continue
+        pk = sum(port) / len(port)
+        sk = sum(stbd) / len(stbd)
+        rows.append(
+            {"tws_min": float(lo), "tws_max": float(hi), "port": round(pk, 4), "stbd": round(sk, 4)}
+        )
+        if gate is None and pk > sk:
+            gate = float(lo)
+    return rows, gate
 
 
 def linreg(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
@@ -254,8 +307,8 @@ def main() -> int:
 
     # Split races into train / holdout (odd/even) so the reported fit is
     # validated out-of-sample rather than just echoing its own data.
-    train: list[tuple[float, float]] = []
-    holdout: list[tuple[float, float]] = []
+    train: list[tuple[float, float, float]] = []
+    holdout: list[tuple[float, float, float]] = []
     used_races = 0
     for idx, race in enumerate(races):
         s = collect_samples(conn, race)
@@ -272,14 +325,14 @@ def main() -> int:
         )
         return 1
 
-    hx = [h for h, _ in train]
-    hy = [k for _, k in train]
+    hx = [h for h, _, _ in train]
+    hy = [k for _, k, _ in train]
     a, b, r2_train = linreg(hx, hy)
-    r2_holdout = r2_on([h for h, _ in holdout], [k for _, k in holdout], a, b)
+    r2_holdout = r2_on([h for h, _, _ in holdout], [k for _, k, _ in holdout], a, b)
 
     # Per-tack means as a sanity read on the residual the model should remove.
-    port = [k for h, k in train if h > 0]
-    stbd = [k for h, k in train if h < 0]
+    port = [k for h, k, _ in train if h > 0]
+    stbd = [k for h, k, _ in train if h < 0]
     port_mean = sum(port) / len(port) if port else float("nan")
     stbd_mean = sum(stbd) / len(stbd) if stbd else float("nan")
 
@@ -287,7 +340,7 @@ def main() -> int:
     print(f"Samples:           train={len(train)}  holdout={len(holdout)}")
     print(f"Observed k (port): {port_mean:.4f}   (starboard): {stbd_mean:.4f}")
     print()
-    print("Fit  k(heel) = a + b * heel_deg   (corrected_STW = raw / k)")
+    print("Heel-linear fit  k(heel) = a + b * heel_deg   (corrected_STW = raw / k)")
     print(f"  a (speed_cal_base)        = {a:.5f}")
     print(f"  b (speed_cal_heel_slope)  = {b:.6f}   per-deg")
     print(f"  R^2 (train)               = {r2_train:.4f}")
@@ -302,10 +355,29 @@ def main() -> int:
         )
     if r2_holdout < 0.05:
         print(
-            "WARNING: near-zero holdout R^2 — heel explains little of the residual."
-            " The linear model may not hold; consider a heel->factor lookup table"
-            " or leave the correction disabled (a=1.0, b=0.0)."
+            "NOTE: near-zero holdout R^2 — heel is a poor *continuous* predictor."
+            " Prefer the TWS x tack table below (speed_cal_table) + breeze gate"
+            " over deploying the heel slope b."
         )
+    print()
+
+    # TWS x tack table — the model the data actually supports. Fit on the full
+    # sample set (train+holdout) since this is the deployable artifact.
+    table, gate = fit_table(train + holdout)
+    print("TWS x tack table (k = paddlewheel / GPS-through-water):")
+    print(f"  {'TWS bin':<10}{'port_k':>9}{'stbd_k':>9}{'port-stbd':>11}")
+    for r in table:
+        diff = (r["port"] - r["stbd"]) / r["stbd"] * 100
+        lo, hi = int(r["tws_min"]), int(r["tws_max"])
+        print(f"  {f'{lo}-{hi}':<10}{r['port']:>9.4f}{r['stbd']:>9.4f}{diff:>+10.1f}%")
+    if not table:
+        print("  (no bin cleared the sample threshold — need more data)")
+    print()
+    print("Paste into app_settings 'speed_cal_table':")
+    print(f"  {json.dumps(table)}")
+    if gate is not None:
+        print(f"Suggested boat_settings 'speed_cal_gate_min_tws': {gate:.0f}")
+        print("  (below this TWS the tack bias reverses sign; gate suppresses it.)")
     return 0
 
 

--- a/scripts/analysis/calibrate_speed_heel.py
+++ b/scripts/analysis/calibrate_speed_heel.py
@@ -22,9 +22,10 @@ is regressed on signed heel to recover ``a`` (intercept) and ``b`` (slope).
 
 The heel-linear fit is reported on a train/holdout split with R² and a sign
 check. In practice the live data shows the tack bias *reverses sign* with wind
-speed, so the heel slope fits poorly (low R²); the script therefore also emits
-a **TWS × tack table** (per-(TWS bin, tack) mean ``k``) plus a suggested
-**breeze gate** — the model the data actually supports.
+speed and differs upwind vs downwind, so the heel slope fits poorly (low R²);
+the script therefore also emits a **TWS × point-of-sail × tack table**
+(per-(TWS bin, upwind/downwind, tack) mean ``k``) plus a suggested **breeze
+gate** — the model the data actually supports.
 
 Usage
 -----
@@ -44,6 +45,7 @@ import os
 import sqlite3
 import sys
 from datetime import datetime, timedelta
+from typing import Any
 
 DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
 
@@ -106,12 +108,12 @@ def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> li
             (start, end),
         )
     }
-    # Corvo logs true wind as reference=0 (wind_angle_deg IS signed TWA); TWS
-    # feeds the per-bin table fit.
+    # Corvo logs true wind as reference=0 (wind_angle_deg IS signed TWA); TWS +
+    # |TWA| feed the per-(TWS bin, point-of-sail) table fit.
     wb = {
-        r[0]: r[1]
+        r[0]: (r[1], r[2])
         for r in conn.execute(
-            "SELECT substr(ts,1,19), AVG(wind_speed_kts) FROM winds"
+            "SELECT substr(ts,1,19), AVG(wind_speed_kts), AVG(wind_angle_deg) FROM winds"
             " WHERE ts BETWEEN ? AND ? AND reference=0 GROUP BY substr(ts,1,19)",
             (start, end),
         )
@@ -119,6 +121,7 @@ def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> li
     out = []
     for k, bsp in sp.items():
         cog, sog = cg.get(k, (None, None))
+        w = wb.get(k)
         out.append(
             {
                 "k": k,
@@ -127,7 +130,8 @@ def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> li
                 "cog": cog,
                 "hdg": hd.get(k),
                 "heel": hl.get(k),
-                "tws": wb.get(k),
+                "tws": w[0] if w else None,
+                "twa_abs": abs(w[1]) if w else None,
             }
         )
     out.sort(key=lambda r: r["k"])
@@ -201,12 +205,23 @@ def race_current(rows: list[dict], legs: list[tuple[int, int]]) -> tuple[float, 
     return (sum(xs) / len(xs), sum(ys) / len(ys))
 
 
-def collect_samples(
-    conn: sqlite3.Connection, race: sqlite3.Row
-) -> list[tuple[float, float, float]]:
-    """Return (heel_signed, k_observed, tws) triples for one race's steady legs.
+# |TWA| below this is upwind, at or above is downwind (matches
+# polar.UPWIND_CUTOFF_DEG / _point_of_sail).
+UPWIND_CUTOFF_DEG = 90.0
 
-    ``tws`` is ``nan`` when no true-wind sample aligns to that second."""
+
+def _point_of_sail(twa_abs: float) -> str:
+    return "upwind" if twa_abs < UPWIND_CUTOFF_DEG else "downwind"
+
+
+# One collected sample: (heel_signed, k_observed, tws, point_of_sail).
+Sample = tuple[float, float, float, str]
+
+
+def collect_samples(conn: sqlite3.Connection, race: sqlite3.Row) -> list[Sample]:
+    """Return (heel_signed, k_observed, tws, point_of_sail) samples for one
+    race's steady legs. Samples without a true-wind fix (no TWS/TWA) are
+    dropped, since the table fit is keyed on both."""
     start = get_effective_start(conn, race)
     rows = load_aligned_with_heel(conn, start, str(race["end_utc"]))
     legs = list(detect_steady_legs(rows))
@@ -216,10 +231,12 @@ def collect_samples(
     if cur is None:
         return []
     cx, cy = cur
-    samples = []
+    samples: list[Sample] = []
     for a, b in legs:
         for x in rows[a:b]:
             if x["sog"] is None or x["cog"] is None or x["heel"] is None:
+                continue
+            if x["tws"] is None or x["twa_abs"] is None:
                 continue
             # GPS-through-water = ground velocity minus the estimated current.
             gx = x["sog"] * math.sin(math.radians(x["cog"])) - cx
@@ -228,42 +245,47 @@ def collect_samples(
             if gps_stw < MIN_GPS_STW:
                 continue
             k_obs = x["bsp"] / gps_stw
-            tws = x["tws"] if x["tws"] is not None else float("nan")
-            samples.append((x["heel"], k_obs, tws))
+            samples.append((x["heel"], k_obs, x["tws"], _point_of_sail(x["twa_abs"])))
     return samples
 
 
 # TWS bins for the emitted table (kt); tws_max exclusive.
 TABLE_TWS_BINS = [(0, 6), (6, 9), (9, 12), (12, 15), (15, 30)]
-# Minimum per-(bin, tack) samples before a bin is trusted / emitted.
+# Minimum per-(bin, pos, tack) samples before a bin is trusted / emitted.
 MIN_BIN_SAMPLES = 100
 
 
-def fit_table(
-    samples: list[tuple[float, float, float]],
-) -> tuple[list[dict[str, float]], float | None]:
-    """Fit per-(TWS bin, tack) mean k and return (table_rows, suggested_gate).
+def fit_table(samples: list[Sample]) -> tuple[list[dict[str, Any]], float | None]:
+    """Fit per-(TWS bin, point-of-sail, tack) mean k and return
+    (table_rows, suggested_gate).
 
     Tack is taken from heel sign (matching runtime ``resolve_stw``): heel > 0 =
-    port. A bin is emitted only when both tacks clear ``MIN_BIN_SAMPLES``. The
-    suggested gate is the lower edge of the lowest bin where port over-reads
-    starboard (``port_k > stbd_k``) — i.e. where the breeze regime begins and
-    the correction stops flipping sign.
+    port. A (bin, pos) cell is emitted only when both tacks clear
+    ``MIN_BIN_SAMPLES``. The suggested gate is the lower edge of the lowest
+    **upwind** bin where port over-reads starboard (``port_k > stbd_k``) — where
+    the breeze regime begins and the tack bias stops flipping sign.
     """
-    rows: list[dict[str, float]] = []
+    rows: list[dict[str, Any]] = []
     gate: float | None = None
     for lo, hi in TABLE_TWS_BINS:
-        port = [k for h, k, t in samples if t == t and lo <= t < hi and h > 0]
-        stbd = [k for h, k, t in samples if t == t and lo <= t < hi and h < 0]
-        if len(port) < MIN_BIN_SAMPLES or len(stbd) < MIN_BIN_SAMPLES:
-            continue
-        pk = sum(port) / len(port)
-        sk = sum(stbd) / len(stbd)
-        rows.append(
-            {"tws_min": float(lo), "tws_max": float(hi), "port": round(pk, 4), "stbd": round(sk, 4)}
-        )
-        if gate is None and pk > sk:
-            gate = float(lo)
+        for pos in ("upwind", "downwind"):
+            port = [k for h, k, t, p in samples if p == pos and lo <= t < hi and h > 0]
+            stbd = [k for h, k, t, p in samples if p == pos and lo <= t < hi and h < 0]
+            if len(port) < MIN_BIN_SAMPLES or len(stbd) < MIN_BIN_SAMPLES:
+                continue
+            pk = sum(port) / len(port)
+            sk = sum(stbd) / len(stbd)
+            rows.append(
+                {
+                    "tws_min": float(lo),
+                    "tws_max": float(hi),
+                    "pos": pos,
+                    "port": round(pk, 4),
+                    "stbd": round(sk, 4),
+                }
+            )
+            if gate is None and pos == "upwind" and pk > sk:
+                gate = float(lo)
     return rows, gate
 
 
@@ -307,8 +329,8 @@ def main() -> int:
 
     # Split races into train / holdout (odd/even) so the reported fit is
     # validated out-of-sample rather than just echoing its own data.
-    train: list[tuple[float, float, float]] = []
-    holdout: list[tuple[float, float, float]] = []
+    train: list[Sample] = []
+    holdout: list[Sample] = []
     used_races = 0
     for idx, race in enumerate(races):
         s = collect_samples(conn, race)
@@ -325,14 +347,14 @@ def main() -> int:
         )
         return 1
 
-    hx = [h for h, _, _ in train]
-    hy = [k for _, k, _ in train]
+    hx = [h for h, _, _, _ in train]
+    hy = [k for _, k, _, _ in train]
     a, b, r2_train = linreg(hx, hy)
-    r2_holdout = r2_on([h for h, _, _ in holdout], [k for _, k, _ in holdout], a, b)
+    r2_holdout = r2_on([h for h, _, _, _ in holdout], [k for _, k, _, _ in holdout], a, b)
 
     # Per-tack means as a sanity read on the residual the model should remove.
-    port = [k for h, k, _ in train if h > 0]
-    stbd = [k for h, k, _ in train if h < 0]
+    port = [k for h, k, _, _ in train if h > 0]
+    stbd = [k for h, k, _, _ in train if h < 0]
     port_mean = sum(port) / len(port) if port else float("nan")
     stbd_mean = sum(stbd) / len(stbd) if stbd else float("nan")
 
@@ -356,28 +378,28 @@ def main() -> int:
     if r2_holdout < 0.05:
         print(
             "NOTE: near-zero holdout R^2 — heel is a poor *continuous* predictor."
-            " Prefer the TWS x tack table below (speed_cal_table) + breeze gate"
-            " over deploying the heel slope b."
+            " Prefer the TWS x PoS x tack table below (speed_cal_table) + breeze"
+            " gate over deploying the heel slope b."
         )
     print()
 
-    # TWS x tack table — the model the data actually supports. Fit on the full
-    # sample set (train+holdout) since this is the deployable artifact.
+    # TWS × point-of-sail × tack table — the model the data supports. Fit on the
+    # full sample set (train+holdout) since this is the deployable artifact.
     table, gate = fit_table(train + holdout)
-    print("TWS x tack table (k = paddlewheel / GPS-through-water):")
-    print(f"  {'TWS bin':<10}{'port_k':>9}{'stbd_k':>9}{'port-stbd':>11}")
+    print("TWS x PoS x tack table (k = paddlewheel / GPS-through-water):")
+    print(f"  {'TWS bin':<9}{'PoS':<10}{'port_k':>9}{'stbd_k':>9}{'port-stbd':>11}")
     for r in table:
         diff = (r["port"] - r["stbd"]) / r["stbd"] * 100
         lo, hi = int(r["tws_min"]), int(r["tws_max"])
-        print(f"  {f'{lo}-{hi}':<10}{r['port']:>9.4f}{r['stbd']:>9.4f}{diff:>+10.1f}%")
+        print(f"  {f'{lo}-{hi}':<9}{r['pos']:<10}{r['port']:>9.4f}{r['stbd']:>9.4f}{diff:>+10.1f}%")
     if not table:
-        print("  (no bin cleared the sample threshold — need more data)")
+        print("  (no (bin, PoS) cell cleared the sample threshold — need more data)")
     print()
     print("Paste into app_settings 'speed_cal_table':")
     print(f"  {json.dumps(table)}")
     if gate is not None:
         print(f"Suggested boat_settings 'speed_cal_gate_min_tws': {gate:.0f}")
-        print("  (below this TWS the tack bias reverses sign; gate suppresses it.)")
+        print("  (below this TWS the upwind tack bias reverses sign; gate suppresses it.)")
     return 0
 
 

--- a/scripts/analysis/calibrate_speed_heel.py
+++ b/scripts/analysis/calibrate_speed_heel.py
@@ -1,0 +1,313 @@
+"""Fit the heel-dependent STW correction coefficients (#810).
+
+Corvo's paddlewheel is offset ~10 cm to port, so under heel it over-reads and
+the error is tack-dependent. This script fits the read-time model applied by
+``helmlog.speed_cal.corrected_stw``:
+
+    k(heel) = a + b * heel_signed          # heel_signed = attitudes.heel_deg,
+                                           # +ve = starboard-down = port tack
+    corrected_STW = raw_STW / k(heel)
+
+Method
+------
+For each completed race, the true water current is estimated from steady legs
+(heading stable, BSP > threshold) by the same least-squares vector average
+``full_analysis.py`` uses — averaging over both tacks lets the paddlewheel's
+tack-dependent error largely cancel, leaving a clean current vector. Removing
+that current from the GPS ground vector gives GPS-through-water, and the ratio
+
+    k_observed = paddlewheel_STW / GPS-through-water
+
+is regressed on signed heel to recover ``a`` (intercept) and ``b`` (slope).
+
+The fit is reported on a train/holdout split so the numbers aren't just an
+in-sample echo, along with R² and a sign check: ``b`` is expected POSITIVE
+(port tack heels to starboard, lifting the port-offset wheel so it over-reads
+most). A non-positive ``b`` or a low R² means the linear model doesn't hold —
+prefer a heel→factor lookup table in that case.
+
+Usage
+-----
+    uv run python scripts/analysis/calibrate_speed_heel.py [path/to/logger.db]
+
+Writes nothing; prints the fit. Persist the chosen coefficients via the admin
+boat-settings UI (``speed_cal_base`` / ``speed_cal_heel_slope``).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+
+DB = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HELMLOG_DB", "data/logger.db")
+
+# Steady-leg gates (mirror full_analysis.py so the current estimate matches).
+MIN_DURATION_S = 60
+MAX_HDG_SPREAD = 15.0
+MIN_BSP = 2.0
+# Drop implausible per-sample current vectors before averaging (kt).
+MAX_CURRENT_KT = 4.0
+# GPS-through-water below this is too slow to trust the ratio (kt).
+MIN_GPS_STW = 3.0
+
+
+def angle_diff(a: float, b: float) -> float:
+    return (a - b + 540) % 360 - 180
+
+
+def hdg_spread(values: list[float]) -> float:
+    """Peak-to-peak heading spread, wrap-aware."""
+    if len(values) < 2:
+        return 0.0
+    xs = [math.sin(math.radians(v)) for v in values]
+    ys = [math.cos(math.radians(v)) for v in values]
+    mean_dir = math.degrees(math.atan2(sum(xs) / len(xs), sum(ys) / len(ys)))
+    deltas = [abs(angle_diff(v, mean_dir)) for v in values]
+    return 2 * max(deltas)
+
+
+def load_aligned_with_heel(conn: sqlite3.Connection, start: str, end: str) -> list[dict]:
+    """Per-second aligned BSP / SOG / COG / HDG / heel over [start, end]."""
+    sp = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(speed_kts) FROM speeds"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    cg = {
+        r[0]: (r[1], r[2])
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(cog_deg), AVG(sog_kts) FROM cogsog"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hd = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heading_deg) FROM headings"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    hl = {
+        r[0]: r[1]
+        for r in conn.execute(
+            "SELECT substr(ts,1,19), AVG(heel_deg) FROM attitudes"
+            " WHERE ts BETWEEN ? AND ? GROUP BY substr(ts,1,19)",
+            (start, end),
+        )
+    }
+    out = []
+    for k, bsp in sp.items():
+        cog, sog = cg.get(k, (None, None))
+        out.append(
+            {
+                "k": k,
+                "bsp": bsp,
+                "sog": sog,
+                "cog": cog,
+                "hdg": hd.get(k),
+                "heel": hl.get(k),
+            }
+        )
+    out.sort(key=lambda r: r["k"])
+    return out
+
+
+def get_effective_start(conn: sqlite3.Connection, race: sqlite3.Row) -> str:
+    """Vakaros gun when available, else start_utc + 5 min (skip pre-start)."""
+    if race["vakaros_session_id"] is not None:
+        gun = conn.execute(
+            "SELECT ts FROM vakaros_race_events"
+            " WHERE session_id=? AND event_type='race_start' AND ts BETWEEN ? AND ?"
+            " ORDER BY ts DESC LIMIT 1",
+            (race["vakaros_session_id"], race["start_utc"], race["end_utc"]),
+        ).fetchone()
+        if gun is not None:
+            return str(gun["ts"])
+    db_start = datetime.fromisoformat(race["start_utc"])
+    return (db_start + timedelta(minutes=5)).isoformat()
+
+
+def detect_steady_legs(rows: list[dict]):
+    """Yield (start_idx, end_idx) of contiguous steady-heading segments."""
+    n = len(rows)
+    if n < MIN_DURATION_S:
+        return
+    i = 0
+    while i < n - MIN_DURATION_S:
+        if rows[i]["hdg"] is None or rows[i]["bsp"] < MIN_BSP or rows[i]["sog"] is None:
+            i += 1
+            continue
+        j = i + 1
+        while j < n:
+            if rows[j]["hdg"] is None or rows[j]["bsp"] < MIN_BSP or rows[j]["sog"] is None:
+                break
+            window = [rows[k]["hdg"] for k in range(i, j + 1) if rows[k]["hdg"] is not None]
+            if hdg_spread(window) > MAX_HDG_SPREAD:
+                break
+            j += 1
+        if j - i >= MIN_DURATION_S:
+            yield (i, j)
+            i = j
+        else:
+            i += 1
+
+
+def race_current(rows: list[dict], legs: list[tuple[int, int]]) -> tuple[float, float] | None:
+    """Least-squares mean current vector (east, north) over the race's steady
+    legs — the same averaging full_analysis.py uses, so the paddlewheel's
+    tack-dependent error largely cancels across port/starboard."""
+    xs, ys = [], []
+    for a, b in legs:
+        lxs, lys = [], []
+        for x in rows[a:b]:
+            if x["sog"] is None or x["cog"] is None or x["hdg"] is None:
+                continue
+            cx = x["sog"] * math.sin(math.radians(x["cog"])) - x["bsp"] * math.sin(
+                math.radians(x["hdg"])
+            )
+            cy = x["sog"] * math.cos(math.radians(x["cog"])) - x["bsp"] * math.cos(
+                math.radians(x["hdg"])
+            )
+            if math.hypot(cx, cy) < MAX_CURRENT_KT:
+                lxs.append(cx)
+                lys.append(cy)
+        if lxs:
+            xs.append(sum(lxs) / len(lxs))
+            ys.append(sum(lys) / len(lys))
+    if not xs:
+        return None
+    return (sum(xs) / len(xs), sum(ys) / len(ys))
+
+
+def collect_samples(conn: sqlite3.Connection, race: sqlite3.Row) -> list[tuple[float, float]]:
+    """Return (heel_signed, k_observed) pairs for one race's steady legs."""
+    start = get_effective_start(conn, race)
+    rows = load_aligned_with_heel(conn, start, str(race["end_utc"]))
+    legs = list(detect_steady_legs(rows))
+    if not legs:
+        return []
+    cur = race_current(rows, legs)
+    if cur is None:
+        return []
+    cx, cy = cur
+    samples = []
+    for a, b in legs:
+        for x in rows[a:b]:
+            if x["sog"] is None or x["cog"] is None or x["heel"] is None:
+                continue
+            # GPS-through-water = ground velocity minus the estimated current.
+            gx = x["sog"] * math.sin(math.radians(x["cog"])) - cx
+            gy = x["sog"] * math.cos(math.radians(x["cog"])) - cy
+            gps_stw = math.hypot(gx, gy)
+            if gps_stw < MIN_GPS_STW:
+                continue
+            k_obs = x["bsp"] / gps_stw
+            samples.append((x["heel"], k_obs))
+    return samples
+
+
+def linreg(xs: list[float], ys: list[float]) -> tuple[float, float, float]:
+    """Ordinary least squares. Returns (intercept a, slope b, R²)."""
+    n = len(xs)
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    sxx = sum((x - mx) ** 2 for x in xs)
+    if sxx == 0:
+        return (my, 0.0, 0.0)
+    b = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True)) / sxx
+    a = my - b * mx
+    ss_tot = sum((y - my) ** 2 for y in ys)
+    ss_res = sum((y - (a + b * x)) ** 2 for x, y in zip(xs, ys, strict=True))
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    return (a, b, r2)
+
+
+def r2_on(xs: list[float], ys: list[float], a: float, b: float) -> float:
+    """R² of the (a, b) model evaluated on a holdout set."""
+    n = len(ys)
+    if n == 0:
+        return 0.0
+    my = sum(ys) / n
+    ss_tot = sum((y - my) ** 2 for y in ys)
+    ss_res = sum((y - (a + b * x)) ** 2 for x, y in zip(xs, ys, strict=True))
+    return 1 - ss_res / ss_tot if ss_tot > 0 else 0.0
+
+
+def main() -> int:
+    conn = sqlite3.connect(DB)
+    conn.row_factory = sqlite3.Row
+    races = conn.execute(
+        "SELECT id, name, start_utc, end_utc, vakaros_session_id FROM races"
+        " WHERE end_utc IS NOT NULL AND source='live' ORDER BY start_utc"
+    ).fetchall()
+    if not races:
+        print("No completed source='live' races found — nothing to fit.")
+        return 1
+
+    # Split races into train / holdout (odd/even) so the reported fit is
+    # validated out-of-sample rather than just echoing its own data.
+    train: list[tuple[float, float]] = []
+    holdout: list[tuple[float, float]] = []
+    used_races = 0
+    for idx, race in enumerate(races):
+        s = collect_samples(conn, race)
+        if not s:
+            continue
+        used_races += 1
+        (holdout if idx % 4 == 0 else train).extend(s)
+    conn.close()
+
+    if len(train) < 100 or len(holdout) < 30:
+        print(
+            f"Too few steady-leg samples (train={len(train)}, holdout={len(holdout)})"
+            f" from {used_races} races — need cleaner/longer data. Aborting."
+        )
+        return 1
+
+    hx = [h for h, _ in train]
+    hy = [k for _, k in train]
+    a, b, r2_train = linreg(hx, hy)
+    r2_holdout = r2_on([h for h, _ in holdout], [k for _, k in holdout], a, b)
+
+    # Per-tack means as a sanity read on the residual the model should remove.
+    port = [k for h, k in train if h > 0]
+    stbd = [k for h, k in train if h < 0]
+    port_mean = sum(port) / len(port) if port else float("nan")
+    stbd_mean = sum(stbd) / len(stbd) if stbd else float("nan")
+
+    print(f"Races used:        {used_races}")
+    print(f"Samples:           train={len(train)}  holdout={len(holdout)}")
+    print(f"Observed k (port): {port_mean:.4f}   (starboard): {stbd_mean:.4f}")
+    print()
+    print("Fit  k(heel) = a + b * heel_deg   (corrected_STW = raw / k)")
+    print(f"  a (speed_cal_base)        = {a:.5f}")
+    print(f"  b (speed_cal_heel_slope)  = {b:.6f}   per-deg")
+    print(f"  R^2 (train)               = {r2_train:.4f}")
+    print(f"  R^2 (holdout)             = {r2_holdout:.4f}")
+    print()
+
+    if b <= 0:
+        print(
+            "WARNING: slope b <= 0 contradicts the expected sign (port tack should"
+            " over-read most). Check the heel sign convention and the current"
+            " estimate before trusting this fit."
+        )
+    if r2_holdout < 0.05:
+        print(
+            "WARNING: near-zero holdout R^2 — heel explains little of the residual."
+            " The linear model may not hold; consider a heel->factor lookup table"
+            " or leave the correction disabled (a=1.0, b=0.0)."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/helmlog/boat_settings.py
+++ b/src/helmlog/boat_settings.py
@@ -90,6 +90,24 @@ PARAMETERS: tuple[ParameterDef, ...] = (
         "number",
         "instrument_calibration",
     ),
+    # Heel-dependent STW correction for the off-center paddlewheel (#810).
+    # corrected_STW = raw / (speed_cal_base + speed_cal_heel_slope * heel_deg).
+    # Defaults (1.0 / 0.0) are an exact no-op; fit via
+    # scripts/analysis/calibrate_speed_heel.py.
+    ParameterDef(
+        "speed_cal_base",
+        "Speed cal base (a)",
+        "",
+        "number",
+        "instrument_calibration",
+    ),
+    ParameterDef(
+        "speed_cal_heel_slope",
+        "Speed cal heel slope (b)",
+        "per-deg",
+        "number",
+        "instrument_calibration",
+    ),
     ParameterDef(
         "rudder_angle_offset",
         "Rudder angle offset",

--- a/src/helmlog/boat_settings.py
+++ b/src/helmlog/boat_settings.py
@@ -108,6 +108,18 @@ PARAMETERS: tuple[ParameterDef, ...] = (
         "number",
         "instrument_calibration",
     ),
+    # Breeze gate for the STW correction (#810): below this TWS the tack/heel
+    # term is suppressed (light air's paddlewheel bias is noisy and reverses
+    # sign), leaving only the base factor. 0 disables the gate. The TWS × tack
+    # table itself is a JSON blob in app_settings ("speed_cal_table"), not a
+    # flat parameter.
+    ParameterDef(
+        "speed_cal_gate_min_tws",
+        "Speed cal breeze gate (min TWS)",
+        "kt",
+        "number",
+        "instrument_calibration",
+    ),
     ParameterDef(
         "rudder_angle_offset",
         "Rudder angle offset",

--- a/src/helmlog/current.py
+++ b/src/helmlog/current.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import math
 
+from helmlog.speed_cal import corrected_stw
+
 
 def _polar_to_ne(speed: float, compass_deg: float) -> tuple[float, float]:
     rad = math.radians(compass_deg)
@@ -28,6 +30,8 @@ def compute_set_drift(
     leeway_k: float | None = None,
     compass_offset_port: float = 0.0,
     compass_offset_stbd: float = 0.0,
+    speed_cal_base: float = 1.0,
+    speed_cal_heel_slope: float = 0.0,
 ) -> tuple[float, float] | None:
     """Return (set_deg, drift_kts) or None if any required input is missing.
 
@@ -71,8 +75,21 @@ def compute_set_drift(
     ``boat_settings.compass_offset_port`` /
     ``boat_settings.compass_offset_stbd`` and are typically derived
     from a joint-fit against a session's maneuvers.
+
+    Heel-dependent STW correction
+    -----------------------------
+    Corvo's paddlewheel is offset to port, so it over-reads under heel and
+    the error is tack-dependent (#810). ``speed_cal_base`` /
+    ``speed_cal_heel_slope`` scale STW by ``1 / (base + slope * heel_deg)``
+    before the water vector is formed, so both the leeway denominator and
+    the current subtraction use corrected boatspeed. Defaults (1.0 / 0.0)
+    are an exact no-op. See ``helmlog.speed_cal``.
     """
     if sog is None or cog is None or stw is None or hdg is None:
+        return None
+
+    stw = corrected_stw(stw, heel_deg, speed_cal_base, speed_cal_heel_slope)
+    if stw is None:
         return None
 
     if heel_deg is not None and leeway_k is not None and leeway_k != 0.0:

--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -397,21 +397,25 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
             ref = int(wind_row.get("reference", -1))
             wind_angle = float(wind_row["wind_angle_deg"])
             tws_kts = float(wind_row["wind_speed_kts"])
-            # Heel/TWS-corrected STW (#810) — self-consistent with the grade path.
-            bsp_kts = resolve_stw(
-                float(spd_row["speed_kts"]),
-                heel_by_s.get(sk),
-                tws_kts,
-                storage._speed_cal,
-            )
-            if bsp_kts is None:
-                continue
 
             hdg_row = hdg_by_s.get(sk)
             heading = float(hdg_row["heading_deg"]) if hdg_row else None
 
             twa = _compute_twa(wind_angle, ref, heading)
             if twa is None:
+                continue
+
+            # Heel/TWS/point-of-sail-corrected STW (#810) — self-consistent with
+            # the grade path. TWA is known here, so the correction can pick the
+            # right upwind/downwind table bin.
+            bsp_kts = resolve_stw(
+                float(spd_row["speed_kts"]),
+                heel_by_s.get(sk),
+                tws_kts,
+                storage._speed_cal,
+                _point_of_sail(twa),
+            )
+            if bsp_kts is None:
                 continue
 
             tb = _tws_bin(tws_kts)
@@ -593,15 +597,6 @@ async def session_polar_comparison(
         ref = int(wind_row.get("reference", -1))
         wind_angle = float(wind_row["wind_angle_deg"])
         tws_kts = float(wind_row["wind_speed_kts"])
-        # Heel/TWS-corrected STW (#810) so this comparison matches the baseline.
-        bsp_kts = resolve_stw(
-            float(spd_row["speed_kts"]),
-            heel_by_s.get(sk),
-            tws_kts,
-            storage._speed_cal,
-        )
-        if bsp_kts is None:
-            continue
 
         hdg_row = hdg_by_s.get(sk)
         heading = float(hdg_row["heading_deg"]) if hdg_row else None
@@ -610,10 +605,22 @@ async def session_polar_comparison(
         if twa_tack is None:
             continue
         twa, tack = twa_tack
+        pos = _point_of_sail(twa)
+
+        # Heel/TWS/point-of-sail-corrected STW (#810) so this comparison matches
+        # the (also-corrected) baseline.
+        bsp_kts = resolve_stw(
+            float(spd_row["speed_kts"]),
+            heel_by_s.get(sk),
+            tws_kts,
+            storage._speed_cal,
+            pos,
+        )
+        if bsp_kts is None:
+            continue
 
         tb = _tws_bin(tws_kts)
         ab = _twa_bin(twa)
-        pos = _point_of_sail(twa)
         bin_samples[(tb, ab, pos, tack)].append(bsp_kts)
 
     # Load full baseline (symmetric, no min_sessions gate — #534)
@@ -805,9 +812,17 @@ def _grade_segments_sync(
         hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
         tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
 
-        # Correct each speed sample by its heel and the segment's mean TWS, so
-        # the breeze gate and TWS × tack table apply consistently with the
-        # baseline (#810).
+        twa: float | None = None
+        if wind_in:
+            wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
+            ref = int(wind_in[0][1].get("reference", -1))
+            heading_mean = _mean(hdg_in) if ref == _WIND_REF_NORTH else None
+            twa = _compute_twa(wind_angle_mean, ref, heading_mean)
+        seg_pos = _point_of_sail(twa) if twa is not None else None
+
+        # Correct each speed sample by its heel and the segment's mean TWS +
+        # point-of-sail, so the gate and TWS × PoS × tack table apply
+        # consistently with the baseline (#810).
         spd_in = [
             c
             for ts, r in speeds_dt
@@ -818,6 +833,7 @@ def _grade_segments_sync(
                     heel_by_s.get(str(r["ts"])[:19]),
                     tws,
                     cal,
+                    seg_pos,
                 )
             )
             is not None
@@ -826,12 +842,6 @@ def _grade_segments_sync(
         lat, lon = _interp_position(positions, t_mid) if positions else (None, None)
 
         bsp = _mean(spd_in)
-        twa: float | None = None
-        if wind_in:
-            wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
-            ref = int(wind_in[0][1].get("reference", -1))
-            heading_mean = _mean(hdg_in) if ref == _WIND_REF_NORTH else None
-            twa = _compute_twa(wind_angle_mean, ref, heading_mean)
 
         target: float | None = None
         pct: float | None = None

--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
 
-from helmlog.speed_cal import corrected_stw
+from helmlog.speed_cal import SpeedCal, resolve_stw
 
 if TYPE_CHECKING:
     from helmlog.storage import Storage
@@ -397,12 +397,12 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
             ref = int(wind_row.get("reference", -1))
             wind_angle = float(wind_row["wind_angle_deg"])
             tws_kts = float(wind_row["wind_speed_kts"])
-            # Heel-corrected STW (#810) — self-consistent with the grade path.
-            bsp_kts = corrected_stw(
+            # Heel/TWS-corrected STW (#810) — self-consistent with the grade path.
+            bsp_kts = resolve_stw(
                 float(spd_row["speed_kts"]),
                 heel_by_s.get(sk),
-                storage._speed_cal_base,
-                storage._speed_cal_heel_slope,
+                tws_kts,
+                storage._speed_cal,
             )
             if bsp_kts is None:
                 continue
@@ -593,12 +593,12 @@ async def session_polar_comparison(
         ref = int(wind_row.get("reference", -1))
         wind_angle = float(wind_row["wind_angle_deg"])
         tws_kts = float(wind_row["wind_speed_kts"])
-        # Heel-corrected STW (#810) so this comparison matches the baseline.
-        bsp_kts = corrected_stw(
+        # Heel/TWS-corrected STW (#810) so this comparison matches the baseline.
+        bsp_kts = resolve_stw(
             float(spd_row["speed_kts"]),
             heel_by_s.get(sk),
-            storage._speed_cal_base,
-            storage._speed_cal_heel_slope,
+            tws_kts,
+            storage._speed_cal,
         )
         if bsp_kts is None:
             continue
@@ -767,17 +767,18 @@ def _grade_segments_sync(
     polar_map: dict[tuple[int, int], dict[str, Any]],
     min_sessions: int = 3,
     attitudes: list[dict[str, Any]] | None = None,
-    speed_cal_base: float = 1.0,
-    speed_cal_heel_slope: float = 0.0,
+    cal: SpeedCal | None = None,
 ) -> tuple[list[GradedSegment], dict[str, int]]:
     """Pure-Python segmentation + grading. No I/O; safe to run in a worker thread.
 
     *polar_map* is the full (tws_bin, twa_bin) → baseline row mapping, pre-fetched
     so no ``await`` is needed inside the loop (#603).
 
-    Speed samples are heel-corrected (#810) before averaging so the graded BSP
-    matches the (also-corrected) baseline.
+    Speed samples are STW-corrected (#810) using each sample's heel and the
+    segment's mean TWS (so the gate + TWS × tack table apply) before averaging,
+    keeping the graded BSP self-consistent with the corrected baseline.
     """
+    cal = cal or SpeedCal()
 
     def _ts_of(rec: dict[str, Any]) -> datetime:
         return datetime.fromisoformat(str(rec["ts"])).replace(tzinfo=UTC)
@@ -800,27 +801,31 @@ def _grade_segments_sync(
         seg_end = min(end, seg_start + timedelta(seconds=width))
         t_mid = seg_start + (seg_end - seg_start) / 2
 
+        wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
+        hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
+        tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
+
+        # Correct each speed sample by its heel and the segment's mean TWS, so
+        # the breeze gate and TWS × tack table apply consistently with the
+        # baseline (#810).
         spd_in = [
             c
             for ts, r in speeds_dt
             if seg_start <= ts < seg_end
             and (
-                c := corrected_stw(
+                c := resolve_stw(
                     float(r["speed_kts"]),
                     heel_by_s.get(str(r["ts"])[:19]),
-                    speed_cal_base,
-                    speed_cal_heel_slope,
+                    tws,
+                    cal,
                 )
             )
             is not None
         ]
-        wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
-        hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
 
         lat, lon = _interp_position(positions, t_mid) if positions else (None, None)
 
         bsp = _mean(spd_in)
-        tws = _mean([float(r["wind_speed_kts"]) for _, r in wind_in])
         twa: float | None = None
         if wind_in:
             wind_angle_mean = sum(float(r["wind_angle_deg"]) for _, r in wind_in) / len(wind_in)
@@ -970,8 +975,7 @@ async def grade_session_segments(
         positions,
         polar_map,
         attitudes=attitudes,
-        speed_cal_base=storage._speed_cal_base,
-        speed_cal_heel_slope=storage._speed_cal_heel_slope,
+        cal=storage._speed_cal,
     )
 
     # Persist cache

--- a/src/helmlog/polar.py
+++ b/src/helmlog/polar.py
@@ -18,8 +18,20 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
 
+from helmlog.speed_cal import corrected_stw
+
 if TYPE_CHECKING:
     from helmlog.storage import Storage
+
+
+def _heel_by_second(attitudes: list[dict[str, Any]]) -> dict[str, float]:
+    """Index heel by truncated-second key (first fix wins), matching the
+    per-second join used for speeds/winds/headings (#810)."""
+    out: dict[str, float] = {}
+    for a in attitudes:
+        out.setdefault(str(a["ts"])[:19], float(a["heel_deg"]))
+    return out
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -355,6 +367,8 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
         speeds = await storage.query_range("speeds", start, end)
         winds = await storage.query_range("winds", start, end)
         headings = await storage.query_range("headings", start, end)
+        attitudes = await storage.query_range("attitudes", start, end)
+        heel_by_s = _heel_by_second(attitudes)
 
         # Index by truncated second key (first 19 chars of ISO string)
         spd_by_s: dict[str, dict[str, Any]] = {}
@@ -383,7 +397,15 @@ async def build_polar_baseline(storage: Storage, min_sessions: int = 3) -> int:
             ref = int(wind_row.get("reference", -1))
             wind_angle = float(wind_row["wind_angle_deg"])
             tws_kts = float(wind_row["wind_speed_kts"])
-            bsp_kts = float(spd_row["speed_kts"])
+            # Heel-corrected STW (#810) — self-consistent with the grade path.
+            bsp_kts = corrected_stw(
+                float(spd_row["speed_kts"]),
+                heel_by_s.get(sk),
+                storage._speed_cal_base,
+                storage._speed_cal_heel_slope,
+            )
+            if bsp_kts is None:
+                continue
 
             hdg_row = hdg_by_s.get(sk)
             heading = float(hdg_row["heading_deg"]) if hdg_row else None
@@ -543,6 +565,8 @@ async def session_polar_comparison(
     speeds = await storage.query_range("speeds", start, end)
     winds = await storage.query_range("winds", start, end)
     headings = await storage.query_range("headings", start, end)
+    attitudes = await storage.query_range("attitudes", start, end)
+    heel_by_s = _heel_by_second(attitudes)
 
     spd_by_s: dict[str, dict[str, Any]] = {}
     for s in speeds:
@@ -569,7 +593,15 @@ async def session_polar_comparison(
         ref = int(wind_row.get("reference", -1))
         wind_angle = float(wind_row["wind_angle_deg"])
         tws_kts = float(wind_row["wind_speed_kts"])
-        bsp_kts = float(spd_row["speed_kts"])
+        # Heel-corrected STW (#810) so this comparison matches the baseline.
+        bsp_kts = corrected_stw(
+            float(spd_row["speed_kts"]),
+            heel_by_s.get(sk),
+            storage._speed_cal_base,
+            storage._speed_cal_heel_slope,
+        )
+        if bsp_kts is None:
+            continue
 
         hdg_row = hdg_by_s.get(sk)
         heading = float(hdg_row["heading_deg"]) if hdg_row else None
@@ -734,16 +766,23 @@ def _grade_segments_sync(
     positions: list[dict[str, Any]],
     polar_map: dict[tuple[int, int], dict[str, Any]],
     min_sessions: int = 3,
+    attitudes: list[dict[str, Any]] | None = None,
+    speed_cal_base: float = 1.0,
+    speed_cal_heel_slope: float = 0.0,
 ) -> tuple[list[GradedSegment], dict[str, int]]:
     """Pure-Python segmentation + grading. No I/O; safe to run in a worker thread.
 
     *polar_map* is the full (tws_bin, twa_bin) → baseline row mapping, pre-fetched
     so no ``await`` is needed inside the loop (#603).
+
+    Speed samples are heel-corrected (#810) before averaging so the graded BSP
+    matches the (also-corrected) baseline.
     """
 
     def _ts_of(rec: dict[str, Any]) -> datetime:
         return datetime.fromisoformat(str(rec["ts"])).replace(tzinfo=UTC)
 
+    heel_by_s = _heel_by_second(attitudes or [])
     speeds_dt = [(_ts_of(r), r) for r in speeds]
     winds_dt = [
         (_ts_of(r), r)
@@ -761,7 +800,20 @@ def _grade_segments_sync(
         seg_end = min(end, seg_start + timedelta(seconds=width))
         t_mid = seg_start + (seg_end - seg_start) / 2
 
-        spd_in = [float(r["speed_kts"]) for ts, r in speeds_dt if seg_start <= ts < seg_end]
+        spd_in = [
+            c
+            for ts, r in speeds_dt
+            if seg_start <= ts < seg_end
+            and (
+                c := corrected_stw(
+                    float(r["speed_kts"]),
+                    heel_by_s.get(str(r["ts"])[:19]),
+                    speed_cal_base,
+                    speed_cal_heel_slope,
+                )
+            )
+            is not None
+        ]
         wind_in = [(ts, r) for ts, r in winds_dt if seg_start <= ts < seg_end]
         hdg_in = [float(r["heading_deg"]) for ts, r in hdg_dt if seg_start <= ts < seg_end]
 
@@ -895,6 +947,7 @@ async def grade_session_segments(
     winds = await storage.query_range("winds", start, end)
     headings = await storage.query_range("headings", start, end)
     positions = await storage.query_range("positions", start, end)
+    attitudes = await storage.query_range("attitudes", start, end)
 
     # Pre-load the entire polar baseline once so the tight per-segment loop
     # has no I/O and can run in a worker thread. Un-migrated DBs (no
@@ -916,6 +969,9 @@ async def grade_session_segments(
         headings,
         positions,
         polar_map,
+        attitudes=attitudes,
+        speed_cal_base=storage._speed_cal_base,
+        speed_cal_heel_slope=storage._speed_cal_heel_slope,
     )
 
     # Persist cache

--- a/src/helmlog/speed_cal.py
+++ b/src/helmlog/speed_cal.py
@@ -1,0 +1,85 @@
+"""Heel-dependent boatspeed (STW) correction for the off-center paddlewheel.
+
+Corvo's paddlewheel sits ~10 cm to port of centerline feeding a display-only
+B&G Triton², so under heel it reads differently on port vs. starboard tack
+(#810). Port tack heels the boat to starboard, lifting the port-offset wheel
+so it over-reads; starboard tack immerses it. Current-corrected
+GPS-through-water is symmetric tack-to-tack, confirming this is a sensor
+artifact, not real boatspeed.
+
+The correction is applied at **read time** in the derivation path — raw
+``speeds``/``attitudes`` rows are never mutated:
+
+    k(heel) = a + b * heel_signed          # heel_signed = attitudes.heel_deg,
+                                           # +ve = starboard-down = port tack
+    corrected_STW = raw_STW / k(heel)
+
+``k`` is a divisor because the paddlewheel *over-reads*; ``k > 1`` scales the
+reading down. The fitted slope ``b`` is expected **positive**: port tack
+(heel > 0) lifts the wheel so it over-reads most and needs the largest
+divisor. ``a`` is a configurable base factor (default 1.0) — the mean
+over-read is expected to be carried by the Triton²'s own global cal, so the
+shipped default (a=1.0, b=0.0) is an exact no-op.
+
+Coefficients live in ``boat_settings`` (``speed_cal_base`` /
+``speed_cal_heel_slope``) alongside ``leeway_coefficient`` and the compass
+offsets, and re-fit per rig/sail era via ``scripts/analysis/calibrate_speed_heel.py``.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+# Sane band for the correction factor. A physically plausible paddlewheel cal
+# factor sits near 1.0 (±~15%); a divisor outside this band means a bad fit or
+# a garbage heel sample, so we fall back to the raw reading rather than emit a
+# wildly scaled — or negative/infinite — speed.
+_K_MIN = 0.5
+_K_MAX = 2.0
+
+
+def corrected_stw(
+    raw_kts: float | None,
+    heel_deg: float | None,
+    a: float = 1.0,
+    b: float = 0.0,
+) -> float | None:
+    """Return heel-corrected STW, or the raw value when correction can't apply.
+
+    Args:
+        raw_kts: Raw paddlewheel speed-through-water (knots), as logged.
+        heel_deg: Signed heel (``attitudes.heel_deg``); +ve = starboard-down =
+            port tack. ``None`` when no attitude sensor / sample is available.
+        a: Base cal factor (``speed_cal_base``). Default 1.0.
+        b: Heel slope per degree (``speed_cal_heel_slope``). Default 0.0.
+
+    Behavior:
+        * ``raw_kts`` that is ``None``, zero, or negative is passed through
+          untouched — there is no meaningful correction of an absent or
+          non-positive reading.
+        * ``heel_deg`` of ``None`` drops the heel term (``k = a``).
+        * A computed factor outside ``[0.5, 2.0]`` falls back to the raw value
+          and logs a warning.
+        * With the shipped defaults (a=1.0, b=0.0) the result is exactly
+          ``raw_kts`` for every input (safe no-op).
+    """
+    if raw_kts is None or raw_kts <= 0.0:
+        return raw_kts
+
+    heel = heel_deg if heel_deg is not None else 0.0
+    k = a + b * heel
+
+    if not (_K_MIN <= k <= _K_MAX):
+        logger.warning(
+            "speed_cal: correction factor k={:.4f} out of band [{}, {}] "
+            "(heel={}, a={}, b={}); using raw STW",
+            k,
+            _K_MIN,
+            _K_MAX,
+            heel_deg,
+            a,
+            b,
+        )
+        return raw_kts
+
+    return raw_kts / k

--- a/src/helmlog/speed_cal.py
+++ b/src/helmlog/speed_cal.py
@@ -94,16 +94,23 @@ def corrected_stw(
 #
 # Live-data regression showed the off-center paddlewheel's tack bias is not a
 # simple function of heel: it *reverses sign* with wind speed (port over-reads
-# most at 12–15 kt but under-reads below ~9 kt), so a single heel slope can't
-# fit it. Two data-driven refinements live here:
+# most at 12–15 kt but under-reads below ~9 kt) AND differs upwind vs downwind,
+# so a single heel slope can't fit it. Two data-driven refinements live here:
 #
 #   * a **breeze gate** — below ``gate_min_tws`` the noisy, sign-reversing
 #     light-air regime is left alone (only the base mean factor applies), and
-#   * a **TWS × tack lookup table** — per-(TWS bin, tack) factors, the model the
-#     data actually supports, used wherever TWS is known (the polar path).
+#   * a **TWS × point-of-sail × tack lookup table** — per-(TWS bin, upwind/
+#     downwind, tack) factors, the model the data actually supports, used
+#     wherever TWS + point-of-sail are known (the polar path).
 #
 # The heel-linear ``corrected_stw`` above remains the fallback for callers
-# without TWS (the live set/drift compute) and when no table bin matches.
+# without TWS/point-of-sail (the live set/drift compute) and when no bin matches.
+
+# Valid point-of-sail labels for a table entry (must match polar._point_of_sail).
+_POINTS_OF_SAIL = ("upwind", "downwind")
+
+# One resolved table entry: (tws_min, tws_max, point_of_sail, port_k, stbd_k).
+TableRow = tuple[float, float, str, float, float]
 
 
 @dataclass(frozen=True)
@@ -116,53 +123,66 @@ class SpeedCal:
             fallback. Default 0.0.
         gate_min_tws: Below this TWS (kt) the tack/heel term is suppressed and
             only ``base`` applies. 0.0 disables the gate.
-        table: Sorted ``(tws_min, tws_max, port_k, stbd_k)`` bins; ``tws_max``
-            exclusive. Empty → no table.
+        table: Sorted ``(tws_min, tws_max, point_of_sail, port_k, stbd_k)``
+            bins; ``tws_max`` exclusive, ``point_of_sail`` in ``upwind`` /
+            ``downwind``. Empty → no table.
     """
 
     base: float = 1.0
     heel_slope: float = 0.0
     gate_min_tws: float = 0.0
-    table: tuple[tuple[float, float, float, float], ...] = field(default_factory=tuple)
+    table: tuple[TableRow, ...] = field(default_factory=tuple)
 
 
 DEFAULT_CAL = SpeedCal()
 
 
-def parse_table(
-    spec: str | list[dict[str, Any]] | None,
-) -> tuple[tuple[float, float, float, float], ...]:
-    """Parse a TWS × tack table from a JSON string (or already-decoded list).
+def parse_table(spec: str | list[dict[str, Any]] | None) -> tuple[TableRow, ...]:
+    """Parse a TWS × point-of-sail × tack table from JSON (or a decoded list).
 
-    Each entry is ``{"tws_min":.., "tws_max":.., "port":.., "stbd":..}``. Bins
-    are returned sorted by ``tws_min``. Empty/blank/malformed input yields an
-    empty table (correction disabled) rather than raising — a bad admin value
-    must never take out the read path.
+    Each entry is
+    ``{"tws_min":.., "tws_max":.., "pos":"upwind"|"downwind", "port":.., "stbd":..}``.
+    Rows are returned sorted by ``(tws_min, pos)``. Empty/blank/malformed input —
+    including an unknown ``pos`` label — yields an empty table (correction
+    disabled) rather than raising: a bad admin value must never take out the
+    read path.
     """
     if not spec:
         return ()
     try:
         rows = json.loads(spec) if isinstance(spec, str) else spec
-        parsed = tuple(
-            (float(r["tws_min"]), float(r["tws_max"]), float(r["port"]), float(r["stbd"]))
-            for r in rows
-        )
+        parsed = []
+        for r in rows:
+            pos = str(r["pos"])
+            if pos not in _POINTS_OF_SAIL:
+                raise ValueError(f"unknown point-of-sail {pos!r}")
+            parsed.append(
+                (
+                    float(r["tws_min"]),
+                    float(r["tws_max"]),
+                    pos,
+                    float(r["port"]),
+                    float(r["stbd"]),
+                )
+            )
     except (ValueError, TypeError, KeyError) as e:
         logger.warning(
             "speed_cal: ignoring malformed speed_cal_table ({}): {}", type(e).__name__, e
         )
         return ()
-    return tuple(sorted(parsed, key=lambda r: r[0]))
+    return tuple(sorted(parsed, key=lambda r: (r[0], r[2])))
 
 
 def _table_lookup(
-    table: tuple[tuple[float, float, float, float], ...],
+    table: tuple[TableRow, ...],
     tws_kts: float,
+    point_of_sail: str,
     tack: str,
 ) -> float | None:
-    """Return the ``k`` for the bin containing ``tws_kts`` on ``tack``, or None."""
-    for lo, hi, port_k, stbd_k in table:
-        if lo <= tws_kts < hi:
+    """Return ``k`` for the bin matching ``tws_kts`` + ``point_of_sail`` on
+    ``tack``, or None if no bin matches."""
+    for lo, hi, pos, port_k, stbd_k in table:
+        if lo <= tws_kts < hi and pos == point_of_sail:
             return port_k if tack == "port" else stbd_k
     return None
 
@@ -172,6 +192,7 @@ def resolve_stw(
     heel_deg: float | None,
     tws_kts: float | None,
     cal: SpeedCal = DEFAULT_CAL,
+    point_of_sail: str | None = None,
 ) -> float | None:
     """Correct STW using the full model: gate → table → heel-linear fallback.
 
@@ -179,10 +200,11 @@ def resolve_stw(
         1. Invalid ``raw_kts`` (None / ≤ 0) is passed through unchanged.
         2. **Gate:** if ``tws_kts`` is known and below ``gate_min_tws``, apply
            only ``base`` (light air's tack bias is noisy and sign-reversing).
-        3. **Table:** if a table is configured and both ``tws_kts`` and
-           ``heel_deg`` are known, use the matching ``(TWS bin, tack)`` factor.
+        3. **Table:** if a table is configured and ``tws_kts``, ``heel_deg`` and
+           ``point_of_sail`` are all known, use the matching
+           ``(TWS bin, point-of-sail, tack)`` factor.
         4. **Fallback:** heel-linear ``corrected_stw`` (base + slope·heel) when
-           there's no table, no TWS, or no matching bin.
+           there's no table, a missing input, or no matching bin.
     """
     if raw_kts is None or raw_kts <= 0.0:
         return raw_kts
@@ -190,10 +212,10 @@ def resolve_stw(
     if tws_kts is not None and cal.gate_min_tws > 0.0 and tws_kts < cal.gate_min_tws:
         return _apply_factor(raw_kts, cal.base, f"gated tws={tws_kts}<{cal.gate_min_tws}")
 
-    if cal.table and tws_kts is not None and heel_deg is not None:
+    if cal.table and tws_kts is not None and heel_deg is not None and point_of_sail is not None:
         tack = "port" if heel_deg > 0 else "stbd"
-        k = _table_lookup(cal.table, tws_kts, tack)
+        k = _table_lookup(cal.table, tws_kts, point_of_sail, tack)
         if k is not None:
-            return _apply_factor(raw_kts, k, f"table tws={tws_kts} tack={tack}")
+            return _apply_factor(raw_kts, k, f"table tws={tws_kts} {point_of_sail} tack={tack}")
 
     return corrected_stw(raw_kts, heel_deg, cal.base, cal.heel_slope)

--- a/src/helmlog/speed_cal.py
+++ b/src/helmlog/speed_cal.py
@@ -28,6 +28,10 @@ offsets, and re-fit per rig/sail era via ``scripts/analysis/calibrate_speed_heel
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
 from loguru import logger
 
 # Sane band for the correction factor. A physically plausible paddlewheel cal
@@ -36,6 +40,20 @@ from loguru import logger
 # wildly scaled — or negative/infinite — speed.
 _K_MIN = 0.5
 _K_MAX = 2.0
+
+
+def _apply_factor(raw_kts: float, k: float, ctx: str = "") -> float:
+    """Divide by ``k`` after a sane-band guard; fall back to raw on a bad ``k``."""
+    if not (_K_MIN <= k <= _K_MAX):
+        logger.warning(
+            "speed_cal: correction factor k={:.4f} out of band [{}, {}]{}; using raw STW",
+            k,
+            _K_MIN,
+            _K_MAX,
+            f" ({ctx})" if ctx else "",
+        )
+        return raw_kts
+    return raw_kts / k
 
 
 def corrected_stw(
@@ -67,19 +85,115 @@ def corrected_stw(
         return raw_kts
 
     heel = heel_deg if heel_deg is not None else 0.0
-    k = a + b * heel
+    return _apply_factor(raw_kts, a + b * heel, f"heel={heel_deg}, a={a}, b={b}")
 
-    if not (_K_MIN <= k <= _K_MAX):
-        logger.warning(
-            "speed_cal: correction factor k={:.4f} out of band [{}, {}] "
-            "(heel={}, a={}, b={}); using raw STW",
-            k,
-            _K_MIN,
-            _K_MAX,
-            heel_deg,
-            a,
-            b,
+
+# ---------------------------------------------------------------------------
+# TWS × tack table + breeze gate (#810 follow-up)
+# ---------------------------------------------------------------------------
+#
+# Live-data regression showed the off-center paddlewheel's tack bias is not a
+# simple function of heel: it *reverses sign* with wind speed (port over-reads
+# most at 12–15 kt but under-reads below ~9 kt), so a single heel slope can't
+# fit it. Two data-driven refinements live here:
+#
+#   * a **breeze gate** — below ``gate_min_tws`` the noisy, sign-reversing
+#     light-air regime is left alone (only the base mean factor applies), and
+#   * a **TWS × tack lookup table** — per-(TWS bin, tack) factors, the model the
+#     data actually supports, used wherever TWS is known (the polar path).
+#
+# The heel-linear ``corrected_stw`` above remains the fallback for callers
+# without TWS (the live set/drift compute) and when no table bin matches.
+
+
+@dataclass(frozen=True)
+class SpeedCal:
+    """Bundle of STW-correction coefficients, resolved by ``resolve_stw``.
+
+    Attributes:
+        base: Mean factor ``a`` (always applied). Default 1.0 (no-op).
+        heel_slope: Heel slope ``b`` per degree, used only in the heel-linear
+            fallback. Default 0.0.
+        gate_min_tws: Below this TWS (kt) the tack/heel term is suppressed and
+            only ``base`` applies. 0.0 disables the gate.
+        table: Sorted ``(tws_min, tws_max, port_k, stbd_k)`` bins; ``tws_max``
+            exclusive. Empty → no table.
+    """
+
+    base: float = 1.0
+    heel_slope: float = 0.0
+    gate_min_tws: float = 0.0
+    table: tuple[tuple[float, float, float, float], ...] = field(default_factory=tuple)
+
+
+DEFAULT_CAL = SpeedCal()
+
+
+def parse_table(
+    spec: str | list[dict[str, Any]] | None,
+) -> tuple[tuple[float, float, float, float], ...]:
+    """Parse a TWS × tack table from a JSON string (or already-decoded list).
+
+    Each entry is ``{"tws_min":.., "tws_max":.., "port":.., "stbd":..}``. Bins
+    are returned sorted by ``tws_min``. Empty/blank/malformed input yields an
+    empty table (correction disabled) rather than raising — a bad admin value
+    must never take out the read path.
+    """
+    if not spec:
+        return ()
+    try:
+        rows = json.loads(spec) if isinstance(spec, str) else spec
+        parsed = tuple(
+            (float(r["tws_min"]), float(r["tws_max"]), float(r["port"]), float(r["stbd"]))
+            for r in rows
         )
+    except (ValueError, TypeError, KeyError) as e:
+        logger.warning(
+            "speed_cal: ignoring malformed speed_cal_table ({}): {}", type(e).__name__, e
+        )
+        return ()
+    return tuple(sorted(parsed, key=lambda r: r[0]))
+
+
+def _table_lookup(
+    table: tuple[tuple[float, float, float, float], ...],
+    tws_kts: float,
+    tack: str,
+) -> float | None:
+    """Return the ``k`` for the bin containing ``tws_kts`` on ``tack``, or None."""
+    for lo, hi, port_k, stbd_k in table:
+        if lo <= tws_kts < hi:
+            return port_k if tack == "port" else stbd_k
+    return None
+
+
+def resolve_stw(
+    raw_kts: float | None,
+    heel_deg: float | None,
+    tws_kts: float | None,
+    cal: SpeedCal = DEFAULT_CAL,
+) -> float | None:
+    """Correct STW using the full model: gate → table → heel-linear fallback.
+
+    Precedence:
+        1. Invalid ``raw_kts`` (None / ≤ 0) is passed through unchanged.
+        2. **Gate:** if ``tws_kts`` is known and below ``gate_min_tws``, apply
+           only ``base`` (light air's tack bias is noisy and sign-reversing).
+        3. **Table:** if a table is configured and both ``tws_kts`` and
+           ``heel_deg`` are known, use the matching ``(TWS bin, tack)`` factor.
+        4. **Fallback:** heel-linear ``corrected_stw`` (base + slope·heel) when
+           there's no table, no TWS, or no matching bin.
+    """
+    if raw_kts is None or raw_kts <= 0.0:
         return raw_kts
 
-    return raw_kts / k
+    if tws_kts is not None and cal.gate_min_tws > 0.0 and tws_kts < cal.gate_min_tws:
+        return _apply_factor(raw_kts, cal.base, f"gated tws={tws_kts}<{cal.gate_min_tws}")
+
+    if cal.table and tws_kts is not None and heel_deg is not None:
+        tack = "port" if heel_deg > 0 else "stbd"
+        k = _table_lookup(cal.table, tws_kts, tack)
+        if k is not None:
+            return _apply_factor(raw_kts, k, f"table tws={tws_kts} tack={tack}")
+
+    return corrected_stw(raw_kts, heel_deg, cal.base, cal.heel_slope)

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -42,6 +42,7 @@ from helmlog.nmea2000 import (
     SpeedRecord,
     WindRecord,
 )
+from helmlog.speed_cal import SpeedCal, parse_table
 from helmlog.video import VideoSession
 
 
@@ -2305,11 +2306,12 @@ class Storage:
         self._compass_offset_port: float = 0.0
         self._compass_offset_stbd: float = 0.0
         # Heel-dependent STW correction for the off-center paddlewheel (#810).
-        # corrected = raw / (base + slope * heel_deg). Loaded from boat_settings
-        # on connect; refresh_speed_cal() picks up admin changes. Defaults are
-        # the identity (base=1.0, slope=0.0) so untuned boats are unaffected.
-        self._speed_cal_base: float = 1.0
-        self._speed_cal_heel_slope: float = 0.0
+        # base/slope/gate come from boat_settings; the TWS × tack table is a
+        # JSON blob in app_settings. refresh_speed_cal() rebuilds this on
+        # connect and on admin changes. The default SpeedCal() is the identity
+        # (base=1.0, slope=0.0, no gate, empty table) so untuned boats are
+        # unaffected.
+        self._speed_cal: SpeedCal = SpeedCal()
         self._last_rudder_write: float = 0.0
         self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
@@ -2444,8 +2446,8 @@ class Storage:
             leeway_k=self._leeway_k,
             compass_offset_port=self._compass_offset_port,
             compass_offset_stbd=self._compass_offset_stbd,
-            speed_cal_base=self._speed_cal_base,
-            speed_cal_heel_slope=self._speed_cal_heel_slope,
+            speed_cal_base=self._speed_cal.base,
+            speed_cal_heel_slope=self._speed_cal.heel_slope,
         )
         if result is None:
             return
@@ -2577,31 +2579,46 @@ class Storage:
                     self._compass_offset_stbd = val
         return (self._compass_offset_port, self._compass_offset_stbd)
 
-    async def refresh_speed_cal(self) -> tuple[float, float]:
-        """Reload the heel-dependent STW correction coefficients (#810).
+    async def refresh_speed_cal(self) -> SpeedCal:
+        """Rebuild the cached STW correction config ``self._speed_cal`` (#810).
 
-        Reads ``boat_settings.speed_cal_base`` / ``speed_cal_heel_slope`` into
-        the cached ``self._speed_cal_base`` / ``self._speed_cal_heel_slope``.
-        Returns ``(base, slope)``. Called from ``connect()`` and on every
-        settings write that touches either parameter, so admin tuning takes
-        effect without a restart."""
+        Reads ``speed_cal_base`` / ``speed_cal_heel_slope`` /
+        ``speed_cal_gate_min_tws`` from ``boat_settings`` and the TWS × tack
+        table (``speed_cal_table``, a JSON blob) from ``app_settings``. Missing
+        values fall back to the identity defaults. Called from ``connect()`` and
+        on every settings write that touches a coefficient, so admin tuning
+        takes effect without a restart. Returns the new ``SpeedCal``."""
+        import contextlib
+
+        base, slope, gate = 1.0, 0.0, 0.0
         try:
             rows = await self.current_boat_settings(race_id=None)
         except Exception:
-            return (self._speed_cal_base, self._speed_cal_heel_slope)
-        import contextlib
-
+            rows = []
         for row in rows:
             param = row["parameter"]
-            if param not in ("speed_cal_base", "speed_cal_heel_slope"):
+            if param not in ("speed_cal_base", "speed_cal_heel_slope", "speed_cal_gate_min_tws"):
                 continue
             with contextlib.suppress(TypeError, ValueError):
                 val = float(row["value"])
                 if param == "speed_cal_base":
-                    self._speed_cal_base = val
+                    base = val
+                elif param == "speed_cal_heel_slope":
+                    slope = val
                 else:
-                    self._speed_cal_heel_slope = val
-        return (self._speed_cal_base, self._speed_cal_heel_slope)
+                    gate = val
+
+        table_json: str | None = None
+        with contextlib.suppress(Exception):
+            table_json = await self.get_setting("speed_cal_table")
+
+        self._speed_cal = SpeedCal(
+            base=base,
+            heel_slope=slope,
+            gate_min_tws=gate,
+            table=parse_table(table_json),
+        )
+        return self._speed_cal
 
     async def refresh_smoothing(self) -> dict[str, float]:
         """Reload per-channel time constants from ``app_settings`` and apply
@@ -10403,7 +10420,10 @@ class Storage:
             await self.refresh_leeway_k()
         if any(e["parameter"] in ("compass_offset_port", "compass_offset_stbd") for e in entries):
             await self.refresh_compass_offsets()
-        if any(e["parameter"] in ("speed_cal_base", "speed_cal_heel_slope") for e in entries):
+        if any(
+            e["parameter"] in ("speed_cal_base", "speed_cal_heel_slope", "speed_cal_gate_min_tws")
+            for e in entries
+        ):
             await self.refresh_speed_cal()
         return ids
 

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -2304,6 +2304,12 @@ class Storage:
         # behavior.
         self._compass_offset_port: float = 0.0
         self._compass_offset_stbd: float = 0.0
+        # Heel-dependent STW correction for the off-center paddlewheel (#810).
+        # corrected = raw / (base + slope * heel_deg). Loaded from boat_settings
+        # on connect; refresh_speed_cal() picks up admin changes. Defaults are
+        # the identity (base=1.0, slope=0.0) so untuned boats are unaffected.
+        self._speed_cal_base: float = 1.0
+        self._speed_cal_heel_slope: float = 0.0
         self._last_rudder_write: float = 0.0
         self._last_attitude_write: float = 0.0
         # Web response cache (#594). Optional; web.py binds a WebCache
@@ -2438,6 +2444,8 @@ class Storage:
             leeway_k=self._leeway_k,
             compass_offset_port=self._compass_offset_port,
             compass_offset_stbd=self._compass_offset_stbd,
+            speed_cal_base=self._speed_cal_base,
+            speed_cal_heel_slope=self._speed_cal_heel_slope,
         )
         if result is None:
             return
@@ -2569,6 +2577,32 @@ class Storage:
                     self._compass_offset_stbd = val
         return (self._compass_offset_port, self._compass_offset_stbd)
 
+    async def refresh_speed_cal(self) -> tuple[float, float]:
+        """Reload the heel-dependent STW correction coefficients (#810).
+
+        Reads ``boat_settings.speed_cal_base`` / ``speed_cal_heel_slope`` into
+        the cached ``self._speed_cal_base`` / ``self._speed_cal_heel_slope``.
+        Returns ``(base, slope)``. Called from ``connect()`` and on every
+        settings write that touches either parameter, so admin tuning takes
+        effect without a restart."""
+        try:
+            rows = await self.current_boat_settings(race_id=None)
+        except Exception:
+            return (self._speed_cal_base, self._speed_cal_heel_slope)
+        import contextlib
+
+        for row in rows:
+            param = row["parameter"]
+            if param not in ("speed_cal_base", "speed_cal_heel_slope"):
+                continue
+            with contextlib.suppress(TypeError, ValueError):
+                val = float(row["value"])
+                if param == "speed_cal_base":
+                    self._speed_cal_base = val
+                else:
+                    self._speed_cal_heel_slope = val
+        return (self._speed_cal_base, self._speed_cal_heel_slope)
+
     async def refresh_smoothing(self) -> dict[str, float]:
         """Reload per-channel time constants from ``app_settings`` and apply
         them to the live smoothers without losing accumulated state.
@@ -2637,6 +2671,7 @@ class Storage:
         await self.refresh_smoothing()
         await self.refresh_leeway_k()
         await self.refresh_compass_offsets()
+        await self.refresh_speed_cal()
 
     async def close(self) -> None:
         """Flush any buffered writes and close the database connections."""
@@ -10368,6 +10403,8 @@ class Storage:
             await self.refresh_leeway_k()
         if any(e["parameter"] in ("compass_offset_port", "compass_offset_stbd") for e in entries):
             await self.refresh_compass_offsets()
+        if any(e["parameter"] in ("speed_cal_base", "speed_cal_heel_slope") for e in entries):
+            await self.refresh_speed_cal()
         return ids
 
     async def list_boat_settings(self, race_id: int | None) -> list[dict[str, Any]]:

--- a/tests/test_current.py
+++ b/tests/test_current.py
@@ -270,3 +270,50 @@ class TestCompassOffsets:
         assert sd_with is not None and sd_manual is not None
         assert sd_with[0] == pytest.approx(sd_manual[0], abs=1e-6)
         assert sd_with[1] == pytest.approx(sd_manual[1], abs=1e-6)
+
+
+class TestSpeedCorrection:
+    """Heel-dependent STW correction (#810) is applied before the water
+    vector is formed, so a paddlewheel over-read no longer surfaces as
+    phantom current, and the same-consistent correction feeds set/drift."""
+
+    def test_defaults_leave_result_unchanged(self) -> None:
+        base = compute_set_drift(sog=5.0, cog=90.0, stw=5.0, hdg=0.0)
+        withcal = compute_set_drift(
+            sog=5.0,
+            cog=90.0,
+            stw=5.0,
+            hdg=0.0,
+            speed_cal_base=1.0,
+            speed_cal_heel_slope=0.0,
+        )
+        assert base == withcal
+
+    def test_base_factor_removes_phantom_current(self) -> None:
+        # Raw STW over-reads 9%: 5.45 kt logged, boat truly making 5 kt due N
+        # over ground. Un-corrected, the longer water vector fakes 0.45 kt of
+        # current toward the south.
+        sd_raw = compute_set_drift(sog=5.0, cog=0.0, stw=5.45, hdg=0.0)
+        assert sd_raw is not None
+        assert sd_raw[1] == pytest.approx(0.45, abs=1e-9)
+        # base=1.09 scales 5.45 → 5.0, matching ground → current collapses.
+        sd_corr = compute_set_drift(
+            sog=5.0, cog=0.0, stw=5.45, hdg=0.0, speed_cal_base=1.09
+        )
+        assert sd_corr is not None
+        assert sd_corr[1] == pytest.approx(0.0, abs=1e-3)
+
+    def test_heel_slope_uses_signed_heel(self) -> None:
+        # Port tack (heel>0): k = 1.0 + 0.01*10 = 1.1 → 5.5/1.1 = 5.0.
+        # No leeway_k passed, so heel only drives the speed correction here.
+        sd = compute_set_drift(
+            sog=5.0,
+            cog=0.0,
+            stw=5.5,
+            hdg=0.0,
+            heel_deg=10.0,
+            speed_cal_base=1.0,
+            speed_cal_heel_slope=0.01,
+        )
+        assert sd is not None
+        assert sd[1] == pytest.approx(0.0, abs=1e-3)

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -174,14 +174,16 @@ async def test_create_boat_settings_hot_refreshes_leeway_k(storage: Storage) -> 
 @pytest.mark.asyncio
 async def test_speed_cal_defaults_are_noop(storage: Storage) -> None:
     """After connect with no rows, the STW cal is the identity (#810)."""
-    assert storage._speed_cal_base == 1.0
-    assert storage._speed_cal_heel_slope == 0.0
+    assert storage._speed_cal.base == 1.0
+    assert storage._speed_cal.heel_slope == 0.0
+    assert storage._speed_cal.gate_min_tws == 0.0
+    assert storage._speed_cal.table == ()
 
 
 @pytest.mark.asyncio
 async def test_create_boat_settings_hot_refreshes_speed_cal(storage: Storage) -> None:
-    """Writing speed_cal_base / speed_cal_heel_slope hot-reloads the cache so
-    the next live compute + polar read uses the new coefficients (#810)."""
+    """Writing speed_cal_base / speed_cal_heel_slope / gate hot-reloads the
+    cache so the next live compute + polar read uses the new config (#810)."""
     from datetime import UTC, datetime
 
     ts = datetime.now(UTC).isoformat()
@@ -190,11 +192,25 @@ async def test_create_boat_settings_hot_refreshes_speed_cal(storage: Storage) ->
         entries=[
             {"ts": ts, "parameter": "speed_cal_base", "value": "1.09"},
             {"ts": ts, "parameter": "speed_cal_heel_slope", "value": "0.008"},
+            {"ts": ts, "parameter": "speed_cal_gate_min_tws", "value": "9.0"},
         ],
         source="manual",
     )
-    assert storage._speed_cal_base == 1.09
-    assert storage._speed_cal_heel_slope == 0.008
+    assert storage._speed_cal.base == 1.09
+    assert storage._speed_cal.heel_slope == 0.008
+    assert storage._speed_cal.gate_min_tws == 9.0
+
+
+@pytest.mark.asyncio
+async def test_speed_cal_table_loaded_from_app_settings(storage: Storage) -> None:
+    """The TWS × tack table is a JSON blob in app_settings; refresh_speed_cal
+    parses it into the cached SpeedCal (#810)."""
+    await storage.set_setting(
+        "speed_cal_table",
+        '[{"tws_min":12,"tws_max":15,"port":1.065,"stbd":1.02}]',
+    )
+    await storage.refresh_speed_cal()
+    assert storage._speed_cal.table == ((12.0, 15.0, 1.065, 1.02),)
 
 
 @pytest.mark.asyncio

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -172,6 +172,32 @@ async def test_create_boat_settings_hot_refreshes_leeway_k(storage: Storage) -> 
 
 
 @pytest.mark.asyncio
+async def test_speed_cal_defaults_are_noop(storage: Storage) -> None:
+    """After connect with no rows, the STW cal is the identity (#810)."""
+    assert storage._speed_cal_base == 1.0
+    assert storage._speed_cal_heel_slope == 0.0
+
+
+@pytest.mark.asyncio
+async def test_create_boat_settings_hot_refreshes_speed_cal(storage: Storage) -> None:
+    """Writing speed_cal_base / speed_cal_heel_slope hot-reloads the cache so
+    the next live compute + polar read uses the new coefficients (#810)."""
+    from datetime import UTC, datetime
+
+    ts = datetime.now(UTC).isoformat()
+    await storage.create_boat_settings(
+        race_id=None,
+        entries=[
+            {"ts": ts, "parameter": "speed_cal_base", "value": "1.09"},
+            {"ts": ts, "parameter": "speed_cal_heel_slope", "value": "0.008"},
+        ],
+        source="manual",
+    )
+    assert storage._speed_cal_base == 1.09
+    assert storage._speed_cal_heel_slope == 0.008
+
+
+@pytest.mark.asyncio
 async def test_set_drift_derived_from_smoothed_inputs(storage: Storage) -> None:
     """Set / drift are computed server-side from the (already-smoothed)
     sog / cog / stw / hdg in self._live, then put through their own EMA

--- a/tests/test_instrument_smoothing_admin.py
+++ b/tests/test_instrument_smoothing_admin.py
@@ -207,10 +207,10 @@ async def test_speed_cal_table_loaded_from_app_settings(storage: Storage) -> Non
     parses it into the cached SpeedCal (#810)."""
     await storage.set_setting(
         "speed_cal_table",
-        '[{"tws_min":12,"tws_max":15,"port":1.065,"stbd":1.02}]',
+        '[{"tws_min":12,"tws_max":15,"pos":"upwind","port":1.065,"stbd":1.02}]',
     )
     await storage.refresh_speed_cal()
-    assert storage._speed_cal.table == ((12.0, 15.0, 1.065, 1.02),)
+    assert storage._speed_cal.table == ((12.0, 15.0, "upwind", 1.065, 1.02),)
 
 
 @pytest.mark.asyncio

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -131,8 +131,13 @@ async def _make_session(
     bsp: float,
     tws: float,
     twa: float,
+    heel: float | None = None,
 ) -> None:
-    """Insert a completed race + 10 matching speed and wind records."""
+    """Insert a completed race + 10 matching speed and wind records.
+
+    When *heel* is given, a matching ``attitudes`` row is inserted per second
+    via direct SQL (the ``_write_attitude`` path is rate-limited, which would
+    drop most rows in a tight test loop)."""
     start = _BASE_TS + timedelta(hours=race_num)
     end = start + timedelta(seconds=10)
     db = storage._conn()
@@ -153,6 +158,26 @@ async def _make_session(
         ts = start + timedelta(seconds=i)
         await storage.write(SpeedRecord(PGN_SPEED_THROUGH_WATER, 5, ts, bsp))
         await storage.write(WindRecord(PGN_WIND_DATA, 5, ts, tws, twa, 0))
+        if heel is not None:
+            await db.execute(
+                "INSERT INTO attitudes (ts, source_addr, heel_deg, trim_deg)"
+                " VALUES (?, ?, ?, 0.0)",
+                (ts.isoformat(), 5, heel),
+            )
+    await db.commit()
+
+
+async def _set_speed_cal(storage: Storage, base: float, slope: float) -> None:
+    """Persist + hot-reload the #810 STW correction coefficients."""
+    ts = datetime.now(UTC).isoformat()
+    await storage.create_boat_settings(
+        race_id=None,
+        entries=[
+            {"ts": ts, "parameter": "speed_cal_base", "value": str(base)},
+            {"ts": ts, "parameter": "speed_cal_heel_slope", "value": str(slope)},
+        ],
+        source="manual",
+    )
 
 
 @pytest.mark.asyncio
@@ -587,8 +612,12 @@ async def _seed_session(
     twa: float,
     with_positions: bool = True,
     with_winds: bool = True,
+    heel: float | None = None,
 ) -> int:
-    """Create a completed race with 1 Hz instrument data and return its id."""
+    """Create a completed race with 1 Hz instrument data and return its id.
+
+    When *heel* is given, one ``attitudes`` row per second is inserted via
+    direct SQL (the ``_write_attitude`` path is rate-limited)."""
     start = datetime(2024, 7, 1, 12, 0, 0, tzinfo=UTC)
     end = start + timedelta(seconds=duration_s)
     db = storage._conn()
@@ -610,6 +639,13 @@ async def _seed_session(
             await storage.write(
                 PositionRecord(PGN_POSITION_RAPID, 5, ts, 37.80 + i * 1e-5, -122.27 + i * 1e-5)
             )
+        if heel is not None:
+            await db.execute(
+                "INSERT INTO attitudes (ts, source_addr, heel_deg, trim_deg)"
+                " VALUES (?, ?, ?, 0.0)",
+                (ts.isoformat(), 5, heel),
+            )
+    await db.commit()
     return sid
 
 
@@ -1084,3 +1120,76 @@ class TestGradeSegmentsWindow:
         # Racing window ≈ 200 s → ~20 segments; the full session (320 s) would be
         # ~32. Comfortably under 25 confirms prestart + post-finish were trimmed.
         assert len(segs) < 25
+
+
+# ---------------------------------------------------------------------------
+# Heel-dependent STW correction flowing through the polar path (#810)
+# ---------------------------------------------------------------------------
+
+
+class TestPolarStwCorrection:
+    """All three read sites (baseline build, session comparison, segment
+    grading) must consume the *corrected* STW so the baseline and the %
+    grade stay self-consistent."""
+
+    @pytest.mark.asyncio
+    async def test_baseline_defaults_unchanged(self, storage: Storage) -> None:
+        """With shipped defaults the baseline mean is the raw BSP (no-op)."""
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_baseline_uses_corrected_stw(self, storage: Storage) -> None:
+        """base=1.0, slope=0.01, heel=+10 → k=1.1 → 6.0/1.1 = 5.4545."""
+        await _set_speed_cal(storage, base=1.0, slope=0.01)
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0 / 1.1, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_baseline_missing_heel_uses_base_only(self, storage: Storage) -> None:
+        """No attitudes rows → heel term drops; only base applies (k=a)."""
+        await _set_speed_cal(storage, base=1.09, slope=0.05)
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0)  # no heel
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0 / 1.09, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_session_comparison_uses_corrected_stw(self, storage: Storage) -> None:
+        await _set_speed_cal(storage, base=1.0, slope=0.01)
+        await _make_session(storage, race_num=10, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)
+        cur = await storage._conn().execute("SELECT id FROM races ORDER BY id DESC LIMIT 1")
+        sid = int((await cur.fetchone())["id"])
+        result = await session_polar_comparison(storage, sid)
+        assert result is not None
+        assert result.cells[0].session_mean_bsp == pytest.approx(6.0 / 1.1, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_grading_uses_corrected_stw(self, storage: Storage) -> None:
+        """Corrected STW feeds the graded segment's BSP and % target."""
+        # Baseline at 6.0 (no correction on the baseline sessions — they have
+        # no heel and default coeffs at build time isn't our concern here; we
+        # set coeffs, so the baseline builds on corrected values too). To keep
+        # this test about the grade path, build the baseline BEFORE setting the
+        # coefficients so target stays 6.0, then set coeffs and grade.
+        await _build_baseline_at(storage, bsp=6.0, tws=10.0, twa=45.0)
+        await _set_speed_cal(storage, base=1.0, slope=0.01)
+        sid = await _seed_session(
+            storage, duration_s=30, bsp=6.6, tws=10.0, twa=45.0, heel=10.0
+        )
+        segs = await grade_session_segments(storage, sid, segment_seconds=10)
+        graded = [s for s in segs if s.bsp_kts is not None]
+        assert graded
+        # 6.6 / 1.1 = 6.0 → matches the 6.0 target → pct ≈ 1.0
+        assert all(s.bsp_kts == pytest.approx(6.0, rel=1e-3) for s in graded)
+        assert all(s.pct_target == pytest.approx(1.0, rel=1e-3) for s in graded)

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -1185,27 +1185,44 @@ class TestPolarStwCorrection:
         assert result.cells[0].session_mean_bsp == pytest.approx(6.0 / 1.1, rel=1e-4)
 
     @pytest.mark.asyncio
-    async def test_baseline_uses_tws_tack_table(self, storage: Storage) -> None:
-        """A TWS × tack table (app_settings JSON) drives the baseline correction:
-        port tack in the 9-12 kt bin → k=1.2 → 6.0/1.2 = 5.0."""
+    async def test_baseline_uses_tws_pos_tack_table(self, storage: Storage) -> None:
+        """A TWS × PoS × tack table (app_settings JSON) drives the baseline:
+        port tack, upwind, 9-12 kt bin → k=1.2 → 6.0/1.2."""
         await storage.set_setting(
             "speed_cal_table",
-            '[{"tws_min":9,"tws_max":12,"port":1.2,"stbd":1.1}]',
+            '[{"tws_min":9,"tws_max":12,"pos":"upwind","port":1.2,"stbd":1.1}]',
         )
         await storage.refresh_speed_cal()
         for i in range(1, 4):
-            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)  # port
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)  # upwind port
         await build_polar_baseline(storage)
         row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
         assert row is not None
         assert row["mean_bsp"] == pytest.approx(6.0 / 1.2, rel=1e-4)
 
     @pytest.mark.asyncio
+    async def test_baseline_downwind_bin_not_applied_to_upwind(self, storage: Storage) -> None:
+        """A downwind-only table entry must NOT correct an upwind sample — it
+        falls back to the (identity) heel-linear, leaving BSP unchanged."""
+        await storage.set_setting(
+            "speed_cal_table",
+            '[{"tws_min":9,"tws_max":12,"pos":"downwind","port":1.2,"stbd":1.2}]',
+        )
+        await storage.refresh_speed_cal()
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)  # upwind
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0, rel=1e-4)  # uncorrected
+
+    @pytest.mark.asyncio
     async def test_baseline_breeze_gate_suppresses_light_air(self, storage: Storage) -> None:
         """Below the gate the table is ignored and only base applies (k=base=1.0
         → no correction), even though a table bin covers this TWS."""
         await storage.set_setting(
-            "speed_cal_table", '[{"tws_min":0,"tws_max":30,"port":1.2,"stbd":1.2}]'
+            "speed_cal_table",
+            '[{"tws_min":0,"tws_max":30,"pos":"upwind","port":1.2,"stbd":1.2}]',
         )
         await _set_speed_cal_gate(storage, gate=12.0)
         for i in range(1, 4):

--- a/tests/test_polar.py
+++ b/tests/test_polar.py
@@ -180,6 +180,16 @@ async def _set_speed_cal(storage: Storage, base: float, slope: float) -> None:
     )
 
 
+async def _set_speed_cal_gate(storage: Storage, gate: float) -> None:
+    """Persist + hot-reload the #810 breeze gate (min TWS)."""
+    ts = datetime.now(UTC).isoformat()
+    await storage.create_boat_settings(
+        race_id=None,
+        entries=[{"ts": ts, "parameter": "speed_cal_gate_min_tws", "value": str(gate)}],
+        source="manual",
+    )
+
+
 @pytest.mark.asyncio
 async def test_returns_zero_no_sessions(storage: Storage) -> None:
     count = await build_polar_baseline(storage)
@@ -1173,6 +1183,37 @@ class TestPolarStwCorrection:
         result = await session_polar_comparison(storage, sid)
         assert result is not None
         assert result.cells[0].session_mean_bsp == pytest.approx(6.0 / 1.1, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_baseline_uses_tws_tack_table(self, storage: Storage) -> None:
+        """A TWS × tack table (app_settings JSON) drives the baseline correction:
+        port tack in the 9-12 kt bin → k=1.2 → 6.0/1.2 = 5.0."""
+        await storage.set_setting(
+            "speed_cal_table",
+            '[{"tws_min":9,"tws_max":12,"port":1.2,"stbd":1.1}]',
+        )
+        await storage.refresh_speed_cal()
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=10.0, twa=45.0, heel=10.0)  # port
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(10.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0 / 1.2, rel=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_baseline_breeze_gate_suppresses_light_air(self, storage: Storage) -> None:
+        """Below the gate the table is ignored and only base applies (k=base=1.0
+        → no correction), even though a table bin covers this TWS."""
+        await storage.set_setting(
+            "speed_cal_table", '[{"tws_min":0,"tws_max":30,"port":1.2,"stbd":1.2}]'
+        )
+        await _set_speed_cal_gate(storage, gate=12.0)
+        for i in range(1, 4):
+            await _make_session(storage, i, bsp=6.0, tws=8.0, twa=45.0, heel=10.0)  # 8 kt < gate
+        await build_polar_baseline(storage)
+        row = await storage.get_polar_point(_tws_bin(8.0), _twa_bin(45.0))
+        assert row is not None
+        assert row["mean_bsp"] == pytest.approx(6.0, rel=1e-4)  # uncorrected
 
     @pytest.mark.asyncio
     async def test_grading_uses_corrected_stw(self, storage: Storage) -> None:

--- a/tests/test_speed_cal.py
+++ b/tests/test_speed_cal.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from helmlog.speed_cal import corrected_stw
+from helmlog.speed_cal import SpeedCal, corrected_stw, parse_table, resolve_stw
 
 
 class TestIdentityDefault:
@@ -97,3 +97,84 @@ class TestSaneBandGuard:
     def test_factor_just_inside_band_applies(self) -> None:
         # k = 0.5 exactly is still applied (inclusive bound)
         assert corrected_stw(3.0, -10.0, a=1.0, b=0.05) == pytest.approx(6.0)
+
+
+class TestParseTable:
+    """parse_table accepts a JSON list of TWS bins with per-tack factors."""
+
+    def test_empty_inputs_give_empty_table(self) -> None:
+        assert parse_table("") == ()
+        assert parse_table(None) == ()
+        assert parse_table("[]") == ()
+
+    def test_parses_and_sorts_bins(self) -> None:
+        spec = (
+            '[{"tws_min":12,"tws_max":15,"port":1.065,"stbd":1.020},'
+            ' {"tws_min":9,"tws_max":12,"port":1.05,"stbd":1.06}]'
+        )
+        table = parse_table(spec)
+        assert table == (
+            (9.0, 12.0, 1.05, 1.06),
+            (12.0, 15.0, 1.065, 1.020),
+        )
+
+    def test_accepts_already_parsed_list(self) -> None:
+        table = parse_table([{"tws_min": 9, "tws_max": 12, "port": 1.05, "stbd": 1.06}])
+        assert table == ((9.0, 12.0, 1.05, 1.06),)
+
+    def test_malformed_json_yields_empty(self) -> None:
+        assert parse_table("{not json") == ()
+
+
+class TestResolveStw:
+    """resolve_stw applies gate → table → heel-linear fallback precedence."""
+
+    def _cal(self, **kw: object) -> SpeedCal:
+        # SpeedCal already defaults base=1.0 / slope=0 / gate=0 / empty table.
+        return SpeedCal(**kw)  # type: ignore[arg-type]
+
+    def test_default_cal_is_identity(self) -> None:
+        assert resolve_stw(6.0, 12.0, 14.0, SpeedCal()) == 6.0
+        assert resolve_stw(6.0, None, None, SpeedCal()) == 6.0
+
+    def test_table_used_for_matching_tws_and_tack(self) -> None:
+        cal = self._cal(table=((12.0, 15.0, 1.10, 1.05),))
+        # port tack (heel>0), tws in bin → k=1.10
+        assert resolve_stw(6.6, 10.0, 13.0, cal) == pytest.approx(6.0)
+        # starboard tack (heel<0) → k=1.05
+        assert resolve_stw(6.3, -10.0, 13.0, cal) == pytest.approx(6.0)
+
+    def test_gate_suppresses_correction_in_light_air(self) -> None:
+        # Below the gate: table + slope ignored, only base applies.
+        cal = self._cal(
+            base=1.0, heel_slope=0.05, gate_min_tws=10.0, table=((0.0, 30.0, 1.2, 1.2),)
+        )
+        assert resolve_stw(6.0, 15.0, 8.0, cal) == 6.0  # k=base=1.0
+
+    def test_gate_applies_base_even_in_light_air(self) -> None:
+        cal = self._cal(base=1.09, gate_min_tws=10.0, table=((0.0, 30.0, 1.2, 1.2),))
+        assert resolve_stw(6.54, 15.0, 8.0, cal) == pytest.approx(6.0)  # k=base=1.09
+
+    def test_table_miss_falls_back_to_heel_linear(self) -> None:
+        # TWS outside every bin → heel-linear (base+slope).
+        cal = self._cal(base=1.0, heel_slope=0.01, table=((12.0, 15.0, 1.2, 1.2),))
+        assert resolve_stw(6.6, 10.0, 20.0, cal) == pytest.approx(6.0)  # k=1.0+0.01*10=1.1
+
+    def test_no_tws_uses_heel_linear_even_with_table(self) -> None:
+        cal = self._cal(base=1.0, heel_slope=0.01, table=((12.0, 15.0, 1.2, 1.2),))
+        assert resolve_stw(6.6, 10.0, None, cal) == pytest.approx(6.0)
+
+    def test_no_heel_with_table_falls_back(self) -> None:
+        # Can't pick a tack without heel → heel-linear (k=base).
+        cal = self._cal(base=1.09, table=((12.0, 15.0, 1.2, 1.2),))
+        assert resolve_stw(6.54, None, 13.0, cal) == pytest.approx(6.0)
+
+    def test_invalid_speed_passthrough(self) -> None:
+        cal = self._cal(table=((12.0, 15.0, 1.2, 1.2),))
+        assert resolve_stw(None, 10.0, 13.0, cal) is None
+        assert resolve_stw(0.0, 10.0, 13.0, cal) == 0.0
+
+    def test_table_band_guard(self) -> None:
+        # A table factor outside [0.5, 2.0] falls back to raw.
+        cal = self._cal(table=((12.0, 15.0, 3.0, 3.0),))
+        assert resolve_stw(6.0, 10.0, 13.0, cal) == 6.0

--- a/tests/test_speed_cal.py
+++ b/tests/test_speed_cal.py
@@ -100,7 +100,8 @@ class TestSaneBandGuard:
 
 
 class TestParseTable:
-    """parse_table accepts a JSON list of TWS bins with per-tack factors."""
+    """parse_table accepts a JSON list of (TWS bin, point-of-sail) entries with
+    per-tack factors."""
 
     def test_empty_inputs_give_empty_table(self) -> None:
         assert parse_table("") == ()
@@ -109,18 +110,33 @@ class TestParseTable:
 
     def test_parses_and_sorts_bins(self) -> None:
         spec = (
-            '[{"tws_min":12,"tws_max":15,"port":1.065,"stbd":1.020},'
-            ' {"tws_min":9,"tws_max":12,"port":1.05,"stbd":1.06}]'
+            '[{"tws_min":12,"tws_max":15,"pos":"upwind","port":1.065,"stbd":1.020},'
+            ' {"tws_min":9,"tws_max":12,"pos":"upwind","port":1.05,"stbd":1.06}]'
         )
         table = parse_table(spec)
         assert table == (
-            (9.0, 12.0, 1.05, 1.06),
-            (12.0, 15.0, 1.065, 1.020),
+            (9.0, 12.0, "upwind", 1.05, 1.06),
+            (12.0, 15.0, "upwind", 1.065, 1.020),
         )
 
+    def test_sorts_by_tws_then_pos(self) -> None:
+        spec = (
+            '[{"tws_min":9,"tws_max":12,"pos":"upwind","port":1.0,"stbd":1.0},'
+            ' {"tws_min":9,"tws_max":12,"pos":"downwind","port":1.1,"stbd":1.1}]'
+        )
+        table = parse_table(spec)
+        # downwind sorts before upwind alphabetically at the same TWS
+        assert [row[2] for row in table] == ["downwind", "upwind"]
+
     def test_accepts_already_parsed_list(self) -> None:
-        table = parse_table([{"tws_min": 9, "tws_max": 12, "port": 1.05, "stbd": 1.06}])
-        assert table == ((9.0, 12.0, 1.05, 1.06),)
+        table = parse_table(
+            [{"tws_min": 9, "tws_max": 12, "pos": "downwind", "port": 1.05, "stbd": 1.06}]
+        )
+        assert table == ((9.0, 12.0, "downwind", 1.05, 1.06),)
+
+    def test_rejects_bad_pos(self) -> None:
+        # An unknown point-of-sail label discards the whole table (fail safe).
+        assert parse_table('[{"tws_min":9,"tws_max":12,"pos":"reach","port":1.0,"stbd":1.0}]') == ()
 
     def test_malformed_json_yields_empty(self) -> None:
         assert parse_table("{not json") == ()
@@ -133,48 +149,72 @@ class TestResolveStw:
         # SpeedCal already defaults base=1.0 / slope=0 / gate=0 / empty table.
         return SpeedCal(**kw)  # type: ignore[arg-type]
 
+    _UP = ((12.0, 15.0, "upwind", 1.10, 1.05),)
+    _UP_DOWN = (
+        (12.0, 15.0, "upwind", 1.10, 1.05),
+        (12.0, 15.0, "downwind", 1.20, 1.15),
+    )
+
     def test_default_cal_is_identity(self) -> None:
-        assert resolve_stw(6.0, 12.0, 14.0, SpeedCal()) == 6.0
+        assert resolve_stw(6.0, 12.0, 14.0, SpeedCal(), "upwind") == 6.0
         assert resolve_stw(6.0, None, None, SpeedCal()) == 6.0
 
-    def test_table_used_for_matching_tws_and_tack(self) -> None:
-        cal = self._cal(table=((12.0, 15.0, 1.10, 1.05),))
-        # port tack (heel>0), tws in bin → k=1.10
-        assert resolve_stw(6.6, 10.0, 13.0, cal) == pytest.approx(6.0)
+    def test_table_used_for_matching_tws_pos_and_tack(self) -> None:
+        cal = self._cal(table=self._UP)
+        # port tack (heel>0), tws in bin, upwind → k=1.10
+        assert resolve_stw(6.6, 10.0, 13.0, cal, "upwind") == pytest.approx(6.0)
         # starboard tack (heel<0) → k=1.05
-        assert resolve_stw(6.3, -10.0, 13.0, cal) == pytest.approx(6.0)
+        assert resolve_stw(6.3, -10.0, 13.0, cal, "upwind") == pytest.approx(6.0)
+
+    def test_upwind_and_downwind_select_different_factors(self) -> None:
+        cal = self._cal(table=self._UP_DOWN)
+        # port, same TWS: upwind uses 1.10, downwind uses 1.20
+        assert resolve_stw(6.6, 10.0, 13.0, cal, "upwind") == pytest.approx(6.0)
+        assert resolve_stw(7.2, 10.0, 13.0, cal, "downwind") == pytest.approx(6.0)
+
+    def test_pos_miss_falls_back_to_heel_linear(self) -> None:
+        # Table only has upwind; a downwind sample → heel-linear fallback.
+        cal = self._cal(base=1.0, heel_slope=0.01, table=self._UP)
+        assert resolve_stw(6.6, 10.0, 13.0, cal, "downwind") == pytest.approx(6.0)
+
+    def test_no_pos_uses_heel_linear_even_with_table(self) -> None:
+        cal = self._cal(base=1.0, heel_slope=0.01, table=self._UP)
+        assert resolve_stw(6.6, 10.0, 13.0, cal, None) == pytest.approx(6.0)
 
     def test_gate_suppresses_correction_in_light_air(self) -> None:
         # Below the gate: table + slope ignored, only base applies.
         cal = self._cal(
-            base=1.0, heel_slope=0.05, gate_min_tws=10.0, table=((0.0, 30.0, 1.2, 1.2),)
+            base=1.0,
+            heel_slope=0.05,
+            gate_min_tws=10.0,
+            table=((0.0, 30.0, "upwind", 1.2, 1.2),),
         )
-        assert resolve_stw(6.0, 15.0, 8.0, cal) == 6.0  # k=base=1.0
+        assert resolve_stw(6.0, 15.0, 8.0, cal, "upwind") == 6.0  # k=base=1.0
 
     def test_gate_applies_base_even_in_light_air(self) -> None:
-        cal = self._cal(base=1.09, gate_min_tws=10.0, table=((0.0, 30.0, 1.2, 1.2),))
-        assert resolve_stw(6.54, 15.0, 8.0, cal) == pytest.approx(6.0)  # k=base=1.09
+        cal = self._cal(base=1.09, gate_min_tws=10.0, table=((0.0, 30.0, "upwind", 1.2, 1.2),))
+        assert resolve_stw(6.54, 15.0, 8.0, cal, "upwind") == pytest.approx(6.0)  # k=base
 
     def test_table_miss_falls_back_to_heel_linear(self) -> None:
         # TWS outside every bin → heel-linear (base+slope).
-        cal = self._cal(base=1.0, heel_slope=0.01, table=((12.0, 15.0, 1.2, 1.2),))
-        assert resolve_stw(6.6, 10.0, 20.0, cal) == pytest.approx(6.0)  # k=1.0+0.01*10=1.1
+        cal = self._cal(base=1.0, heel_slope=0.01, table=self._UP)
+        assert resolve_stw(6.6, 10.0, 20.0, cal, "upwind") == pytest.approx(6.0)
 
     def test_no_tws_uses_heel_linear_even_with_table(self) -> None:
-        cal = self._cal(base=1.0, heel_slope=0.01, table=((12.0, 15.0, 1.2, 1.2),))
-        assert resolve_stw(6.6, 10.0, None, cal) == pytest.approx(6.0)
+        cal = self._cal(base=1.0, heel_slope=0.01, table=self._UP)
+        assert resolve_stw(6.6, 10.0, None, cal, "upwind") == pytest.approx(6.0)
 
     def test_no_heel_with_table_falls_back(self) -> None:
         # Can't pick a tack without heel → heel-linear (k=base).
-        cal = self._cal(base=1.09, table=((12.0, 15.0, 1.2, 1.2),))
-        assert resolve_stw(6.54, None, 13.0, cal) == pytest.approx(6.0)
+        cal = self._cal(base=1.09, table=self._UP)
+        assert resolve_stw(6.54, None, 13.0, cal, "upwind") == pytest.approx(6.0)
 
     def test_invalid_speed_passthrough(self) -> None:
-        cal = self._cal(table=((12.0, 15.0, 1.2, 1.2),))
-        assert resolve_stw(None, 10.0, 13.0, cal) is None
-        assert resolve_stw(0.0, 10.0, 13.0, cal) == 0.0
+        cal = self._cal(table=self._UP)
+        assert resolve_stw(None, 10.0, 13.0, cal, "upwind") is None
+        assert resolve_stw(0.0, 10.0, 13.0, cal, "upwind") == 0.0
 
     def test_table_band_guard(self) -> None:
         # A table factor outside [0.5, 2.0] falls back to raw.
-        cal = self._cal(table=((12.0, 15.0, 3.0, 3.0),))
-        assert resolve_stw(6.0, 10.0, 13.0, cal) == 6.0
+        cal = self._cal(table=((12.0, 15.0, "upwind", 3.0, 3.0),))
+        assert resolve_stw(6.0, 10.0, 13.0, cal, "upwind") == 6.0

--- a/tests/test_speed_cal.py
+++ b/tests/test_speed_cal.py
@@ -1,0 +1,99 @@
+"""Tests for the heel-dependent STW correction (#810).
+
+Sign convention under test: ``heel_deg`` positive = starboard-down = port
+tack, and the paddlewheel over-reads *most* on port tack, so the fitted
+slope ``b`` is positive and the correction divides the reading down more as
+heel grows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helmlog.speed_cal import corrected_stw
+
+
+class TestIdentityDefault:
+    """R4 — shipped defaults (a=1.0, b=0.0) are an exact no-op."""
+
+    @pytest.mark.parametrize("heel", [-25.0, -10.0, 0.0, 10.0, 25.0, None])
+    @pytest.mark.parametrize("raw", [3.0, 5.5, 6.789, 8.0])
+    def test_default_is_exact_identity(self, raw: float, heel: float | None) -> None:
+        assert corrected_stw(raw, heel) == raw
+
+    def test_base_one_zero_slope_explicit(self) -> None:
+        assert corrected_stw(6.0, 12.0, a=1.0, b=0.0) == 6.0
+
+
+class TestCorrectionMath:
+    """R1 — corrected = raw / (a + b * heel)."""
+
+    def test_base_only_scales_by_a(self) -> None:
+        # a=1.09 removes a ~9% over-read; heel term off.
+        assert corrected_stw(6.54, 0.0, a=1.09, b=0.0) == pytest.approx(6.0)
+
+    def test_heel_term_applied_with_sign(self) -> None:
+        # k = 1.0 + 0.01 * 10 = 1.1  →  6.6 / 1.1 = 6.0
+        assert corrected_stw(6.6, 10.0, a=1.0, b=0.01) == pytest.approx(6.0)
+
+    def test_starboard_heel_smaller_divisor(self) -> None:
+        # heel < 0 (starboard tack) → k < a → less reduction than port.
+        # k = 1.0 + 0.01 * -10 = 0.9  →  5.4 / 0.9 = 6.0
+        assert corrected_stw(5.4, -10.0, a=1.0, b=0.01) == pytest.approx(6.0)
+
+
+class TestSignAndMonotonicity:
+    """The port-over-reads-most physics: corrected STW falls as heel rises."""
+
+    def test_monotonic_decreasing_in_heel_for_positive_slope(self) -> None:
+        raw = 6.0
+        vals = [corrected_stw(raw, h, a=1.0, b=0.01) for h in (-20, -10, 0, 10, 20)]
+        assert vals is not None
+        # strictly decreasing
+        assert all(vals[i] > vals[i + 1] for i in range(len(vals) - 1))  # type: ignore[operator]
+
+    def test_port_corrected_below_starboard_at_equal_raw(self) -> None:
+        # Same raw reading on each tack: port (heel>0) is scaled down more.
+        port = corrected_stw(6.0, 15.0, a=1.0, b=0.008)
+        stbd = corrected_stw(6.0, -15.0, a=1.0, b=0.008)
+        assert port is not None and stbd is not None
+        assert port < stbd
+
+
+class TestMissingHeel:
+    """R2 — missing heel drops the heel term (k = a)."""
+
+    def test_none_heel_uses_base_only(self) -> None:
+        assert corrected_stw(6.54, None, a=1.09, b=0.05) == pytest.approx(6.0)
+
+    def test_none_heel_with_default_base_is_identity(self) -> None:
+        assert corrected_stw(6.0, None, a=1.0, b=0.05) == 6.0
+
+
+class TestInvalidSpeed:
+    """R5 — absent / non-positive speed passes through untouched."""
+
+    def test_none_speed_passthrough(self) -> None:
+        assert corrected_stw(None, 10.0, a=1.09, b=0.01) is None
+
+    def test_zero_speed_passthrough(self) -> None:
+        assert corrected_stw(0.0, 10.0, a=1.09, b=0.01) == 0.0
+
+    def test_negative_speed_passthrough(self) -> None:
+        assert corrected_stw(-2.0, 10.0, a=1.09, b=0.01) == -2.0
+
+
+class TestSaneBandGuard:
+    """R3 — a divisor outside [0.5, 2.0] falls back to raw (no wild scaling)."""
+
+    def test_factor_below_floor_falls_back(self) -> None:
+        # k = 1.0 + 0.05 * -20 = 0.0  → out of band → raw returned
+        assert corrected_stw(6.0, -20.0, a=1.0, b=0.05) == 6.0
+
+    def test_factor_above_ceiling_falls_back(self) -> None:
+        # k = 1.0 + 0.1 * 20 = 3.0 → out of band → raw returned
+        assert corrected_stw(6.0, 20.0, a=1.0, b=0.1) == 6.0
+
+    def test_factor_just_inside_band_applies(self) -> None:
+        # k = 0.5 exactly is still applied (inclusive bound)
+        assert corrected_stw(3.0, -10.0, a=1.0, b=0.05) == pytest.approx(6.0)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3120,7 +3120,7 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
     # Should be the last category
     assert cats[-1] == "instrument_calibration"
 
-    # All 17 calibration params present
+    # All 19 calibration params present
     cal_params = next(c for c in data["categories"] if c["category"] == "instrument_calibration")
     param_names = [p["name"] for p in cal_params["parameters"]]
     expected = [
@@ -3137,6 +3137,8 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
         "heel_offset",
         "trim_offset",
         "leeway_coefficient",
+        "speed_cal_base",
+        "speed_cal_heel_slope",
         "rudder_angle_offset",
         "compass_offset_port",
         "compass_offset_stbd",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3120,7 +3120,7 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
     # Should be the last category
     assert cats[-1] == "instrument_calibration"
 
-    # All 19 calibration params present
+    # All 20 calibration params present
     cal_params = next(c for c in data["categories"] if c["category"] == "instrument_calibration")
     param_names = [p["name"] for p in cal_params["parameters"]]
     expected = [
@@ -3139,6 +3139,7 @@ async def test_instrument_calibration_in_parameters(storage: Storage) -> None:
         "leeway_coefficient",
         "speed_cal_base",
         "speed_cal_heel_slope",
+        "speed_cal_gate_min_tws",
         "rudder_angle_offset",
         "compass_offset_port",
         "compass_offset_stbd",


### PR DESCRIPTION
## Summary

Corvo's paddlewheel is mounted ~10 cm to **port** of centerline feeding a display-only B&G Triton². Under heel it over-reads, and the error is **tack-dependent** — starboard upwind reads ~6–8% slower than port at matched TWS. Current-corrected GPS-through-water is tack-symmetric, confirming this is a **sensor artifact, not real boatspeed**. The Triton² has no per-tack/heel STW cal, so the correction lives in HelmLog and is applied **at read time** — raw `speeds` / `attitudes` rows are never mutated.

Model (`helmlog.speed_cal.corrected_stw`):

```
k(heel) = a + b · heel_deg        # +ve heel = starboard-down = port tack
corrected_STW = raw_STW / k(heel)
```

`b` is expected **positive** (port tack lifts the port-offset wheel → it over-reads most → largest divisor). Defaults (`a=1.0, b=0.0`) are an **exact no-op**, so nothing changes until a boat_settings write enables it.

## What's in the diff

| Area | Change |
|---|---|
| `speed_cal.py` (new) | Pure `corrected_stw()` — identity default, missing-heel fallback (`k=a`), sane-band guard (`[0.5, 2.0]` → raw), invalid-speed passthrough. |
| `boat_settings.py` | `speed_cal_base` / `speed_cal_heel_slope` params (instrument_calibration); auto-sync to `controls`, **no migration**. |
| `storage.py` | Cache both coeffs; `refresh_speed_cal()` on connect + on settings-write hot-reload; fed into the live set/drift compute. |
| `current.py` | Correct STW at entry so both the leeway denominator and the water vector use corrected boatspeed. |
| `polar.py` | Corrected STW at **all three** self-consistent read sites — baseline build, session comparison, segment grading — joining `attitudes.heel_deg`. |
| `calibrate_speed_heel.py` (new) | Offline fit of `a,b` from steady legs, per-race current removed; reports R² on a **train/holdout split**, a sign check, and a linearity warning. |

## Self-consistency

The baseline aggregates both tacks while a graded segment is a single tack, so all three polar read sites must consume corrected STW or the `%` grade drifts from the baseline. All three are corrected here.

## Testing

- `tests/test_speed_cal.py` — 38 cases: identity default, math, sign/monotonicity, missing heel, invalid speed, band guard.
- `tests/test_current.py` — correction feeds set/drift; phantom-current removal; signed-heel slope.
- `tests/test_polar.py` — corrected STW flows through baseline build, session comparison, and grading; defaults unchanged; missing-heel base-only.
- `tests/test_instrument_smoothing_admin.py` — connect defaults + settings-write hot-reload.
- Full suite: **2820 passed, 2 skipped** (updated one hardcoded calibration-param list). `ruff check`, `ruff format`, `mypy src/` all clean.

## Spec

EARS spec + sign-convention table posted on the issue: https://github.com/weaties/helmlog/issues/810#issuecomment-4894045481

## Notes / non-goals

- No Triton² config change, no transducer relocation, no rewriting historical rows.
- SignalK publishing (issue task 5) is out of scope — HelmLog has no SK-writer capability.
- Fitting real coefficients from race data is a follow-up (run `calibrate_speed_heel.py`, then persist via the admin boat-settings UI).

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137fLP4gdEmMGAXvAvGBuvo