### PR TITLE
feat(display): configurable, selectable screens for the e-paper repeater (#822)

### DIFF
--- a/src/helmlog/display_render.py
+++ b/src/helmlog/display_render.py
@@ -1,22 +1,19 @@
-"""Render the remote e-paper display image (#820).
+"""Render the remote e-paper display image (#820, #822).
 
 HelmLog drives a LilyGo T5-S3 4.7" e-paper panel (960x540, 16 grey levels)
 as a cockpit instrument repeater.  Rather than lay out fonts on the ESP32,
 the panel is a thin frame-buffer client: it fetches a pre-rendered image
 from HelmLog and blits it.  This module does the rendering with Pillow.
 
-The layout shows six live values plus a derived one:
+#820 shipped one fixed layout.  #822 makes a *screen* data-driven — a
+``template`` (grid geometry) plus ``slots`` bound to metrics, defined in
+``display_screens.py``.  This module turns a resolved :class:`Screen` into
+pixels via :func:`render_screen`, renders the touch :func:`render_menu`, and
+packs frames into the device's 4-bit framebuffer.
 
-    STW   boat speed through water          (bsp_kts)
-    VMG   velocity made good to wind        (derived: STW * cos(TWA))
-    TWA   true wind angle                   (twa_deg)
-    TWS   true wind speed                   (tws_kts)
-    AWA   apparent wind angle               (awa_deg)
-    AWS   apparent wind speed               (aws_kts)
-
-Rendering is a pure function of the instrument snapshot so it is trivially
-testable and the same code path serves both the human-preview ``.png`` and
-the device ``.raw`` endpoints in ``routes/display.py``.
+Rendering is a pure function of the screen config + instrument snapshot so it
+is trivially testable, and the same code path serves both the human-preview
+``.png`` and the device ``.raw`` endpoints in ``routes/display.py``.
 """
 
 from __future__ import annotations
@@ -30,17 +27,42 @@ from zoneinfo import ZoneInfo
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
+from helmlog.display_screens import (
+    HEADER_H,
+    HEIGHT,
+    METRICS,
+    TEMPLATES,
+    WIDTH,
+    Screen,
+    Slot,
+    SlotBinding,
+    compute_vmg,
+    default_screens,
+    enabled_screens,
+    metric_value,
+    resolve_format,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from datetime import datetime
 
+# Re-exported so existing importers (tests, #820 callers) keep working after
+# the geometry constants and VMG math moved into display_screens.
+__all__ = [
+    "HEIGHT",
+    "WIDTH",
+    "compute_vmg",
+    "menu_regions",
+    "pack_epd_4bit",
+    "render_display",
+    "render_menu",
+    "render_screen",
+]
+
 # Pillow returns a FreeType face for a real .ttf and a bitmap face from
 # load_default(); draw.text/textbbox accept either.
 type AnyFont = ImageFont.FreeTypeFont | ImageFont.ImageFont
-
-# Panel geometry (LilyGo T5-S3 4.7"). Origin top-left, landscape.
-WIDTH = 960
-HEIGHT = 540
 
 # Greyscale values (8-bit "L"); the device quantises to 16 levels.
 BLACK = 0
@@ -67,19 +89,6 @@ def _font(size: int, *, bold: bool = True) -> AnyFont:
         return ImageFont.load_default()
 
 
-def compute_vmg(stw_kts: float | None, twa_deg: float | None) -> float | None:
-    """Velocity made good to the wind: ``STW * cos(TWA)``.
-
-    Matches HelmLog's semantic-layer definition (see ``semantic_layer.py``).
-    Positive upwind (TWA near 0), negative downwind (TWA near 180) — i.e. the
-    component of boat speed directly toward the true-wind direction.  Returns
-    None if either input is missing.
-    """
-    if stw_kts is None or twa_deg is None:
-        return None
-    return round(stw_kts * math.cos(math.radians(twa_deg)), 2)
-
-
 def _fmt(value: float | None, decimals: int) -> str:
     """Format a number, or an em-dash placeholder when unavailable."""
     if value is None:
@@ -92,6 +101,34 @@ def _fmt_angle(value: float | None) -> str:
     if value is None:
         return "—"
     return f"{round(value)}°"
+
+
+def _local_clock(now: datetime, tz: str) -> str:
+    try:
+        local = now.astimezone(ZoneInfo(tz))
+    except Exception:  # noqa: BLE001 — bad tz string shouldn't break the screen
+        local = now
+    return local.strftime("%H:%M:%S")
+
+
+def _format_metric_value(fmt: str, value: float | None, *, now: datetime, tz: str) -> str:
+    """Render a metric value string per its concrete format token."""
+    if fmt == "clock":
+        return _local_clock(now, tz)
+    if fmt == "angle":
+        return _fmt_angle(value)
+    decimals = {"num0": 0, "num1": 1, "num2": 2}.get(fmt, 1)
+    return _fmt(value, decimals)
+
+
+def _slot_label(binding: SlotBinding, fmt: str) -> str:
+    """The cell label: override or the metric's name, plus its unit."""
+    metric = METRICS[binding.metric]
+    label = binding.label if binding.label is not None else metric.label
+    # Only numeric readings carry a unit; angles/clock read cleaner without one.
+    if metric.unit and fmt in ("num0", "num1", "num2"):
+        return f"{label}  {metric.unit}"
+    return label
 
 
 def _centered_text(
@@ -124,8 +161,158 @@ def _cell(
     """Draw one labelled value cell: small label top-left, big value centered."""
     x0, y0, x1, y1 = box
     # Labels in black: mid-grey renders too faint on the e-paper panel.
-    draw.text((x0 + 18, y0 + 12), label, font=_font(label_size), fill=BLACK)
+    if label:
+        draw.text((x0 + 18, y0 + 12), label, font=_font(label_size), fill=BLACK)
     _centered_text(draw, (x0, y0 + label_size // 2, x1, y1), value, _font(value_size))
+
+
+def _draw_header(
+    draw: ImageDraw.ImageDraw,
+    *,
+    title: str,
+    now: datetime,
+    tz: str,
+    badge: str | None,
+) -> None:
+    """Draw the shared black header strip: title left, clock + badge right."""
+    draw.rectangle((0, 0, WIDTH, HEADER_H), fill=BLACK)
+    draw.text((20, 14), title, font=_font(40), fill=WHITE)
+
+    clock = _local_clock(now, tz)
+    clock_font = _font(30)
+    c_w = draw.textbbox((0, 0), clock, font=clock_font)[2]
+    if badge:
+        badge_font = _font(30)
+        b_w = draw.textbbox((0, 0), badge, font=badge_font)[2]
+        draw.text((WIDTH - b_w - 20, 18), badge, font=badge_font, fill=WHITE)
+        draw.text((WIDTH - b_w - c_w - 54, 18), clock, font=clock_font, fill=WHITE)
+    else:
+        draw.text((WIDTH - c_w - 20, 18), clock, font=clock_font, fill=WHITE)
+
+
+def _draw_compass(
+    draw: ImageDraw.ImageDraw,
+    slot: Slot,
+    binding: SlotBinding | None,
+    instruments: Mapping[str, float | None],
+) -> None:
+    """Draw a compass dial in *slot*: a ring, cardinal marks, a needle at the
+    bound heading metric's bearing, and the value at the centre.
+    """
+    x0, y0, x1, y1 = slot.box
+    cx = (x0 + x1) / 2
+    cy = (y0 + y1) / 2
+    radius = min(x1 - x0, y1 - y0) / 2 - 40
+
+    draw.ellipse((cx - radius, cy - radius, cx + radius, cy + radius), outline=GREY, width=3)
+
+    # Cardinal ticks + letters (N up, clockwise).
+    for label, bearing_deg in (("N", 0), ("E", 90), ("S", 180), ("W", 270)):
+        rad = math.radians(bearing_deg)
+        ox = cx + radius * math.sin(rad)
+        oy = cy - radius * math.cos(rad)
+        ix = cx + (radius - 18) * math.sin(rad)
+        iy = cy - (radius - 18) * math.cos(rad)
+        draw.line((ix, iy, ox, oy), fill=GREY, width=3)
+        _centered_text(
+            draw,
+            (int(ox - 20), int(oy - 20), int(ox + 20), int(oy + 20)),
+            label,
+            _font(26),
+            fill=BLACK,
+        )
+
+    bearing = metric_value(binding.metric, instruments) if binding is not None else None
+    if bearing is not None:
+        rad = math.radians(bearing)
+        tip = (cx + (radius - 6) * math.sin(rad), cy - (radius - 6) * math.cos(rad))
+        left = math.radians(bearing + 150)
+        right = math.radians(bearing - 150)
+        base_r = 26
+        draw.polygon(
+            [
+                tip,
+                (cx + base_r * math.sin(left), cy - base_r * math.cos(left)),
+                (cx, cy),
+                (cx + base_r * math.sin(right), cy - base_r * math.cos(right)),
+            ],
+            fill=BLACK,
+        )
+
+    metric = METRICS[binding.metric] if binding is not None else None
+    label = binding.label if binding and binding.label else (metric.label if metric else "")
+    if label:
+        _centered_text(
+            draw,
+            (int(cx - 100), int(cy - radius / 2 - 6), int(cx + 100), int(cy - radius / 2 + 26)),
+            label,
+            _font(slot.label_size),
+            fill=BLACK,
+        )
+    _centered_text(
+        draw,
+        (
+            int(cx - 130),
+            int(cy - slot.value_size / 2),
+            int(cx + 130),
+            int(cy + slot.value_size / 2),
+        ),
+        _fmt_angle(bearing),
+        _font(slot.value_size),
+    )
+
+
+def render_screen(
+    screen: Screen,
+    instruments: Mapping[str, float | None],
+    *,
+    now: datetime,
+    tz: str = "UTC",
+    status: str | None = None,
+) -> Image.Image:
+    """Render *screen* to a 960x540 greyscale ``"L"`` image.
+
+    *instruments* is a ``latest_instruments()`` snapshot.  *status* overrides
+    the header badge; when None it is derived — "NO DATA" if the snapshot has
+    no headline value, otherwise "LIVE".
+    """
+    if status is None:
+        any_data = any(instruments.get(k) is not None for k in ("bsp_kts", "twa_deg", "tws_kts"))
+        status = "LIVE" if any_data else "NO DATA"
+
+    img = Image.new("L", (WIDTH, HEIGHT), WHITE)
+    draw = ImageDraw.Draw(img)
+    _draw_header(draw, title="HELMLOG", now=now, tz=tz, badge=status)
+
+    template = TEMPLATES.get(screen.template)
+    if template is None:  # defensive: parse_screens validates this
+        template = TEMPLATES["single"]
+
+    for slot in template.slots:
+        binding = screen.slots.get(slot.id)
+        if slot.kind == "compass":
+            _draw_compass(draw, slot, binding, instruments)
+            continue
+        if binding is None:
+            _cell(draw, slot.box, "", "—", value_size=slot.value_size, label_size=slot.label_size)
+            continue
+        fmt = resolve_format(binding.metric, binding.fmt)
+        value = metric_value(binding.metric, instruments)
+        text = _format_metric_value(fmt, value, now=now, tz=tz)
+        _cell(
+            draw,
+            slot.box,
+            _slot_label(binding, fmt),
+            text,
+            value_size=slot.value_size,
+            label_size=slot.label_size,
+        )
+
+    # Separators drawn last so cells sit on top.
+    for line in template.separators:
+        draw.line(line, fill=GREY, width=3)
+
+    return img
 
 
 def render_display(
@@ -135,94 +322,72 @@ def render_display(
     tz: str = "UTC",
     status: str | None = None,
 ) -> Image.Image:
-    """Render the 960x540 instrument repeater to a greyscale ``"L"`` image.
+    """Render the default #820 layout (kept for back-compat).
 
-    *instruments* is a ``latest_instruments()`` snapshot.  *status* overrides
-    the header badge; when None it is derived — "NO DATA" if the whole
-    snapshot is empty, otherwise "LIVE".
+    Equivalent to rendering the first seeded screen (``Wind & Speed``); the
+    ``?screen=``-less endpoints use this so behaviour is unchanged from #820.
     """
-    stw = instruments.get("bsp_kts")
-    twa = instruments.get("twa_deg")
-    tws = instruments.get("tws_kts")
-    awa = instruments.get("awa_deg")
-    aws = instruments.get("aws_kts")
-    vmg = compute_vmg(stw, twa)
+    return render_screen(default_screens()[0], instruments, now=now, tz=tz, status=status)
 
-    if status is None:
-        any_data = any(instruments.get(k) is not None for k in ("bsp_kts", "twa_deg", "tws_kts"))
-        status = "LIVE" if any_data else "NO DATA"
 
+# ---------------------------------------------------------------------------
+# Touch menu (#822 milestone 2)
+# ---------------------------------------------------------------------------
+
+_MENU_COLS = 2
+
+
+def _menu_tiles(screens: list[Screen]) -> list[tuple[Screen, tuple[int, int, int, int]]]:
+    """Lay enabled screens out as a grid of tiles below the header."""
+    items = enabled_screens(screens)
+    if not items:
+        return []
+    rows = (len(items) + _MENU_COLS - 1) // _MENU_COLS
+    tile_w = WIDTH // _MENU_COLS
+    tile_h = (HEIGHT - HEADER_H) // rows
+    tiles: list[tuple[Screen, tuple[int, int, int, int]]] = []
+    for i, screen in enumerate(items):
+        col = i % _MENU_COLS
+        row = i // _MENU_COLS
+        x0 = col * tile_w
+        y0 = HEADER_H + row * tile_h
+        tiles.append((screen, (x0, y0, x0 + tile_w, y0 + tile_h)))
+    return tiles
+
+
+def menu_regions(screens: list[Screen]) -> list[dict[str, object]]:
+    """Tap regions for the touch menu: ``[{x, y, w, h, id, name}, …]``.
+
+    Shares geometry with :func:`render_menu` so a tap maps to exactly the tile
+    the device drew.  Only enabled screens appear, ordered like the menu.
+    """
+    return [
+        {"x": x0, "y": y0, "w": x1 - x0, "h": y1 - y0, "id": s.id, "name": s.name}
+        for s, (x0, y0, x1, y1) in _menu_tiles(screens)
+    ]
+
+
+def render_menu(
+    screens: list[Screen],
+    *,
+    now: datetime,
+    tz: str = "UTC",
+) -> Image.Image:
+    """Render the screen-picker menu: a numbered tile per enabled screen."""
     img = Image.new("L", (WIDTH, HEIGHT), WHITE)
     draw = ImageDraw.Draw(img)
+    _draw_header(draw, title="SELECT SCREEN", now=now, tz=tz, badge=None)
 
-    # --- Header strip -----------------------------------------------------
-    header_h = 66
-    draw.rectangle((0, 0, WIDTH, header_h), fill=BLACK)
-    draw.text((20, 14), "HELMLOG", font=_font(40), fill=WHITE)
+    tiles = _menu_tiles(screens)
+    if not tiles:
+        _centered_text(draw, (0, HEADER_H, WIDTH, HEIGHT), "No screens", _font(60))
+        return img
 
-    try:
-        local = now.astimezone(ZoneInfo(tz))
-    except Exception:  # noqa: BLE001 — bad tz string shouldn't break the screen
-        local = now
-    clock = local.strftime("%H:%M:%S")
-    badge = status
-    badge_font = _font(30)
-    clock_font = _font(30)
-    b_w = draw.textbbox((0, 0), badge, font=badge_font)[2]
-    c_w = draw.textbbox((0, 0), clock, font=clock_font)[2]
-    draw.text((WIDTH - b_w - 20, 18), badge, font=badge_font, fill=WHITE)
-    draw.text((WIDTH - b_w - c_w - 54, 18), clock, font=clock_font, fill=WHITE)
-
-    # --- Grid -------------------------------------------------------------
-    # Row 1: STW | VMG  (the two headline numbers)
-    # Row 2: TWA | TWS | AWA | AWS
-    row1_top = header_h
-    row1_bot = header_h + 268
-    row2_bot = HEIGHT
-    mid_x = WIDTH // 2
-
-    _cell(
-        draw,
-        (0, row1_top, mid_x, row1_bot),
-        "STW  kts",
-        _fmt(stw, 1),
-        value_size=180,
-        label_size=34,
-    )
-    _cell(
-        draw,
-        (mid_x, row1_top, WIDTH, row1_bot),
-        "VMG  kts",
-        _fmt(vmg, 1),
-        value_size=180,
-        label_size=34,
-    )
-
-    col_w = WIDTH // 4
-    row2_cells = (
-        ("TWA", _fmt_angle(twa)),
-        ("TWS  kts", _fmt(tws, 1)),
-        ("AWA", _fmt_angle(awa)),
-        ("AWS  kts", _fmt(aws, 1)),
-    )
-    for i, (label, value) in enumerate(row2_cells):
-        x0 = i * col_w
-        _cell(
-            draw,
-            (x0, row1_bot, x0 + col_w, row2_bot),
-            label,
-            value,
-            value_size=86,
-            label_size=30,
-        )
-
-    # --- Separators (drawn last so cells sit on top) ----------------------
-    draw.line((0, row1_bot, WIDTH, row1_bot), fill=GREY, width=3)
-    draw.line((mid_x, row1_top, mid_x, row1_bot), fill=GREY, width=3)
-    for i in range(1, 4):
-        x = i * col_w
-        draw.line((x, row1_bot, x, row2_bot), fill=GREY, width=3)
-
+    for i, (screen, box) in enumerate(tiles, start=1):
+        x0, y0, x1, y1 = box
+        draw.rectangle((x0 + 6, y0 + 6, x1 - 6, y1 - 6), outline=GREY, width=3)
+        draw.text((x0 + 22, y0 + 18), str(i), font=_font(40), fill=BLACK)
+        _centered_text(draw, (x0 + 60, y0, x1, y1), screen.name, _font(48))
     return img
 
 

--- a/src/helmlog/display_render.py
+++ b/src/helmlog/display_render.py
@@ -334,36 +334,44 @@ def render_display(
 # Touch menu (#822 milestone 2)
 # ---------------------------------------------------------------------------
 
-_MENU_COLS = 2
-
 
 def _menu_tiles(screens: list[Screen]) -> list[tuple[Screen, tuple[int, int, int, int]]]:
-    """Lay enabled screens out as a grid of tiles below the header."""
+    """Lay enabled screens out as full-width rows, top to bottom.
+
+    A single column (rather than a grid) makes tap hit-testing one-dimensional:
+    with the panel mounted in any rotation the firmware only has to get one axis
+    right, which removes the class of touch/orientation mismatch flagged in
+    eink-screen#1.  Tiles are also larger and easier to hit.
+    """
     items = enabled_screens(screens)
     if not items:
         return []
-    rows = (len(items) + _MENU_COLS - 1) // _MENU_COLS
-    tile_w = WIDTH // _MENU_COLS
-    tile_h = (HEIGHT - HEADER_H) // rows
-    tiles: list[tuple[Screen, tuple[int, int, int, int]]] = []
-    for i, screen in enumerate(items):
-        col = i % _MENU_COLS
-        row = i // _MENU_COLS
-        x0 = col * tile_w
-        y0 = HEADER_H + row * tile_h
-        tiles.append((screen, (x0, y0, x0 + tile_w, y0 + tile_h)))
-    return tiles
+    tile_h = (HEIGHT - HEADER_H) // len(items)
+    return [
+        (screen, (0, HEADER_H + i * tile_h, WIDTH, HEADER_H + (i + 1) * tile_h))
+        for i, screen in enumerate(items)
+    ]
 
 
 def menu_regions(screens: list[Screen]) -> list[dict[str, object]]:
-    """Tap regions for the touch menu: ``[{x, y, w, h, id, name}, …]``.
+    """Tap regions for the touch menu: ``[{index, x, y, w, h, id, name}, …]``.
 
     Shares geometry with :func:`render_menu` so a tap maps to exactly the tile
     the device drew.  Only enabled screens appear, ordered like the menu.
+    ``index`` is the 1-based number drawn on the tile — the firmware can hit-test
+    by rectangle *or*, as a fallback, select by the tile number it drew.
     """
     return [
-        {"x": x0, "y": y0, "w": x1 - x0, "h": y1 - y0, "id": s.id, "name": s.name}
-        for s, (x0, y0, x1, y1) in _menu_tiles(screens)
+        {
+            "index": i,
+            "x": x0,
+            "y": y0,
+            "w": x1 - x0,
+            "h": y1 - y0,
+            "id": s.id,
+            "name": s.name,
+        }
+        for i, (s, (x0, y0, x1, y1)) in enumerate(_menu_tiles(screens), start=1)
     ]
 
 

--- a/src/helmlog/display_screens.py
+++ b/src/helmlog/display_screens.py
@@ -1,0 +1,446 @@
+"""Data-driven screen layout model for the e-paper repeater (#822).
+
+The #820 repeater renders one fixed layout.  This module makes a *screen* a
+data-driven, server-rendered layout so the crew can compose new screens from
+the web UI — no reflashing, no code deploy.
+
+A **screen** is a *template* plus *slots*:
+
+- A **template** (``two-big-four-small``, ``single``, ``quad``, ``compass``)
+  fixes the grid geometry — where each slot sits on the 960x540 panel and how
+  big its value/label fonts are.  Templates are code, not config: they are the
+  reusable primitives.
+- Each **slot** is bound to a **metric** (STW, VMG, TWA/TWS/AWA/AWS, HDG/COG/
+  SOG/TWD, rudder, clock) with an optional label override and number format.
+
+Screens are stored as **JSON** in the ``DISPLAY_SCREENS`` app-setting (v1)
+rather than a dedicated table, so shipping this needs no ``storage.py``
+migration (a Critical-tier change).  It can be promoted to a table later; the
+``?screen=`` / ``/screens`` API contract is identical either way.
+
+This module is pure data + math (no Pillow) so it stays trivially testable and
+importable without the imaging stack; ``display_render.py`` consumes it to draw
+pixels.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# Panel geometry (LilyGo T5-S3 4.7"). Origin top-left, landscape. The header
+# strip is shared by every screen; templates lay out the area below it.
+WIDTH = 960
+HEIGHT = 540
+HEADER_H = 66
+
+# App-setting key holding the JSON screen list. Kept out of the generic
+# settings registry (SETTINGS_BY_KEY) so it is edited via the composer UI,
+# not as a raw textarea.
+SCREENS_SETTING_KEY = "DISPLAY_SCREENS"
+
+# Number-format tokens a slot may request. "auto" means "use the metric's
+# own default format".
+FORMATS = ("auto", "num0", "num1", "num2", "angle", "clock")
+
+
+# ---------------------------------------------------------------------------
+# Metric registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetricDef:
+    """One bindable value: where it comes from and how it reads by default."""
+
+    key: str  # registry key, e.g. "stw"
+    label: str  # default cell label, e.g. "STW"
+    unit: str  # display unit appended to the label, e.g. "kts" ("" for none)
+    fmt: str  # default format token (one of FORMATS, never "auto")
+    column: str | None = None  # key in a latest_instruments() snapshot
+    source: str = "instrument"  # "instrument" | "vmg" | "clock"
+
+
+# Ordered so the composer UI lists them sensibly. Columns match
+# Storage.latest_instruments() keys.
+METRICS: dict[str, MetricDef] = {
+    "stw": MetricDef("stw", "STW", "kts", "num1", column="bsp_kts"),
+    "vmg": MetricDef("vmg", "VMG", "kts", "num1", source="vmg"),
+    "sog": MetricDef("sog", "SOG", "kts", "num1", column="sog_kts"),
+    "tws": MetricDef("tws", "TWS", "kts", "num1", column="tws_kts"),
+    "aws": MetricDef("aws", "AWS", "kts", "num1", column="aws_kts"),
+    "twa": MetricDef("twa", "TWA", "", "angle", column="twa_deg"),
+    "awa": MetricDef("awa", "AWA", "", "angle", column="awa_deg"),
+    "twd": MetricDef("twd", "TWD", "", "angle", column="twd_deg"),
+    "hdg": MetricDef("hdg", "HDG", "", "angle", column="heading_deg"),
+    "cog": MetricDef("cog", "COG", "", "angle", column="cog_deg"),
+    "rudder": MetricDef("rudder", "RUD", "", "angle", column="rudder_deg"),
+    "clock": MetricDef("clock", "TIME", "", "clock", source="clock"),
+}
+
+
+def compute_vmg(stw_kts: float | None, twa_deg: float | None) -> float | None:
+    """Velocity made good to the wind: ``STW * cos(TWA)``.
+
+    Matches HelmLog's semantic-layer definition (see ``semantic_layer.py``).
+    Positive upwind (TWA near 0), negative downwind (TWA near 180) — i.e. the
+    component of boat speed directly toward the true-wind direction.  Returns
+    None if either input is missing.
+    """
+    if stw_kts is None or twa_deg is None:
+        return None
+    return round(stw_kts * math.cos(math.radians(twa_deg)), 2)
+
+
+def metric_value(metric_key: str, instruments: Mapping[str, float | None]) -> float | None:
+    """Resolve a metric's numeric value from an instrument snapshot.
+
+    ``clock`` has no numeric value (it reads the render time) and returns None
+    here; the renderer formats it from ``now``.  Derived metrics (VMG) are
+    computed from the snapshot.
+    """
+    m = METRICS[metric_key]
+    if m.source == "clock":
+        return None
+    if m.source == "vmg":
+        return compute_vmg(instruments.get("bsp_kts"), instruments.get("twa_deg"))
+    assert m.column is not None  # every "instrument" metric declares a column
+    return instruments.get(m.column)
+
+
+def resolve_format(metric_key: str, fmt: str) -> str:
+    """Return the concrete format token for a slot, resolving ``"auto"``."""
+    if fmt == "auto":
+        return METRICS[metric_key].fmt
+    return fmt
+
+
+# ---------------------------------------------------------------------------
+# Templates (fixed geometry) and screens (config)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Slot:
+    """One placement within a template's grid.
+
+    ``box`` is an absolute ``(x0, y0, x1, y1)`` pixel rectangle on the panel.
+    ``kind`` is ``"value"`` for a labelled number or ``"compass"`` for a dial
+    whose bound metric is drawn as a heading needle.
+    """
+
+    id: str
+    box: tuple[int, int, int, int]
+    value_size: int
+    label_size: int
+    kind: str = "value"
+
+
+@dataclass(frozen=True)
+class Template:
+    """A reusable layout: named slots plus the separator lines between them."""
+
+    id: str
+    name: str
+    slots: tuple[Slot, ...]
+    separators: tuple[tuple[int, int, int, int], ...] = ()
+
+    def slot_ids(self) -> tuple[str, ...]:
+        return tuple(s.id for s in self.slots)
+
+    def slot(self, slot_id: str) -> Slot | None:
+        for s in self.slots:
+            if s.id == slot_id:
+                return s
+        return None
+
+
+_MID_X = WIDTH // 2
+_ROW1_BOT = HEADER_H + 268  # matches the #820 fixed layout
+_QUARTER = WIDTH // 4
+_HALF_Y = HEADER_H + (HEIGHT - HEADER_H) // 2
+
+TEMPLATES: dict[str, Template] = {
+    # The #820 headline layout: two big numbers over a row of four small ones.
+    "two-big-four-small": Template(
+        id="two-big-four-small",
+        name="2 big + 4 small",
+        slots=(
+            Slot("big1", (0, HEADER_H, _MID_X, _ROW1_BOT), value_size=180, label_size=34),
+            Slot("big2", (_MID_X, HEADER_H, WIDTH, _ROW1_BOT), value_size=180, label_size=34),
+            Slot("s1", (0, _ROW1_BOT, _QUARTER, HEIGHT), value_size=86, label_size=30),
+            Slot("s2", (_QUARTER, _ROW1_BOT, 2 * _QUARTER, HEIGHT), value_size=86, label_size=30),
+            Slot(
+                "s3", (2 * _QUARTER, _ROW1_BOT, 3 * _QUARTER, HEIGHT), value_size=86, label_size=30
+            ),
+            Slot("s4", (3 * _QUARTER, _ROW1_BOT, WIDTH, HEIGHT), value_size=86, label_size=30),
+        ),
+        separators=(
+            (0, _ROW1_BOT, WIDTH, _ROW1_BOT),
+            (_MID_X, HEADER_H, _MID_X, _ROW1_BOT),
+            (_QUARTER, _ROW1_BOT, _QUARTER, HEIGHT),
+            (2 * _QUARTER, _ROW1_BOT, 2 * _QUARTER, HEIGHT),
+            (3 * _QUARTER, _ROW1_BOT, 3 * _QUARTER, HEIGHT),
+        ),
+    ),
+    # One huge number filling the panel.
+    "single": Template(
+        id="single",
+        name="Single huge number",
+        slots=(Slot("main", (0, HEADER_H, WIDTH, HEIGHT), value_size=300, label_size=48),),
+    ),
+    # Four equal cells.
+    "quad": Template(
+        id="quad",
+        name="Four equal cells",
+        slots=(
+            Slot("q1", (0, HEADER_H, _MID_X, _HALF_Y), value_size=150, label_size=34),
+            Slot("q2", (_MID_X, HEADER_H, WIDTH, _HALF_Y), value_size=150, label_size=34),
+            Slot("q3", (0, _HALF_Y, _MID_X, HEIGHT), value_size=150, label_size=34),
+            Slot("q4", (_MID_X, _HALF_Y, WIDTH, HEIGHT), value_size=150, label_size=34),
+        ),
+        separators=(
+            (_MID_X, HEADER_H, _MID_X, HEIGHT),
+            (0, _HALF_Y, WIDTH, _HALF_Y),
+        ),
+    ),
+    # A compass dial: one slot, bound to a heading-type metric.
+    "compass": Template(
+        id="compass",
+        name="Compass dial",
+        slots=(
+            Slot(
+                "dial", (0, HEADER_H, WIDTH, HEIGHT), value_size=96, label_size=32, kind="compass"
+            ),
+        ),
+    ),
+}
+
+
+@dataclass(frozen=True)
+class SlotBinding:
+    """A slot's metric assignment, with optional label/format overrides."""
+
+    metric: str
+    label: str | None = None
+    fmt: str = "auto"
+
+
+@dataclass(frozen=True)
+class Screen:
+    """A named, ordered, toggleable layout instance."""
+
+    id: str
+    name: str
+    template: str
+    order: int = 0
+    enabled: bool = True
+    slots: dict[str, SlotBinding] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Seed / default screens
+# ---------------------------------------------------------------------------
+
+
+def default_screens() -> list[Screen]:
+    """The screens a fresh install ships with.
+
+    The first screen reproduces the #820 fixed layout, so the ``?screen=``-less
+    endpoints render exactly what they did before this feature landed.
+    """
+    return [
+        Screen(
+            id="wind-speed",
+            name="Wind & Speed",
+            template="two-big-four-small",
+            order=0,
+            slots={
+                "big1": SlotBinding("stw"),
+                "big2": SlotBinding("vmg"),
+                "s1": SlotBinding("twa"),
+                "s2": SlotBinding("tws"),
+                "s3": SlotBinding("awa"),
+                "s4": SlotBinding("aws"),
+            },
+        ),
+        Screen(
+            id="big-speed",
+            name="Big Speed",
+            template="single",
+            order=1,
+            slots={"main": SlotBinding("stw")},
+        ),
+        Screen(
+            id="compass",
+            name="Compass",
+            template="compass",
+            order=2,
+            slots={"dial": SlotBinding("hdg")},
+        ),
+        Screen(
+            id="numbers",
+            name="Numbers",
+            template="quad",
+            order=3,
+            slots={
+                "q1": SlotBinding("twa"),
+                "q2": SlotBinding("tws"),
+                "q3": SlotBinding("stw"),
+                "q4": SlotBinding("vmg"),
+            },
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Parsing / validation / serialization
+# ---------------------------------------------------------------------------
+
+
+class ScreenConfigError(ValueError):
+    """Raised when a screen JSON payload is structurally or semantically bad."""
+
+
+def _parse_slot(raw: object, *, screen_id: str, slot_id: str, template: Template) -> SlotBinding:
+    if not isinstance(raw, dict):
+        raise ScreenConfigError(f"screen {screen_id!r} slot {slot_id!r}: must be an object")
+    if template.slot(slot_id) is None:
+        valid = ", ".join(template.slot_ids())
+        raise ScreenConfigError(
+            f"screen {screen_id!r}: slot {slot_id!r} is not in template "
+            f"{template.id!r} (valid: {valid})"
+        )
+    metric = raw.get("metric")
+    if not isinstance(metric, str) or metric not in METRICS:
+        raise ScreenConfigError(f"screen {screen_id!r} slot {slot_id!r}: unknown metric {metric!r}")
+    fmt = raw.get("fmt", "auto")
+    if not isinstance(fmt, str) or fmt not in FORMATS:
+        raise ScreenConfigError(f"screen {screen_id!r} slot {slot_id!r}: bad format {fmt!r}")
+    label = raw.get("label")
+    if label is not None and not isinstance(label, str):
+        raise ScreenConfigError(f"screen {screen_id!r} slot {slot_id!r}: label must be a string")
+    return SlotBinding(metric=metric, label=label, fmt=fmt)
+
+
+def parse_screen(raw: object) -> Screen:
+    """Validate and build a single :class:`Screen` from a plain dict.
+
+    Raises :class:`ScreenConfigError` on any structural or semantic problem so
+    callers can surface a 400 with a specific message.
+    """
+    if not isinstance(raw, dict):
+        raise ScreenConfigError("screen must be an object")
+
+    screen_id = raw.get("id")
+    if not isinstance(screen_id, str) or not screen_id.strip():
+        raise ScreenConfigError("screen id must be a non-empty string")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ScreenConfigError(f"screen {screen_id!r}: name must be a non-empty string")
+
+    template_id = raw.get("template")
+    if not isinstance(template_id, str) or template_id not in TEMPLATES:
+        raise ScreenConfigError(f"screen {screen_id!r}: unknown template {template_id!r}")
+    template = TEMPLATES[template_id]
+
+    order = raw.get("order", 0)
+    if not isinstance(order, int) or isinstance(order, bool):
+        raise ScreenConfigError(f"screen {screen_id!r}: order must be an integer")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise ScreenConfigError(f"screen {screen_id!r}: enabled must be a boolean")
+
+    raw_slots = raw.get("slots", {})
+    if not isinstance(raw_slots, dict):
+        raise ScreenConfigError(f"screen {screen_id!r}: slots must be an object")
+
+    slots: dict[str, SlotBinding] = {}
+    for slot_id, slot_raw in raw_slots.items():
+        slots[slot_id] = _parse_slot(
+            slot_raw, screen_id=screen_id, slot_id=slot_id, template=template
+        )
+
+    return Screen(
+        id=screen_id,
+        name=name,
+        template=template_id,
+        order=order,
+        enabled=enabled,
+        slots=slots,
+    )
+
+
+def parse_screens(raw: str | list[Any]) -> list[Screen]:
+    """Validate a JSON string (or already-decoded list) into ``Screen``s.
+
+    Enforces unique screen ids.  Raises :class:`ScreenConfigError` on any
+    problem.
+    """
+    data: object
+    if isinstance(raw, str):
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ScreenConfigError(f"invalid JSON: {exc}") from exc
+    else:
+        data = raw
+
+    if not isinstance(data, list):
+        raise ScreenConfigError("screens config must be a JSON list")
+
+    screens = [parse_screen(item) for item in data]
+
+    seen: set[str] = set()
+    for s in screens:
+        if s.id in seen:
+            raise ScreenConfigError(f"duplicate screen id {s.id!r}")
+        seen.add(s.id)
+    return screens
+
+
+def screen_to_dict(screen: Screen) -> dict[str, object]:
+    """Serialize a :class:`Screen` to a JSON-safe dict (round-trips parsing)."""
+    return {
+        "id": screen.id,
+        "name": screen.name,
+        "template": screen.template,
+        "order": screen.order,
+        "enabled": screen.enabled,
+        "slots": {
+            slot_id: {"metric": b.metric, "label": b.label, "fmt": b.fmt}
+            for slot_id, b in screen.slots.items()
+        },
+    }
+
+
+def screens_to_json(screens: list[Screen]) -> str:
+    return json.dumps([screen_to_dict(s) for s in screens])
+
+
+def enabled_screens(screens: list[Screen]) -> list[Screen]:
+    """Enabled screens, ordered by ``order`` then ``id`` (stable device menu)."""
+    return sorted((s for s in screens if s.enabled), key=lambda s: (s.order, s.id))
+
+
+def resolve_screen(screens: list[Screen], screen_id: str | None) -> Screen | None:
+    """Pick the screen to render.
+
+    With an explicit *screen_id*, return that screen (enabled or not) or None
+    if it does not exist.  Without one, return the default: the first *enabled*
+    screen by order, or None if none are enabled.
+    """
+    if screen_id is not None:
+        for s in screens:
+            if s.id == screen_id:
+                return s
+        return None
+    ordered = enabled_screens(screens)
+    return ordered[0] if ordered else None

--- a/src/helmlog/routes/display.py
+++ b/src/helmlog/routes/display.py
@@ -1,17 +1,27 @@
-"""Remote e-paper display endpoints (#820).
+"""Remote e-paper display endpoints (#820, #822).
 
-Serves a pre-rendered instrument-repeater image for the LilyGo T5-S3 4.7"
+Serves pre-rendered instrument-repeater images for the LilyGo T5-S3 4.7"
 e-paper panel (960x540, 16 grey levels).
 
-- ``GET /api/display.png`` — human-previewable PNG (open it in a browser to
-  see exactly what the device shows).
-- ``GET /api/display.raw`` — the same frame packed into the device's 4-bit
-  framebuffer layout, streamed straight onto the panel with no decoding.
+#820 shipped one fixed layout.  #822 makes screens **data-driven** — a screen
+is a template + slots bound to metrics, stored as JSON in the
+``DISPLAY_SCREENS`` app-setting and composed from the web UI.
 
-Both accept ``?invert=1`` (flip black/white — a panel-polarity escape hatch)
-and the ``.raw`` response carries the server-controlled refresh cadence in
-``X-Refresh-Seconds`` / ``X-Full-Refresh-Seconds`` headers so the panel can be
-retuned from HelmLog's settings without reflashing.
+Device-facing (viewer auth):
+- ``GET /api/display.png`` / ``.raw`` — render a screen (``?screen=<id>``, or
+  the default when omitted).  ``.raw`` is the 4-bit framebuffer; ``.png`` is a
+  browser preview.  Both accept ``?invert=1`` (panel-polarity escape hatch).
+- ``GET /api/display/screens`` — enabled screens ``[{id, name, order}]`` for
+  the device to build its touch menu.
+- ``GET /api/display/menu.png`` / ``.raw`` — the menu image.
+- ``GET /api/display/menu`` — tap regions ``[{x, y, w, h, id, name}]`` so a
+  touch maps to a screen.
+
+Composer (admin auth):
+- ``GET/PUT /api/admin/display/screens`` — read/replace the full screen list.
+- ``GET /api/admin/display/catalog`` — templates + metrics for the editor.
+- ``POST /api/admin/display/preview.png`` — render an unsaved screen.
+- ``GET /admin/display`` — the composer page.
 """
 
 from __future__ import annotations
@@ -20,12 +30,33 @@ import io
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends, Query, Request
-from fastapi.responses import Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+from loguru import logger
 
 from helmlog.auth import require_auth
-from helmlog.display_render import pack_epd_4bit, render_display
-from helmlog.routes._helpers import get_storage
+from helmlog.display_render import (
+    menu_regions,
+    pack_epd_4bit,
+    render_menu,
+    render_screen,
+)
+from helmlog.display_screens import (
+    FORMATS,
+    METRICS,
+    SCREENS_SETTING_KEY,
+    TEMPLATES,
+    Screen,
+    ScreenConfigError,
+    default_screens,
+    enabled_screens,
+    parse_screen,
+    parse_screens,
+    resolve_screen,
+    screen_to_dict,
+    screens_to_json,
+)
+from helmlog.routes._helpers import get_storage, templates, tpl_ctx
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -57,26 +88,37 @@ async def _refresh_seconds(request: Request, key: str) -> int:
     return max(1, value)
 
 
-async def _render_current(request: Request) -> Image.Image:
-    """Render the current instrument snapshot to a greyscale image."""
+async def _load_screens(request: Request) -> list[Screen]:
+    """Load the configured screens, falling back to the seed when unset/bad.
+
+    The PUT endpoint validates before saving, so a stored value is normally
+    valid; a corrupt value (e.g. hand-edited env override) is logged and the
+    seed is used so the panel never goes dark.
+    """
+    raw = await get_storage(request).get_setting(SCREENS_SETTING_KEY)
+    if not raw:
+        return default_screens()
+    try:
+        return parse_screens(raw)
+    except ScreenConfigError as exc:
+        logger.warning("Invalid {} setting, using defaults: {}", SCREENS_SETTING_KEY, exc)
+        return default_screens()
+
+
+async def _render_current(request: Request, screen_id: str | None) -> Image.Image:
+    """Render the requested screen (or the default) from live instruments."""
+    screens = await _load_screens(request)
+    screen = resolve_screen(screens, screen_id)
+    if screen is None:
+        detail = f"unknown screen {screen_id!r}" if screen_id else "no screens configured"
+        raise HTTPException(status_code=404, detail=detail)
     storage = get_storage(request)
     instruments = await storage.latest_instruments()
     tz = await _current_timezone(request)
-    return render_display(instruments, now=datetime.now(UTC), tz=tz)
+    return render_screen(screen, instruments, now=datetime.now(UTC), tz=tz)
 
 
-@router.get("/api/display.png")
-async def api_display_png(
-    request: Request,
-    invert: bool = Query(False),  # noqa: B008
-    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
-) -> Response:
-    """Render the current instruments as a 960x540 greyscale PNG."""
-    img = await _render_current(request)
-    if invert:
-        from PIL import ImageOps
-
-        img = ImageOps.invert(img)
+def _png_response(img: Image.Image) -> Response:
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     return Response(
@@ -84,18 +126,40 @@ async def api_display_png(
     )
 
 
-@router.get("/api/display.raw")
-async def api_display_raw(
+# ---------------------------------------------------------------------------
+# Device-facing screen rendering
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/display.png")
+async def api_display_png(
     request: Request,
+    screen: str | None = Query(None),  # noqa: B008
     invert: bool = Query(False),  # noqa: B008
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> Response:
-    """Return the current frame packed as EPD47 4-bit framebuffer bytes.
+    """Render a screen as a 960x540 greyscale PNG (default when ``?screen=`` omitted)."""
+    img = await _render_current(request, screen)
+    if invert:
+        from PIL import ImageOps
+
+        img = ImageOps.invert(img)
+    return _png_response(img)
+
+
+@router.get("/api/display.raw")
+async def api_display_raw(
+    request: Request,
+    screen: str | None = Query(None),  # noqa: B008
+    invert: bool = Query(False),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> Response:
+    """Return a screen packed as EPD47 4-bit framebuffer bytes.
 
     The body is exactly ``WIDTH * HEIGHT / 2`` bytes (259200) in row-major,
     2-pixels-per-byte order — read it straight into the device framebuffer.
     """
-    img = await _render_current(request)
+    img = await _render_current(request, screen)
     packed = pack_epd_4bit(img, invert=invert)
 
     refresh = await _refresh_seconds(request, "DISPLAY_REFRESH_SECONDS")
@@ -108,4 +172,147 @@ async def api_display_raw(
             "X-Refresh-Seconds": str(refresh),
             "X-Full-Refresh-Seconds": str(full_refresh),
         },
+    )
+
+
+@router.get("/api/display/screens")
+async def api_display_screens(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """List enabled screens ``[{id, name, order}]`` for the device menu."""
+    screens = await _load_screens(request)
+    return JSONResponse(
+        [{"id": s.id, "name": s.name, "order": s.order} for s in enabled_screens(screens)]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Touch menu (milestone 2)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/display/menu.png")
+async def api_display_menu_png(
+    request: Request,
+    invert: bool = Query(False),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> Response:
+    """Render the screen-picker menu as a PNG."""
+    screens = await _load_screens(request)
+    tz = await _current_timezone(request)
+    img = render_menu(screens, now=datetime.now(UTC), tz=tz)
+    if invert:
+        from PIL import ImageOps
+
+        img = ImageOps.invert(img)
+    return _png_response(img)
+
+
+@router.get("/api/display/menu.raw")
+async def api_display_menu_raw(
+    request: Request,
+    invert: bool = Query(False),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> Response:
+    """Return the menu image packed as EPD47 4-bit framebuffer bytes."""
+    screens = await _load_screens(request)
+    tz = await _current_timezone(request)
+    img = render_menu(screens, now=datetime.now(UTC), tz=tz)
+    packed = pack_epd_4bit(img, invert=invert)
+    return Response(
+        content=packed,
+        media_type="application/octet-stream",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.get("/api/display/menu")
+async def api_display_menu_regions(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
+) -> JSONResponse:
+    """Tap regions ``[{x, y, w, h, id, name}]`` matching the menu image tiles."""
+    screens = await _load_screens(request)
+    return JSONResponse(menu_regions(screens))
+
+
+# ---------------------------------------------------------------------------
+# Composer (admin)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/admin/display/screens")
+async def api_admin_display_screens(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Return the full screen list (including disabled) for the composer."""
+    screens = await _load_screens(request)
+    return JSONResponse([screen_to_dict(s) for s in screens])
+
+
+@router.put("/api/admin/display/screens")
+async def api_admin_display_screens_save(
+    request: Request,
+    payload: list[dict[str, Any]] = Body(...),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Validate and replace the whole screen list."""
+    try:
+        screens = parse_screens(payload)
+    except ScreenConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    await get_storage(request).set_setting(SCREENS_SETTING_KEY, screens_to_json(screens))
+    return JSONResponse([screen_to_dict(s) for s in screens])
+
+
+@router.get("/api/admin/display/catalog")
+async def api_admin_display_catalog(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> JSONResponse:
+    """Templates (with their slots) + bindable metrics + formats for the editor."""
+    return JSONResponse(
+        {
+            "templates": [
+                {
+                    "id": t.id,
+                    "name": t.name,
+                    "slots": [{"id": s.id, "kind": s.kind} for s in t.slots],
+                }
+                for t in TEMPLATES.values()
+            ],
+            "metrics": [{"key": m.key, "label": m.label, "unit": m.unit} for m in METRICS.values()],
+            "formats": list(FORMATS),
+        }
+    )
+
+
+@router.post("/api/admin/display/preview.png")
+async def api_admin_display_preview(
+    request: Request,
+    payload: dict[str, Any] = Body(...),  # noqa: B008
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Render an unsaved screen config to a PNG for the composer's live preview."""
+    try:
+        screen = parse_screen(payload)
+    except ScreenConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    storage = get_storage(request)
+    instruments = await storage.latest_instruments()
+    tz = await _current_timezone(request)
+    img = render_screen(screen, instruments, now=datetime.now(UTC), tz=tz)
+    return _png_response(img)
+
+
+@router.get("/admin/display", response_class=HTMLResponse, include_in_schema=False)
+async def admin_display_page(
+    request: Request,
+    _user: dict[str, Any] = Depends(require_auth("admin")),  # noqa: B008
+) -> Response:
+    """Composer page: CRUD screens with a live preview."""
+    return templates.TemplateResponse(
+        request, "admin/display.html", tpl_ctx(request, "/admin/display")
     )

--- a/src/helmlog/routes/display.py
+++ b/src/helmlog/routes/display.py
@@ -14,8 +14,8 @@ Device-facing (viewer auth):
 - ``GET /api/display/screens`` — enabled screens ``[{id, name, order}]`` for
   the device to build its touch menu.
 - ``GET /api/display/menu.png`` / ``.raw`` — the menu image.
-- ``GET /api/display/menu`` — tap regions ``[{x, y, w, h, id, name}]`` so a
-  touch maps to a screen.
+- ``GET /api/display/menu`` — tap regions ``[{index, x, y, w, h, id, name}]``
+  so a touch maps to a screen.
 
 Composer (admin auth):
 - ``GET/PUT /api/admin/display/screens`` — read/replace the full screen list.
@@ -232,7 +232,7 @@ async def api_display_menu_regions(
     request: Request,
     _user: dict[str, Any] = Depends(require_auth("viewer")),  # noqa: B008
 ) -> JSONResponse:
-    """Tap regions ``[{x, y, w, h, id, name}]`` matching the menu image tiles."""
+    """Tap regions ``[{index, x, y, w, h, id, name}]`` matching the menu tiles."""
     screens = await _load_screens(request)
     return JSONResponse(menu_regions(screens))
 

--- a/src/helmlog/templates/admin/display.html
+++ b/src/helmlog/templates/admin/display.html
@@ -1,0 +1,236 @@
+{% extends "base.html" %}
+{% block title %}Display Screens — HelmLog{% endblock %}
+{% block extra_css %}
+<style>
+h1{font-size:1.3rem;font-weight:700;color:var(--accent)}
+.card{background:var(--bg-secondary);border-radius:12px;padding:16px;margin-bottom:12px}
+.layout{display:grid;grid-template-columns:minmax(240px,320px) 1fr;gap:12px;align-items:start}
+@media(max-width:760px){.layout{grid-template-columns:1fr}}
+.screen-list{list-style:none;padding:0;margin:0}
+.screen-list li{display:flex;align-items:center;gap:8px;padding:8px;border-bottom:1px solid var(--border);cursor:pointer;font-size:.86rem}
+.screen-list li.active{background:var(--bg-input);border-left:3px solid var(--accent)}
+.screen-list li .nm{flex:1;font-weight:600}
+.screen-list li .tpl{font-size:.72rem;color:var(--text-secondary)}
+.muted{color:var(--text-secondary);font-size:.75rem}
+.btn-sm{padding:6px 10px;border:1px solid var(--border);border-radius:4px;background:var(--bg-input);font-size:.78rem;cursor:pointer;color:var(--text-primary)}
+.btn-primary{color:var(--accent);border-color:var(--accent-strong)}
+.btn-del{color:var(--danger);border-color:var(--danger)}
+label.fld{display:block;font-size:.74rem;color:var(--text-secondary);text-transform:uppercase;letter-spacing:.05em;margin:10px 0 3px}
+input.inline,select.inline{background:var(--bg-input);border:1px solid var(--border);border-radius:4px;padding:6px 8px;color:var(--text-primary);font-size:.85rem;width:100%;box-sizing:border-box}
+.slot-row{display:grid;grid-template-columns:70px 1fr 1fr 110px;gap:8px;align-items:center;margin-bottom:6px}
+.slot-row .slot-id{font-family:monospace;font-size:.78rem;color:var(--text-secondary)}
+.preview-wrap{margin-top:12px;text-align:center}
+.preview-wrap img{max-width:100%;border:1px solid var(--border);border-radius:6px;background:#fff}
+#flash{font-size:.8rem;margin:6px 0;min-height:1.1em}
+.toolbar{display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-bottom:10px}
+</style>
+{% endblock %}
+{% block content %}
+<h1 style="margin-bottom:6px">Display Screens</h1>
+<p class="muted" style="margin-bottom:12px">
+  Compose the screens the e-paper repeater (LilyGo T5-S3) can show. Each screen
+  is a <em>template</em> with <em>slots</em> bound to metrics. The device picks a
+  screen via its touch menu; HelmLog does not push. Save to apply.
+</p>
+
+<div class="card">
+  <div class="toolbar">
+    <button class="btn-sm btn-primary" onclick="addScreen()">+ Add screen</button>
+    <button class="btn-sm btn-primary" onclick="saveAll()">Save all</button>
+    <span style="flex:1"></span>
+    <span id="flash"></span>
+  </div>
+
+  <div class="layout">
+    <div>
+      <ul class="screen-list" id="screen-list"></ul>
+    </div>
+    <div id="editor"><p class="muted">Select or add a screen to edit.</p></div>
+  </div>
+</div>
+
+<script>
+let CATALOG = {templates: [], metrics: [], formats: []};
+let SCREENS = [];
+let selectedId = null;
+let previewTimer = null;
+
+function esc(s){return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+function flash(msg, err){const el = document.getElementById('flash'); el.textContent = msg; el.style.color = err ? 'var(--danger)' : 'var(--text-secondary)';}
+function templateById(id){return CATALOG.templates.find(t => t.id === id);}
+
+async function load(){
+  const [cat, scr] = await Promise.all([
+    fetch('/api/admin/display/catalog').then(r => r.json()),
+    fetch('/api/admin/display/screens').then(r => r.json()),
+  ]);
+  CATALOG = cat;
+  SCREENS = scr;
+  if (SCREENS.length && !selectedId) selectedId = SCREENS[0].id;
+  renderList();
+  renderEditor();
+}
+
+function renderList(){
+  const ul = document.getElementById('screen-list');
+  SCREENS.sort((a,b) => (a.order - b.order) || a.id.localeCompare(b.id));
+  ul.innerHTML = SCREENS.map(s =>
+    '<li class="' + (s.id === selectedId ? 'active' : '') + '" onclick="selectScreen(\'' + esc(s.id) + '\')">'
+    + '<span class="nm">' + esc(s.name) + (s.enabled ? '' : ' <span class="muted">(off)</span>') + '</span>'
+    + '<span class="tpl">' + esc(s.template) + '</span>'
+    + '</li>'
+  ).join('') || '<li class="muted">No screens yet.</li>';
+}
+
+function selectScreen(id){selectedId = id; renderList(); renderEditor();}
+
+function currentScreen(){return SCREENS.find(s => s.id === selectedId);}
+
+function renderEditor(){
+  const s = currentScreen();
+  const ed = document.getElementById('editor');
+  if (!s){ed.innerHTML = '<p class="muted">Select or add a screen to edit.</p>'; return;}
+  const tpl = templateById(s.template);
+  const metricOpts = CATALOG.metrics.map(m => '<option value="' + m.key + '">' + esc(m.label) + (m.unit ? ' (' + esc(m.unit) + ')' : '') + '</option>').join('');
+  const fmtOpts = CATALOG.formats.map(f => '<option value="' + f + '">' + f + '</option>').join('');
+  const slotRows = (tpl ? tpl.slots : []).map(slot => {
+    const b = s.slots[slot.id] || {metric: '', label: null, fmt: 'auto'};
+    return '<div class="slot-row" data-slot="' + esc(slot.id) + '">'
+      + '<span class="slot-id">' + esc(slot.id) + '</span>'
+      + '<select class="inline sl-metric" onchange="onEdit()"><option value="">—</option>' + metricOpts + '</select>'
+      + '<input class="inline sl-label" placeholder="label (optional)" oninput="onEdit()" />'
+      + '<select class="inline sl-fmt" onchange="onEdit()">' + fmtOpts + '</select>'
+      + '</div>';
+  }).join('');
+
+  ed.innerHTML =
+      '<label class="fld">Name</label><input id="ed-name" class="inline" oninput="onEdit()" />'
+    + '<div style="display:grid;grid-template-columns:1fr 90px 90px;gap:8px">'
+    +   '<div><label class="fld">Template</label><select id="ed-template" class="inline" onchange="onTemplateChange()">'
+    +     CATALOG.templates.map(t => '<option value="' + t.id + '">' + esc(t.name) + '</option>').join('') + '</select></div>'
+    +   '<div><label class="fld">Order</label><input id="ed-order" class="inline" type="number" oninput="onEdit()" /></div>'
+    +   '<div><label class="fld">Enabled</label><select id="ed-enabled" class="inline" onchange="onEdit()"><option value="true">Yes</option><option value="false">No</option></select></div>'
+    + '</div>'
+    + '<label class="fld">Slots (slot · metric · label · format)</label>' + slotRows
+    + '<div style="margin-top:12px;display:flex;gap:6px">'
+    +   '<button class="btn-sm btn-del" onclick="deleteScreen()">Delete screen</button>'
+    + '</div>'
+    + '<div class="preview-wrap"><label class="fld" style="text-align:left">Live preview</label><img id="preview" alt="preview" /></div>';
+
+  document.getElementById('ed-name').value = s.name;
+  document.getElementById('ed-template').value = s.template;
+  document.getElementById('ed-order').value = s.order;
+  document.getElementById('ed-enabled').value = s.enabled ? 'true' : 'false';
+  if (tpl) tpl.slots.forEach(slot => {
+    const row = ed.querySelector('.slot-row[data-slot="' + slot.id + '"]');
+    if (!row) return;
+    const b = s.slots[slot.id] || {};
+    row.querySelector('.sl-metric').value = b.metric || '';
+    row.querySelector('.sl-label').value = b.label || '';
+    row.querySelector('.sl-fmt').value = b.fmt || 'auto';
+  });
+  schedulePreview();
+}
+
+function readEditorInto(s){
+  s.name = document.getElementById('ed-name').value.trim();
+  s.template = document.getElementById('ed-template').value;
+  s.order = parseInt(document.getElementById('ed-order').value, 10) || 0;
+  s.enabled = document.getElementById('ed-enabled').value === 'true';
+  const slots = {};
+  document.querySelectorAll('.slot-row').forEach(row => {
+    const metric = row.querySelector('.sl-metric').value;
+    if (!metric) return;
+    const label = row.querySelector('.sl-label').value.trim();
+    const fmt = row.querySelector('.sl-fmt').value;
+    const b = {metric: metric, fmt: fmt};
+    if (label) b.label = label;
+    slots[row.dataset.slot] = b;
+  });
+  s.slots = slots;
+}
+
+function onEdit(){
+  const s = currentScreen();
+  if (!s) return;
+  readEditorInto(s);
+  renderList();
+  schedulePreview();
+}
+
+function onTemplateChange(){
+  const s = currentScreen();
+  if (!s) return;
+  s.template = document.getElementById('ed-template').value;
+  // Keep bindings whose slot id still exists in the new template.
+  const tpl = templateById(s.template);
+  const valid = new Set((tpl ? tpl.slots : []).map(x => x.id));
+  const kept = {};
+  Object.keys(s.slots || {}).forEach(k => {if (valid.has(k)) kept[k] = s.slots[k];});
+  s.slots = kept;
+  renderEditor();
+}
+
+function schedulePreview(){
+  clearTimeout(previewTimer);
+  previewTimer = setTimeout(updatePreview, 300);
+}
+
+async function updatePreview(){
+  const s = currentScreen();
+  const img = document.getElementById('preview');
+  if (!s || !img) return;
+  const r = await fetch('/api/admin/display/preview.png', {
+    method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(s),
+  });
+  if (!r.ok){img.removeAttribute('src'); flash('Preview: ' + (await r.json()).detail, true); return;}
+  const blob = await r.blob();
+  if (img.dataset.url) URL.revokeObjectURL(img.dataset.url);
+  const url = URL.createObjectURL(blob);
+  img.dataset.url = url;
+  img.src = url;
+}
+
+function slugify(name){return (name || 'screen').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'screen';}
+
+function addScreen(){
+  let base = 'screen', id = base, n = 1;
+  while (SCREENS.some(s => s.id === id)) id = base + '-' + (++n);
+  const order = SCREENS.reduce((m, s) => Math.max(m, s.order), -1) + 1;
+  const tpl = CATALOG.templates[0];
+  SCREENS.push({id: id, name: 'New Screen', template: tpl.id, order: order, enabled: true, slots: {}});
+  selectedId = id;
+  renderList();
+  renderEditor();
+}
+
+function deleteScreen(){
+  SCREENS = SCREENS.filter(s => s.id !== selectedId);
+  selectedId = SCREENS.length ? SCREENS[0].id : null;
+  renderList();
+  renderEditor();
+}
+
+async function saveAll(){
+  // Re-derive ids from names so they stay stable + unique.
+  const seen = new Set();
+  SCREENS.forEach(s => {
+    let id = slugify(s.name), base = id, n = 1;
+    while (seen.has(id)) id = base + '-' + (++n);
+    if (s.id === selectedId) selectedId = id;
+    s.id = id;
+    seen.add(id);
+  });
+  const r = await fetch('/api/admin/display/screens', {
+    method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(SCREENS),
+  });
+  if (!r.ok){flash('Save failed: ' + (await r.json()).detail, true); return;}
+  SCREENS = await r.json();
+  flash('Saved ' + SCREENS.length + ' screen(s).');
+  renderList();
+  renderEditor();
+}
+
+load();
+</script>
+{% endblock %}

--- a/src/helmlog/templates/base.html
+++ b/src/helmlog/templates/base.html
@@ -31,6 +31,7 @@
     <a href="/admin/aruco" class="admin-link{% if active_page == "/admin/aruco" %} active{% endif %}">ArUco</a>
     <a href="/admin/devices" class="admin-link{% if active_page == "/admin/devices" %} active{% endif %}">Devices</a>
     <a href="/admin/instruments" class="admin-link{% if active_page == "/admin/instruments" %} active{% endif %}">Instruments</a>
+    <a href="/admin/display" class="admin-link{% if active_page == "/admin/display" %} active{% endif %}">Display</a>
     <a href="/admin/pgn-audit" class="admin-link{% if active_page == "/admin/pgn-audit" %} active{% endif %}">PGN Audit</a>
     <a href="/admin/network" class="admin-link{% if active_page == "/admin/network" %} active{% endif %}">Network</a>
     <a href="/admin/events" class="admin-link{% if active_page == "/admin/events" %} active{% endif %}">Events</a>

--- a/tests/test_display_screens.py
+++ b/tests/test_display_screens.py
@@ -225,6 +225,18 @@ def test_menu_regions_are_within_panel_bounds() -> None:
         assert r["y"] + r["h"] <= HEIGHT  # type: ignore[operator]
 
 
+def test_menu_regions_are_single_column_and_indexed() -> None:
+    # Single column: every tile spans the full width, stacked top→bottom with
+    # a sequential 1-based index (robustness aid for rotated-panel hit-testing).
+    regions = menu_regions(default_screens())
+    assert [r["index"] for r in regions] == list(range(1, len(regions) + 1))
+    assert all(r["x"] == 0 and r["w"] == WIDTH for r in regions)
+    ys = [r["y"] for r in regions]
+    assert ys == sorted(ys)
+    for a, b in zip(regions, regions[1:], strict=False):
+        assert a["y"] + a["h"] <= b["y"]  # type: ignore[operator]  # no overlap
+
+
 def test_menu_regions_empty_when_none_enabled() -> None:
     screens = [Screen(id="a", name="A", template="single", enabled=False)]
     assert menu_regions(screens) == []

--- a/tests/test_display_screens.py
+++ b/tests/test_display_screens.py
@@ -1,0 +1,369 @@
+"""Tests for the data-driven display screen model + endpoints (#822)."""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from httpx import ASGITransport
+from PIL import Image
+
+from helmlog.display_render import (
+    HEIGHT,
+    WIDTH,
+    menu_regions,
+    render_menu,
+    render_screen,
+)
+from helmlog.display_screens import (
+    METRICS,
+    TEMPLATES,
+    Screen,
+    ScreenConfigError,
+    SlotBinding,
+    compute_vmg,
+    default_screens,
+    enabled_screens,
+    metric_value,
+    parse_screen,
+    parse_screens,
+    resolve_format,
+    resolve_screen,
+    screens_to_json,
+)
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from helmlog.storage import Storage
+
+_NOW = datetime(2026, 7, 7, 15, 30, 0, tzinfo=UTC)
+_SNAP = {"bsp_kts": 6.4, "twa_deg": 42.0, "tws_kts": 12.1, "heading_deg": 210.0}
+
+
+# --- metric registry -------------------------------------------------------
+
+
+def test_metric_value_reads_column() -> None:
+    assert metric_value("stw", _SNAP) == 6.4
+    assert metric_value("twa", _SNAP) == 42.0
+
+
+def test_metric_value_derived_vmg_matches_compute() -> None:
+    assert metric_value("vmg", _SNAP) == compute_vmg(6.4, 42.0)
+
+
+def test_metric_value_clock_is_none() -> None:
+    # The clock has no snapshot value; the renderer formats it from `now`.
+    assert metric_value("clock", _SNAP) is None
+
+
+def test_metric_value_missing_returns_none() -> None:
+    assert metric_value("sog", _SNAP) is None
+
+
+def test_resolve_format_auto_uses_metric_default() -> None:
+    assert resolve_format("twa", "auto") == "angle"
+    assert resolve_format("stw", "auto") == "num1"
+    assert resolve_format("stw", "num2") == "num2"
+
+
+# --- template + screen model ----------------------------------------------
+
+
+def test_default_screens_reference_only_known_templates_and_metrics() -> None:
+    for s in default_screens():
+        assert s.template in TEMPLATES
+        tpl = TEMPLATES[s.template]
+        for slot_id, binding in s.slots.items():
+            assert tpl.slot(slot_id) is not None
+            assert binding.metric in METRICS
+
+
+def test_enabled_screens_orders_and_filters() -> None:
+    screens = [
+        Screen(id="b", name="B", template="single", order=2),
+        Screen(id="a", name="A", template="single", order=1),
+        Screen(id="c", name="C", template="single", order=3, enabled=False),
+    ]
+    assert [s.id for s in enabled_screens(screens)] == ["a", "b"]
+
+
+def test_resolve_screen_default_is_first_enabled() -> None:
+    screens = [
+        Screen(id="off", name="Off", template="single", order=0, enabled=False),
+        Screen(id="on", name="On", template="single", order=1),
+    ]
+    assert resolve_screen(screens, None).id == "on"  # type: ignore[union-attr]
+
+
+def test_resolve_screen_by_id_allows_disabled() -> None:
+    screens = [Screen(id="off", name="Off", template="single", order=0, enabled=False)]
+    assert resolve_screen(screens, "off").id == "off"  # type: ignore[union-attr]
+
+
+def test_resolve_screen_unknown_id_is_none() -> None:
+    assert resolve_screen(default_screens(), "nope") is None
+
+
+# --- parsing / validation --------------------------------------------------
+
+
+def _valid_screen_dict() -> dict[str, object]:
+    return {
+        "id": "s1",
+        "name": "Screen 1",
+        "template": "single",
+        "order": 0,
+        "enabled": True,
+        "slots": {"main": {"metric": "stw", "fmt": "num2", "label": "Speed"}},
+    }
+
+
+def test_parse_screen_roundtrips() -> None:
+    s = parse_screen(_valid_screen_dict())
+    assert s.id == "s1"
+    assert s.slots["main"] == SlotBinding(metric="stw", label="Speed", fmt="num2")
+
+
+def test_parse_screens_from_json_string() -> None:
+    raw = json.dumps([_valid_screen_dict()])
+    assert [s.id for s in parse_screens(raw)] == ["s1"]
+
+
+def test_parse_screens_roundtrip_via_serialize() -> None:
+    screens = default_screens()
+    assert [s.id for s in parse_screens(screens_to_json(screens))] == [s.id for s in screens]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda d: d.update(template="bogus"), "unknown template"),
+        (lambda d: d.update(slots={"nope": {"metric": "stw"}}), "not in template"),
+        (lambda d: d.update(slots={"main": {"metric": "xyz"}}), "unknown metric"),
+        (lambda d: d.update(slots={"main": {"metric": "stw", "fmt": "bad"}}), "bad format"),
+        (lambda d: d.update(id=""), "id must be"),
+        (lambda d: d.update(name=""), "name must be"),
+        (lambda d: d.update(order="1"), "order must be an integer"),
+        (lambda d: d.update(enabled="yes"), "enabled must be a boolean"),
+    ],
+)
+def test_parse_screen_rejects_bad_config(
+    mutate: Callable[[dict[str, object]], object], match: str
+) -> None:
+    d = _valid_screen_dict()
+    mutate(d)
+    with pytest.raises(ScreenConfigError, match=match):
+        parse_screen(d)
+
+
+def test_parse_screens_rejects_duplicate_ids() -> None:
+    d = _valid_screen_dict()
+    with pytest.raises(ScreenConfigError, match="duplicate"):
+        parse_screens([d, dict(d)])
+
+
+def test_parse_screens_rejects_non_list() -> None:
+    with pytest.raises(ScreenConfigError, match="must be a JSON list"):
+        parse_screens(json.dumps({"not": "a list"}))
+
+
+# --- rendering -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template_id", list(TEMPLATES))
+def test_render_screen_every_template_is_panel_sized(template_id: str) -> None:
+    tpl = TEMPLATES[template_id]
+    # Bind every slot to a plausible metric (hdg for the compass dial).
+    slots = {s.id: SlotBinding("hdg" if s.kind == "compass" else "stw") for s in tpl.slots}
+    screen = Screen(id="t", name="T", template=template_id, slots=slots)
+    img = render_screen(screen, _SNAP, now=_NOW)
+    assert img.size == (WIDTH, HEIGHT)
+    assert img.mode == "L"
+
+
+def test_render_screen_unbound_slot_renders() -> None:
+    # A screen with no bindings still produces a full image (em-dash cells).
+    screen = Screen(id="empty", name="Empty", template="quad")
+    img = render_screen(screen, _SNAP, now=_NOW)
+    assert img.size == (WIDTH, HEIGHT)
+
+
+def test_render_screen_missing_data_is_no_data_badge() -> None:
+    screen = default_screens()[0]
+    img = render_screen(screen, dict.fromkeys(("bsp_kts", "twa_deg", "tws_kts"), None), now=_NOW)
+    assert img.size == (WIDTH, HEIGHT)
+
+
+# --- menu ------------------------------------------------------------------
+
+
+def test_render_menu_panel_sized() -> None:
+    img = render_menu(default_screens(), now=_NOW)
+    assert img.size == (WIDTH, HEIGHT)
+    assert img.mode == "L"
+
+
+def test_menu_regions_match_enabled_screens() -> None:
+    screens = default_screens()
+    regions = menu_regions(screens)
+    assert len(regions) == len(enabled_screens(screens))
+    ids = {r["id"] for r in regions}
+    assert ids == {s.id for s in enabled_screens(screens)}
+
+
+def test_menu_regions_are_within_panel_bounds() -> None:
+    for r in menu_regions(default_screens()):
+        assert r["x"] >= 0 and r["y"] >= 0  # type: ignore[operator]
+        assert r["x"] + r["w"] <= WIDTH  # type: ignore[operator]
+        assert r["y"] + r["h"] <= HEIGHT  # type: ignore[operator]
+
+
+def test_menu_regions_empty_when_none_enabled() -> None:
+    screens = [Screen(id="a", name="A", template="single", enabled=False)]
+    assert menu_regions(screens) == []
+    # Still renders (a "No screens" placeholder), not a crash.
+    assert render_menu(screens, now=_NOW).size == (WIDTH, HEIGHT)
+
+
+# --- endpoints -------------------------------------------------------------
+
+
+async def _client(storage: Storage) -> httpx.AsyncClient:
+    app = create_app(storage)
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_screens_endpoint_returns_seed(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.get("/api/display/screens")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert {"id", "name", "order"} <= set(rows[0])
+    assert [r["id"] for r in rows] == [s.id for s in enabled_screens(default_screens())]
+
+
+@pytest.mark.asyncio
+async def test_display_png_selects_screen(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.get("/api/display.png", params={"screen": "compass"})
+    assert resp.status_code == 200
+    assert Image.open(io.BytesIO(resp.content)).size == (WIDTH, HEIGHT)
+
+
+@pytest.mark.asyncio
+async def test_display_raw_default_screen_unchanged(storage: Storage) -> None:
+    # No ?screen= → default (#820 layout), still a full framebuffer.
+    async with await _client(storage) as client:
+        resp = await client.get("/api/display.raw")
+    assert resp.status_code == 200
+    assert len(resp.content) == WIDTH * HEIGHT // 2
+
+
+@pytest.mark.asyncio
+async def test_display_png_unknown_screen_404(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.get("/api/display.png", params={"screen": "nope"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_menu_endpoints(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        img_resp = await client.get("/api/display/menu.png")
+        raw_resp = await client.get("/api/display/menu.raw")
+        reg_resp = await client.get("/api/display/menu")
+    assert img_resp.status_code == 200
+    assert Image.open(io.BytesIO(img_resp.content)).size == (WIDTH, HEIGHT)
+    assert len(raw_resp.content) == WIDTH * HEIGHT // 2
+    regions = reg_resp.json()
+    assert regions and {"x", "y", "w", "h", "id", "name"} <= set(regions[0])
+
+
+@pytest.mark.asyncio
+async def test_admin_catalog_lists_templates_and_metrics(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.get("/api/admin/display/catalog")
+    body = resp.json()
+    assert {t["id"] for t in body["templates"]} == set(TEMPLATES)
+    assert {m["key"] for m in body["metrics"]} == set(METRICS)
+
+
+@pytest.mark.asyncio
+async def test_admin_save_and_reload_screens(storage: Storage) -> None:
+    new_screens = [
+        {
+            "id": "only",
+            "name": "Only Speed",
+            "template": "single",
+            "order": 0,
+            "enabled": True,
+            "slots": {"main": {"metric": "stw", "fmt": "auto"}},
+        }
+    ]
+    async with await _client(storage) as client:
+        put = await client.put("/api/admin/display/screens", json=new_screens)
+        assert put.status_code == 200
+        got = await client.get("/api/admin/display/screens")
+        device = await client.get("/api/display/screens")
+    assert [s["id"] for s in got.json()] == ["only"]
+    assert [s["id"] for s in device.json()] == ["only"]
+
+
+@pytest.mark.asyncio
+async def test_admin_save_rejects_invalid(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.put(
+            "/api/admin/display/screens",
+            json=[{"id": "x", "name": "X", "template": "bogus", "slots": {}}],
+        )
+    assert resp.status_code == 400
+    assert "template" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_admin_preview_renders_unsaved(storage: Storage) -> None:
+    payload = {
+        "id": "draft",
+        "name": "Draft",
+        "template": "quad",
+        "slots": {"q1": {"metric": "stw"}, "q2": {"metric": "vmg"}},
+    }
+    async with await _client(storage) as client:
+        resp = await client.post("/api/admin/display/preview.png", json=payload)
+    assert resp.status_code == 200
+    assert Image.open(io.BytesIO(resp.content)).size == (WIDTH, HEIGHT)
+
+
+@pytest.mark.asyncio
+async def test_admin_preview_rejects_invalid(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.post(
+            "/api/admin/display/preview.png",
+            json={"id": "d", "name": "D", "template": "single", "slots": {"main": {"metric": "z"}}},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_corrupt_setting_falls_back_to_seed(storage: Storage) -> None:
+    await storage.set_setting("DISPLAY_SCREENS", "{ not valid json")
+    async with await _client(storage) as client:
+        resp = await client.get("/api/display/screens")
+    assert resp.status_code == 200
+    assert [r["id"] for r in resp.json()] == [s.id for s in enabled_screens(default_screens())]
+
+
+@pytest.mark.asyncio
+async def test_admin_display_page_renders(storage: Storage) -> None:
+    async with await _client(storage) as client:
+        resp = await client.get("/admin/display")
+    assert resp.status_code == 200
+    assert "Display Screens" in resp.text


### PR DESCRIPTION
## Summary

The #820 repeater showed **one fixed layout**. This PR makes a *screen* a data-driven, server-rendered layout that the crew can **compose from the web UI** (no reflashing, no code deploy) and the device can **select via its touch menu**. All three milestones from the issue are included.

### Layout model — `display_screens.py` (pure data + math, no Pillow)
- **Metric registry**: STW, VMG (derived `STW·cos(TWA)`), SOG, TWS, AWS, TWA, AWA, TWD, HDG, COG, rudder, clock — resolved from a `latest_instruments()` snapshot.
- **Templates** fix grid geometry + fonts: `two-big-four-small` (the #820 headline layout), `single`, `quad`, and `compass` (a heading dial).
- A **Screen** = template + slots, each slot bound to a metric with optional label/format override. Validated on the way in and stored as **JSON in the `DISPLAY_SCREENS` app-setting**, so v1 needs **no `storage.py` migration** (Critical tier), exactly as the issue requested. Seeded with four screens; **the first reproduces #820 exactly**.

### Generic renderer — `display_render.py`
- `render_screen()` draws any screen; `render_display()` is kept as a thin back-compat wrapper over the seeded default, so the `?screen=`-less endpoints are unchanged from #820.
- `render_menu()` + `menu_regions()` share tile geometry, so a device touch maps to exactly the tile that was drawn.

### Endpoints — `routes/display.py`
Device-facing (viewer auth):
- `GET /api/display.png|.raw?screen=<id>` — render a screen (default when omitted; unknown id → 404)
- `GET /api/display/screens` → `[{id, name, order}]`
- `GET /api/display/menu.png|.raw` — menu image
- `GET /api/display/menu` → tap regions `[{x, y, w, h, id, name}]`

Composer (admin auth):
- `GET/PUT /api/admin/display/screens` — read / replace the whole list (validated)
- `GET /api/admin/display/catalog` — templates + metrics + formats for the editor
- `POST /api/admin/display/preview.png` — render an unsaved screen for live preview

### Admin composer UI — `templates/admin/display.html` (+ nav link)
CRUD screens: pick a template, assign a metric per slot, set label/format, reorder/enable, with a **live `.png` preview** of unsaved edits.

Device selection stays **device-only** (touch on the LilyGo); HelmLog does not push. Firmware counterpart: weaties/eink-screen#1.

## Data policy
Layout **configuration** only — no PII, no storage of readings, no export, no co-op sharing. Reuses the existing authenticated `latest_instruments()` snapshot already exposed by #820. Reviewed against `docs/data-licensing.md`: no impact. If v1's JSON config is later promoted to a `storage.py` table, that migration is Critical-tier and gets the usual review.

## Testing
- `uv run pytest` — **2831 passed, 2 skipped** (incl. 45 new tests + the 13 existing #820 tests, all green)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run mypy src/` — clean

New tests cover metric resolution, validation (good + 8 bad-config cases), per-template rendering, menu geometry consistency, and every endpoint (select / default / 404 / menu / catalog / save-reload / preview / corrupt-fallback / admin page).

## Rendered output
Default `Wind & Speed` (reproduces #820), the `Compass` dial, and the touch menu all render correctly (needle at 215° points SW as expected). Verified via the `.png` endpoints.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2axQYSgsQ5vmcUtuvBQq8