### PR TITLE
docs: deploys go through the web Deploy admin, not hand-run scripts

### DIFF
--- a/.claude/skills/deploy-pi/SKILL.md
+++ b/.claude/skills/deploy-pi/SKILL.md
@@ -6,7 +6,28 @@ disable-model-invocation: true
 
 # Deploying to the Raspberry Pi
 
-## Quick Deploy (after PR merges to main)
+## Deploy (preferred: the web Deploy admin)
+
+Deploys are driven from the **Deploy admin page** — `/admin/deployment`
+(nav → "Deploy") — **not by hand on the Pi**. The Pi runs an evergreen
+auto-deployer that polls the tracked branch (~every 300 s) and deploys when it
+changes.
+
+- **Point the Pi at a branch:** in the CONFIGURATION panel set **Track branch**
+  (and **Mode**), then Save. In **evergreen** mode it auto-deploys within one
+  poll interval whenever that branch advances. The CURRENT VERSION panel shows
+  the running/tracking sha and last-deploy status; the button reads "Up to
+  date" when nothing is pending and offers a deploy when the branch is ahead.
+- **Promote `main → stage → live`:** use the PROMOTION PIPELINE on the same page
+  (the `main → stage` / `stage → live` links) — promotions run via GitHub
+  Actions, not manual git. The `main → stage` gate needs a `RELEASES.md` entry
+  (see `/release-notes`); `stage → live` has no gate.
+
+So "deploy #N to corvopi-live" = set Track branch to the merged branch (usually
+`main`) on the Deploy page; switching branches is a config change there, not an
+ssh session.
+
+## Manual deploy (fallback — only when the web Deploy admin is unreachable)
 
 ```bash
 ssh <pi-user>@<pi-host>
@@ -14,8 +35,8 @@ cd ~/helmlog
 ./scripts/deploy.sh
 ```
 
-The script: pulls `main`, syncs Python deps, re-applies Tailscale Funnel
-routes, updates `PUBLIC_URL` in `.env`, restarts `helmlog`, prints status.
+The script: pulls the tracked branch, syncs Python deps, re-applies Tailscale
+Funnel routes, updates `PUBLIC_URL` in `.env`, restarts `helmlog`, prints status.
 
 ## Full Setup (if systemd units or apt packages changed)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ those rules here. The non-enforceable ones:
 | Read device paths from `.env` / config (`.env.example` is the reference). | Hardcode `/dev/can0` or similar paths. |
 | Keep `main.py` as wiring only — start the loop, no business logic. | Mix decode/storage/web logic into `main.py`. |
 | Add deps via `uv add <pkg>` then `uv sync`; verify the import. | Edit `pyproject.toml` by hand for deps, or use `uv pip install`. |
-| After a pull or branch switch, run `uv sync` (or `./scripts/deploy.sh` on the Pi). | Assume the venv is up to date — the Pi service runs `--no-sync`. |
+| After a local pull or branch switch, run `uv sync`. Deploy to the Pi from the web **Deploy admin** (`/admin/deployment`). | Hand-run `./scripts/deploy.sh` / `systemctl` on the Pi as the routine path, or assume the venv is up to date — the service runs `--no-sync`. |
 | Commit + push every change before stopping work. | Leave uncommitted edits on the Pi — the next deploy wipes them. |
 | Run `uv run pytest tests/integration/ -v` for federation/co-op/peer-API changes. | Skip integration tests for federation work because unit tests pass. |
 | Keep `.db` files and the `data/` directory out of git. | Commit `helmlog.db` or other local data. |
@@ -204,6 +204,13 @@ review (`docs/data-licensing.md`) + a structured spec before implementation. See
 </important>
 
 <important if="working on the Pi (deployed device, not Mac dev)">
+- **Deploys go through the web Deploy admin** (`/admin/deployment`, nav →
+  "Deploy"), not by hand. Set the **tracked branch** + mode there; in evergreen
+  mode the Pi's auto-deployer (polls ~every 300 s) pulls, `uv sync`s, and
+  restarts on its own when that branch advances. The same page promotes
+  `main → stage → live`. `scripts/deploy.sh` / `sudo systemctl restart helmlog`
+  are the underlying fallback for when the web UI is unreachable (see
+  `/deploy-pi`).
 - After `uv add <pkg>` or any dependency change, restart the service:
   `sudo systemctl restart helmlog`. The service runs with `--no-sync` and
   trusts the venv.


### PR DESCRIPTION
## Summary

Records the actual deploy workflow: deploys are driven from the **Deploy admin page** (`/admin/deployment`, nav → "Deploy"), not by SSHing and hand-running `scripts/deploy.sh`. The Pi runs an evergreen auto-deployer that polls the tracked branch (~300s) and deploys on change; `main → stage → live` promotion happens from the same page's promotion pipeline.

- **`.claude/skills/deploy-pi/SKILL.md`** — leads with the web Deploy admin (set Track branch + mode; promote via the pipeline). `scripts/deploy.sh` / `systemctl` demoted to a "fallback when the UI is unreachable" section.
- **`AGENTS.md`** — the Pi `<important>` block gets a "deploys go through the web Deploy admin" bullet; the Do/Don't venv row no longer implies hand-running `deploy.sh` is the routine path.

Docs only — no code or behavior change.