### PR TITLE
feat(history): video thumbnail on races with a linked YouTube video (#827)

### DIFF
--- a/src/helmlog/static/history.js
+++ b/src/helmlog/static/history.js
@@ -172,6 +172,34 @@ function clearTagFilter() {
   load();
 }
 
+// Thumbnail for a session's first linked YouTube video (#827). Hotlinks
+// img.youtube.com, so it must degrade cleanly: on the boat the Pi has no
+// uplink and every one of these 404s. The onerror handler swaps the dead
+// image for a text badge rather than leaving a broken-image icon — knowing
+// a race *has* video is useful even when the thumbnail can't load.
+function renderVideoThumb(s) {
+  if (!s.first_video_id) return '';
+  const vid = String(s.first_video_id);
+  const url = s.first_video_url || ('https://www.youtube.com/watch?v=' + encodeURIComponent(vid));
+  const extra = (s.video_count || 0) - 1;
+  const more = extra > 0
+    ? '<span class="hist-video-more">+' + extra + ' more</span>'
+    : '';
+  const title = extra > 0
+    ? 'Watch on YouTube (' + s.video_count + ' videos linked)'
+    : 'Watch on YouTube';
+  return '<a class="hist-video" href="' + esc(url) + '"'
+    + ' target="_blank" rel="noopener noreferrer" title="' + esc(title) + '">'
+    + '<span class="hist-video-frame">'
+    + '<img src="https://img.youtube.com/vi/' + encodeURIComponent(vid) + '/mqdefault.jpg"'
+    + ' alt="" loading="lazy"'
+    + ' onerror="this.closest(\'.hist-video\').classList.add(\'hist-video-broken\')">'
+    + '<span class="hist-video-play" aria-hidden="true"></span>'
+    + '</span>'
+    + more
+    + '</a>';
+}
+
 function render(data) {
   const el = document.getElementById('results');
   if (!data.sessions.length) {
@@ -192,11 +220,18 @@ function render(data) {
       ? '<div class="session-summary" id="hist-summary-' + s.id + '"><div class="summary-skeleton"></div></div>'
       : '';
     const tagChips = renderSessionTagChips(s.tag_summary);
-    return '<div class="card"><div class="session-name">' + nameLink + '</div>'
+    const videoThumb = renderVideoThumb(s);
+    // Text column and thumbnail sit side by side; the lazily-loaded summary
+    // row stays outside the flex row so it still spans the full card width.
+    return '<div class="card"><div class="hist-card-row"><div class="hist-card-main">'
+      + '<div class="session-name">' + nameLink + '</div>'
       + '<div class="session-meta">' + s.date + ' &nbsp;·&nbsp; ' + start + ' → ' + end + dur + '</div>'
       + localNameHint
       + parent
       + tagChips
+      + '</div>'
+      + videoThumb
+      + '</div>'
       + summaryHtml
       + '</div>';
   }).join('');

--- a/src/helmlog/storage.py
+++ b/src/helmlog/storage.py
@@ -5238,7 +5238,11 @@ class Storage:
                 f"   WHERE p.ts >= r.start_utc AND p.ts <= COALESCE(r.end_utc, r.start_utc)"
                 f" ) AS has_track,"
                 f" (SELECT rv.youtube_url FROM race_videos rv"
-                f"   WHERE rv.race_id = r.id LIMIT 1) AS first_video_url,"
+                f"   WHERE rv.race_id = r.id ORDER BY rv.id LIMIT 1) AS first_video_url,"
+                f" (SELECT rv.video_id FROM race_videos rv"
+                f"   WHERE rv.race_id = r.id ORDER BY rv.id LIMIT 1) AS first_video_id,"
+                f" (SELECT COUNT(*) FROM race_videos rv"
+                f"   WHERE rv.race_id = r.id) AS video_count,"
                 f" (SELECT COUNT(*) > 0 FROM transcripts t"
                 f"   JOIN audio_sessions a2 ON a2.id = t.audio_session_id"
                 f"   WHERE a2.race_id = r.id AND t.status = 'done'"
@@ -5290,6 +5294,7 @@ class Storage:
                 f" 1 AS has_audio, a.id AS audio_session_id,"
                 f" r.id AS parent_race_id, r.name AS parent_race_name,"
                 f" 0 AS has_track, NULL AS first_video_url,"
+                f" NULL AS first_video_id, 0 AS video_count,"
                 f" (SELECT COUNT(*) > 0 FROM transcripts t"
                 f"   WHERE t.audio_session_id = a.id AND t.status = 'done'"
                 f" ) AS has_transcript,"
@@ -5340,6 +5345,8 @@ class Storage:
                     "parent_race_name": row["parent_race_name"],
                     "has_track": bool(row["has_track"]),
                     "first_video_url": row["first_video_url"],
+                    "first_video_id": row["first_video_id"],
+                    "video_count": int(row["video_count"] or 0),
                     "has_transcript": bool(row["has_transcript"]),
                     "has_results": bool(row["has_results"]),
                     "has_crew": bool(row["has_crew"]),

--- a/src/helmlog/templates/history.html
+++ b/src/helmlog/templates/history.html
@@ -11,6 +11,19 @@
 .tag-mode-toggle{display:inline-flex;border:1px solid var(--border);border-radius:3px;overflow:hidden;margin-left:4px;vertical-align:middle}
 .tag-mode-toggle button{font-size:.68rem;padding:2px 8px;border:none;background:transparent;color:var(--text-secondary);cursor:pointer}
 .tag-mode-toggle button.active{background:var(--accent);color:var(--bg-primary)}
+/* Video thumbnail (#827) — flags races that have a linked YouTube video. */
+.hist-card-row{display:flex;gap:12px;align-items:flex-start}
+.hist-card-main{flex:1;min-width:0}
+.hist-video{flex:0 0 auto;display:block;width:128px;text-decoration:none;color:inherit}
+.hist-video-frame{position:relative;display:block;border-radius:4px;overflow:hidden;border:1px solid var(--border);background:var(--bg-secondary)}
+.hist-video img{display:block;width:100%;height:72px;object-fit:cover}
+.hist-video-play{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:0;height:0;border-style:solid;border-width:7px 0 7px 12px;border-color:transparent transparent transparent #fff;filter:drop-shadow(0 1px 3px rgba(0,0,0,.9))}
+.hist-video-more{display:block;font-size:.65rem;text-align:center;margin-top:2px;color:var(--text-secondary)}
+/* Thumbnail failed to load (offline on the boat) — show a text badge instead
+   of a broken image, so the card still reports that video exists. */
+.hist-video-broken img,.hist-video-broken .hist-video-play{display:none}
+.hist-video-broken .hist-video-frame::after{content:"\25B6\00A0Video";display:block;font-size:.72rem;text-align:center;padding:26px 4px;color:var(--text-secondary)}
+@media (max-width:520px){.hist-video{width:96px}.hist-video img{height:54px}.hist-video-broken .hist-video-frame::after{padding:17px 4px}}
 </style>
 {% endblock %}
 

--- a/tests/test_history_video.py
+++ b/tests/test_history_video.py
@@ -1,0 +1,138 @@
+"""History-page video surfacing (#827).
+
+The history list already carried ``first_video_url`` but nothing to build a
+thumbnail from. These tests pin the added ``first_video_id`` / ``video_count``
+fields and the deterministic choice of *which* video is "first".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from helmlog.web import create_app
+
+if TYPE_CHECKING:
+    from helmlog.storage import Storage
+
+
+async def _race_with_videos(storage: Storage, videos: list[tuple[str, str]]) -> int:
+    """Create a race and link the given ``(video_id, url)`` pairs to it."""
+    race = await storage.start_race(
+        event="TestEvent",
+        start_utc=datetime(2026, 7, 21, 17, 24, 52, tzinfo=UTC),
+        date_str="2026-07-21",
+        race_num=1,
+        name="20260721-rw-d2r1",
+    )
+    await storage.end_race(race.id, datetime(2026, 7, 21, 19, 27, 55, tzinfo=UTC))
+    for video_id, url in videos:
+        await storage.add_race_video(
+            race_id=race.id,
+            youtube_url=url,
+            video_id=video_id,
+            title=f"title-{video_id}",
+            label="",
+            sync_utc=datetime(2026, 7, 21, 17, 24, 52, tzinfo=UTC),
+            sync_offset_s=0.0,
+        )
+    return race.id
+
+
+@pytest.mark.asyncio
+async def test_session_with_video_exposes_video_id_and_count(storage: Storage) -> None:
+    race_id = await _race_with_videos(storage, [("abc123XYZ_-", "https://youtu.be/abc123XYZ_-")])
+
+    _total, sessions = await storage.list_sessions()
+    row = next(s for s in sessions if s["id"] == race_id)
+
+    assert row["first_video_id"] == "abc123XYZ_-"
+    assert row["first_video_url"] == "https://youtu.be/abc123XYZ_-"
+    assert row["video_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_session_without_video_reports_none_and_zero(storage: Storage) -> None:
+    race = await storage.start_race(
+        event="TestEvent",
+        start_utc=datetime(2026, 7, 18, 21, 24, 38, tzinfo=UTC),
+        date_str="2026-07-18",
+        race_num=1,
+        name="20260718-no-video",
+    )
+    await storage.end_race(race.id, datetime(2026, 7, 18, 22, 22, 41, tzinfo=UTC))
+
+    _total, sessions = await storage.list_sessions()
+    row = next(s for s in sessions if s["id"] == race.id)
+
+    assert row["first_video_id"] is None
+    assert row["first_video_url"] is None
+    assert row["video_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_videos_counted_and_first_is_lowest_row_id(storage: Storage) -> None:
+    """``first_video_*`` must be stable, not whatever SQLite happens to return.
+
+    The pre-existing subquery used a bare ``LIMIT 1`` with no ``ORDER BY``,
+    so the "first" video was unspecified. Insertion order decides it now.
+    """
+    race_id = await _race_with_videos(
+        storage,
+        [
+            ("firstVid_01", "https://youtu.be/firstVid_01"),
+            ("secondVid02", "https://youtu.be/secondVid02"),
+            ("thirdVid_03", "https://youtu.be/thirdVid_03"),
+        ],
+    )
+
+    _total, sessions = await storage.list_sessions()
+    row = next(s for s in sessions if s["id"] == race_id)
+
+    assert row["video_count"] == 3
+    assert row["first_video_id"] == "firstVid_01"
+    assert row["first_video_url"] == "https://youtu.be/firstVid_01"
+
+
+@pytest.mark.asyncio
+async def test_debrief_rows_carry_null_video_fields(storage: Storage) -> None:
+    """The debrief UNION branch must supply matching columns, not blow up."""
+    from helmlog.audio import AudioSession
+
+    await storage.write_audio_session(
+        AudioSession(
+            file_path="/tmp/debrief.wav",
+            device_name="test-mic",
+            start_utc=datetime(2026, 7, 21, 23, 0, tzinfo=UTC),
+            end_utc=datetime(2026, 7, 21, 23, 30, tzinfo=UTC),
+            sample_rate=48_000,
+            channels=1,
+        ),
+        session_type="debrief",
+        name="Debrief after d2r4",
+    )
+
+    _total, sessions = await storage.list_sessions(session_type="debrief")
+    assert sessions, "expected the debrief to be listed"
+    for row in sessions:
+        assert row["first_video_id"] is None
+        assert row["video_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_api_sessions_surfaces_video_fields(storage: Storage) -> None:
+    race_id = await _race_with_videos(storage, [("apiVid_0001", "https://youtu.be/apiVid_0001")])
+
+    app = create_app(storage)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/sessions?type=race")
+
+    assert resp.status_code == 200
+    row = next(s for s in resp.json()["sessions"] if s["id"] == race_id)
+    assert row["first_video_id"] == "apiVid_0001"
+    assert row["video_count"] == 1


### PR DESCRIPTION
## What

Adds a YouTube thumbnail to history cards for races that have a linked video, so you can see at a glance which races have footage and click straight through to watch.

Closes #827

## Why this was mostly plumbing

`Storage.list_sessions()` already selected `first_video_url` from `race_videos` and returned it in every session dict — but `static/history.js` never read it, so it was dead weight on the wire. This wires it up and adds the one field that was actually missing: the YouTube video id needed to build a thumbnail URL.

## Changes

- **`storage.py`** — `list_sessions()` now also returns `first_video_id` and `video_count`. While there: the existing `race_videos` subquery used a bare `LIMIT 1` with no `ORDER BY`, so *which* video counted as "first" was unspecified — it is now ordered by `rv.id` (insertion order). The debrief branch of the UNION gets matching `NULL` / `0` columns.
- **`static/history.js`** — `renderVideoThumb()` renders the thumbnail as a link opening YouTube in a new tab, with a play badge and a "+N more" label when a race has several clips. Card markup becomes a two-column flex row; the lazily-loaded summary row stays outside it so it still spans the full card width.
- **`templates/history.html`** — thumbnail styles, including the offline fallback and a narrow-viewport size step.

No schema migration — `race_videos.video_id` already exists.

## Offline behaviour

Thumbnails hotlink `img.youtube.com`, which is unreachable from the boat where the Pi has no uplink. On load error the image is swapped for a `▶ Video` text badge instead of leaving a broken-image icon, so the card still reports that video exists and the link remains usable. Images are `loading="lazy"` so cards without video cost nothing.

## Testing

New `tests/test_history_video.py` (5 tests, TDD — written failing first):

- race with one video exposes `first_video_id` / `first_video_url` / `video_count`
- race with no video reports `None` / `0`
- race with three videos counts them and picks the lowest-row-id one deterministically
- debrief rows carry the null video columns without blowing up the UNION
- `/api/sessions` surfaces both new fields end-to-end

Full suite: **2844 passed, 2 skipped**. `ruff check`, `ruff format --check`, and `mypy --strict` all clean.

Also verified in a browser against a seeded DB covering all four states — video, no video, three videos, and an unresolvable video id:

- thumbnail + play badge render, and the badge stays legible over a bright image
- `+2 more` shows on the multi-video race
- the no-video card is byte-for-byte what it is today
- forcing every thumbnail to fail (simulating no uplink) produced the `▶ Video` fallback on all three, with hrefs intact and no console errors

One thing worth knowing: an *invalid* video id doesn't hit the fallback, because YouTube serves a generic grey placeholder with `200 OK` rather than a 404. The fallback covers the unreachable-network case, which is the one that matters on the boat.