### PR TITLE
fix(backup): catch the stale/torn logger.db that #808 still lets through (#807)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -395,6 +395,23 @@ run_rsync_step() {
 # the failure mode that silently broke every backup from 2026-06-16 on. (#807)
 PI_STAGE="$PI_STAGE_DIR/logger.db.snap"
 DB_SNAP_OK=0
+
+# Per-table newest record in the LIVE DB, read *before* staging. The .backup is
+# taken after this, so a faithful copy can only be newer. Comparing the snapshot
+# against this catches a copy that is valid SQLite but missing recent data.
+#
+# Per table, not one max() over the whole DB: 20260708T100002Z held races
+# current to 07-08 while positions and winds stopped at 06-30 — a torn copy with
+# race rows whose telemetry was absent. A whole-DB max reads 07-08 and calls that
+# fresh. Absolute age is useless as a signal (the boat sits idle for weeks
+# between regattas); fidelity to the source is the thing to assert. (#807)
+LIVE_MAX_TS=$($SSH "$PI" "sqlite3 -noheader -separator = 'file:$PI_HELMLOG_DIR/data/logger.db?mode=ro' \
+  \"SELECT 'positions', max(ts) FROM positions
+    UNION ALL SELECT 'winds', max(ts) FROM winds
+    UNION ALL SELECT 'races', max(start_utc) FROM races;\"" 2>/dev/null \
+  | grep -v '=$' | paste -sd, -)
+[ -n "$LIVE_MAX_TS" ] && log "  live DB newest records: $LIVE_MAX_TS"
+
 if $SSH "$PI" "mkdir -p '$PI_STAGE_DIR' && rm -f '$PI_STAGE'*; \
     sqlite3 '$PI_HELMLOG_DIR/data/logger.db' \".backup '$PI_STAGE'\" && \
     [ \"\$(sqlite3 'file:$PI_STAGE?immutable=1' 'PRAGMA quick_check;' 2>/dev/null | head -1)\" = ok ]" 2>/dev/null; then
@@ -432,21 +449,43 @@ fi
 # users.avatar_path row must point at a file that actually exists in the
 # snapshot. Silent losses here are how corvopi-tst1 ended up with 25 photo
 # rows pointing at empty directories (#676).
+#
+# Exit codes are graded (#807): orphaned rows (1) are a warning — the DB is
+# sound, some referenced file is missing. A corrupt (2) or stale (3) logger.db
+# means the backup did not capture the data at all, so it must FAIL the run and
+# skip rotation, keeping the last good snapshots on disk. Reporting those as a
+# mere WARN on an otherwise "SUCCESS" run is how the corruption went unnoticed
+# from 2026-06-16 to 2026-07-14.
 VALIDATOR="$SCRIPT_DIR/validate_snapshot.py"
+DB_INVALID=0
 if [ -f "$SNAP/data/logger.db" ] && [ -f "$VALIDATOR" ] && command -v python3 >/dev/null; then
   log "Step: Snapshot validation"
   VALIDATE_OUT="/tmp/helmlog-validate-$DATE.txt"
-  if python3 "$VALIDATOR" "$SNAP/data" > "$VALIDATE_OUT" 2>&1; then
-    log "  OK (all referenced files present)"
-    report_line "- **Snapshot validation**: OK (all referenced files present)"
+  VALIDATE_ARGS=("$SNAP/data")
+  [ -n "$LIVE_MAX_TS" ] && VALIDATE_ARGS+=(--expect-min-ts "$LIVE_MAX_TS")
+  if python3 "$VALIDATOR" "${VALIDATE_ARGS[@]}" > "$VALIDATE_OUT" 2>&1; then
+    log "  OK (all referenced files present; logger.db readable and current)"
+    report_line "- **Snapshot validation**: OK (files present; logger.db readable and current)"
   else
     rc=$?
-    log "  WARNING: orphaned DB rows detected (rc=$rc)"
-    report_line "- **Snapshot validation**: WARN (rc=$rc) — orphaned DB rows detected"
+    case "$rc" in
+      2) reason="logger.db is CORRUPT / unreadable" ;;
+      3) reason="logger.db is STALE — missing records present in the live DB" ;;
+      *) reason="orphaned DB rows detected" ;;
+    esac
+    if [ "$rc" -ge 2 ]; then
+      DB_INVALID=1
+      log "  FAIL: $reason (rc=$rc)"
+      report_line "- **Snapshot validation**: FAILED (rc=$rc) — $reason"
+      mark_failed "snapshot validation: $reason"
+    else
+      log "  WARNING: $reason (rc=$rc)"
+      report_line "- **Snapshot validation**: WARN (rc=$rc) — $reason"
+      mark_warning "Snapshot validation: orphaned rows (see report body)"
+    fi
     report_line '```'
     head -40 "$VALIDATE_OUT" >> "$REPORT" || true
     report_line '```'
-    mark_warning "Snapshot validation: orphaned rows (see report body)"
   fi
   rm -f "$VALIDATE_OUT"
 fi
@@ -543,6 +582,14 @@ if [ "$snap_bytes" -lt "$MIN_SNAPSHOT_BYTES" ]; then
   log "  FAIL: snapshot too small ($snap_bytes bytes)"
   report_line ""
   report_line "**Safety gate**: FAILED — snapshot size $snap_bytes bytes is below the $MIN_SNAPSHOT_BYTES-byte minimum. Rotation skipped; old snapshots preserved."
+  exit 11
+fi
+# A corrupt or stale logger.db must never rotate away the last good snapshots —
+# that is how a broken backup becomes an unrecoverable one. (#807)
+if [ "$DB_INVALID" = 1 ]; then
+  log "  FAIL: logger.db failed snapshot validation (corrupt or stale)"
+  report_line ""
+  report_line "**Safety gate**: FAILED — \`data/logger.db\` is corrupt or stale (see Snapshot validation above). Rotation skipped; old snapshots preserved."
   exit 11
 fi
 # logger.db must be a VALID SQLite database, not just present and large. The

--- a/scripts/validate_snapshot.py
+++ b/scripts/validate_snapshot.py
@@ -163,7 +163,15 @@ def validate(data_root: Path, expect_min_ts: str | None = None) -> tuple[int, li
     if not db_path.is_file():
         print(f"ERROR: {db_path} not found", file=sys.stderr)
         return 2, []
-    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    # immutable=1, NOT mode=ro. `mode=ro` still creates a -shm (and can create a
+    # -wal) for a WAL-mode DB, so validating a snapshot resurrected the sidecar
+    # files backup.sh had just deleted — the check was mutating the thing it
+    # checks. immutable=1 promises SQLite the file cannot change, so it opens
+    # with no sidecars at all. It also ignores any WAL that happens to sit next
+    # to the DB, which is what we want: a copy whose recent data lives only in a
+    # stray WAL is not a trustworthy backup, and reading it without that WAL
+    # makes it fail the staleness check instead of passing on borrowed data.
+    db = sqlite3.connect(f"file:{db_path}?immutable=1", uri=True)
     try:
         # A corrupt DB (zeroed header, truncated .backup) only raises when we
         # actually read it — connect() is lazy. Report it as rc=2 rather than

--- a/scripts/validate_snapshot.py
+++ b/scripts/validate_snapshot.py
@@ -9,6 +9,13 @@ point outside the backed-up root). This script cross-checks:
   audio_sessions.file_path → absolute, or <data_root>/audio/<path>
   users.avatar_path        → <data_root>/avatars/<path>
 
+It also guards the DB itself (#807): a snapshot is only good if logger.db is
+readable AND holds the data it should. Two real failures motivated this — a
+corrupt copy (sqlite3 .backup ran out of room on the Pi's tmpfs and left a
+zeroed header) and, worse, a *torn* copy that passed every gate with race rows
+from 07-08 whose telemetry stopped at 06-30. Pass --expect-min-ts with the live
+DB's per-table maxima to catch the latter.
+
 Usage:
   python3 scripts/validate_snapshot.py <data_root>
     data_root should contain logger.db plus the notes/, audio/,
@@ -18,7 +25,8 @@ Usage:
 Exit codes:
   0   all referenced files present
   1   one or more orphaned DB rows (missing files)
-  2   could not open the DB or data root
+  2   could not open the DB or data root, or the DB is corrupt
+  3   the DB is stale — some table lags its live counterpart in --expect-min-ts
 """
 
 from __future__ import annotations
@@ -27,7 +35,13 @@ import argparse
 import sqlite3
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+
+# Tables whose newest row tells us how current the snapshot is. positions is
+# the high-rate one; the others cover a DB captured outside a sail. Missing
+# tables/columns are skipped, so this stays safe across schema versions.
+_RECENCY_TABLES = (("positions", "ts"), ("winds", "ts"), ("races", "start_utc"))
 
 
 @dataclass
@@ -92,20 +106,95 @@ def _check_avatars(db: sqlite3.Connection, avatars_root: Path) -> OrphanReport:
     return OrphanReport("users.avatar_path", len(rows), len(missing), missing[:5])
 
 
-def validate(data_root: Path) -> tuple[int, list[OrphanReport]]:
+def _parse_ts(raw: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def newest_per_table(db: sqlite3.Connection) -> dict[str, str]:
+    """Newest timestamp in each recency table that exists in this DB."""
+    out: dict[str, str] = {}
+    for table, column in _RECENCY_TABLES:
+        try:
+            row = db.execute(f"SELECT max({column}) FROM {table}").fetchone()  # noqa: S608
+        except sqlite3.OperationalError:
+            continue  # table/column absent in this schema version
+        if row and row[0] is not None:
+            out[table] = str(row[0])
+    return out
+
+
+def parse_expectation(spec: str) -> dict[str, str]:
+    """Parse `positions=<ts>,winds=<ts>` into a per-table expectation."""
+    want: dict[str, str] = {}
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        table, _, ts = part.partition("=")
+        if ts:
+            want[table.strip()] = ts.strip()
+    return want
+
+
+def _stale_tables(have: dict[str, str], want: dict[str, str]) -> list[str]:
+    """Tables whose snapshot max lags the live DB's max.
+
+    Compared PER TABLE, never as a single max across tables: 20260708T100002Z
+    had races current to 07-08 while positions and winds stopped at 06-30, so a
+    whole-DB max would have called that torn copy fresh. (#807)
+    """
+    stale = []
+    for table, want_raw in want.items():
+        if table not in have:
+            continue
+        want_dt, have_dt = _parse_ts(want_raw), _parse_ts(have[table])
+        if want_dt is None or have_dt is None:
+            continue
+        if have_dt < want_dt:
+            stale.append(f"{table}: snapshot {have[table]} < live {want_raw}")
+    return stale
+
+
+def validate(data_root: Path, expect_min_ts: str | None = None) -> tuple[int, list[OrphanReport]]:
     db_path = data_root / "logger.db"
     if not db_path.is_file():
         print(f"ERROR: {db_path} not found", file=sys.stderr)
         return 2, []
     db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     try:
-        reports = [
-            _check_attachments(db, data_root / "notes"),
-            _check_audio(db, data_root),
-            _check_avatars(db, data_root / "avatars"),
-        ]
+        # A corrupt DB (zeroed header, truncated .backup) only raises when we
+        # actually read it — connect() is lazy. Report it as rc=2 rather than
+        # letting a DatabaseError traceback escape, which is how the 2026-07-14
+        # corruption got logged as a WARN on an otherwise "SUCCESS" run. (#807)
+        try:
+            reports = [
+                _check_attachments(db, data_root / "notes"),
+                _check_audio(db, data_root),
+                _check_avatars(db, data_root / "avatars"),
+            ]
+            have = newest_per_table(db)
+        except sqlite3.DatabaseError as exc:
+            print(f"ERROR: {db_path} is not a readable SQLite database: {exc}", file=sys.stderr)
+            return 2, []
     finally:
         db.close()
+
+    # Faithfulness to the source, not absolute age: the boat sits idle for
+    # weeks between regattas, so "old data" is only a fault when the LIVE DB
+    # has newer records than the copy we just took. (#807)
+    if expect_min_ts:
+        stale = _stale_tables(have, parse_expectation(expect_min_ts))
+        if stale:
+            print(
+                f"ERROR: {db_path} is stale — it is valid SQLite but lags the live DB:",
+                file=sys.stderr,
+            )
+            for line in stale:
+                print(f"  {line}", file=sys.stderr)
+            return 3, reports
 
     worst = 0 if all(r.missing == 0 for r in reports) else 1
     return worst, reports
@@ -130,17 +219,32 @@ def main() -> int:
         action="store_true",
         help="Only print output on failure or when orphans are found",
     )
+    p.add_argument(
+        "--expect-min-ts",
+        default=None,
+        metavar="TABLE=ISO_TS,...",
+        help=(
+            "Per-table newest record in the LIVE DB at staging time, e.g. "
+            "'positions=2026-07-14T03:45:55+00:00,races=...'. Any table in the "
+            "snapshot that lags its live counterpart fails the run as stale (rc=3)."
+        ),
+    )
     args = p.parse_args()
 
     if not args.data_root.is_dir():
         print(f"ERROR: {args.data_root} is not a directory", file=sys.stderr)
         return 2
 
-    rc, reports = validate(args.data_root)
+    rc, reports = validate(args.data_root, expect_min_ts=args.expect_min_ts)
     if rc == 0 and args.quiet:
         return 0
-    header = "Snapshot validation: " + ("OK" if rc == 0 else "ORPHANED ROWS FOUND")
-    print(header)
+    headers = {
+        0: "OK",
+        1: "ORPHANED ROWS FOUND",
+        2: "DB UNREADABLE / CORRUPT",
+        3: "DB STALE — missing recent data",
+    }
+    print("Snapshot validation: " + headers.get(rc, "FAILED"))
     print(_format_report(reports))
     return rc
 

--- a/tests/test_validate_snapshot.py
+++ b/tests/test_validate_snapshot.py
@@ -164,6 +164,27 @@ def test_torn_copy_caught_per_table(tmp_path: Path) -> None:
     assert rc == 3
 
 
+def test_validation_does_not_mutate_the_snapshot(tmp_path: Path) -> None:
+    """Reading a backup must leave no trace on it.
+
+    `?mode=ro` still creates a `-shm` (and can create a `-wal`) for a WAL-mode
+    DB, so the validator was resurrecting the very sidecar files backup.sh had
+    just deleted — the tool meant to verify the backup was modifying it.
+    `immutable=1` is the only open mode that truly cannot write. (#807)
+    """
+    _make_db(tmp_path)
+    db = sqlite3.connect(tmp_path / "logger.db")
+    db.execute("PRAGMA journal_mode=WAL")  # what the live logger.db actually is
+    db.close()
+    for sidecar in ("logger.db-wal", "logger.db-shm"):
+        (tmp_path / sidecar).unlink(missing_ok=True)
+
+    rc, _ = validate_snapshot.validate(tmp_path)
+    assert rc == 0
+    assert not (tmp_path / "logger.db-wal").exists(), "validator recreated the WAL"
+    assert not (tmp_path / "logger.db-shm").exists(), "validator recreated the SHM"
+
+
 def test_fresh_db_passes_recency_check(tmp_path: Path) -> None:
     _make_db(tmp_path)
     _add_telemetry(tmp_path, ["2026-07-14T03:45:55.911000+00:00"])

--- a/tests/test_validate_snapshot.py
+++ b/tests/test_validate_snapshot.py
@@ -92,6 +92,103 @@ def test_missing_db_returns_rc_2(tmp_path: Path) -> None:
     assert reports == []
 
 
+def _add_telemetry(data_root: Path, positions: list[str], races: list[str] | None = None) -> None:
+    """Give the DB positions(ts) and races(start_utc) rows."""
+    db = sqlite3.connect(data_root / "logger.db")
+    db.execute("CREATE TABLE IF NOT EXISTS positions (id INTEGER PRIMARY KEY, ts TEXT)")
+    db.execute("CREATE TABLE IF NOT EXISTS races (id INTEGER PRIMARY KEY, start_utc TEXT)")
+    db.executemany("INSERT INTO positions(ts) VALUES (?)", [(t,) for t in positions])
+    db.executemany("INSERT INTO races(start_utc) VALUES (?)", [(t,) for t in races or []])
+    db.commit()
+    db.close()
+
+
+# ── #807: a corrupt or stale logger.db must be caught, not shrugged off ──────
+
+
+@pytest.mark.parametrize(
+    ("name", "blob"),
+    [
+        # The exact shape the 2026-07-14 backup produced: sqlite3 .backup ran
+        # out of room on the Pi's 4 GB /tmp tmpfs and left a zeroed header.
+        ("zeroed_header", b"\x00" * 8192),
+        ("not_a_db", b"garbage" * 512),
+    ],
+)
+def test_corrupt_db_returns_rc_2_without_raising(tmp_path: Path, name: str, blob: bytes) -> None:
+    """A malformed DB must exit 2, not escape as an sqlite3.DatabaseError.
+
+    The 2026-07-14 run crashed with an unhandled `database disk image is
+    malformed` traceback, which the backup script then logged as a mere
+    WARN — so a corrupt snapshot was reported as SUCCESS. (#807)
+    """
+    (tmp_path / "logger.db").write_bytes(blob)
+    rc, reports = validate_snapshot.validate(tmp_path)
+    assert rc == 2
+    assert reports == []
+
+
+def test_stale_db_returns_rc_3(tmp_path: Path) -> None:
+    """A valid DB whose records lag the live DB is a failed backup.
+
+    Validity is not enough; the copy must be faithful. (#807)
+    """
+    _make_db(tmp_path)
+    _add_telemetry(tmp_path, ["2026-06-30T03:08:28.278000+00:00"])
+    rc, _ = validate_snapshot.validate(
+        tmp_path, expect_min_ts="positions=2026-07-14T03:45:55.911000+00:00"
+    )
+    assert rc == 3
+
+
+def test_torn_copy_caught_per_table(tmp_path: Path) -> None:
+    """One current table must not mask another that lags — compare PER TABLE.
+
+    This is the real shape of `20260708T100002Z`: races current to 07-08 while
+    positions stopped at 06-30 (race rows whose telemetry isn't there). A single
+    max() across the whole DB reads 07-08 and calls it fresh; only a per-table
+    comparison catches it. (#807)
+    """
+    _make_db(tmp_path)
+    _add_telemetry(
+        tmp_path,
+        positions=["2026-06-30T03:08:28.278000+00:00"],  # 8 days behind
+        races=["2026-07-08T07:26:54.186102+00:00"],  # current
+    )
+    rc, _ = validate_snapshot.validate(
+        tmp_path,
+        expect_min_ts=(
+            "positions=2026-07-08T07:26:54.186102+00:00,races=2026-07-08T07:26:54.186102+00:00"
+        ),
+    )
+    assert rc == 3
+
+
+def test_fresh_db_passes_recency_check(tmp_path: Path) -> None:
+    _make_db(tmp_path)
+    _add_telemetry(tmp_path, ["2026-07-14T03:45:55.911000+00:00"])
+    rc, _ = validate_snapshot.validate(
+        tmp_path, expect_min_ts="positions=2026-07-14T03:45:55.911000+00:00"
+    )
+    assert rc == 0
+
+
+def test_recency_check_skipped_without_expectation(tmp_path: Path) -> None:
+    """No --expect-min-ts (or no such table) → recency is simply not judged.
+
+    The boat sits idle for weeks between regattas, so absolute data age is a
+    useless signal; we only ever compare against the live DB's own maxima.
+    """
+    _make_db(tmp_path)
+    _add_telemetry(tmp_path, ["2026-01-01T00:00:00+00:00"])
+    rc, _ = validate_snapshot.validate(tmp_path)
+    assert rc == 0
+
+    # An expectation naming a table this DB doesn't have is not a failure.
+    rc, _ = validate_snapshot.validate(tmp_path, expect_min_ts="winds=2026-07-14T00:00:00+00:00")
+    assert rc == 0
+
+
 @pytest.mark.parametrize("abs_path", [True, False])
 def test_audio_absolute_and_relative(tmp_path: Path, abs_path: bool) -> None:
     _make_db(tmp_path)


### PR DESCRIPTION
## Correction first

My original PR body said the #807 fix "was never pushed." **That was wrong** — I read a stale local `main`. The fix **did land**, as #808 on **2026-07-01**. `origin/main`'s `backup.sh` is byte-identical to the 6/30 work.

**The real reason 7/14 still corrupted:** the Mac's checkout at `/Users/dweatbrook/src/helmlog` — which is what the launchd job actually executes — was **stuck at 2026-06-27** and never pulled. The fixed script sat on `main` for 13 days while cron kept running the old one. That's a deploy gap, not a code gap, and it's being fixed separately by pulling that checkout.

This PR is therefore **rebased onto main** and now contains only the delta that #808 does *not* cover.

## What #808 already handles

Staging `.backup` on disk-backed `/var/tmp` instead of the 4 GB `/tmp` tmpfs, only replacing the rsync'd copy when it exits 0 and passes `quick_check`, and a safety gate that rejects an invalid SQLite DB. **Had it actually been running on 7/14, it would have caught the corruption.**

## What it still misses — and this PR adds

A backup can be **valid SQLite and still wrong**. `20260708T100002Z` passed every gate in #808 while being a **torn live-file copy** (it carries `-wal`/`-shm`, so it's the rsync'd live DB, not a consistent `.backup`):

| table | newest record | rows |
|---|---|---|
| `positions` | 2026-06-30T03:08 | 4,461,356 |
| `winds` | 2026-06-30T03:08 | 21,393,915 |
| `races` | **2026-07-08T07:26** | 138 |

Race rows from 07-08 whose telemetry doesn't exist. `quick_check` says `ok`. A restore would have quietly rolled the boat back eight days — worse than a corrupt file, which at least fails loudly.

1. **Staleness check (new, rc=3), compared PER TABLE.** This is the subtle part: a single `max()` across the DB reads the 07-08 `races` row and calls that torn copy **fresh**. Only a per-table comparison catches `positions` lagging. It asserts **fidelity to the live DB's per-table maxima**, not absolute age — the boat sits idle for weeks between regattas, so "old data" is meaningless as a signal.

2. **Corrupt DB → rc=2 instead of a traceback.** `validate_snapshot.py` *did* detect the 7/14 corruption, but escaped as an unhandled `sqlite3.DatabaseError`, which `backup.sh` logged as a mere **WARN**. Now it's a clean rc.

3. **rc>=2 fails the run and skips rotation.** A broken backup must never rotate away the last good snapshots.

## Verification

Against the **real artifacts**, not just fixtures:

- corrupt 7/14 `logger.db` → **rc=2**, clean error, no traceback
- torn 7/8 snapshot → **rc=3**, naming `positions` — including with the expectation set to the snapshot's *own* newest row, the exact case a whole-DB `max()` would wave through
- fresh `.backup` staged on the Pi's `/var/tmp` → 5.95 GB, `quick_check ok`, 24s → **rc=0**
- `LIVE_MAX_TS` pipeline against the real Pi → `positions=2026-07-14T03:45:55.911000+00:00,winds=...,races=...`

Gates: 2711 passed / 2 skipped, ruff + mypy clean. A full end-to-end backup run against corvopi-live is in progress on this exact script.

## Remediation already applied

`20260714T100005Z/data/logger.db` **repaired** from a verified `/var/tmp` `.backup` — current to `2026-07-14T03:45`, 145 races, 4.78M positions, `quick_check ok`. Corrupt original kept as `logger.db.CORRUPT`.

Before that repair the true recovery point was **6/30**: races 138→145 and ~320k positions had no valid backup anywhere.

## Note for hand-verifying a snapshot

The plain `sqlite3` CLI opens a DB **read-write** and replays/truncates its WAL, mutating the backup. Use `sqlite3 'file:<db>?immutable=1'` — which is what the hardened script does.

Fixes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hG9LERPnM5ids5ZUpvgg4